### PR TITLE
Set BaseRequest timeout to 30 seconds

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -4,7 +4,6 @@ import android.util.Base64;
 
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Response.ErrorListener;
-import com.android.volley.RetryPolicy;
 
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.AuthenticateErrorPayload;
 
@@ -20,15 +19,14 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
     private static final int DEFAULT_REQUEST_TIMEOUT = 30000;
 
     protected OnAuthFailedListener mOnAuthFailedListener;
-    protected RetryPolicy mRetryPolicy;
     protected final Map<String, String> mHeaders = new HashMap<>(2);
 
     public BaseRequest(int method, String url, ErrorListener listener) {
         super(method, url, listener);
         // Make sure all our custom Requests are never cached.
         setShouldCache(false);
-        mRetryPolicy = new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT,
-                DefaultRetryPolicy.DEFAULT_MAX_RETRIES, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT);
+        setRetryPolicy(new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT,
+                DefaultRetryPolicy.DEFAULT_MAX_RETRIES, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
     }
 
     @Override
@@ -53,7 +51,10 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
         mHeaders.put(USER_AGENT_HEADER, userAgent);
     }
 
+    /**
+     * Convenience method for setting a {@link com.android.volley.RetryPolicy} with no retries.
+     */
     public void disableRetries() {
-        mRetryPolicy = new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT);
+        setRetryPolicy(new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -2,7 +2,9 @@ package org.wordpress.android.fluxc.network;
 
 import android.util.Base64;
 
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Response.ErrorListener;
+import com.android.volley.RetryPolicy;
 
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.AuthenticateErrorPayload;
 
@@ -15,13 +17,18 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
     }
 
     private static final String USER_AGENT_HEADER = "User-Agent";
+    private static final int DEFAULT_REQUEST_TIMEOUT = 30000;
+
     protected OnAuthFailedListener mOnAuthFailedListener;
+    protected RetryPolicy mRetryPolicy;
     protected final Map<String, String> mHeaders = new HashMap<>(2);
 
     public BaseRequest(int method, String url, ErrorListener listener) {
         super(method, url, listener);
         // Make sure all our custom Requests are never cached.
         setShouldCache(false);
+        mRetryPolicy = new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT,
+                DefaultRetryPolicy.DEFAULT_MAX_RETRIES, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT);
     }
 
     @Override
@@ -44,5 +51,9 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
 
     public void setUserAgent(String userAgent) {
         mHeaders.put(USER_AGENT_HEADER, userAgent);
+    }
+
+    public void disableRetries() {
+        mRetryPolicy = new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -168,7 +168,9 @@ public class AccountRestClient extends BaseWPComRestClient {
         params.put("validate", dryRun ? "1" : "0");
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
-        add(new WPComGsonRequest<>(Method.POST, url, params, NewAccountResponse.class,
+
+        WPComGsonRequest<NewAccountResponse> request = new WPComGsonRequest<>(Method.POST, url, params,
+                NewAccountResponse.class,
                 new Listener<NewAccountResponse>() {
                     @Override
                     public void onResponse(NewAccountResponse response) {
@@ -186,7 +188,10 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newCreatedNewAccountAction(payload));
                     }
                 }
-        ));
+        );
+
+        request.disableRetries();
+        add(request);
     }
 
     private NewAccountResponsePayload volleyErrorToAccountResponsePayload(VolleyError error) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -116,7 +116,9 @@ public class SiteRestClient extends BaseWPComRestClient {
         params.put("validate", dryRun ? "1" : "0");
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
-        add(new WPComGsonRequest<>(Method.POST, url, params, NewAccountResponse.class,
+
+        WPComGsonRequest<NewAccountResponse> request = new WPComGsonRequest<>(Method.POST, url, params,
+                NewAccountResponse.class,
                 new Listener<NewAccountResponse>() {
                     @Override
                     public void onResponse(NewAccountResponse response) {
@@ -135,7 +137,10 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newCreatedNewSiteAction(payload));
                     }
                 }
-        ));
+        );
+
+        request.disableRetries();
+        add(request);
     }
 
     public void pullPostFormats(@NonNull final SiteModel site) {


### PR DESCRIPTION
Updated our `BaseRequest` to timeout at 30 seconds instead of the default 2.5 seconds. The default was causing issues with longer-running requests such as post creation over WP.COM REST.

I also added a method for disabling retries, and updated new account and new site creation to never attempt to retry.

cc @maxme 