### PR TITLE
Issue #173: Make PostModel cloneable

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/PayloadTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/PayloadTest.java
@@ -1,0 +1,51 @@
+package org.wordpress.android.fluxc;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.wordpress.android.fluxc.network.BaseRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(RobolectricTestRunner.class)
+public class PayloadTest {
+
+    private class CloneablePayload extends Payload implements Cloneable {
+        @Override
+        public CloneablePayload clone() {
+            try {
+                return (CloneablePayload) super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new AssertionError(); // Can't happen
+            }
+        }
+    }
+
+    @Test
+    public void testClone() {
+        // Cloning default (no error) payload
+        CloneablePayload errorlessPayload = new CloneablePayload();
+
+        CloneablePayload errorlessClone = errorlessPayload.clone();
+
+        assertFalse(errorlessPayload == errorlessClone);
+        assertNull(errorlessPayload.error);
+        assertNull(errorlessClone.error);
+
+        // Cloning payload with error field
+        CloneablePayload errorPayload = new CloneablePayload();
+
+        errorPayload.error = new BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.SERVER_ERROR);
+
+        CloneablePayload errorClone = errorPayload.clone();
+
+        assertFalse(errorPayload == errorClone);
+
+        // The error field should be cloned
+        assertNotEquals(errorClone.error, errorPayload.error);
+        assertEquals(errorClone.error.type, errorPayload.error.type);
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.post.PostStatus;
+import org.wordpress.android.fluxc.network.BaseRequest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +25,28 @@ public class PostModelTest {
         assertFalse(testPost.equals(testPost2));
         testPost2.setRemotePostId(testPost.getRemotePostId());
         assertTrue(testPost.equals(testPost2));
+    }
+
+    @Test
+    public void testClone() {
+        PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
+
+        // Fill a few more sample fields
+        testPost.setDateCreated("1955-11-05T06:15:00-0800");
+        testPost.setStatus(PostStatus.SCHEDULED.toString());
+        List<Long> categoryList = new ArrayList<>();
+        categoryList.add(45L);
+        testPost.setCategoryIdList(categoryList);
+
+        testPost.error = new BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.PARSE_ERROR);
+
+        PostModel clonedPost = (PostModel) testPost.clone();
+
+        assertFalse(testPost == clonedPost);
+        assertTrue(testPost.equals(clonedPost));
+
+        // The inherited error should also be cloned
+        assertFalse(testPost.error == clonedPost.error);
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc;
 
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
-public class Payload {
+public abstract class Payload {
     public BaseNetworkError error;
     public boolean isError() {
         return error != null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
@@ -1,10 +1,28 @@
 package org.wordpress.android.fluxc;
 
+import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
 public abstract class Payload {
     public BaseNetworkError error;
+
     public boolean isError() {
         return error != null;
+    }
+
+    @Override
+    protected Payload clone() throws CloneNotSupportedException {
+        if (!(this instanceof Cloneable)) {
+            throw new CloneNotSupportedException("Class " + getClass().getName() + " doesn't implement Cloneable");
+        }
+
+        Payload clonedPayload = (Payload) super.clone();
+
+        // Clone non-primitive, mutable fields
+        if (this.error != null) {
+            clonedPayload.error = new BaseRequest.BaseNetworkError(this.error);
+        }
+
+        return clonedPayload;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Table
-public class PostModel extends Payload implements Identifiable, Serializable {
+public class PostModel extends Payload implements Cloneable, Identifiable, Serializable {
     private static final long FEATURED_IMAGE_INIT_VALUE = -2;
 
     @PrimaryKey
@@ -436,5 +436,14 @@ public class PostModel extends Payload implements Identifiable, Serializable {
             return "";
         }
         return TextUtils.join(",", ids);
+    }
+
+    @Override
+    public PostModel clone() {
+        try {
+            return (PostModel) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError(); // Can't happen
+        }
     }
 }


### PR DESCRIPTION
Fixes #173, making `PostModel` cloneable.

In order to make `PostModel` cloneable, the mutable `BaseNetworkError` field inherited from its `Payload` superclass needed to also be 'cloned', which should be handled by `Payload` (not by `PostModel`).

I intended to make `Payload` itself cloneable, but this risks `clone()` being called on an instance of a subclass that hasn't properly set up cloning for its own non-mutable fields.

Instead:

- `Payload` is now abstract since we don't intend for any pure `Payload` objects to exist, and so never needs to be cloned itself (so, it also doesn't implement `Cloneable`)
- `Payload` provides a safe `clone()` method its subclasses can use
- Any model (or other `Payload` subclass) that wants to be cloneable needs to explicitly implement `Cloneable` and override `clone()` in the usual way

This got a bit convoluted, but I still think this is the best way to allow the client (in this case, [`EditPostActivity`](https://github.com/wordpress-mobile/WordPress-Android/blob/4d4ad90a7fe7b9c89220dbe8b4395f14b6cb764c/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L267)) to make an independent copy of a model it already has without making an extra call to a store.

We could add a copy constructor so we could call `mClonedPost = new PostModel(mOriginalPost)`, but we don't want clients to instantiate models directly.

cc @maxme