### PR TITLE
Error handling changes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -261,7 +261,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
     }
 
     private void checkSelfHostedHTTPAuthFetchForSite(String url, String username, String password, String auth_username,
-                                                    String auth_password) throws InterruptedException {
+                                                     String auth_password) throws InterruptedException {
         mPayload = new RefreshSitesXMLRPCPayload();
         mPayload.url = url;
         mPayload.username = username;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -9,7 +9,6 @@ import com.android.volley.NetworkError;
 import com.android.volley.NoConnectionError;
 import com.android.volley.ParseError;
 import com.android.volley.Request;
-import com.android.volley.ServerError;
 import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 
@@ -165,11 +164,6 @@ public abstract class BaseRequest<T> extends Request<T> {
         // Parse Error
         if (volleyError instanceof ParseError) {
             return new BaseNetworkError(GenericErrorType.PARSE_ERROR, volleyError);
-        }
-
-        // Parse Error
-        if (volleyError instanceof ServerError) {
-            return new BaseNetworkError(GenericErrorType.SERVER_ERROR, volleyError);
         }
 
         // Null networkResponse? Can't get more infos

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -43,6 +43,12 @@ public abstract class BaseRequest<T> extends Request<T> {
         public String message;
         public VolleyError volleyError;
 
+        public BaseNetworkError(@NonNull BaseNetworkError error) {
+            this.message = error.message;
+            this.error = error.error;
+            this.volleyError = error.volleyError;
+        }
+
         public BaseNetworkError(@NonNull GenericErrorType error, @NonNull String message, @NonNull VolleyError volleyError) {
             this.message = message;
             this.error = error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -38,36 +38,36 @@ public abstract class BaseRequest<T> extends Request<T> {
     private BaseErrorListener mErrorListener;
 
     public static class BaseNetworkError {
-        public GenericErrorType error;
+        public GenericErrorType type;
         public String message;
         public VolleyError volleyError;
 
         public BaseNetworkError(@NonNull BaseNetworkError error) {
             this.message = error.message;
-            this.error = error.error;
+            this.type = error.type;
             this.volleyError = error.volleyError;
         }
 
         public BaseNetworkError(@NonNull GenericErrorType error, @NonNull String message, @NonNull VolleyError volleyError) {
             this.message = message;
-            this.error = error;
+            this.type = error;
             this.volleyError = volleyError;
         }
         public BaseNetworkError(@NonNull GenericErrorType error, @NonNull VolleyError volleyError) {
             this.message = "";
-            this.error = error;
+            this.type = error;
             this.volleyError = volleyError;
         }
         public BaseNetworkError(@NonNull VolleyError volleyError) {
-            this.error = UNKNOWN;
+            this.type = UNKNOWN;
             this.message = "";
             this.volleyError = volleyError;
         }
         public BaseNetworkError(@NonNull GenericErrorType error) {
-            this.error = error;
+            this.type = error;
         }
         public boolean isGeneric() {
-            return error != null;
+            return type != null;
         }
         public boolean hasVolleyError() {
             return volleyError != null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -1,11 +1,15 @@
 package org.wordpress.android.fluxc.network;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Base64;
 
+import com.android.volley.AuthFailureError;
 import com.android.volley.DefaultRetryPolicy;
-import com.android.volley.Response.ErrorListener;
+import com.android.volley.NetworkError;
+import com.android.volley.NoConnectionError;
+import com.android.volley.ParseError;
+import com.android.volley.Request;
+import com.android.volley.ServerError;
 import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 
@@ -15,9 +19,16 @@ import org.wordpress.android.util.AppLog;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
+import javax.net.ssl.SSLHandshakeException;
+
+import static org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN;
+
+public abstract class BaseRequest<T> extends Request<T> {
     public interface OnAuthFailedListener {
         void onAuthFailed(AuthenticateErrorPayload errorType);
+    }
+    public interface BaseErrorListener {
+        void onErrorResponse(@NonNull BaseNetworkError error);
     }
 
     private static final String USER_AGENT_HEADER = "User-Agent";
@@ -25,18 +36,26 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
 
     protected OnAuthFailedListener mOnAuthFailedListener;
     protected final Map<String, String> mHeaders = new HashMap<>(2);
+    private BaseErrorListener mErrorListener;
 
     public static class BaseNetworkError {
         public GenericErrorType error;
         public String message;
         public VolleyError volleyError;
 
-        public BaseNetworkError(@NonNull GenericErrorType error, @Nullable String message, @NonNull VolleyError volleyError) {
+        public BaseNetworkError(@NonNull GenericErrorType error, @NonNull String message, @NonNull VolleyError volleyError) {
             this.message = message;
             this.error = error;
             this.volleyError = volleyError;
         }
+        public BaseNetworkError(@NonNull GenericErrorType error, @NonNull VolleyError volleyError) {
+            this.message = "";
+            this.error = error;
+            this.volleyError = volleyError;
+        }
         public BaseNetworkError(@NonNull VolleyError volleyError) {
+            this.error = UNKNOWN;
+            this.message = "";
             this.volleyError = volleyError;
         }
         public BaseNetworkError(@NonNull GenericErrorType error) {
@@ -51,43 +70,31 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
     }
 
     public enum GenericErrorType {
+        // Network Layer
+        TIMEOUT,
+        NO_CONNECTION,
+        NETWORK_ERROR,
+
+        // HTTP Layer
         NOT_FOUND,
         CENSORED,
         SERVER_ERROR,
-        TIMEOUT,
-        INVALID_RESPONSE
+        INVALID_SSL_CERTIFICATE,
+        HTTP_AUTH_ERROR,
+
+        // Web Application Layer
+        INVALID_RESPONSE,
+        AUTHORIZATION_REQUIRED,
+        NOT_AUTHENTICATED,
+        PARSE_ERROR,
+
+        // Other
+        UNKNOWN,
     }
 
-    public static abstract class BaseErrorListener implements ErrorListener {
-        @Override
-        public void onErrorResponse(VolleyError error) {
-            AppLog.e(AppLog.T.API, "Volley error", error);
-            this.onErrorResponse(getGenericError(error));
-        }
-
-        private @NonNull BaseNetworkError getGenericError(VolleyError volleyError) {
-            if (volleyError.networkResponse == null) {
-                return new BaseNetworkError(volleyError);
-            }
-            if (volleyError instanceof TimeoutError) {
-                return new BaseNetworkError(GenericErrorType.TIMEOUT, "", volleyError);
-            }
-            switch (volleyError.networkResponse.statusCode) {
-                case 404:
-                    return new BaseNetworkError(GenericErrorType.NOT_FOUND, volleyError.getMessage(), volleyError);
-                case 451:
-                    return new BaseNetworkError(GenericErrorType.CENSORED, volleyError.getMessage(), volleyError);
-                case 500:
-                    return new BaseNetworkError(GenericErrorType.SERVER_ERROR, volleyError.getMessage(), volleyError);
-            }
-            return new BaseNetworkError(volleyError);
-        }
-
-        public abstract void onErrorResponse(@NonNull BaseNetworkError error);
-    }
-
-    public BaseRequest(int method, String url, BaseErrorListener listener) {
-        super(method, url, listener);
+    public BaseRequest(int method, String url, BaseErrorListener errorListener) {
+        super(method, url, null);
+        mErrorListener = errorListener;
         // Make sure all our custom Requests are never cached.
         setShouldCache(false);
         setRetryPolicy(new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT,
@@ -123,5 +130,68 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
         setRetryPolicy(new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
     }
 
+    private @NonNull BaseNetworkError getBaseNetworkError(VolleyError volleyError) {
+        // No connection
+        if (volleyError.getCause() instanceof NoConnectionError) {
+            return new BaseNetworkError(GenericErrorType.NO_CONNECTION, volleyError);
+        }
 
+        // Network error
+        if (volleyError.getCause() instanceof NetworkError) {
+            return new BaseNetworkError(GenericErrorType.NETWORK_ERROR, volleyError);
+        }
+
+        // Invalid SSL Handshake
+        if (volleyError.getCause() instanceof SSLHandshakeException) {
+            return new BaseNetworkError(GenericErrorType.INVALID_SSL_CERTIFICATE, volleyError);
+        }
+
+        // Invalid HTTP Auth
+        if (volleyError instanceof AuthFailureError) {
+            return new BaseNetworkError(GenericErrorType.HTTP_AUTH_ERROR, volleyError);
+        }
+
+        // Timeout
+        if (volleyError instanceof TimeoutError) {
+            return new BaseNetworkError(GenericErrorType.TIMEOUT, volleyError);
+        }
+
+        // Parse Error
+        if (volleyError instanceof ParseError) {
+            return new BaseNetworkError(GenericErrorType.PARSE_ERROR, volleyError);
+        }
+
+        // Parse Error
+        if (volleyError instanceof ServerError) {
+            return new BaseNetworkError(GenericErrorType.SERVER_ERROR, volleyError);
+        }
+
+        // Null networkResponse? Can't get more infos
+        if (volleyError.networkResponse == null) {
+            return new BaseNetworkError(volleyError);
+        }
+
+        // Get Error by HTTP response code
+        switch (volleyError.networkResponse.statusCode) {
+            case 404:
+                return new BaseNetworkError(GenericErrorType.NOT_FOUND, volleyError.getMessage(), volleyError);
+            case 451:
+                return new BaseNetworkError(GenericErrorType.CENSORED, volleyError.getMessage(), volleyError);
+            case 500:
+                return new BaseNetworkError(GenericErrorType.SERVER_ERROR, volleyError.getMessage(), volleyError);
+        }
+
+        // Nothing found
+        return new BaseNetworkError(volleyError);
+    }
+
+    public abstract BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error);
+
+    @Override
+    public final void deliverError(VolleyError volleyError) {
+        AppLog.e(AppLog.T.API, "Volley error", volleyError);
+        BaseNetworkError baseNetworkError = getBaseNetworkError(volleyError);
+        BaseNetworkError modifiedBaseNetworkError = deliverBaseNetworkError(baseNetworkError);
+        mErrorListener.onErrorResponse(modifiedBaseNetworkError);
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeoutException;
  *
  * @param <T> The type of parsed response this future expects.
  */
-public class BaseRequestFuture<T> extends BaseErrorListener implements Future<T>, Response.Listener<T>  {
+public class BaseRequestFuture<T> implements Future<T>, Response.Listener<T>, BaseErrorListener  {
     private Request<?> mRequest;
     private boolean mResultReceived = false;
     private T mResult;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.discovery;
 
+import android.support.annotation.NonNull;
+
 import com.android.volley.NetworkResponse;
 import com.android.volley.Response;
 import com.android.volley.Response.Listener;
@@ -9,7 +11,6 @@ import org.wordpress.android.fluxc.network.BaseRequest;
 
 import java.io.UnsupportedEncodingException;
 
-// TODO: Would be great to use generics / return POJO or model direclty (see GSON code?)
 public class DiscoveryRequest extends BaseRequest<String> {
     private static final String PROTOCOL_CHARSET = "utf-8";
     private static final String PROTOCOL_CONTENT_TYPE = String.format("text/xml; charset=%s", PROTOCOL_CHARSET);
@@ -35,6 +36,12 @@ public class DiscoveryRequest extends BaseRequest<String> {
             parsed = new String(response.data);
         }
         return Response.success(parsed, HttpHeaderParser.parseCacheHeaders(response));
+    }
+
+    @Override
+    public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
+        // no op
+        return error;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.network.discovery;
 
-import com.android.volley.Response.ErrorListener;
+import android.support.annotation.NonNull;
+
 import com.android.volley.Response.Listener;
-import com.android.volley.VolleyError;
 
 import org.wordpress.android.fluxc.action.AuthenticationAction;
 import org.wordpress.android.fluxc.generated.endpoint.XMLRPC;
@@ -15,18 +15,14 @@ import java.util.List;
  * {@link AuthenticationAction#AUTHENTICATE_ERROR} events.
  */
 public class DiscoveryXMLRPCRequest extends XMLRPCRequest {
-    private final ErrorListener mErrorListener;
-
     public DiscoveryXMLRPCRequest(String url, XMLRPC method, List<Object> params, Listener listener,
                                   BaseErrorListener errorListener) {
         super(url, method, params, listener, errorListener);
-        mErrorListener = errorListener;
     }
 
     @Override
-    public void deliverError(VolleyError error) {
-        if (mErrorListener != null) {
-            mErrorListener.onErrorResponse(error);
-        }
+    public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
+        // no op
+        return error;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.network.BaseRequest;
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
-public class GsonRequest<T> extends BaseRequest<T> {
+public abstract class GsonRequest<T> extends BaseRequest<T> {
     private static final String PROTOCOL_CHARSET = "utf-8";
     private static final String PROTOCOL_CONTENT_TYPE = String.format("application/json; charset=%s", PROTOCOL_CHARSET);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom;
 
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.android.volley.Response.Listener;
 import com.android.volley.toolbox.HttpHeaderParser;
@@ -64,7 +65,11 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
                 jsonObject = new JSONObject();
             }
             String apiError = jsonObject.optString("error", "");
-            String apiMessage = jsonObject.optString("error_description", "");
+            String apiMessage = jsonObject.optString("message", "");
+            if (TextUtils.isEmpty(apiMessage)) {
+                // Auth endpoints use "error_description" instead of "message"
+                apiMessage = jsonObject.optString("error_description", "");
+            }
 
             // Augment BaseNetworkError by what we can parse from the response
             returnedError.apiError = apiError;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCFault.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCFault.java
@@ -18,8 +18,4 @@ public class XMLRPCFault extends XMLRPCException {
     public int getFaultCode() {
         return faultCode;
     }
-
-    public String getMessage() {
-        return super.getMessage() + " [Code: " + this.faultCode + "]";
-    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -99,16 +99,13 @@ public class XMLRPCRequest extends BaseRequest<Object> {
         if (error.hasVolleyError() && error.volleyError.getCause() instanceof XMLRPCFault) {
             XMLRPCFault xmlrpcFault = (XMLRPCFault) error.volleyError.getCause();
             if (xmlrpcFault.getFaultCode() == 401) {
-                // Augmented error
-                error.type = GenericErrorType.AUTHORIZATION_REQUIRED;
-                // Unauthorized
+                error.type = GenericErrorType.AUTHORIZATION_REQUIRED; // Augmented error
                 payload.error.type = AuthenticationErrorType.AUTHORIZATION_REQUIRED;
             } else if (xmlrpcFault.getFaultCode() == 403) {
-                // Augmented error
-                error.type = GenericErrorType.NOT_AUTHENTICATED;
-                // Not authenticated
+                error.type = GenericErrorType.NOT_AUTHENTICATED; // Augmented error
                 payload.error.type = AuthenticationErrorType.NOT_AUTHENTICATED;
             }
+            error.message = xmlrpcFault.getMessage();
         }
 
         // TODO: mOnAuthFailedListener should not be called here and the class/callback should de renamed to something

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -100,12 +100,12 @@ public class XMLRPCRequest extends BaseRequest<Object> {
             XMLRPCFault xmlrpcFault = (XMLRPCFault) error.volleyError.getCause();
             if (xmlrpcFault.getFaultCode() == 401) {
                 // Augmented error
-                error.error = GenericErrorType.AUTHORIZATION_REQUIRED;
+                error.type = GenericErrorType.AUTHORIZATION_REQUIRED;
                 // Unauthorized
                 payload.error.type = AuthenticationErrorType.AUTHORIZATION_REQUIRED;
             } else if (xmlrpcFault.getFaultCode() == 403) {
                 // Augmented error
-                error.error = GenericErrorType.NOT_AUTHENTICATED;
+                error.type = GenericErrorType.NOT_AUTHENTICATED;
                 // Not authenticated
                 payload.error.type = AuthenticationErrorType.NOT_AUTHENTICATED;
             }
@@ -113,7 +113,7 @@ public class XMLRPCRequest extends BaseRequest<Object> {
 
         // TODO: mOnAuthFailedListener should not be called here and the class/callback should de renamed to something
         // like "onLowNetworkLevelError"
-        switch (error.error) {
+        switch (error.type) {
             case HTTP_AUTH_ERROR:
                 payload.error.type = AuthenticationErrorType.HTTP_AUTH_ERROR;
                 break;


### PR DESCRIPTION
Replace Volley `deliverError` by `deliverBaseNetworkError` in our Requests sub classes.

One improvement we could do: move the `OnAuthFailedListener` to the BaseRequest and rename it to something like `OnLowLevelNetworkButHighPriorityErrorListener`, because some network errors need special handling (ssl certs, http auth, unauth)