### PR TITLE
Better incorrect response handling

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/AccountStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/AccountStoreTest.java
@@ -1,15 +1,8 @@
 package org.wordpress.android.fluxc.mocked;
 
-import android.content.Context;
-import android.test.InstrumentationTestCase;
-
-import com.yarolegovich.wellsql.WellSql;
-
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
-import org.wordpress.android.fluxc.module.AppContextModule;
-import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
@@ -19,7 +12,7 @@ import javax.inject.Inject;
 /**
  * Tests using a Mocked Network app component. Test the Store itself and not the underlying network component(s).
  */
-public class AccountStoreTest extends InstrumentationTestCase {
+public class AccountStoreTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
 
@@ -28,19 +21,8 @@ public class AccountStoreTest extends InstrumentationTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        // Needed for Mockito
-        System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
-
-        Context appContext = getInstrumentation().getTargetContext().getApplicationContext();
-
-        MockedNetworkAppComponent testComponent =  DaggerMockedNetworkAppComponent.builder()
-                .appContextModule(new AppContextModule(appContext))
-                .build();
-        testComponent.inject(this);
-        WellSqlConfig config = new WellSqlConfig(appContext);
-        WellSql.init(config);
-        config.reset();
-
+        // Inject
+        mMockedNetworkAppComponent.inject(this);
         // Register
         mDispatcher.register(this);
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -19,6 +19,7 @@ import dagger.Component;
         ReleaseStoreModule.class
 })
 public interface MockedNetworkAppComponent {
-    void inject(AccountStoreTest application);
+    void inject(AccountStoreTest object);
+    void inject(MockedStack_SiteTest object);
 }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
