### PR TITLE
Fix #136: ClassCastException in AccountRestClient

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -137,7 +137,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
         mExpectedAction = ACCOUNT_TEST_ACTIONS.POSTED;
         PostAccountSettingsPayload payload = new PostAccountSettingsPayload();
-        String newValue = String.valueOf(mAccountStore.getAccount().getPrimaryBlogId());
+        String newValue = String.valueOf(mAccountStore.getAccount().getPrimarySiteId());
         mExpectAccountInfosChanged = false;
         payload.params = new HashMap<>();
         payload.params.put("primary_site_ID", newValue);
@@ -145,7 +145,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(newValue, String.valueOf(mAccountStore.getAccount().getPrimaryBlogId()));
+        assertEquals(newValue, String.valueOf(mAccountStore.getAccount().getPrimarySiteId()));
     }
 
     @Subscribe

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -39,7 +39,6 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     }
 
     ACCOUNT_TEST_ACTIONS mExpectedAction;
-    String mExpectedValue;
 
     @Override
     protected void setUp() throws Exception {
@@ -85,12 +84,39 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         }
         mExpectedAction = ACCOUNT_TEST_ACTIONS.POSTED;
         PostAccountSettingsPayload payload = new PostAccountSettingsPayload();
-        mExpectedValue = String.valueOf(System.currentTimeMillis());
+        String newValue = String.valueOf(System.currentTimeMillis());
         payload.params = new HashMap<>();
-        payload.params.put("description", mExpectedValue);
+        payload.params.put("description", newValue);
         mDispatcher.dispatch(AccountActionBuilder.newPostSettingsAction(payload));
         mCountDownLatch = new CountDownLatch(1);
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
+    }
+
+    public void testWPCOMPostPrimarySiteId() throws InterruptedException {
+        if (!mAccountStore.hasAccessToken()) {
+            mExpectedAction = ACCOUNT_TEST_ACTIONS.AUTHENTICATE;
+            authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        }
+
+        // First, fetch account settings
+        mExpectedAction = ACCOUNT_TEST_ACTIONS.FETCHED;
+        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+        mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
+        mCountDownLatch = new CountDownLatch(2);
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        mExpectedAction = ACCOUNT_TEST_ACTIONS.POSTED;
+        PostAccountSettingsPayload payload = new PostAccountSettingsPayload();
+        String newValue = String.valueOf(mAccountStore.getAccount().getPrimaryBlogId());
+        payload.params = new HashMap<>();
+        payload.params.put("primary_site_ID", newValue);
+        mDispatcher.dispatch(AccountActionBuilder.newPostSettingsAction(payload));
+        mCountDownLatch = new CountDownLatch(1);
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        assertEquals(newValue, String.valueOf(mAccountStore.getAccount().getPrimaryBlogId()));
     }
 
     @Subscribe
