### PR TITLE
Update WellSql libs to 1.0.8

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -50,8 +50,8 @@ dependencies {
     }
 
     // Custom WellSql version
-    compile 'org.wordpress:wellsql:1.0.6'
-    apt 'org.wordpress:wellsql-processor:1.0.6'
+    compile 'org.wordpress:wellsql:1.0.8'
+    apt 'org.wordpress:wellsql-processor:1.0.8'
 
     // FluxC annotations
     compile project(':fluxc-annotations')


### PR DESCRIPTION
I wanted to add a new `closeDb()` method somewhere in FluxC, the only place I found that could make sense is `WellSqlConfig`. But since any app using FluxC could directly call `WellSql.closeDb()`, I don't think that's necessary (Documentation / Warning is more suitable, but too early IMO).