### PR TITLE
Append params to URL for GET requests in GsonRequest

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/UtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/UtilsTest.java
@@ -1,0 +1,41 @@
+package org.wordpress.android.fluxc;
+
+import com.android.volley.Request.Method;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.wordpress.android.fluxc.network.rest.GsonRequest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class UtilsTest {
+    @Test
+    public void testAddParamsToUrlIfGet() {
+        String baseUrl = "https://public-api.wordpress.com/rest/v1.1/sites/56/posts/";
+        Map<String, String> params = new HashMap<>();
+
+        params.put("type", "post");
+        assertEquals(baseUrl + "?type=post", GsonRequest.addParamsToUrlIfGet(Method.GET, baseUrl, params));
+
+        params.put("offset", "20");
+        assertEquals(baseUrl + "?offset=20&type=post", GsonRequest.addParamsToUrlIfGet(Method.GET, baseUrl, params));
+
+        // No change to URL if params are null or empty
+        assertEquals(baseUrl, GsonRequest.addParamsToUrlIfGet(Method.GET, baseUrl, null));
+        assertEquals(baseUrl, GsonRequest.addParamsToUrlIfGet(Method.GET, baseUrl,
+                Collections.<String, String>emptyMap()));
+
+        // No change to URL if method is not GET
+        assertEquals(baseUrl, GsonRequest.addParamsToUrlIfGet(Method.POST, baseUrl, null));
+        assertEquals(baseUrl, GsonRequest.addParamsToUrlIfGet(Method.POST, baseUrl,
+                Collections.<String, String>emptyMap()));
+        assertEquals(baseUrl, GsonRequest.addParamsToUrlIfGet(Method.POST, baseUrl, params));
+
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -19,12 +19,9 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
     private static final String REST_AUTHORIZATION_HEADER = "Authorization";
     private static final String REST_AUTHORIZATION_FORMAT = "Bearer %s";
 
-    private final Map<String, String> mParams;
-
     public WPComGsonRequest(int method, String url, Map<String, String> params, Class<T> clazz,
                             Listener<T> listener, ErrorListener errorListener) {
-        super(method, url, clazz, listener, errorListener);
-        mParams = params;
+        super(method, params, url, clazz, listener, errorListener);
     }
 
     public void removeAccessToken() {
@@ -37,11 +34,6 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         } else {
             mHeaders.put(REST_AUTHORIZATION_HEADER, String.format(REST_AUTHORIZATION_FORMAT, token));
         }
-    }
-
-    @Override
-    protected Map<String, String> getParams() {
-        return mParams;
     }
 
     @Override


### PR DESCRIPTION
Modifies `GsonRequest` to add params to the URL for GET requests. This allows our various `RestClient`s to treat params the same way for `POST` and `GET` requests.

We aren't currently using any params for `GET` requests, but they'll be needed soon (e.g. for fetching posts with offset or specifying pages).