### PR TITLE
Fix #167: Order posts returned from db by local draft status and date created

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     }
 
     // Custom WellSql version
-    compile 'org.wordpress:wellsql:1.0.9'
-    apt 'org.wordpress:wellsql-processor:1.0.9'
+    compile 'org.wordpress:wellsql:1.1.0'
+    apt 'org.wordpress:wellsql-processor:1.1.0'
 
     // FluxC annotations
     compile project(':fluxc-annotations')

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.persistence;
 
 import com.wellsql.generated.PostModelTable;
+import com.yarolegovich.wellsql.SelectQuery;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.PostModel;
@@ -65,7 +66,10 @@ public class PostSqlUtils {
                 .where().beginGroup()
                 .equals(PostModelTable.LOCAL_SITE_ID, site.getId())
                 .equals(PostModelTable.IS_PAGE, getPages)
-                .endGroup().endWhere().getAsModel();
+                .endGroup().endWhere()
+                .orderBy(PostModelTable.IS_LOCAL_DRAFT, SelectQuery.ORDER_DESCENDING)
+                .orderBy(PostModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
+                .getAsModel();
     }
 
     public static List<PostModel> getUploadedPostsForSite(SiteModel site, boolean getPages) {
@@ -78,7 +82,10 @@ public class PostSqlUtils {
                 .equals(PostModelTable.LOCAL_SITE_ID, site.getId())
                 .equals(PostModelTable.IS_PAGE, getPages)
                 .equals(PostModelTable.IS_LOCAL_DRAFT, false)
-                .endGroup().endWhere().getAsModel();
+                .endGroup().endWhere()
+                .orderBy(PostModelTable.IS_LOCAL_DRAFT, SelectQuery.ORDER_DESCENDING)
+                .orderBy(PostModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
+                .getAsModel();
     }
 
     public static PostModel insertPostForResult(PostModel post) {


### PR DESCRIPTION
Fixes #167. When selecting posts from the db, they're now returned sorted first by local draft status (local drafts float to the top) and then by date created (just like [`WordPressDB`](https://github.com/wordpress-mobile/WordPress-Android/blob/61ba7d2df6d231aa1e657c677c33545c497d4e5a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java#L1191)).