### PR TITLE
Fix #150: Make PostModel serializable

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -16,13 +16,13 @@ import org.wordpress.android.fluxc.model.post.PostLocation;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 @Table
-public class PostModel extends Payload implements Identifiable {
+public class PostModel extends Payload implements Identifiable, Serializable {
     private static long FEATURED_IMAGE_INIT_VALUE = -2;
 
     @PrimaryKey


### PR DESCRIPTION
Fixes #150. `PostModel` needs to be serializable so it can be saved and restored in [`EditPostActivity`](https://github.com/wordpress-mobile/WordPress-Android/blob/6290960d4419ca2745d5109cf71ed25f95d85786/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L417).