### PR TITLE
MediaStore EndpointProcessor tweaks

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -19,10 +19,15 @@ public class WPComEndpointTest {
 
         // Sites - Posts
         assertEquals("/sites/56/posts/", WPCOMREST.sites.site(56).posts.getEndpoint());
-        assertEquals("/sites/56/posts/new/", WPCOMREST.sites.site(56).posts.new_.getEndpoint());
         assertEquals("/sites/56/posts/78/", WPCOMREST.sites.site(56).posts.post(78).getEndpoint());
         assertEquals("/sites/56/posts/78/delete/", WPCOMREST.sites.site(56).posts.post(78).delete.getEndpoint());
         assertEquals("/sites/56/posts/new/", WPCOMREST.sites.site(56).posts.new_.getEndpoint());
+
+        // Sites - Media
+        assertEquals("/sites/56/media/", WPCOMREST.sites.site(56).media.getEndpoint());
+        assertEquals("/sites/56/media/78/", WPCOMREST.sites.site(56).media.item(78).getEndpoint());
+        assertEquals("/sites/56/media/78/delete/", WPCOMREST.sites.site(56).media.item(78).delete.getEndpoint());
+        assertEquals("/sites/56/media/new/", WPCOMREST.sites.site(56).media.new_.getEndpoint());
 
         // Me
         assertEquals("/me/", WPCOMREST.me.getEndpoint());

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -11,6 +11,10 @@ import org.wordpress.android.fluxc.annotations.endpoint.WPComEndpoint;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -25,6 +29,18 @@ import javax.lang.model.element.TypeElement;
 public class EndpointProcessor extends AbstractProcessor {
     private static final String WPCOMREST_ENDPOINT_FILE = "fluxc/src/main/tools/wp-com-endpoints.txt";
     private static final String XMLRPC_ENDPOINT_FILE = "fluxc/src/main/tools/xmlrpc-endpoints.txt";
+
+    private static final Map<String, List<String>> XML_RPC_ALIASES;
+    static {
+        XML_RPC_ALIASES = new HashMap<>();
+        List<String> editPostAliases = new ArrayList<>();
+        editPostAliases.add("EDIT_MEDIA");
+        XML_RPC_ALIASES.put("wp.editPost", editPostAliases);
+
+        List<String> deletePostAliases = new ArrayList<>();
+        deletePostAliases.add("DELETE_MEDIA");
+        XML_RPC_ALIASES.put("wp.deletePost", deletePostAliases);
+    }
 
     private Filer mFiler;
 
@@ -56,7 +72,7 @@ public class EndpointProcessor extends AbstractProcessor {
     private void generateXMLRPCEndpointFile() throws IOException {
         File file = new File(XMLRPC_ENDPOINT_FILE);
 
-        TypeSpec endpointClass = XMLRPCPoet.generate(file, "XMLRPC");
+        TypeSpec endpointClass = XMLRPCPoet.generate(file, "XMLRPC", XML_RPC_ALIASES);
         writeEndpointClassToFile(endpointClass);
     }
 

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/XMLRPCPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/XMLRPCPoet.java
@@ -10,12 +10,15 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.lang.model.element.Modifier;
 
 public class XMLRPCPoet {
-    public static TypeSpec generate(File endpointFile, String fileName) throws IOException {
+    public static TypeSpec generate(File endpointFile, String fileName, Map<String, List<String>> aliases)
+            throws IOException {
         TypeSpec.Builder XMLRPCBuilder = TypeSpec.enumBuilder(fileName)
                 .addModifiers(Modifier.PUBLIC)
                 .addField(String.class, "mEndpoint", Modifier.PRIVATE, Modifier.FINAL);
@@ -51,6 +54,17 @@ public class XMLRPCPoet {
                             .addMember("value", "$S", fullEndpoint)
                             .build())
                     .build());
+        }
+
+        // Add endpoint aliases
+        for (String endpoint : aliases.keySet()) {
+            for (String alias : aliases.get(endpoint)) {
+                XMLRPCBuilder.addEnumConstant(alias, TypeSpec.anonymousClassBuilder("$S", endpoint)
+                        .addAnnotation(AnnotationSpec.builder(Endpoint.class)
+                                .addMember("value", "$S", endpoint)
+                                .build())
+                        .build());
+            }
         }
 
         in.close();

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -11,4 +11,9 @@
 /sites/$site/posts/$post_ID/delete/
 /sites/$site/posts/new/
 
+/sites/$site/media/
+/sites/$site/media/$media_ID/
+/sites/$site/media/$media_ID/delete/
+/sites/$site/media/new/
+
 /users/new/

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -1,4 +1,9 @@
 wp.getOptions
 wp.getPostFormats
 wp.getUsersBlogs
+wp.getMediaLibrary
+wp.getMediaItem
+wp.editPost
+wp.deletePost
+wp.uploadFile
 system.listMethods


### PR DESCRIPTION
Makes a few improvements to the `EndpointProcessor` that came up with @tonyr59h's work on the `MediaStore`.

1. Fixed handling of the `../media/$media_ID/` WP.COM REST endpoint, which previously didn't work as the generator attempted to add a `MediaEndpoint` class inside a `MediaEndpoint` class (it will now call the inner class `MediaItemEndpoint`)
2. Added support for aliases to the XML-RPC endpoint generator, allowing us to define `EDIT_MEDIA` and `DELETE_MEDIA` and have them point to `wp.editMedia` and `wp.deleteMedia`, for improved readability

When the rule from point 1 is applied, the generated method is also changed: `item()` instead of `media()`, since we felt `WPCOMREST.sites.site(siteId).media.item(mediaId)` reads better than `WPCOMREST.sites.site(siteId).media.media(mediaId)` (see tests for usage examples).