### PR TITLE
fix #103: get the XMLRPC endpoint from the /me/sites response

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -174,6 +174,12 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setHasCapabilityRemoveUsers(from.capabilities.remove_users);
             site.setHasCapabilityViewStats(from.capabilities.view_stats);
         }
+        if (from.meta != null) {
+            if (from.meta.links != null) {
+                site.setXmlRpcUrl(from.meta.links.xmlrpc);
+            }
+        }
+
         site.setIsWPCom(true);
         return site;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -44,6 +44,14 @@ public class SiteWPComRestResponse implements Payload, Response {
         public boolean view_stats;
     }
 
+    public class Meta {
+        public class Links {
+            public String xmlrpc;
+        }
+
+        public Links links;
+    }
+
     public int ID;
     public String URL;
     public String name;
@@ -53,4 +61,5 @@ public class SiteWPComRestResponse implements Payload, Response {
     public Options options;
     public Capabilities capabilities;
     public Plan plan;
+    public Meta meta;
 }


### PR DESCRIPTION
fix #103: get the XMLRPC endpoint from the /me/sites response