### PR TITLE
REST API endpoint builder

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -1,0 +1,38 @@
+package org.wordpress.android.fluxc;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPCOMREST;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class WPComEndpointTest {
+    @Test
+    public void testAllEndpoints() {
+        assertEquals("/sites/", WPCOMREST.sites.getEndpoint());
+        assertEquals("/sites/56/", WPCOMREST.sites.site(56).getEndpoint());
+        assertEquals("/sites/56/posts/", WPCOMREST.sites.site(56).posts.getEndpoint());
+        assertEquals("/sites/56/posts/new/", WPCOMREST.sites.site(56).posts.new_.getEndpoint());
+        assertEquals("/sites/56/posts/78/", WPCOMREST.sites.site(56).posts.post(78).getEndpoint());
+        assertEquals("/sites/56/posts/78/delete/", WPCOMREST.sites.site(56).posts.post(78).delete.getEndpoint());
+        assertEquals("/sites/56/posts/new/", WPCOMREST.sites.site(56).posts.new_.getEndpoint());
+        assertEquals("/sites/new/", WPCOMREST.sites.new_.getEndpoint());
+
+        assertEquals("/me/", WPCOMREST.me.getEndpoint());
+        assertEquals("/me/settings/", WPCOMREST.me.settings.getEndpoint());
+        assertEquals("/me/sites/", WPCOMREST.me.sites.getEndpoint());
+
+        assertEquals("/users/new/", WPCOMREST.users.new_.getEndpoint());
+        assertEquals("/users/new/", WPCOMREST.users.new_.getEndpoint());
+    }
+
+    @Test
+    public void testUrls() {
+        assertEquals("https://public-api.wordpress.com/rest/v1/sites/", WPCOMREST.sites.getUrlV1());
+        assertEquals("https://public-api.wordpress.com/rest/v1.1/sites/", WPCOMREST.sites.getUrlV1_1());
+        assertEquals("https://public-api.wordpress.com/rest/v1.2/sites/", WPCOMREST.sites.getUrlV1_2());
+        assertEquals("https://public-api.wordpress.com/rest/v1.3/sites/", WPCOMREST.sites.getUrlV1_3());
+    }
+}

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/Endpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/Endpoint.java
@@ -1,11 +1,13 @@
 package org.wordpress.android.fluxc.annotations;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 /**
  * Declares a valid REST endpoint.
  */
