### PR TITLE
Fix #3: Error management using a BaseErrorListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ Action naming guide:
 
 Each action enum should be annotated with `@ActionEnum`, with individual actions receiving an `@Action` annotation with an optional `payloadType` setting (see [SiteAction][5] for an example).
 
-### Events
+### On Changed Events
 
-Events naming guide:
+All On Changed Events extend the OnChanged class. They encapsulate an `error`
+field. Events can be checked for an error by calling `isError()`.
+
+On Changed Events naming guide:
 
     onXChanged(int rowsAffected) - Keep X singular even if multiple X were changed
     onXRemoved(int rowsAffected) - Keep X singular even if multiple X were removed

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Each action enum should be annotated with `@ActionEnum`, with individual actions
 ### On Changed Events
 
 All On Changed Events extend the OnChanged class. They encapsulate an `error`
-field. Events can be checked for an error by calling `isError()`.
+field. Events can be checked for an error by calling `event.isError()`.
 
 On Changed Events naming guide:
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/AccountStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/AccountStoreTest.java
@@ -61,6 +61,6 @@ public class AccountStoreTest extends InstrumentationTestCase {
 
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
-        assertEquals(mIsError, event.isError);
+        assertEquals(mIsError, event.isError());
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -1,14 +1,15 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
-import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.PostAccountSettingsPayload;
@@ -94,10 +95,10 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
-        if (event.isError) {
-            if (event.errorType == AccountStore.AuthenticationError.NEEDS_2FA) {
+        if (event.isError()) {
+            if (event.error.type == AuthenticationErrorType.NEEDS_2FA) {
                 assertEquals(mExpectedAction, ACCOUNT_TEST_ACTIONS.AUTHENTICATE_2FA_ERROR);
-            } else if (event.errorType == AccountStore.AuthenticationError.INCORRECT_USERNAME_OR_PASSWORD) {
+            } else if (event.error.type == AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD) {
                 assertEquals(mExpectedAction, ACCOUNT_TEST_ACTIONS.AUTHENTICATE_ERROR);
             }
         } else {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -327,29 +327,30 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
     }
 
     @Subscribe
-    public void onDiscoverySucceeded(AccountStore.OnDiscoverySucceeded event) {
-        AppLog.i(T.API, "Discovery succeeded, endpoint: " + event.xmlRpcEndpoint);
-        assertEquals(TEST_EVENTS.DISCOVERY_SUCCEEDED, mNextEvent);
-        mPayload.url = event.xmlRpcEndpoint;
-        mCountDownLatch.countDown();
-    }
-
-    @Subscribe
-    public void onDiscoveryFailed(AccountStore.OnDiscoveryFailed event) {
-        AppLog.i(T.API, "Discovery error: " + event.error);
-        if (event.error == DiscoveryError.NO_SITE_ERROR) {
-            assertEquals(TEST_EVENTS.NO_SITE_ERROR, mNextEvent);
-        } else if (event.error == DiscoveryError.WORDPRESS_COM_SITE) {
-            assertEquals(TEST_EVENTS.WORDPRESS_COM_SITE, mNextEvent);
-        } else if (event.error == DiscoveryError.HTTP_AUTH_REQUIRED) {
-            assertEquals(TEST_EVENTS.HTTP_AUTH_REQUIRED, mNextEvent);
-        } else if (event.error == DiscoveryError.ERRONEOUS_SSL_CERTIFICATE) {
-            assertEquals(TEST_EVENTS.ERRONEOUS_SSL_CERTIFICATE, mNextEvent);
+    public void onDiscoveryResponse(AccountStore.OnDiscoveryResponse event) {
+        if (event.isError()) {
+            // ERROR :(
+            AppLog.i(T.API, "Discovery error: " + event.error);
+            if (event.error == DiscoveryError.NO_SITE_ERROR) {
+                assertEquals(TEST_EVENTS.NO_SITE_ERROR, mNextEvent);
+            } else if (event.error == DiscoveryError.WORDPRESS_COM_SITE) {
+                assertEquals(TEST_EVENTS.WORDPRESS_COM_SITE, mNextEvent);
+            } else if (event.error == DiscoveryError.HTTP_AUTH_REQUIRED) {
+                assertEquals(TEST_EVENTS.HTTP_AUTH_REQUIRED, mNextEvent);
+            } else if (event.error == DiscoveryError.ERRONEOUS_SSL_CERTIFICATE) {
+                assertEquals(TEST_EVENTS.ERRONEOUS_SSL_CERTIFICATE, mNextEvent);
+            } else {
+                throw new AssertionError("Didn't get the correct error, expected: " + mNextEvent + ", and got: "
+                        + event.error);
+            }
+            mPayload.url = event.failedEndpoint;
         } else {
-            throw new AssertionError("Didn't get the correct error, expected: " + mNextEvent + ", and got: "
-                    + event.error);
+            // SUCCESS :)
+            AppLog.i(T.API, "Discovery succeeded, endpoint: " + event.xmlRpcEndpoint);
+            assertEquals(TEST_EVENTS.DISCOVERY_SUCCEEDED, mNextEvent);
+            mPayload.url = event.xmlRpcEndpoint;
+            mCountDownLatch.countDown();
         }
-        mPayload.url = event.failedEndpoint;
         mCountDownLatch.countDown();
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTest.java
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
@@ -221,6 +222,10 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
     @Subscribe
     public void onSiteChanged(OnSiteChanged event) {
         AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
+        if (event.isError()) {
+            AppLog.i(T.TESTS, "event error type: " + event.error.type);
+            return;
+        }
         assertEquals(true, mSiteStore.hasSite());
         assertEquals(true, mSiteStore.hasDotOrgSite());
         assertEquals(TEST_EVENTS.SITE_CHANGED, mNextEvent);
@@ -238,12 +243,12 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
 
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
-        if (event.isError) {
-            AppLog.i(T.TESTS, "error " + event.errorType + " - " + event.errorMessage);
-            if (event.errorType == AuthenticationError.HTTP_AUTH_ERROR) {
+        if (event.isError()) {
+            AppLog.i(T.TESTS, "error " + event.error.type + " - " + event.error.message);
+            if (event.error.type == AuthenticationErrorType.GENERIC_ERROR) {
                 assertEquals(TEST_EVENTS.HTTP_AUTH_ERROR, mNextEvent);
             }
-            if (event.errorType == AuthenticationError.INVALID_SSL_CERTIFICATE) {
+            if (event.error.type == AuthenticationErrorType.INVALID_SSL_CERTIFICATE) {
                 assertEquals(TEST_EVENTS.INVALID_SSL_CERTIFICATE, mNextEvent);
             }
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCOM.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCOM.java
@@ -113,13 +113,17 @@ public class ReleaseStack_SiteTestWPCOM extends ReleaseStack_Base {
 
     @Subscribe
     public void onAuthenticationChanged(AccountStore.OnAuthenticationChanged event) {
-        assertEquals(false, event.isError);
+        assertEquals(false, event.isError());
         mCountDownLatch.countDown();
     }
 
     @Subscribe
     public void onSiteChanged(OnSiteChanged event) {
         AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
+        if (event.isError()) {
+            AppLog.i(T.TESTS, "event error type: " + event.error.type);
+            return;
+        }
         assertEquals(true, mSiteStore.hasSite());
         assertEquals(true, mSiteStore.hasDotComSite());
         assertEquals(TEST_EVENTS.SITE_CHANGED, mExpectedEvent);

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
@@ -417,8 +417,8 @@ public class MainExampleActivity extends AppCompatActivity {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onNewSiteCreated(OnNewSiteCreated event) {
         String message = event.dryRun ? "validated" : "created";
-        if (event.isError) {
-            prependToLog("New site " + message + ", error: " + event.errorMessage + " - " + event.errorType);
+        if (event.isError()) {
+            prependToLog("New site " + message + ", error: " + event.error.type + " - " + event.error.message);
         } else {
             prependToLog("New site " + message + ": success!");
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
@@ -412,7 +412,7 @@ public class MainExampleActivity extends AppCompatActivity {
     public void onNewUserValidated(OnNewUserCreated event) {
         String message = event.dryRun ? "validation" : "creation";
         if (event.isError()) {
-            prependToLog("New user " + message + ", error: " + event.error.type);
+            prependToLog("New user " + message + ": error: " + event.error.type + " - " + event.error.message);
         } else {
             prependToLog("New user " + message + ": success!");
         }
@@ -422,7 +422,7 @@ public class MainExampleActivity extends AppCompatActivity {
     public void onNewSiteCreated(OnNewSiteCreated event) {
         String message = event.dryRun ? "validated" : "created";
         if (event.isError()) {
-            prependToLog("New site " + message + ", error: " + event.error.type + " - " + event.error.message);
+            prependToLog("New site " + message + ": error: " + event.error.type + " - " + event.error.message);
         } else {
             prependToLog("New site " + message + ": success!");
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
@@ -395,6 +395,10 @@ public class MainExampleActivity extends AppCompatActivity {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
+        if (event.isError()) {
+            prependToLog("SiteChanged error: " + event.error.type);
+            return;
+        }
         if (mSiteStore.hasSite()) {
             SiteModel firstSite = mSiteStore.getSites().get(0);
             prependToLog("First site name: " + firstSite.getName() + " - Total sites: " + mSiteStore.getSitesCount());

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
@@ -375,7 +375,7 @@ public class MainExampleActivity extends AppCompatActivity {
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onDiscoveryFailed(OnDiscoveryResponse event) {
+    public void onDiscoveryResponse(OnDiscoveryResponse event) {
         if (event.isError()) {
             if (event.error == DiscoveryError.WORDPRESS_COM_SITE) {
                 wpcomFetchSites(mSelfhostedPayload.username, mSelfhostedPayload.password);

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
@@ -353,9 +353,9 @@ public class MainExampleActivity extends AppCompatActivity {
         mAccountSettings.setEnabled(mAccountStore.hasAccessToken());
         mNewSite.setEnabled(mAccountStore.hasAccessToken());
         if (event.isError()) {
-            prependToLog("Authentication error: " + event.error);
+            prependToLog("Authentication error: " + event.error.type);
 
-            switch (event.error) {
+            switch (event.error.type) {
                 case HTTP_AUTH_ERROR:
                     // Show a Dialog prompting for http username and password
                     showHTTPAuthDialog(mSelfhostedPayload.url);
@@ -368,6 +368,7 @@ public class MainExampleActivity extends AppCompatActivity {
                     show2faDialog();
                     break;
                 default:
+                    // Show Toast "Network Error"?
                     break;
             }
         }
@@ -407,7 +408,7 @@ public class MainExampleActivity extends AppCompatActivity {
     public void onNewUserValidated(OnNewUserCreated event) {
         String message = event.dryRun ? "validation" : "creation";
         if (event.isError()) {
-            prependToLog("New user " + message + ", error: " + event.error);
+            prependToLog("New user " + message + ", error: " + event.error.type);
         } else {
             prependToLog("New user " + message + ": success!");
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/MapPayload.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/MapPayload.java
@@ -1,6 +1,0 @@
-package org.wordpress.android.fluxc;
-
-import java.util.HashMap;
-
-public class MapPayload<T> extends HashMap<String, T> implements Payload {
-}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
@@ -1,4 +1,10 @@
 package org.wordpress.android.fluxc;
 
-public interface Payload {
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
+
+public class Payload {
+    public BaseNetworkError error;
+    public boolean isError() {
+        return error != null;
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.util.StringUtils;
 
 @Table
-public class AccountModel implements Identifiable, Payload {
+public class AccountModel extends Payload implements Identifiable {
     @PrimaryKey
     @Column private int mId;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
-public class SiteModel implements Identifiable, Payload, Serializable {
+public class SiteModel extends Payload implements Identifiable, Serializable {
 
     @PrimaryKey
     @Column private int mId;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
@@ -2,6 +2,20 @@ package org.wordpress.android.fluxc.model;
 
 import org.wordpress.android.fluxc.Payload;
 
-import java.util.ArrayList;
+import java.util.List;
 
-public class SitesModel extends ArrayList<SiteModel> implements Payload {}
+public class SitesModel extends Payload {
+    private List<SiteModel> mSites;
+
+    public SitesModel(List<SiteModel> sites) {
+        mSites = sites;
+    }
+
+    public List<SiteModel> getSites() {
+        return mSites;
+    }
+
+    public void setSites(List<SiteModel> sites) {
+        this.mSites = sites;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
@@ -1,13 +1,20 @@
 package org.wordpress.android.fluxc.model;
 
+import android.support.annotation.NonNull;
+
 import org.wordpress.android.fluxc.Payload;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SitesModel extends Payload {
     private List<SiteModel> mSites;
 
-    public SitesModel(List<SiteModel> sites) {
+    public SitesModel() {
+        mSites = new ArrayList<>();
+    }
+
+    public SitesModel(@NonNull List<SiteModel> sites) {
         mSites = sites;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -31,17 +31,22 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
         public String message;
         public VolleyError volleyError;
 
-        public BaseNetworkError(GenericErrorType error, @Nullable String message, @NonNull VolleyError volleyError) {
+        public BaseNetworkError(@NonNull GenericErrorType error, @Nullable String message, @NonNull VolleyError volleyError) {
             this.message = message;
             this.error = error;
             this.volleyError = volleyError;
         }
-
         public BaseNetworkError(@NonNull VolleyError volleyError) {
             this.volleyError = volleyError;
         }
+        public BaseNetworkError(@NonNull GenericErrorType error) {
+            this.error = error;
+        }
         public boolean isGeneric() {
             return error != null;
+        }
+        public boolean hasVolleyError() {
+            return volleyError != null;
         }
     }
 
@@ -49,7 +54,8 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
         NOT_FOUND,
         CENSORED,
         SERVER_ERROR,
-        TIMEOUT
+        TIMEOUT,
+        INVALID_RESPONSE
     }
 
     public static abstract class BaseErrorListener implements ErrorListener {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -10,6 +10,7 @@ import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.AuthenticateErrorPayload;
+import org.wordpress.android.util.AppLog;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -54,6 +55,7 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
     public static abstract class BaseErrorListener implements ErrorListener {
         @Override
         public void onErrorResponse(VolleyError error) {
+            AppLog.e(AppLog.T.API, "Volley error", error);
             this.onErrorResponse(getGenericError(error));
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.android.volley.toolbox;
+// NOTE: this was forked from com.android.volley.toolbox.RequestFuture
+
+package org.wordpress.android.fluxc.network;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.android.volley.Request;
 import com.android.volley.Response;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.android.volley.Request;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+
+import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
+import org.wordpress.android.fluxc.network.BaseRequest.GenericError;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A Future that represents a Volley request.
+ *
+ * Used by providing as your response and error listeners. For example:
+ * <pre>
+ * RequestFuture&lt;JSONObject&gt; future = RequestFuture.newFuture();
+ * MyRequest request = new MyRequest(URL, future, future);
+ *
+ * // If you want to be able to cancel the request:
+ * future.setRequest(requestQueue.add(request));
+ *
+ * // Otherwise:
+ * requestQueue.add(request);
+ *
+ * try {
+ *   JSONObject response = future.get();
+ *   // do something with response
+ * } catch (InterruptedException e) {
+ *   // handle the error
+ * } catch (ExecutionException e) {
+ *   // handle the error
+ * }
+ * </pre>
+ *
+ * @param <T> The type of parsed response this future expects.
+ */
+public class BaseRequestFuture<T> extends BaseErrorListener implements Future<T>, Response.Listener<T>  {
+    private Request<?> mRequest;
+    private boolean mResultReceived = false;
+    private T mResult;
+    private VolleyError mException;
+
+    public static <E> BaseRequestFuture<E> newFuture() {
+        return new BaseRequestFuture<E>();
+    }
+
+    private BaseRequestFuture() {}
+
+    public void setRequest(Request<?> request) {
+        mRequest = request;
+    }
+
+    @Override
+    public synchronized boolean cancel(boolean mayInterruptIfRunning) {
+        if (mRequest == null) {
+            return false;
+        }
+
+        if (!isDone()) {
+            mRequest.cancel();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        try {
+            return doGet(null);
+        } catch (TimeoutException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return doGet(TimeUnit.MILLISECONDS.convert(timeout, unit));
+    }
+
+    private synchronized T doGet(Long timeoutMs)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        if (mException != null) {
+            throw new ExecutionException(mException);
+        }
+
+        if (mResultReceived) {
+            return mResult;
+        }
+
+        if (timeoutMs == null) {
+            wait(0);
+        } else if (timeoutMs > 0) {
+            wait(timeoutMs);
+        }
+
+        if (mException != null) {
+            throw new ExecutionException(mException);
+        }
+
+        if (!mResultReceived) {
+            throw new TimeoutException();
+        }
+
+        return mResult;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        if (mRequest == null) {
+            return false;
+        }
+        return mRequest.isCanceled();
+    }
+
+    @Override
+    public synchronized boolean isDone() {
+        return mResultReceived || mException != null || isCancelled();
+    }
+
+    @Override
+    public synchronized void onResponse(T response) {
+        mResultReceived = true;
+        mResult = response;
+        notifyAll();
+    }
+
+    @Override
+    public synchronized void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
+        mException = error;
+        notifyAll();
+    }
+}
+

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
@@ -24,7 +24,7 @@ import com.android.volley.Response;
 import com.android.volley.VolleyError;
 
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.GenericError;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -150,8 +150,8 @@ public class BaseRequestFuture<T> extends BaseErrorListener implements Future<T>
     }
 
     @Override
-    public synchronized void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
-        mException = error;
+    public synchronized void onErrorResponse(@NonNull BaseNetworkError error) {
+        mException = error.volleyError;
         notifyAll();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.discovery;
 
 import com.android.volley.NetworkResponse;
 import com.android.volley.Response;
-import com.android.volley.Response.ErrorListener;
 import com.android.volley.Response.Listener;
 import com.android.volley.toolbox.HttpHeaderParser;
 
@@ -17,7 +16,7 @@ public class DiscoveryRequest extends BaseRequest<String> {
 
     private final Listener<String> mListener;
 
-    public DiscoveryRequest(String url, Listener<String> listener, ErrorListener errorListener) {
+    public DiscoveryRequest(String url, Listener<String> listener, BaseErrorListener errorListener) {
         super(Method.GET, url, errorListener);
         mListener = listener;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
@@ -18,7 +18,7 @@ public class DiscoveryXMLRPCRequest extends XMLRPCRequest {
     private final ErrorListener mErrorListener;
 
     public DiscoveryXMLRPCRequest(String url, XMLRPC method, List<Object> params, Listener listener,
-                                  ErrorListener errorListener) {
+                                  BaseErrorListener errorListener) {
         super(url, method, params, listener, errorListener);
         mErrorListener = errorListener;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -7,7 +7,7 @@ import android.webkit.URLUtil;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.NoConnectionError;
-import com.android.volley.toolbox.RequestFuture;
+import com.android.volley.toolbox.BaseRequestFuture;
 
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
@@ -365,7 +365,7 @@ public class SelfHostedEndpointFinder {
      * Obtain the HTML response from a GET request for the given URL.
      */
     private String getResponse(String url) throws DiscoveryException {
-        RequestFuture<String> future = RequestFuture.newFuture();
+        BaseRequestFuture<String> future = BaseRequestFuture.newFuture();
         DiscoveryRequest request = new DiscoveryRequest(url, future, future);
         mClient.add(request);
         try {
@@ -457,7 +457,7 @@ public class SelfHostedEndpointFinder {
         params.add(httpUsername);
         params.add(httpPassword);
 
-        RequestFuture<Object[]> future = RequestFuture.newFuture();
+        BaseRequestFuture<Object[]> future = BaseRequestFuture.newFuture();
         DiscoveryXMLRPCRequest request = new DiscoveryXMLRPCRequest(url, XMLRPC.LIST_METHODS, params, future, future);
         mClient.add(request);
         try {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPC;
-import org.wordpress.android.fluxc.store.Store.ErrorType;
+import org.wordpress.android.fluxc.store.Store.OnChangedError;
 import org.wordpress.android.fluxc.utils.WPUrlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -43,7 +43,7 @@ public class SelfHostedEndpointFinder {
     private final Dispatcher mDispatcher;
     private final BaseXMLRPCClient mClient;
 
-    public enum DiscoveryError implements ErrorType {
+    public enum DiscoveryError implements OnChangedError {
         SITE_URL_CANNOT_BE_EMPTY,
         INVALID_URL,
         MISSING_XMLRPC_METHOD,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -63,7 +63,7 @@ public class SelfHostedEndpointFinder {
         }
     }
 
-    public static class DiscoveryResultPayload implements Payload {
+    public static class DiscoveryResultPayload extends Payload {
         public String xmlRpcEndpoint;
         public String wpRestEndpoint;
         public boolean isError;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -50,7 +50,8 @@ public class SelfHostedEndpointFinder {
         ERRONEOUS_SSL_CERTIFICATE,
         HTTP_AUTH_REQUIRED,
         NO_SITE_ERROR,
-        WORDPRESS_COM_SITE
+        WORDPRESS_COM_SITE,
+        GENERIC_ERROR
     }
 
     static class DiscoveryException extends Exception {
@@ -66,8 +67,7 @@ public class SelfHostedEndpointFinder {
     public static class DiscoveryResultPayload extends Payload {
         public String xmlRpcEndpoint;
         public String wpRestEndpoint;
-        public boolean isError;
-        public DiscoveryError error;
+        public DiscoveryError discoveryError;
         public String failedEndpoint;
 
         public DiscoveryResultPayload(String xmlRpcEndpoint, String wpRestEndpoint) {
@@ -75,10 +75,13 @@ public class SelfHostedEndpointFinder {
             this.wpRestEndpoint = wpRestEndpoint;
         }
 
-        public DiscoveryResultPayload(DiscoveryError error, String failedEndpoint) {
-            this.isError = true;
-            this.error = error;
+        public DiscoveryResultPayload(DiscoveryError discoveryError, String failedEndpoint) {
+            this.discoveryError = discoveryError;
             this.failedEndpoint = failedEndpoint;
+        }
+
+        public boolean isDiscoveryError() {
+            return discoveryError != null;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -7,11 +7,11 @@ import android.webkit.URLUtil;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.NoConnectionError;
-import com.android.volley.toolbox.BaseRequestFuture;
 
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.network.BaseRequestFuture;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPC;
 import org.wordpress.android.fluxc.store.Store.OnChangedError;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPC;
+import org.wordpress.android.fluxc.store.Store.ErrorType;
 import org.wordpress.android.fluxc.utils.WPUrlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -42,7 +43,7 @@ public class SelfHostedEndpointFinder {
     private final Dispatcher mDispatcher;
     private final BaseXMLRPCClient mClient;
 
-    public enum DiscoveryError {
+    public enum DiscoveryError implements ErrorType {
         SITE_URL_CANNOT_BE_EMPTY,
         INVALID_URL,
         MISSING_XMLRPC_METHOD,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -4,7 +4,6 @@ import com.android.volley.NetworkResponse;
 import com.android.volley.ParseError;
 import com.android.volley.Request;
 import com.android.volley.Response;
-import com.android.volley.Response.ErrorListener;
 import com.android.volley.Response.Listener;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.google.gson.Gson;
@@ -25,7 +24,7 @@ public class GsonRequest<T> extends BaseRequest<T> {
     private final Map<String, String> mParams;
 
     public GsonRequest(int method, Map<String, String> params, String url, Class<T> clazz, Listener<T> listener,
-                       ErrorListener errorListener) {
+                       BaseErrorListener errorListener) {
         super(method, addParamsToUrlIfGet(method, url, params), errorListener);
         mClass = clazz;
         mListener = listener;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -63,9 +63,9 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
                     || apiResponseError.equals("invalid_token")
                     || apiResponseError.equals("access_denied")
                     || apiResponseError.equals("needs_2fa")) {
-                AuthenticationError error = Authenticator.jsonErrorToAuthenticationError(jsonObject);
-                AuthenticateErrorPayload payload = new AuthenticateErrorPayload(error, jsonObject.optString
-                        ("error_description", ""));
+                AuthenticationError error = new AuthenticationError(Authenticator.jsonErrorToAuthenticationError
+                        (jsonObject), jsonObject.optString("error_description", ""));
+                AuthenticateErrorPayload payload = new AuthenticateErrorPayload(error);
                 mOnAuthFailedListener.onAuthFailed(payload);
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -37,7 +37,7 @@ import javax.inject.Singleton;
 public class AccountRestClient extends BaseWPComRestClient {
     private final AppSecrets mAppSecrets;
 
-    public static class AccountRestPayload implements Payload {
+    public static class AccountRestPayload extends Payload {
         public AccountRestPayload(AccountModel account, BaseNetworkError error) {
             this.account = account;
             this.error = error;
@@ -47,7 +47,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         public AccountModel account;
     }
 
-    public static class AccountPostSettingsResponsePayload implements Payload {
+    public static class AccountPostSettingsResponsePayload extends Payload {
         public AccountPostSettingsResponsePayload(BaseNetworkError error) {
             this.error = error;
         }
@@ -58,7 +58,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         public Map<String, Object> settings;
     }
 
-    public static class NewAccountResponsePayload implements Payload {
+    public static class NewAccountResponsePayload extends Payload {
         public NewUserError error;
         public boolean dryRun;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.account;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
-import com.android.volley.Response.ErrorListener;
 import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
 
@@ -15,6 +15,8 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.model.AccountModel;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
+import org.wordpress.android.fluxc.network.BaseRequest.GenericError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPCOMREST;
@@ -87,9 +89,8 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedAccountAction(payload));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AccountRestPayload payload = new AccountRestPayload(null, error);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedAccountAction(payload));
                     }
@@ -114,9 +115,8 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedSettingsAction(payload));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AccountRestPayload payload = new AccountRestPayload(null, error);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedSettingsAction(payload));
                     }
@@ -146,9 +146,8 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newPostedSettingsAction(payload));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AccountPostSettingsResponsePayload payload = new AccountPostSettingsResponsePayload(error);
                         mDispatcher.dispatch(AccountActionBuilder.newPostedSettingsAction(payload));
                     }
@@ -178,9 +177,8 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newCreatedNewAccountAction(payload));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         NewAccountResponsePayload payload = volleyErrorToAccountResponsePayload(error);
                         payload.dryRun = dryRun;
                         mDispatcher.dispatch(AccountActionBuilder.newCreatedNewAccountAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -10,18 +10,19 @@ import com.android.volley.VolleyError;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.wordpress.android.fluxc.generated.AccountActionBuilder;
-import org.wordpress.android.fluxc.network.UserAgent;
-import org.wordpress.android.fluxc.network.rest.wpcom.WPCOMREST;
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.AccountAction;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.model.AccountModel;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPCOMREST;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserError;
+import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -57,10 +58,7 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     public static class NewAccountResponsePayload implements Payload {
-        public NewAccountResponsePayload() {
-        }
-        public NewUserError errorType;
-        public String errorMessage;
+        public NewUserError error;
         public boolean isError;
         public boolean dryRun;
     }
@@ -196,15 +194,14 @@ public class AccountRestClient extends BaseWPComRestClient {
 
     private NewAccountResponsePayload volleyErrorToAccountResponsePayload(VolleyError error) {
         NewAccountResponsePayload payload = new NewAccountResponsePayload();
-        payload.isError = true;
-        payload.errorType = NewUserError.GENERIC_ERROR;
+        payload.error = new NewUserError(NewUserErrorType.GENERIC_ERROR, "");
         if (error.networkResponse != null && error.networkResponse.data != null) {
             AppLog.e(T.API, new String(error.networkResponse.data));
             String jsonString = new String(error.networkResponse.data);
             try {
                 JSONObject errorObj = new JSONObject(jsonString);
-                payload.errorType = NewUserError.fromString((String) errorObj.get("error"));
-                payload.errorMessage = (String) errorObj.get("message");
+                payload.error.type = NewUserErrorType.fromString((String) errorObj.get("error"));
+                payload.error.message = (String) errorObj.get("message");
             } catch (JSONException e) {
                 // Do nothing (keep default error)
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -146,7 +146,6 @@ public class AccountRestClient extends BaseWPComRestClient {
                 },
                 new BaseErrorListener() {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(T.API, "Volley error", error.volleyError);
                         AccountPostSettingsResponsePayload payload = new AccountPostSettingsResponsePayload(error);
                         mDispatcher.dispatch(AccountActionBuilder.newPostedSettingsAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -88,6 +88,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AccountRestPayload payload = new AccountRestPayload(null, error);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedAccountAction(payload));
@@ -114,6 +115,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AccountRestPayload payload = new AccountRestPayload(null, error);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedSettingsAction(payload));
@@ -145,6 +147,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AccountPostSettingsResponsePayload payload = new AccountPostSettingsResponsePayload(error);
                         mDispatcher.dispatch(AccountActionBuilder.newPostedSettingsAction(payload));
@@ -175,6 +178,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         NewAccountResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
                         payload.dryRun = dryRun;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -15,6 +15,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -57,11 +58,12 @@ public class Authenticator {
     }
 
     public static class AuthenticateErrorPayload implements Payload {
-        public AuthenticationError errorType;
-        public String errorMessage;
-        public AuthenticateErrorPayload(@NonNull AuthenticationError errorType, @NonNull String errorMessage) {
-            this.errorType = errorType;
-            this.errorMessage = errorMessage;
+        public AuthenticationError error;
+        public AuthenticateErrorPayload(@NonNull AuthenticationError error) {
+            this.error = error;
+        }
+        public AuthenticateErrorPayload(@NonNull AuthenticationErrorType errorType) {
+            this.error = new AuthenticationError(errorType, "");
         }
     }
 
@@ -190,7 +192,7 @@ public class Authenticator {
         }
     }
 
-    public static AuthenticationError volleyErrorToAuthenticationError(VolleyError error) {
+    public static AuthenticationErrorType volleyErrorToAuthenticationError(VolleyError error) {
         if (error != null && error.networkResponse != null && error.networkResponse.data != null) {
             String jsonString = new String(error.networkResponse.data);
             try {
@@ -200,7 +202,7 @@ public class Authenticator {
                 AppLog.e(T.API, e);
             }
         }
-        return AuthenticationError.GENERIC_ERROR;
+        return AuthenticationErrorType.GENERIC_ERROR;
     }
 
     public static String volleyErrorToErrorMessage(VolleyError error) {
@@ -216,17 +218,17 @@ public class Authenticator {
         return null;
     }
 
-    public static AuthenticationError jsonErrorToAuthenticationError(JSONObject jsonObject) {
-        AuthenticationError error = AuthenticationError.GENERIC_ERROR;
+    public static AuthenticationErrorType jsonErrorToAuthenticationError(JSONObject jsonObject) {
+        AuthenticationErrorType error = AuthenticationErrorType.GENERIC_ERROR;
         if (jsonObject != null) {
             String errorType = jsonObject.optString("error", "");
             String errorMessage = jsonObject.optString("error_description", "");
-            error = AuthenticationError.fromString(errorType);
+            error = AuthenticationErrorType.fromString(errorType);
             // Special cases for vague error types
-            if (error == AuthenticationError.INVALID_REQUEST) {
+            if (error == AuthenticationErrorType.INVALID_REQUEST) {
                 // Try to parse the error message to specify the error
                 if (errorMessage.contains("Incorrect username or password.")) {
-                    return AuthenticationError.INCORRECT_USERNAME_OR_PASSWORD;
+                    return AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD;
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -57,7 +57,7 @@ public class Authenticator {
     public interface ErrorListener extends Response.ErrorListener {
     }
 
-    public static class AuthenticateErrorPayload implements Payload {
+    public static class AuthenticateErrorPayload extends Payload {
         public AuthenticationError error;
         public AuthenticateErrorPayload(@NonNull AuthenticationError error) {
             this.error = error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -38,8 +38,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import static org.wordpress.android.fluxc.network.rest.wpcom.WPCOMREST.sites;
-
 @Singleton
 public class SiteRestClient extends BaseWPComRestClient {
     private final AppSecrets mAppSecrets;
@@ -85,7 +83,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSite(final SiteModel site) {
-        String url = sites.getUrlV1_1() + site.getSiteId();
+        String url = WPCOMREST.sites.getUrlV1_1() + site.getSiteId();
         final WPComGsonRequest<SiteWPComRestResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SiteWPComRestResponse.class,
                 new Listener<SiteWPComRestResponse>() {
@@ -108,7 +106,7 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void newSite(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
                         @NonNull SiteVisibility visibility, final boolean dryRun) {
-        String url = sites.new_.getUrlV1();
+        String url = WPCOMREST.sites.new_.getUrlV1();
         Map<String, String> params = new HashMap<>();
         params.put("blog_name", siteName);
         params.put("blog_title", siteTitle);
@@ -142,7 +140,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullPostFormats(@NonNull final SiteModel site) {
-        String url = sites.site(site.getSiteId()).post_formats.getUrlV1_1();
+        String url = WPCOMREST.sites.site(site.getSiteId()).post_formats.getUrlV1_1();
         final WPComGsonRequest<PostFormatsResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, PostFormatsResponse.class,
                 new Listener<PostFormatsResponse>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
@@ -17,7 +16,7 @@ import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.GenericError;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPCOMREST;
@@ -74,8 +73,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
-                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
-                        AppLog.e(T.API, "Volley error", error);
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AppLog.e(T.API, "Volley error", error.volleyError);
 
                         // TODO: Error, dispatch network error
                     }
@@ -96,8 +95,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
-                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
-                        AppLog.e(T.API, "Volley error", error);
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AppLog.e(T.API, "Volley error", error.volleyError);
                         // TODO: Error, dispatch network error
                     }
                 }
@@ -128,9 +127,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
-                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
-                        AppLog.e(T.API, new String(error.networkResponse.data));
-                        NewSiteResponsePayload payload = volleyErrorToAccountResponsePayload(error);
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AppLog.e(T.API, "Volley error", error.volleyError);
+                        NewSiteResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
                         payload.dryRun = dryRun;
                         mDispatcher.dispatch(SiteActionBuilder.newCreatedNewSiteAction(payload));
                     }
@@ -162,8 +161,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
-                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
-                        AppLog.e(T.API, "Volley error", error);
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AppLog.e(T.API, "Volley error", error.volleyError);
                         // TODO: Error, dispatch network error
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -29,8 +29,6 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
-import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,7 +59,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSites() {
-        String url = WPCOMREST.me.sites.getUrlV1_1() + "/FIXME: 404";
+        String url = WPCOMREST.me.sites.getUrlV1_1();
         final WPComGsonRequest<SitesResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SitesResponse.class,
                 new Listener<SitesResponse>() {
@@ -99,8 +97,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                 },
                 new BaseErrorListener() {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(T.API, "Volley error", error.volleyError);
-                        // TODO: Error, dispatch network error
+                        SiteModel payload = new SiteModel();
+                        payload.error = error;
+                        mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(payload));
                     }
                 }
         );
@@ -131,7 +130,6 @@ public class SiteRestClient extends BaseWPComRestClient {
                 },
                 new BaseErrorListener() {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(T.API, "Volley error", error.volleyError);
                         NewSiteResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
                         payload.dryRun = dryRun;
                         mDispatcher.dispatch(SiteActionBuilder.newCreatedNewSiteAction(payload));
@@ -165,12 +163,10 @@ public class SiteRestClient extends BaseWPComRestClient {
                 },
                 new BaseErrorListener() {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(T.API, "Volley error", error.volleyError);
-                        // FIXME
-                        //Payload payload = new FetchedPostFormatsPayload(null, null);
-                        //payload.error = error;
-                        //mDispatcher.dispatch(SiteActionBuilder.newFetchedPostFormatsAction(payload));
-                        // TODO: Error, dispatch network error
+                        FetchedPostFormatsPayload payload = new FetchedPostFormatsPayload(site,
+                                new ArrayList<PostFormatModel>());
+                        payload.error = error;
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchedPostFormatsAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -72,6 +72,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         SitesModel payload = new SitesModel(new ArrayList<SiteModel>());
                         payload.error = error;
@@ -94,6 +95,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         SiteModel payload = new SiteModel();
                         payload.error = error;
@@ -127,6 +129,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         NewSiteResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
                         payload.dryRun = dryRun;
@@ -160,6 +163,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         FetchedPostFormatsPayload payload = new FetchedPostFormatsPayload(site,
                                 new ArrayList<PostFormatModel>());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
-import com.android.volley.Response.ErrorListener;
 import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
 
@@ -16,6 +16,8 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
+import org.wordpress.android.fluxc.network.BaseRequest.GenericError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPCOMREST;
@@ -24,10 +26,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.account.NewAccountResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteWPComRestResponse.SitesResponse;
+import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
-import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -58,7 +60,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSites() {
-        String url = WPCOMREST.me.sites.getUrlV1_1();
+        String url = WPCOMREST.me.sites.getUrlV1_1() + "/FIXME: 404";
         final WPComGsonRequest<SitesResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SitesResponse.class,
                 new Listener<SitesResponse>() {
@@ -71,10 +73,10 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sites));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AppLog.e(T.API, "Volley error", error);
+
                         // TODO: Error, dispatch network error
                     }
                 }
@@ -93,9 +95,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(site));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AppLog.e(T.API, "Volley error", error);
                         // TODO: Error, dispatch network error
                     }
@@ -126,9 +127,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newCreatedNewSiteAction(payload));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AppLog.e(T.API, new String(error.networkResponse.data));
                         NewSiteResponsePayload payload = volleyErrorToAccountResponsePayload(error);
                         payload.dryRun = dryRun;
@@ -161,9 +161,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 FetchedPostFormatsPayload(site, postFormats)));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AppLog.e(T.API, "Volley error", error);
                         // TODO: Error, dispatch network error
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.Payload;
 
 import java.util.List;
 
-public class SiteWPComRestResponse implements Payload, Response {
+public class SiteWPComRestResponse extends Payload implements Response {
     public class SitesResponse {
         public List<SiteWPComRestResponse> sites;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -6,7 +6,6 @@ import com.android.volley.AuthFailureError;
 import com.android.volley.NetworkResponse;
 import com.android.volley.ParseError;
 import com.android.volley.Response;
-import com.android.volley.Response.ErrorListener;
 import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.HttpHeaderParser;
@@ -40,7 +39,7 @@ public class XMLRPCRequest extends BaseRequest<Object> {
     private final XmlSerializer mSerializer = Xml.newSerializer();
 
     public XMLRPCRequest(String url, XMLRPC method, List<Object> params, Listener listener,
-                         ErrorListener errorListener) {
+                         BaseErrorListener errorListener) {
         super(Method.POST, url, errorListener);
         mListener = listener;
         mMethod = method;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -11,9 +11,9 @@ import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.HttpHeaderParser;
 
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.AuthenticateErrorPayload;
-import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError;
 import org.wordpress.android.fluxc.network.BaseRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.AuthenticateErrorPayload;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.xmlpull.v1.XmlPullParserException;
@@ -98,24 +98,24 @@ public class XMLRPCRequest extends BaseRequest<Object> {
     public void deliverError(VolleyError error) {
         super.deliverError(error);
         // XMLRPC Error
-        AuthenticateErrorPayload payload = new AuthenticateErrorPayload(AuthenticationError.GENERIC_ERROR, "");
+        AuthenticateErrorPayload payload = new AuthenticateErrorPayload(AuthenticationErrorType.GENERIC_ERROR);
         if (error.getCause() instanceof XMLRPCFault) {
             XMLRPCFault xmlrpcFault = (XMLRPCFault) error.getCause();
             if (xmlrpcFault.getFaultCode() == 401) {
                 // Unauthorized
-                payload.errorType = AuthenticationError.AUTHORIZATION_REQUIRED;
+                payload.error.type = AuthenticationErrorType.AUTHORIZATION_REQUIRED;
             } else if (xmlrpcFault.getFaultCode() == 403) {
                 // Not authenticated
-                payload.errorType = AuthenticationError.NOT_AUTHENTICATED;
+                payload.error.type = AuthenticationErrorType.NOT_AUTHENTICATED;
             }
         }
         // Invalid SSL Handshake
         if (error.getCause() instanceof SSLHandshakeException) {
-            payload.errorType = AuthenticationError.INVALID_SSL_CERTIFICATE;
+            payload.error.type = AuthenticationErrorType.INVALID_SSL_CERTIFICATE;
         }
         // Invalid HTTP Auth
         if (error instanceof AuthFailureError) {
-            payload.errorType = AuthenticationError.HTTP_AUTH_ERROR;
+            payload.error.type = AuthenticationErrorType.HTTP_AUTH_ERROR;
         }
         mOnAuthFailedListener.onAuthFailed(payload);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -1,11 +1,9 @@
 package org.wordpress.android.fluxc.network.xmlrpc.site;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
-import com.android.volley.VolleyError;
 
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
@@ -13,7 +11,7 @@ import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.GenericError;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
@@ -54,9 +52,8 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                     }
                 },
                 new BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
-                        AppLog.e(T.API, "Volley error", error);
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AppLog.e(T.API, "Volley error", error.volleyError);
                         // TODO: Error, dispatch network error
                     }
                 }
@@ -94,9 +91,8 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                     }
                 },
                 new BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
-                        AppLog.e(T.API, "Volley error", error);
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AppLog.e(T.API, "Volley error", error.volleyError);
                     }
                 }
         );
@@ -120,8 +116,8 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                     }
                 },
                 new BaseErrorListener() {
-                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
-                        AppLog.e(T.API, "Volley error", error);
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AppLog.e(T.API, "Volley error", error.volleyError);
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -1,7 +1,9 @@
 package org.wordpress.android.fluxc.network.xmlrpc.site;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.android.volley.RequestQueue;
-import com.android.volley.Response.ErrorListener;
 import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
 
@@ -10,6 +12,8 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
+import org.wordpress.android.fluxc.network.BaseRequest.GenericError;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
@@ -49,9 +53,9 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                         }
                     }
                 },
-                new ErrorListener() {
+                new BaseErrorListener() {
                     @Override
-                    public void onErrorResponse(VolleyError error) {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AppLog.e(T.API, "Volley error", error);
                         // TODO: Error, dispatch network error
                     }
@@ -89,9 +93,9 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                         mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(updatedSite));
                     }
                 },
-                new ErrorListener() {
+                new BaseErrorListener() {
                     @Override
-                    public void onErrorResponse(VolleyError error) {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AppLog.e(T.API, "Volley error", error);
                     }
                 }
@@ -115,9 +119,8 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                                 FetchedPostFormatsPayload(site, postFormats)));
                     }
                 },
-                new ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
+                new BaseErrorListener() {
+                    public void onErrorResponse(@Nullable GenericError genericError, @NonNull VolleyError error) {
                         AppLog.e(T.API, "Volley error", error);
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
@@ -19,8 +20,6 @@ import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPC;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
-import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.MapUtils;
 
 import java.util.ArrayList;
@@ -47,14 +46,17 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                         if (sites != null) {
                             mDispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sites));
                         } else {
-                            // TODO: do nothing or dispatch error?
+                            sites = new SitesModel();
+                            sites.error = new BaseNetworkError(GenericErrorType.INVALID_RESPONSE);
+                            mDispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sites));
                         }
                     }
                 },
                 new BaseErrorListener() {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(T.API, "Volley error", error.volleyError);
-                        // TODO: Error, dispatch network error
+                        SitesModel sites = new SitesModel();
+                        sites.error = error;
+                        mDispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sites));
                     }
                 }
         );
@@ -92,7 +94,9 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                 },
                 new BaseErrorListener() {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(T.API, "Volley error", error.volleyError);
+                        SiteModel site = new SiteModel();
+                        site.error = error;
+                        mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(site));
                     }
                 }
         );
@@ -117,7 +121,10 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                 },
                 new BaseErrorListener() {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(T.API, "Volley error", error.volleyError);
+                        FetchedPostFormatsPayload payload = new FetchedPostFormatsPayload(site,
+                                new ArrayList<PostFormatModel>());
+                        payload.error = error;
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchedPostFormatsAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -129,7 +129,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             return null;
         }
         Object[] responseArray = (Object[]) response;
-        SitesModel sites = new SitesModel();
+        List<SiteModel> siteArray = new ArrayList<>();
         for (Object siteObject: responseArray) {
             if (!(siteObject instanceof HashMap)) {
                 continue;
@@ -150,14 +150,14 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             site.setIsWPCom(false);
             site.setUsername(username);
             site.setPassword(password);
-            sites.add(site);
+            siteArray.add(site);
         }
 
-        if (sites.isEmpty()) {
+        if (siteArray.isEmpty()) {
             return null;
         }
 
-        return sites;
+        return new SitesModel(siteArray);
     }
 
     private SiteModel updateSiteFromOptions(Object response, SiteModel oldModel) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -53,6 +53,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         SitesModel sites = new SitesModel();
                         sites.error = error;
@@ -93,6 +94,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         SiteModel site = new SiteModel();
                         site.error = error;
@@ -120,6 +122,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                     }
                 },
                 new BaseErrorListener() {
+                    @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         FetchedPostFormatsPayload payload = new FetchedPostFormatsPayload(site,
                                 new ArrayList<PostFormatModel>());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -39,7 +39,7 @@ import javax.inject.Singleton;
 @Singleton
 public class AccountStore extends Store {
     // Payloads
-    public static class AuthenticatePayload implements Payload {
+    public static class AuthenticatePayload extends Payload {
         public String username;
         public String password;
         public String twoStepCode;
@@ -51,13 +51,13 @@ public class AccountStore extends Store {
         }
     }
 
-    public static class PostAccountSettingsPayload implements Payload {
+    public static class PostAccountSettingsPayload extends Payload {
         public Map<String, String> params;
         public PostAccountSettingsPayload() {
         }
     }
 
-    public static class NewAccountPayload implements Payload {
+    public static class NewAccountPayload extends Payload {
         public String username;
         public String password;
         public String email;
@@ -71,7 +71,7 @@ public class AccountStore extends Store {
         }
     }
 
-    public static class UpdateTokenPayload implements Payload {
+    public static class UpdateTokenPayload extends Payload {
         public UpdateTokenPayload(String token) { this.token = token; }
         public String token;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -392,7 +392,7 @@ public class AccountStore extends Store {
 
     private boolean checkError(AccountRestPayload payload, String log) {
         if (payload.isError()) {
-            AppLog.w(T.API, log + "\nError: " + payload.error.getMessage());
+            AppLog.w(T.API, log + "\nError: " + payload.error.volleyError);
             return true;
         }
         return false;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -238,17 +238,18 @@ public class AccountStore extends Store {
             mSelfHostedEndpointFinder.findEndpoint(payload.url, payload.username, payload.password);
         } else if (actionType == AuthenticationAction.DISCOVERY_RESULT) {
             DiscoveryResultPayload payload = (DiscoveryResultPayload) action.getPayload();
-            if (payload.isError) {
-                OnDiscoveryResponse discoveryFailed = new OnDiscoveryResponse();
-                discoveryFailed.error = payload.error;
-                discoveryFailed.failedEndpoint = payload.failedEndpoint;
-                emitChange(discoveryFailed);
+            OnDiscoveryResponse discoveryResponse = new OnDiscoveryResponse();
+            if (payload.isError()) {
+                discoveryResponse.error = DiscoveryError.GENERIC_ERROR;
+                discoveryResponse.failedEndpoint = payload.failedEndpoint;
+            } else if (payload.isDiscoveryError()) {
+                discoveryResponse.error = payload.discoveryError;
+                discoveryResponse.failedEndpoint = payload.failedEndpoint;
             } else {
-                OnDiscoveryResponse discoverySucceeded = new OnDiscoveryResponse();
-                discoverySucceeded.xmlRpcEndpoint = payload.xmlRpcEndpoint;
-                discoverySucceeded.wpRestEndpoint = payload.wpRestEndpoint;
-                emitChange(discoverySucceeded);
+                discoveryResponse.xmlRpcEndpoint = payload.xmlRpcEndpoint;
+                discoveryResponse.wpRestEndpoint = payload.wpRestEndpoint;
             }
+            emitChange(discoveryResponse);
         } else if (actionType == AccountAction.FETCH_ACCOUNT) {
             // fetch only Account
             mAccountRestClient.fetchAccount();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -65,27 +65,34 @@ public class SiteStore extends Store {
         }
     }
 
-    // OnChanged Events
-    public class OnSiteChanged extends OnChanged {
-        public int rowsAffected;
+    public static class SiteError implements OnChangedError {
+    }
 
+    public static class NewSiteError implements OnChangedError {
+        public NewSiteErrorType type;
+        public String message;
+        public NewSiteError(NewSiteErrorType type, @NonNull String message) {
+            this.type = type;
+            this.message = message;
+        }
+    }
+
+    // OnChanged Events
+    public class OnSiteChanged extends OnChanged<SiteError> {
+        public int rowsAffected;
         public OnSiteChanged(int rowsAffected) {
             this.rowsAffected = rowsAffected;
         }
     }
 
-    public class OnSiteRemoved extends OnChanged {
+    public class OnSiteRemoved extends OnChanged<SiteError> {
         public int mRowsAffected;
-
         public OnSiteRemoved(int rowsAffected) {
             mRowsAffected = rowsAffected;
         }
     }
 
-    public class OnNewSiteCreated extends OnChanged {
-        public boolean isError;
-        public NewSiteError errorType;
-        public String errorMessage;
+    public class OnNewSiteCreated extends OnChanged<NewSiteError> {
         public boolean dryRun;
     }
 
@@ -97,7 +104,7 @@ public class SiteStore extends Store {
     }
 
     // Enums
-    public enum NewSiteError {
+    public enum NewSiteErrorType {
         BLOG_NAME_REQUIRED,
         BLOG_NAME_NOT_ALLOWED,
         BLOG_NAME_MUST_BE_AT_LEAST_FOUR_CHARACTERS,
@@ -113,9 +120,9 @@ public class SiteStore extends Store {
         BLOG_TITLE_INVALID,
         GENERIC_ERROR;
 
-        public static NewSiteError fromString(String string) {
+        public static NewSiteErrorType fromString(String string) {
             if (string != null) {
-                for (NewSiteError v : NewSiteError.values()) {
+                for (NewSiteErrorType v : NewSiteErrorType.values()) {
                     if (string.equalsIgnoreCase(v.name())) {
                         return v;
                     }
@@ -512,9 +519,7 @@ public class SiteStore extends Store {
         } else if (actionType == SiteAction.CREATED_NEW_SITE) {
             NewSiteResponsePayload payload = (NewSiteResponsePayload) action.getPayload();
             OnNewSiteCreated onNewSiteCreated = new OnNewSiteCreated();
-            onNewSiteCreated.isError = payload.isError;
-            onNewSiteCreated.errorType = payload.errorType;
-            onNewSiteCreated.errorMessage = payload.errorMessage;
+            onNewSiteCreated.error = payload.error;
             onNewSiteCreated.dryRun = payload.dryRun;
             emitChange(onNewSiteCreated);
         } else if (actionType == SiteAction.FETCH_POST_FORMATS) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
@@ -12,7 +12,16 @@ public abstract class Store {
         mDispatcher = dispatcher;
         mDispatcher.register(this);
     }
-    public class OnChanged {}
+
+    public interface ErrorType {}
+
+    public class OnChanged<T extends ErrorType> {
+        public T error = null;
+
+        public boolean isError() {
+            return error != null;
+        }
+    }
 
     /**
      * onAction should {@link Subscribe} with ASYNC {@link ThreadMode}.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
@@ -13,9 +13,9 @@ public abstract class Store {
         mDispatcher.register(this);
     }
 
-    public interface ErrorType {}
+    public interface OnChangedError {}
 
-    public class OnChanged<T extends ErrorType> {
+    public class OnChanged<T extends OnChangedError> {
         public T error = null;
 
         public boolean isError() {


### PR DESCRIPTION
Fix #3 
Things I don't like:

* Having different type of error in the network code and in Stores.
* Building dummy action payloads in the `onError()` callbacks. Thi could be solved by: 
  1. a better internal communication (not using actions)
  2. a single action per store: `ACTION_ERROR` (or similar), the payload could contain: the action type callee (example `FETCH_STORE`) so we could easily emit the right `OnChangedEvent`.