@@ -117,7 +143,6 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
             assertEquals(BuildConfig.TEST_WPCOM_USERNAME_TEST1, mAccountStore.getAccount().getUserName());
         } else if (event.causeOfChange == AccountAction.POST_SETTINGS) {
             assertEquals(mExpectedAction, ACCOUNT_TEST_ACTIONS.POSTED);
-            assertEquals(mExpectedValue, mAccountStore.getAccount().getAboutMe());
         }
         mCountDownLatch.countDown();
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
@@ -35,7 +35,7 @@ public class AccountModelTest {
         copyAccount.setDisplayName("copyDisplayName");
         copyAccount.setProfileUrl("copyProfileUrl");
         copyAccount.setAvatarUrl("copyAvatarUrl");
-        copyAccount.setPrimaryBlogId(testAccount.getPrimaryBlogId() + 1);
+        copyAccount.setPrimarySiteId(testAccount.getPrimarySiteId() + 1);
         copyAccount.setSiteCount(testAccount.getSiteCount() + 1);
         copyAccount.setVisibleSiteCount(testAccount.getVisibleSiteCount() + 1);
         copyAccount.setEmail("copyEmail");
@@ -52,7 +52,7 @@ public class AccountModelTest {
         AccountModel testAccount = getTestAccount();
         AccountModel copyAccount = getTestAccount();
         copyAccount.setUserName("copyUsername");
-        copyAccount.setPrimaryBlogId(testAccount.getPrimaryBlogId() + 1);
+        copyAccount.setPrimarySiteId(testAccount.getPrimarySiteId() + 1);
         copyAccount.setFirstName("copyFirstName");
         copyAccount.setLastName("copyLastName");
         copyAccount.setAboutMe("copyAboutMe");

--- a/example/src/test/java/org/wordpress/android/fluxc/account/AccountStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/account/AccountStoreTest.java
@@ -41,7 +41,7 @@ public class AccountStoreTest {
     @Test
     public void testLoadAccount() {
         AccountModel testAccount = new AccountModel();
-        testAccount.setPrimaryBlogId(100);
+        testAccount.setPrimarySiteId(100);
         testAccount.setAboutMe("testAboutMe");
         AccountSqlUtils.insertOrUpdateDefaultAccount(testAccount);
         AccountStore testStore = new AccountStore(new Dispatcher(), getMockRestClient(),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -19,7 +19,7 @@ public class AccountModel extends Payload implements Identifiable {
     @Column private String mDisplayName;
     @Column private String mProfileUrl; // profile_URL
     @Column private String mAvatarUrl; // avatar_URL
-    @Column private long mPrimaryBlogId;
+    @Column private long mPrimarySiteId;
     @Column private int mSiteCount;
     @Column private int mVisibleSiteCount;
     @Column private String mEmail;
@@ -57,7 +57,7 @@ public class AccountModel extends Payload implements Identifiable {
                 StringUtils.equals(getDisplayName(), otherAccount.getDisplayName()) &&
                 StringUtils.equals(getProfileUrl(), otherAccount.getProfileUrl()) &&
                 StringUtils.equals(getAvatarUrl(), otherAccount.getAvatarUrl()) &&
-                getPrimaryBlogId() == otherAccount.getPrimaryBlogId() &&
+                getPrimarySiteId() == otherAccount.getPrimarySiteId() &&
                 getSiteCount() == otherAccount.getSiteCount() &&
                 getVisibleSiteCount() == otherAccount.getVisibleSiteCount() &&
                 StringUtils.equals(getFirstName(), otherAccount.getFirstName()) &&
@@ -75,7 +75,7 @@ public class AccountModel extends Payload implements Identifiable {
         mDisplayName = "";
         mProfileUrl = "";
         mAvatarUrl = "";
-        mPrimaryBlogId = 0;
+        mPrimarySiteId = 0;
         mSiteCount = 0;
         mVisibleSiteCount = 0;
         mEmail = "";
@@ -98,7 +98,7 @@ public class AccountModel extends Payload implements Identifiable {
         setDisplayName(other.getDisplayName());
         setProfileUrl(other.getProfileUrl());
         setAvatarUrl(other.getAvatarUrl());
-        setPrimaryBlogId(other.getPrimaryBlogId());
+        setPrimarySiteId(other.getPrimarySiteId());
         setSiteCount(other.getSiteCount());
         setVisibleSiteCount(other.getVisibleSiteCount());
         setEmail(other.getEmail());
@@ -110,7 +110,7 @@ public class AccountModel extends Payload implements Identifiable {
     public void copyAccountSettingsAttributes(AccountModel other) {
         if (other == null) return;
         setUserName(other.getUserName());
-        setPrimaryBlogId(other.getPrimaryBlogId());
+        setPrimarySiteId(other.getPrimarySiteId());
         setFirstName(other.getFirstName());
         setLastName(other.getLastName());
         setAboutMe(other.getAboutMe());
@@ -129,12 +129,12 @@ public class AccountModel extends Payload implements Identifiable {
         mUserId = userId;
     }
 
-    public void setPrimaryBlogId(long primaryBlogId) {
-        mPrimaryBlogId = primaryBlogId;
+    public void setPrimarySiteId(long primarySiteId) {
+        mPrimarySiteId = primarySiteId;
     }
 
-    public long getPrimaryBlogId() {
-        return mPrimaryBlogId;
+    public long getPrimarySiteId() {
+        return mPrimarySiteId;
     }
 
     public String getUserName() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -241,6 +241,7 @@ public class AccountRestClient extends BaseWPComRestClient {
     public static boolean updateAccountModelFromPostSettingsResponse(AccountModel accountModel, Map<String, Object> from) {
         AccountModel old = new AccountModel();
         old.copyAccountAttributes(accountModel);
+        old.setId(accountModel.getId());
         old.copyAccountSettingsAttributes(accountModel);
         if (from.containsKey("display_name")) accountModel.setDisplayName((String) from.get("display_name"));
         if (from.containsKey("first_name")) accountModel.setFirstName((String) from.get("first_name"));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -251,7 +251,8 @@ public class AccountRestClient extends BaseWPComRestClient {
                 ("user_email_change_pending"));
         if (from.containsKey("new_user_email")) accountModel.setEmail((String) from.get("new_user_email"));
         if (from.containsKey("user_URL")) accountModel.setWebAddress((String) from.get("user_URL"));
-        if (from.containsKey("primary_site_ID")) accountModel.setPrimaryBlogId((Long) from.get("primary_site_ID"));
+        if (from.containsKey("primary_site_ID")) accountModel.setPrimaryBlogId(
+                ((Double) from.get("primary_site_ID")).longValue());
         return !old.equals(accountModel);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -127,8 +127,8 @@ public class AccountRestClient extends BaseWPComRestClient {
     /**
      * Performs an HTTP POST call to the v1.1 /me/settings/ endpoint. Upon receiving
      * a response (success or error) a {@link AccountAction#POSTED_SETTINGS} action is dispatched
-     * with a payload of type {@link AccountPostSettingsResponsePayload}. {@link AccountPostSettingsResponsePayload#isError()} can
-     * be used to determine the result of the request.
+     * with a payload of type {@link AccountPostSettingsResponsePayload}.
+     * {@link AccountPostSettingsResponsePayload#isError()} can be used to determine the result of the request.
      *
      * No HTTP POST call is made if the given parameter map is null or contains no entries.
      */
@@ -214,7 +214,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         account.setDisplayName(from.display_name);
         account.setUserName(from.username);
         account.setEmail(from.email);
-        account.setPrimaryBlogId(from.primary_blog);
+        account.setPrimarySiteId(from.primary_blog);
         account.setAvatarUrl(from.avatar_URL);
         account.setProfileUrl(from.profile_URL);
         account.setDate(from.date);
@@ -234,11 +234,12 @@ public class AccountRestClient extends BaseWPComRestClient {
         account.setAvatarUrl(from.avatar_URL);
         account.setPendingEmailChange(from.user_email_change_pending);
         account.setWebAddress(from.user_URL);
-        account.setPrimaryBlogId(from.primary_site_ID);
+        account.setPrimarySiteId(from.primary_site_ID);
         return account;
     }
 
-    public static boolean updateAccountModelFromPostSettingsResponse(AccountModel accountModel, Map<String, Object> from) {
+    public static boolean updateAccountModelFromPostSettingsResponse(AccountModel accountModel,
+                Map<String, Object> from) {
         AccountModel old = new AccountModel();
         old.copyAccountAttributes(accountModel);
         old.setId(accountModel.getId());
@@ -252,7 +253,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                 ("user_email_change_pending"));
         if (from.containsKey("new_user_email")) accountModel.setEmail((String) from.get("new_user_email"));
         if (from.containsKey("user_URL")) accountModel.setWebAddress((String) from.get("user_URL"));
-        if (from.containsKey("primary_site_ID")) accountModel.setPrimaryBlogId(
+        if (from.containsKey("primary_site_ID")) accountModel.setPrimarySiteId(
                 ((Double) from.get("primary_site_ID")).longValue());
         return !old.equals(accountModel);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -283,6 +283,7 @@ public class AccountStore extends Store {
                     updateDefaultAccount(mAccount, AccountAction.POST_SETTINGS);
                 } else {
                     OnAccountChanged accountChanged = new OnAccountChanged();
+                    accountChanged.causeOfChange = AccountAction.POST_SETTINGS;
                     accountChanged.accountInfosChanged = false;
                     emitChange(accountChanged);
                 }


### PR DESCRIPTION
The underlying problem is that when posting settings to an account (`POST_SETTINGS`) we don't use the `AccountResponse` custom response object but instead let Gson do its own interpretation and give us a  `Map<String, Object>`. The trap is that Gson will save any JSON number as a `Double` unless told otherwise, as that's the most permissive number object - and our straight cast to `(long)` for the `primary_site_ID` threw an exception.

I opted for the simple fix of fixing the cast rather than using the specific `AccountResponse` response object for posting settings (or keeping track of which settings were set in `params` in the first place). That's a valid option too, but we will probably have to jump through some hoops to make sure we don't think a value was returned empty when it actually wasn't returned at all (we might wrongly set the 'about me' to the empty string, as an example).

I also made a few other tweaks to posting settings and added some tests.