### PR TITLE
Fix #171: Emit OnPostUploaded on failed post uploads

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCOM.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCOM.java
@@ -46,7 +46,7 @@ public class ReleaseStack_PostTestWPCOM extends ReleaseStack_Base {
 
     private boolean mCanLoadMorePosts;
 
-    enum TEST_EVENTS {
+    private enum TEST_EVENTS {
         NONE,
         SITE_CHANGED,
         POST_INSTANTIATED,
@@ -535,6 +535,20 @@ public class ReleaseStack_PostTestWPCOM extends ReleaseStack_Base {
     @Subscribe
     public void onPostUploaded(OnPostUploaded event) {
         AppLog.i(T.API, "Received OnPostUploaded");
+        if (event.isError()) {
+            AppLog.i(T.API, "OnPostUploaded has error: " + event.error.type + " - " + event.error.message);
+            if (mNextEvent.equals(TEST_EVENTS.ERROR_UNKNOWN_POST)) {
+                assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
+                mCountDownLatch.countDown();
+            } else if (mNextEvent.equals(TEST_EVENTS.ERROR_UNKNOWN_POST_TYPE)) {
+                assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
+                mCountDownLatch.countDown();
+            } else if (mNextEvent.equals(TEST_EVENTS.ERROR_GENERIC)) {
+                assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
+                mCountDownLatch.countDown();
+            }
+            return;
+        }
         assertEquals(false, event.post.isLocalDraft());
         assertEquals(false, event.post.isLocallyChanged());
         assertNotSame(0, event.post.getRemotePostId());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -42,7 +42,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
 
     private PostError mLastPostError;
 
-    enum TEST_EVENTS {
+    private enum TEST_EVENTS {
         NONE,
         POST_INSTANTIATED,
         POST_UPLOADED,
@@ -724,6 +724,21 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
     @Subscribe
     public void onPostUploaded(OnPostUploaded event) {
         AppLog.i(T.API, "Received OnPostUploaded");
+        if (event.isError()) {
+            AppLog.i(T.API, "OnPostUploaded has error: " + event.error.type + " - " + event.error.message);
+            mLastPostError = event.error;
+            if (mNextEvent.equals(TEST_EVENTS.ERROR_UNKNOWN_POST)) {
+                assertEquals(PostStore.PostErrorType.UNKNOWN_POST, event.error.type);
+                mCountDownLatch.countDown();
+            } else if (mNextEvent.equals(TEST_EVENTS.ERROR_UNKNOWN_POST_TYPE)) {
+                assertEquals(PostStore.PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
+                mCountDownLatch.countDown();
+            } else if (mNextEvent.equals(TEST_EVENTS.ERROR_GENERIC)) {
+                assertEquals(PostStore.PostErrorType.GENERIC_ERROR, event.error.type);
+                mCountDownLatch.countDown();
+            }
+            return;
+        }
         assertEquals(TEST_EVENTS.POST_UPLOADED, mNextEvent);
         assertEquals(false, event.post.isLocalDraft());
         assertEquals(false, event.post.isLocallyChanged());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -414,10 +414,9 @@ public class PostStore extends Store {
 
     private void handlePushPostCompleted(RemotePostPayload payload) {
         if (payload.isError()) {
-            OnPostChanged onPostChanged = new OnPostChanged(0);
-            onPostChanged.error = payload.error;
-            onPostChanged.causeOfChange = PostAction.PUSH_POST;
-            emitChange(onPostChanged);
+            OnPostUploaded onPostUploaded = new OnPostUploaded(payload.post);
+            onPostUploaded.error = payload.error;
+            emitChange(onPostUploaded);
         } else {
             emitChange(new OnPostUploaded(payload.post));
 


### PR DESCRIPTION
Fixes #171, emitting `OnPostUploaded` instead of `OnPostChanged` when a post upload fails. This is more consistent with our general pattern of emitting expected events (even if the initial action was not successful), especially since the post was not 'changed'.

'OnPostUploaded` is also better suited for this task since it includes a reference to the post that failed to upload, which we'll need WPAndroid-side when handling failed uploads.