### PR TITLE
Fix #147: Fetch all post statuses (except trashed) by default from WP.com REST

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.utils.DateTimeUtils;
 
 import java.util.Date;
+import java.util.List;
 
 public enum PostStatus {
     UNKNOWN,
@@ -12,7 +13,7 @@ public enum PostStatus {
     PRIVATE,
     PENDING,
     TRASHED,
-    SCHEDULED; // NOTE: Only used locally, WP has a 'future' status but it is not returned from the metaWeblog API
+    SCHEDULED; // NOTE: Only recognized for .com REST posts - XML-RPC returns scheduled posts with status 'publish'
 
     private static synchronized PostStatus fromStringAndDateGMT(String value, long dateCreatedGMT) {
         if (value == null) {
@@ -69,5 +70,21 @@ public enum PostStatus {
             default:
                 return "";
         }
+    }
+
+    public static String postStatusListToString(List<PostStatus> statusList) {
+        String statusString = "";
+        boolean firstTime = true;
+
+        for (PostStatus postStatus : statusList) {
+            if (firstTime) {
+                firstTime = false;
+            } else {
+                statusString += ",";
+            }
+            statusString += postStatus.toString();
+        }
+
+        return statusString;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
@@ -74,15 +75,22 @@ public class PostRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void fetchPosts(final SiteModel site, final boolean getPages, final int offset) {
+    public void fetchPosts(final SiteModel site, final boolean getPages, final List<PostStatus> statusList,
+                           final int offset) {
         String url = WPCOMREST.sites.site(site.getSiteId()).posts.getUrlV1_1();
 
         Map<String, String> params = new HashMap<>();
 
         params.put("number", String.valueOf(PostStore.NUM_POSTS_PER_FETCH));
+
         if (getPages) {
             params.put("type", "page");
         }
+
+        if (statusList.size() > 0) {
+            params.put("status", PostStatus.postStatusListToString(statusList));
+        }
+
         if (offset > 0) {
             params.put("offset", String.valueOf(offset));
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -15,11 +15,14 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.PostSqlUtils;
 import org.wordpress.android.util.AppLog;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -28,6 +31,13 @@ import javax.inject.Singleton;
 @Singleton
 public class PostStore extends Store {
     public static final int NUM_POSTS_PER_FETCH = 20;
+
+    public static final List<PostStatus> DEFAULT_POST_STATUS_LIST = Collections.unmodifiableList(Arrays.asList(
+            PostStatus.DRAFT,
+            PostStatus.PENDING,
+            PostStatus.PRIVATE,
+            PostStatus.PUBLISHED,
+            PostStatus.SCHEDULED));
 
     public static class FetchPostsPayload extends Payload {
         public SiteModel site;
@@ -52,7 +62,7 @@ public class PostStore extends Store {
         public boolean canLoadMore;
 
         public FetchPostsResponsePayload(PostsModel posts, SiteModel site, boolean isPages, boolean loadedMore,
-                boolean canLoadMore) {
+                                         boolean canLoadMore) {
             this.posts = posts;
             this.site = site;
             this.isPages = isPages;
@@ -113,6 +123,7 @@ public class PostStore extends Store {
     public static class PostError implements OnChangedError {
         public PostErrorType type;
         public String message;
+
         public PostError(PostErrorType type, @NonNull String message) {
             this.type = type;
             this.message = message;
@@ -337,7 +348,7 @@ public class PostStore extends Store {
         }
 
         if (payload.site.isWPCom()) {
-            mPostRestClient.fetchPosts(payload.site, pages, offset);
+            mPostRestClient.fetchPosts(payload.site, pages, DEFAULT_POST_STATUS_LIST, offset);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
             mPostXMLRPCClient.fetchPosts(payload.site, pages, offset);


### PR DESCRIPTION
By default, the WP.com REST API only returns published posts. By requesting draft/pending/private/publish/future posts, we get the same results as the XML-RPC wp.getPosts default (which is what WPAndroid already uses).

For now there's no way to request anything but the default values, but in the future with https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/145 we'll be able to request specific post statuses (or groups of statuses) from WPAndroid.

#### Note about XML-RPC defaults

I opted not to add a default array for XML-RPC. By default, XML-RPC will return posts of any status except `trash`. The `future` status is omitted from the result of `wp.getPostStatusList`, but if we specify `post_status=publish,private,pending,draft` in the `wp.getPosts` request, we don't get Scheduled posts in the response. It seems that the default request implicitly includes Scheduled posts, though those posts have `post_status` set to `publish` in the response.

We can get the same as the default response if we request posts with `post_status=publish,private,pending,draft,future` (i.e., the same defaults as WP.com REST), but I'm hesitant to change the request when it will have no benefits and might introduce unexpected bugs (different behavior on earlier WP versions or custom installations, perhaps).

cc @maxme 