### PR TITLE
Fix #118 normalize urls and select site by its local id when updating

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/SiteStoreUnitTest.java
@@ -372,7 +372,6 @@ public class SiteStoreUnitTest {
 
     public SiteModel generateDotComSite() {
         SiteModel example = new SiteModel();
-        example.setId(1);
         example.setSiteId(556);
         example.setIsWPCom(true);
         example.setIsVisible(true);
@@ -381,7 +380,6 @@ public class SiteStoreUnitTest {
 
     public SiteModel generateSelfHostedNonJPSite() {
         SiteModel example = new SiteModel();
-        example.setId(2);
         example.setDotOrgSiteId(6);
         example.setIsWPCom(false);
         example.setIsJetpack(false);
@@ -392,7 +390,6 @@ public class SiteStoreUnitTest {
 
     public SiteModel generateJetpackSite() {
         SiteModel example = new SiteModel();
-        example.setId(3);
         example.setSiteId(982);
         example.setDotOrgSiteId(8);
         example.setIsWPCom(false);
@@ -404,7 +401,6 @@ public class SiteStoreUnitTest {
 
     public SiteModel generateJetpackSiteOverRestOnly() {
         SiteModel example = new SiteModel();
-        example.setId(4);
         example.setSiteId(5623);
         example.setIsWPCom(false);
         example.setIsJetpack(true);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.model;
 
+import android.support.annotation.NonNull;
+
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
@@ -7,8 +9,12 @@ import com.yarolegovich.wellsql.core.annotation.RawConstraints;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 
 import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
@@ -90,8 +96,14 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
         return mUrl;
     }
 
-    public void setUrl(String url) {
-        mUrl = url;
+    public void setUrl(@NonNull String url) {
+        try {
+            // Normalize the URL, because it can be used as an identifier.
+            mUrl = (new URI(url)).normalize().toString();
+        } catch (URISyntaxException e) {
+            // Don't set the URL
+            AppLog.e(T.API, "Trying to set an invalid url: " + url);
+        }
     }
 
     public String getLoginUrl() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -149,7 +149,6 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             // TODO: use MapUtils.getX(map,"", defaultValue) here
             site.setDotOrgSiteId(Integer.parseInt((String) siteMap.get("blogid")));
             site.setName((String) siteMap.get("blogName"));
-            // TODO: set a canonical URL here
             site.setUrl((String) siteMap.get("url"));
             site.setLoginUrl((String) siteMap.get("login_url"));
             site.setXmlRpcUrl((String) siteMap.get("xmlrpc"));


### PR DESCRIPTION
Fix #118 normalize urls and select site by its local id when updating

To test:

**Without the patch:**

1. Using the example app, sign In a self hosted site
1. Notice the log: "First site name: XXX - Total sites: 1"
1. Tap the "Fetch Site" button
1. Notice the log: "First site name: XXX - Total sites: 2", same site has been inserted a second time because the URL is different (ends with "/").

**With the patch:**

1. Using the example app, sign In a self hosted site
1. Notice the log: "First site name: XXX - Total sites: 1"
1. Tap the "Fetch Site" button
1. Notice the log: "First site name: XXX - Total sites: 1"