+@Documented
 @Target({ElementType.FIELD, ElementType.METHOD})
 public @interface Endpoint {
     String value();

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/Endpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/Endpoint.java
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a valid REST endpoint.
+ */
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface Endpoint {
+    String value();
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPCOMREST.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPCOMREST.java
@@ -1,16 +1,22 @@
 package org.wordpress.android.fluxc.network.rest.wpcom;
 
+import org.wordpress.android.fluxc.annotations.Endpoint;
 
 public class WPCOMREST {
     // Top-level endpoints
+    @Endpoint("/me/")
     public static MeEndpoint me = new MeEndpoint();
+    @Endpoint("/sites/")
     public static SitesEndpoint sites = new SitesEndpoint();
+    @Endpoint("/users/")
     public static UsersEndpoint users = new UsersEndpoint();
 
     public static class MeEndpoint extends WPComEndpoint {
         private static final String ME_ENDPOINT = "/me/";
 
+        @Endpoint("/me/settings/")
         public WPComEndpoint settings = new WPComEndpoint(ME_ENDPOINT + "settings/");
+        @Endpoint("/me/sites/")
         public WPComEndpoint sites = new WPComEndpoint(ME_ENDPOINT + "sites/");
 
         private MeEndpoint() {
@@ -21,17 +27,20 @@ public class WPCOMREST {
     public static class SitesEndpoint extends WPComEndpoint {
         private static final String SITES_ENDPOINT = "/sites/";
 
+        @Endpoint("/sites/new/")
         public WPComEndpoint new_ = new WPComEndpoint(SITES_ENDPOINT + "new/");
 
         private SitesEndpoint() {
             super("/sites/");
         }
 
+        @Endpoint("/sites/$site/")
         public SiteEndpoint site(int siteId) {
             return new SiteEndpoint(getEndpoint(), siteId);
         }
 
         public static class SiteEndpoint extends WPComEndpoint {
+            @Endpoint("/sites/$site/posts/")
             public final PostsEndpoint posts = new PostsEndpoint(getEndpoint());
 
             private SiteEndpoint(String previousEndpoint, long siteId) {
@@ -39,17 +48,20 @@ public class WPCOMREST {
             }
 
             public static class PostsEndpoint extends WPComEndpoint {
+                @Endpoint("/sites/$site/posts/new/")
                 public WPComEndpoint new_ = new WPComEndpoint(getEndpoint() + "new/");
 
                 private PostsEndpoint(String previousEndpoint) {
                     super(previousEndpoint + "posts/");
                 }
 
+                @Endpoint("/sites/$site/posts/$post_ID/")
                 public PostEndpoint post(long postId) {
                     return new PostEndpoint(getEndpoint(), postId);
                 }
 
                 public static class PostEndpoint extends WPComEndpoint {
+                    @Endpoint("/sites/$site/posts/$post_ID/delete/")
                     public final WPComEndpoint delete = new WPComEndpoint(getEndpoint() + "delete/");
 
                     private PostEndpoint(String previousEndpoint, long postId) {
@@ -63,6 +75,7 @@ public class WPCOMREST {
     public static class UsersEndpoint extends WPComEndpoint {
         private static final String USERS_ENDPOINT = "/users/";
 
+        @Endpoint("/users/new/")
         public WPComEndpoint new_ = new WPComEndpoint(USERS_ENDPOINT + "new/");
 
         private UsersEndpoint() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPCOMREST.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPCOMREST.java
@@ -1,48 +1,72 @@
 package org.wordpress.android.fluxc.network.rest.wpcom;
 
-public enum WPCOMREST {
-    // Me
-    ME("/me/"),
-    ME_SETTINGS("/me/settings/"),
-    ME_SITES("/me/sites/"),
 
-    // Sites
-    SITES("/sites/"),
-    SITES_NEW("/sites/new"),
+public class WPCOMREST {
+    // Top-level endpoints
+    public static MeEndpoint me = new MeEndpoint();
+    public static SitesEndpoint sites = new SitesEndpoint();
+    public static UsersEndpoint users = new UsersEndpoint();
 
-    // Users
-    USERS_NEW("/users/new");
+    public static class MeEndpoint extends WPComEndpoint {
+        private static final String ME_ENDPOINT = "/me/";
 
-    private static final String WPCOM_REST_PREFIX = "https://public-api.wordpress.com/rest";
-    private static final String WPCOM_PREFIX_V1 = WPCOM_REST_PREFIX + "/v1";
-    private static final String WPCOM_PREFIX_V1_1 = WPCOM_REST_PREFIX + "/v1.1";
-    private static final String WPCOM_PREFIX_V1_2 = WPCOM_REST_PREFIX + "/v1.2";
-    private static final String WPCOM_PREFIX_V1_3 = WPCOM_REST_PREFIX + "/v1.3";
+        public WPComEndpoint settings = new WPComEndpoint(ME_ENDPOINT + "settings/");
+        public WPComEndpoint sites = new WPComEndpoint(ME_ENDPOINT + "sites/");
 
-    private final String mEndpoint;
-
-    WPCOMREST(String endpoint) {
-        mEndpoint = endpoint;
+        private MeEndpoint() {
+            super(ME_ENDPOINT);
+        }
     }
 
-    @Override
-    public String toString() {
-        return mEndpoint;
+    public static class SitesEndpoint extends WPComEndpoint {
+        private static final String SITES_ENDPOINT = "/sites/";
+
+        public WPComEndpoint new_ = new WPComEndpoint(SITES_ENDPOINT + "new/");
+
+        private SitesEndpoint() {
+            super("/sites/");
+        }
+
+        public SiteEndpoint site(int siteId) {
+            return new SiteEndpoint(getEndpoint(), siteId);
+        }
+
+        public static class SiteEndpoint extends WPComEndpoint {
+            public final PostsEndpoint posts = new PostsEndpoint(getEndpoint());
+
+            private SiteEndpoint(String previousEndpoint, long siteId) {
+                super(previousEndpoint, siteId);
+            }
+
+            public static class PostsEndpoint extends WPComEndpoint {
+                public WPComEndpoint new_ = new WPComEndpoint(getEndpoint() + "new/");
+
+                private PostsEndpoint(String previousEndpoint) {
+                    super(previousEndpoint + "posts/");
+                }
+
+                public PostEndpoint post(long postId) {
+                    return new PostEndpoint(getEndpoint(), postId);
+                }
+
+                public static class PostEndpoint extends WPComEndpoint {
+                    public final WPComEndpoint delete = new WPComEndpoint(getEndpoint() + "delete/");
+
+                    private PostEndpoint(String previousEndpoint, long postId) {
+                        super(previousEndpoint, postId);
+                    }
+                }
+            }
+        }
     }
 
-    public String getUrlV1() {
-        return WPCOM_PREFIX_V1 + mEndpoint;
-    }
+    public static class UsersEndpoint extends WPComEndpoint {
+        private static final String USERS_ENDPOINT = "/users/";
 
-    public String getUrlV1_1() {
-        return WPCOM_PREFIX_V1_1 + mEndpoint;
-    }
+        public WPComEndpoint new_ = new WPComEndpoint(USERS_ENDPOINT + "new/");
 
-    public String getUrlV1_2() {
-        return WPCOM_PREFIX_V1_2 + mEndpoint;
-    }
-
-    public String getUrlV1_3() {
-        return WPCOM_PREFIX_V1_3 + mEndpoint;
+        private UsersEndpoint() {
+            super(USERS_ENDPOINT);
+        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPCOMREST.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPCOMREST.java
@@ -35,7 +35,7 @@ public class WPCOMREST {
         }
 
         @Endpoint("/sites/$site/")
-        public SiteEndpoint site(int siteId) {
+        public SiteEndpoint site(long siteId) {
             return new SiteEndpoint(getEndpoint(), siteId);
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComEndpoint.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComEndpoint.java
@@ -1,0 +1,39 @@
+package org.wordpress.android.fluxc.network.rest.wpcom;
+
+public class WPComEndpoint {
+    private static final String WPCOM_REST_PREFIX = "https://public-api.wordpress.com/rest";
+    private static final String WPCOM_PREFIX_V1 = WPCOM_REST_PREFIX + "/v1";
+    private static final String WPCOM_PREFIX_V1_1 = WPCOM_REST_PREFIX + "/v1.1";
+    private static final String WPCOM_PREFIX_V1_2 = WPCOM_REST_PREFIX + "/v1.2";
+    private static final String WPCOM_PREFIX_V1_3 = WPCOM_REST_PREFIX + "/v1.3";
+
+    private final String mEndpoint;
+
+    protected WPComEndpoint(String endpoint) {
+        mEndpoint = endpoint;
+    }
+
+    protected WPComEndpoint(String endpoint, long id) {
+        this(endpoint + id + "/");
+    }
+
+    public String getEndpoint() {
+        return mEndpoint;
+    }
+
+    public String getUrlV1() {
+        return WPCOM_PREFIX_V1 + mEndpoint;
+    }
+
+    public String getUrlV1_1() {
+        return WPCOM_PREFIX_V1_1 + mEndpoint;
+    }
+
+    public String getUrlV1_2() {
+        return WPCOM_PREFIX_V1_2 + mEndpoint;
+    }
+
+    public String getUrlV1_3() {
+        return WPCOM_PREFIX_V1_3 + mEndpoint;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -73,13 +73,13 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     /**
-     * Performs an HTTP GET call to the v1.1 {@link WPCOMREST#ME} endpoint. Upon receiving a
+     * Performs an HTTP GET call to the v1.1 /me/ endpoint. Upon receiving a
      * response (success or error) a {@link AccountAction#FETCHED_ACCOUNT} action is dispatched
      * with a payload of type {@link AccountRestPayload}. {@link AccountRestPayload#isError()} can
      * be used to determine the result of the request.
      */
     public void fetchAccount() {
-        String url = WPCOMREST.ME.getUrlV1_1();
+        String url = WPCOMREST.me.getUrlV1_1();
         add(new WPComGsonRequest<>(Method.GET, url, null, AccountResponse.class,
                 new Listener<AccountResponse>() {
                     @Override
@@ -100,13 +100,13 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     /**
-     * Performs an HTTP GET call to the v1.1 {@link WPCOMREST#ME_SETTINGS} endpoint. Upon receiving
+     * Performs an HTTP GET call to the v1.1 /me/settings/ endpoint. Upon receiving
      * a response (success or error) a {@link AccountAction#FETCHED_SETTINGS} action is dispatched
      * with a payload of type {@link AccountRestPayload}. {@link AccountRestPayload#isError()} can
      * be used to determine the result of the request.
      */
     public void fetchAccountSettings() {
-        String url = WPCOMREST.ME_SETTINGS.getUrlV1_1();
+        String url = WPCOMREST.me.settings.getUrlV1_1();
         add(new WPComGsonRequest<>(Method.GET, url, null, AccountSettingsResponse.class,
                 new Listener<AccountSettingsResponse>() {
                     @Override
@@ -127,7 +127,7 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     /**
-     * Performs an HTTP POST call to the v1.1 {@link WPCOMREST#ME_SETTINGS} endpoint. Upon receiving
+     * Performs an HTTP POST call to the v1.1 /me/settings/ endpoint. Upon receiving
      * a response (success or error) a {@link AccountAction#POSTED_SETTINGS} action is dispatched
      * with a payload of type {@link AccountPostSettingsResponsePayload}. {@link AccountPostSettingsResponsePayload#isError()} can
      * be used to determine the result of the request.
@@ -136,7 +136,7 @@ public class AccountRestClient extends BaseWPComRestClient {
      */
     public void postAccountSettings(Map<String, String> params) {
         if (params == null || params.isEmpty()) return;
-        String url = WPCOMREST.ME_SETTINGS.getUrlV1_1();
+        String url = WPCOMREST.me.settings.getUrlV1_1();
         // Note: we have to use a HashMap as a response here because the API response format is different depending
         // of the request we do.
         add(new WPComGsonRequest<>(Method.POST, url, params, HashMap.class,
@@ -160,7 +160,7 @@ public class AccountRestClient extends BaseWPComRestClient {
 
     public void newAccount(@NonNull String username, @NonNull String password, @NonNull String email,
                            final boolean dryRun) {
-        String url = WPCOMREST.USERS_NEW.getUrlV1();
+        String url = WPCOMREST.users.new_.getUrlV1();
         Map<String, String> params = new HashMap<>();
         params.put("username", username);
         params.put("password", password);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -55,7 +55,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSites() {
-        String url = WPCOMREST.ME_SITES.getUrlV1_1();
+        String url = WPCOMREST.me.sites.getUrlV1_1();
         final WPComGsonRequest<SitesResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SitesResponse.class,
                 new Listener<SitesResponse>() {
@@ -80,7 +80,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSite(final SiteModel site) {
-        String url = WPCOMREST.SITES.getUrlV1_1() + site.getSiteId();
+        String url = WPCOMREST.sites.getUrlV1_1() + site.getSiteId();
         final WPComGsonRequest<SiteWPComRestResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SiteWPComRestResponse.class,
                 new Listener<SiteWPComRestResponse>() {
@@ -103,7 +103,7 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void newSite(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
                         @NonNull SiteVisibility visibility, final boolean dryRun) {
-        String url = WPCOMREST.SITES_NEW.getUrlV1();
+        String url = WPCOMREST.sites.new_.getUrlV1();
         Map<String, String> params = new HashMap<>();
         params.put("blog_name", siteName);
         params.put("blog_title", siteTitle);


### PR DESCRIPTION
Changed `WPCOMREST` from an `enum` to a builder with nested classes.

This lets us do things like call `WPCOMREST.sites.site(56).posts.post(45).getEndpoint()` when requesting post `45` from site `56`. Full use cases demonstrated in [WPComEndpointTest](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/abbd1e76145995eb1c763a3da4c724d39d21a702/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java).

The `@Endpoint` annotation doesn't have any programmatic use currently - I added that to make it easier to pick out the implemented endpoints from the nested classes in `WPCOMREST`. It also has the benefit of showing up in the endpoint's Javadoc comment with the full API string for reference.

cc @maxme