@@ -1,0 +1,29 @@
+package org.wordpress.android.fluxc.mocked;
+
+import android.content.Context;
+import android.test.InstrumentationTestCase;
+
+import com.yarolegovich.wellsql.WellSql;
+
+import org.wordpress.android.fluxc.module.AppContextModule;
+import org.wordpress.android.fluxc.persistence.WellSqlConfig;
+
+public class MockedStack_Base extends InstrumentationTestCase {
+    Context mAppContext;
+    MockedNetworkAppComponent mMockedNetworkAppComponent;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Needed for Mockito
+        System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
+        mAppContext = getInstrumentation().getTargetContext().getApplicationContext();
+
+        mMockedNetworkAppComponent =  DaggerMockedNetworkAppComponent.builder()
+                .appContextModule(new AppContextModule(mAppContext))
+                .build();
+        WellSqlConfig config = new WellSqlConfig(mAppContext);
+        WellSql.init(config);
+        config.reset();
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
@@ -1,0 +1,18 @@
+package org.wordpress.android.fluxc.mocked;
+
+import org.wordpress.android.fluxc.Dispatcher;
+
+import javax.inject.Inject;
+
+public class MockedStack_SiteTest extends MockedStack_Base {
+    @Inject Dispatcher mDispatcher;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Inject
+        mMockedNetworkAppComponent.inject(this);
+        // Register
+        mDispatcher.register(this);
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/TestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/TestUtils.java
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc;
+
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+public class TestUtils {
+    public static int DEFAULT_TIMEOUT_MS = 30000;
+
+    public static void waitFor(long milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch(InterruptedException e) {
+            AppLog.e(T.API, "Thread interrupted");
+        }
+    }
+
+    public static void waitForNetworkCall() {
+        waitFor(DEFAULT_TIMEOUT_MS);
+    }
+}
+

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -28,15 +28,10 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateDotComSite;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSite;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSiteOverRestOnly;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generatePostFormats;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateSelfHostedNonJPSite;
+import static org.wordpress.android.fluxc.utils.SiteUtils.*;
 
 @RunWith(RobolectricTestRunner.class)
 public class SiteStoreUnitTest {
-    private Dispatcher mDispatcher = new Dispatcher();
     private SiteStore mSiteStore = new SiteStore(new Dispatcher(), Mockito.mock(SiteRestClient.class),
             Mockito.mock(SiteXMLRPCClient.class));
 

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc;
+package org.wordpress.android.fluxc.site;
 
 import android.content.Context;
 
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
@@ -19,7 +20,6 @@ import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.SiteStore;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -28,9 +28,15 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.wordpress.android.fluxc.utils.SiteUtils.generateDotComSite;
+import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSite;
+import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSiteOverRestOnly;
+import static org.wordpress.android.fluxc.utils.SiteUtils.generatePostFormats;
+import static org.wordpress.android.fluxc.utils.SiteUtils.generateSelfHostedNonJPSite;
 
 @RunWith(RobolectricTestRunner.class)
 public class SiteStoreUnitTest {
+    private Dispatcher mDispatcher = new Dispatcher();
     private SiteStore mSiteStore = new SiteStore(new Dispatcher(), Mockito.mock(SiteRestClient.class),
             Mockito.mock(SiteXMLRPCClient.class));
 
@@ -368,59 +374,5 @@ public class SiteStoreUnitTest {
         matchingSites = SiteSqlUtils.getAllSitesMatchingUrlOrNameWith(
                 SiteModelTable.IS_WPCOM, true, "EYE");
         assertEquals(1, matchingSites.size());
-    }
-
-    public SiteModel generateDotComSite() {
-        SiteModel example = new SiteModel();
-        example.setId(1);
-        example.setSiteId(556);
-        example.setIsWPCom(true);
-        example.setIsVisible(true);
-        return example;
-    }
-
-    public SiteModel generateSelfHostedNonJPSite() {
-        SiteModel example = new SiteModel();
-        example.setId(2);
-        example.setDotOrgSiteId(6);
-        example.setIsWPCom(false);
-        example.setIsJetpack(false);
-        example.setIsVisible(true);
-        example.setXmlRpcUrl("http://some.url/xmlrpc.php");
-        return example;
-    }
-
-    public SiteModel generateJetpackSite() {
-        SiteModel example = new SiteModel();
-        example.setId(3);
-        example.setSiteId(982);
-        example.setDotOrgSiteId(8);
-        example.setIsWPCom(false);
-        example.setIsJetpack(true);
-        example.setIsVisible(true);
-        example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");
-        return example;
-    }
-
-    public SiteModel generateJetpackSiteOverRestOnly() {
-        SiteModel example = new SiteModel();
-        example.setId(4);
-        example.setSiteId(5623);
-        example.setIsWPCom(false);
-        example.setIsJetpack(true);
-        example.setIsVisible(true);
-        example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");
-        return example;
-    }
-
-    public List<PostFormatModel> generatePostFormats(String... names) {
-        List<PostFormatModel> res = new ArrayList<>();
-        for (String name : names) {
-            PostFormatModel postFormat = new PostFormatModel();
-            postFormat.setSlug(name.toLowerCase());
-            postFormat.setDisplayName(name);
-            res.add(postFormat);
-        }
-        return res;
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -1,0 +1,131 @@
+package org.wordpress.android.fluxc.site;
+
+import android.content.Context;
+
+import com.android.volley.NetworkResponse;
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.Response;
+import com.yarolegovich.wellsql.WellSql;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.shadows.ShadowLog;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.HTTPAuthManager;
+import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
+import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
+import org.wordpress.android.fluxc.persistence.WellSqlConfig;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.wordpress.android.fluxc.utils.SiteUtils.generateDotComSite;
+
+@RunWith(RobolectricTestRunner.class)
+public class SiteXMLRPCClientTest {
+    private SiteXMLRPCClient mSiteXMLRPCClient;
+    private RequestQueue mMockedQueue;
+    private String mMockedResponse = "";
+    private CountDownLatch mCountDownLatch;
+
+    @Before
+    public void setUp() {
+        ShadowLog.stream = System.out;
+
+        mMockedQueue = mock(RequestQueue.class);
+        when(mMockedQueue.add(any(Request.class))).thenAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                XMLRPCRequest request = (XMLRPCRequest) invocation.getArguments()[0];
+                try {
+                    Class<XMLRPCRequest> requestClass = (Class<XMLRPCRequest>) Class.forName("org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest");
+                    // Object o = request.parseNetworkResponse(data)
+                    Method parseNetworkResponse = requestClass.getDeclaredMethod("parseNetworkResponse", NetworkResponse.class);
+                    parseNetworkResponse.setAccessible(true);
+                    NetworkResponse nr = new NetworkResponse(mMockedResponse.getBytes());
+                    Response<Object> o = (Response<Object>) parseNetworkResponse.invoke(request, nr);
+                    // request.deliverResponse(Object o)
+                    Method deliverResponse = requestClass.getDeclaredMethod("deliverResponse", Object.class);
+                    deliverResponse.setAccessible(true);
+                    deliverResponse.invoke(request, o.result);
+                } catch (Exception e) {
+                    AppLog.e(T.API, e);
+                }
+                mCountDownLatch.countDown();
+                return null;
+            }
+        });
+        mSiteXMLRPCClient = new SiteXMLRPCClient(new Dispatcher(), mMockedQueue,
+                mock(AccessToken.class), mock(UserAgent.class),
+                mock(HTTPAuthManager.class));
+
+        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+
+        WellSqlConfig config = new WellSqlConfig(appContext);
+        WellSql.init(config);
+        config.reset();
+    }
+
+    @Test
+    public void testFetchSite() throws Exception {
+        SiteModel site = generateDotComSite();
+        mCountDownLatch = new CountDownLatch(1);
+        mMockedResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<methodResponse>\n" +
+                "  <params>\n" +
+                "    <param>\n" +
+                "      <value>\n" +
+                "      <struct>\n" +
+                "  <member><name>post_thumbnail</name><value><struct>\n" +
+                "  <member><name>value</name><value><boolean>1</boolean></value></member>\n" +
+                "</struct></value></member>\n" +
+                "  <member><name>time_zone</name><value><struct>\n" +
+                "  <member><name>value</name><value><string>0</string></value></member>\n" +
+                "</struct></value></member>\n" +
+                "  <member><name>login_url</name><value><struct>\n" +
+                "  <member><name>value</name><value><string>https://taliwutblog.wordpress.com/wp-login.php</string></value></member>\n" +
+                "</struct></value></member>\n" +
+                "  <member><name>blog_public</name><value><struct>\n" +
+                "  <member><name>value</name><value><string>0</string></value></member>\n" +
+                "</struct></value></member>\n" +
+                "  <member><name>blog_title</name><value><struct>\n" +
+                "  <member><name>value</name><value><string>@tal&amp;amp;wut blog</string></value></member>\n" +
+                "</struct></value></member>\n" +
+                "  <member><name>admin_url</name><value><struct>\n" +
+                "  <member><name>readonly</name><value><boolean>1</boolean></value></member>\n" +
+                "  <member><name>value</name><value><string>https://taliwutblog.wordpress.com/wp-admin/</string></value></member>\n" +
+                "</struct></value></member>\n" +
+                "  <member><name>software_version</name><value><struct>\n" +
+                "  <member><name>value</name><value><string>4.5.3-20160628</string></value></member>\n" +
+                "</struct></value></member>\n" +
+                "  <member><name>jetpack_client_id</name><value><struct>\n" +
+                "  <member><name>value</name><value><string>false</string></value></member>\n" +
+                "</struct></value></member>\n" +
+                "  <member><name>home_url</name><value><struct>\n" +
+                "  <member><name>value</name><value><string>http://taliwutblog.wordpress.com</string></value></member>\n" +
+                "</struct></value></member>\n" +
+                "</struct>\n" +
+                "      </value>\n" +
+                "    </param>\n" +
+                "  </params>\n" +
+                "</methodResponse>\n";
+        mSiteXMLRPCClient.pullSite(site);
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -53,9 +53,11 @@ public class SiteXMLRPCClientTest {
             public Void answer(InvocationOnMock invocation) {
                 XMLRPCRequest request = (XMLRPCRequest) invocation.getArguments()[0];
                 try {
-                    Class<XMLRPCRequest> requestClass = (Class<XMLRPCRequest>) Class.forName("org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest");
+                    Class<XMLRPCRequest> requestClass = (Class<XMLRPCRequest>)
+                                    Class.forName("org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest");
                     // Object o = request.parseNetworkResponse(data)
-                    Method parseNetworkResponse = requestClass.getDeclaredMethod("parseNetworkResponse", NetworkResponse.class);
+                    Method parseNetworkResponse = requestClass.getDeclaredMethod("parseNetworkResponse",
+                            NetworkResponse.class);
                     parseNetworkResponse.setAccessible(true);
                     NetworkResponse nr = new NetworkResponse(mMockedResponse.getBytes());
                     Response<Object> o = (Response<Object>) parseNetworkResponse.invoke(request, nr);

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -25,14 +25,13 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
-import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -65,7 +64,7 @@ public class SiteXMLRPCClientTest {
                     deliverResponse.setAccessible(true);
                     deliverResponse.invoke(request, o.result);
                 } catch (Exception e) {
-                    AppLog.e(T.API, e);
+                    assertTrue("Unexpected exception: " + e, false);
                 }
                 mCountDownLatch.countDown();
                 return null;

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateDotComSite;
+import static org.wordpress.android.fluxc.utils.SiteUtils.*;
 
 @RunWith(RobolectricTestRunner.class)
 public class SiteXMLRPCClientTest {

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -55,13 +55,15 @@ public class SiteXMLRPCClientTest {
                 try {
                     Class<XMLRPCRequest> requestClass = (Class<XMLRPCRequest>)
                                     Class.forName("org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest");
+                    // Reflection code equivalent to:
                     // Object o = request.parseNetworkResponse(data)
                     Method parseNetworkResponse = requestClass.getDeclaredMethod("parseNetworkResponse",
                             NetworkResponse.class);
                     parseNetworkResponse.setAccessible(true);
                     NetworkResponse nr = new NetworkResponse(mMockedResponse.getBytes());
                     Response<Object> o = (Response<Object>) parseNetworkResponse.invoke(request, nr);
-                    // request.deliverResponse(Object o)
+                    // Reflection code equivalent to:
+                    // request.deliverResponse(o)
                     Method deliverResponse = requestClass.getDeclaredMethod("deliverResponse", Object.class);
                     deliverResponse.setAccessible(true);
                     deliverResponse.invoke(request, o.result);

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.utils;
+
+import org.wordpress.android.fluxc.model.PostFormatModel;
+import org.wordpress.android.fluxc.model.SiteModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SiteUtils {
+    public static SiteModel generateDotComSite() {
+        SiteModel example = new SiteModel();
+        example.setSiteId(556);
+        example.setIsWPCom(true);
+        example.setIsVisible(true);
+        return example;
+    }
+
+    public static SiteModel generateSelfHostedNonJPSite() {
+        SiteModel example = new SiteModel();
+        example.setDotOrgSiteId(6);
+        example.setIsWPCom(false);
+        example.setIsJetpack(false);
+        example.setIsVisible(true);
+        example.setXmlRpcUrl("http://some.url/xmlrpc.php");
+        return example;
+    }
+
+    public static SiteModel generateJetpackSite() {
+        SiteModel example = new SiteModel();
+        example.setSiteId(982);
+        example.setDotOrgSiteId(8);
+        example.setIsWPCom(false);
+        example.setIsJetpack(true);
+        example.setIsVisible(true);
+        example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");
+        return example;
+    }
+
+    public static SiteModel generateJetpackSiteOverRestOnly() {
+        SiteModel example = new SiteModel();
+        example.setSiteId(5623);
+        example.setIsWPCom(false);
+        example.setIsJetpack(true);
+        example.setIsVisible(true);
+        example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");
+        return example;
+    }
+
+    public static List<PostFormatModel> generatePostFormats(String... names) {
+        List<PostFormatModel> res = new ArrayList<>();
+        for (String name : names) {
+            PostFormatModel postFormat = new PostFormatModel();
+            postFormat.setSlug(name.toLowerCase());
+            postFormat.setDisplayName(name);
+            res.add(postFormat);
+        }
+        return res;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -170,6 +170,14 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         return new SitesModel(siteArray);
     }
 
+    private long string2Long(String s, long defvalue) {
+        try {
+            return Long.valueOf(s);
+        } catch (NumberFormatException e) {
+            return defvalue;
+        }
+    }
+
     private SiteModel updateSiteFromOptions(Object response, SiteModel oldModel) {
         Map<?, ?> blogOptions = (Map<?, ?>) response;
         oldModel.setName(getOption(blogOptions, "blog_title", String.class));
@@ -179,7 +187,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         Boolean post_thumbnail = getOption(blogOptions, "post_thumbnail", Boolean.class);
         oldModel.setIsFeaturedImageSupported((post_thumbnail != null) && post_thumbnail);
         oldModel.setTimezone(getOption(blogOptions, "time_zone", String.class));
-        long dotComIdForJetpack = Long.valueOf(getOption(blogOptions, "jetpack_client_id", String.class));
+        long dotComIdForJetpack = string2Long(getOption(blogOptions, "jetpack_client_id", String.class), -1);
         oldModel.setSiteId(dotComIdForJetpack);
         // If the blog is not public, it's private. Note: this field doesn't always exist.
         oldModel.setIsPrivate(false);


### PR DESCRIPTION
To test:

Checkout 41b236d and run the tests, check 1 test is failing (due to ` NumberFormatException`) - checkout fad4503 and check the test is fixed.

Note this doesn't fxi #134 (need more work and tests to have bullet proof clients) but is required for sitestore integration.