### PR TITLE
Fix #158: Incorrect post statuses being sent in WP.com REST requests

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
@@ -15,6 +15,25 @@ public enum PostStatus {
     TRASHED,
     SCHEDULED; // NOTE: Only recognized for .com REST posts - XML-RPC returns scheduled posts with status 'publish'
 
+    public String toString() {
+        switch (this) {
+            case PUBLISHED:
+                return "publish";
+            case DRAFT:
+                return "draft";
+            case PRIVATE:
+                return "private";
+            case PENDING:
+                return "pending";
+            case TRASHED:
+                return "trash";
+            case SCHEDULED:
+                return "future";
+            default:
+                return "";
+        }
+    }
+
     private static synchronized PostStatus fromStringAndDateGMT(String value, long dateCreatedGMT) {
         if (value == null) {
             return UNKNOWN;
@@ -51,25 +70,6 @@ public enum PostStatus {
             }
         }
         return fromStringAndDateGMT(value, dateCreatedGMT);
-    }
-
-    public static String toString(PostStatus status) {
-        switch (status) {
-            case PUBLISHED:
-                return "publish";
-            case DRAFT:
-                return "draft";
-            case PRIVATE:
-                return "private";
-            case PENDING:
-                return "pending";
-            case TRASHED:
-                return "trash";
-            case SCHEDULED:
-                return "future";
-            default:
-                return "";
-        }
     }
 
     public static String postStatusListToString(List<PostStatus> statusList) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -140,7 +140,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
     public void pushPost(final PostModel post, final SiteModel site) {
         if (TextUtils.isEmpty(post.getStatus())) {
-            post.setStatus(PostStatus.toString(PostStatus.PUBLISHED));
+            post.setStatus(PostStatus.PUBLISHED.toString());
         }
 
         Map<String, Object> contentStruct = postModelToContentStruct(post);


### PR DESCRIPTION
Fixes #158. The problem was that [this call](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/154/files#diff-5232274a2e1be4691bbced897ec8bf1eR85) assumed `PostStatus.toString()` had been implemented, but it was actually calling `Enum.toString()`.

I replaced the static `PostStatus.toString(PostStatus)` method with an instance method, which fixes the problem. We'll need to make a few changes WPAndroid-side, which will be handled in the PostStore branch (which is replacing WPAndroid's version of `PostStatus` with this FluxC one).