### PR TITLE
MediaStore should use SiteModel as parameter

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaXmlRpcTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaXmlRpcTest.java
@@ -94,11 +94,10 @@ public class ReleaseStack_MediaXmlRpcTest extends ReleaseStack_Base {
     public void testPushMediaChanges() throws InterruptedException {
         // fetch site media
         SiteModel site = mSiteStore.getSites().get(0);
-        long siteId = site.getSiteId();
         fetchAllMedia(site);
 
         // some media is expected
-        List<MediaModel> siteMedia = mMediaStore.getAllSiteMedia(siteId);
+        List<MediaModel> siteMedia = mMediaStore.getAllSiteMedia(site);
         assertFalse(siteMedia.isEmpty());
 
         // store existing properties for restoration
@@ -123,7 +122,7 @@ public class ReleaseStack_MediaXmlRpcTest extends ReleaseStack_Base {
         pushMedia(site, testMedia, TEST_EVENTS.PUSHED_MEDIA);
 
         // verify local media has changes
-        final MediaModel updatedMedia = mMediaStore.getSiteMediaWithId(siteId, testId);
+        final MediaModel updatedMedia = mMediaStore.getSiteMediaWithId(site, testId);
         assertNotNull(updatedMedia);
         assertEquals(updatedMedia.getTitle(), newTitle);
         assertEquals(updatedMedia.getDescription(), newDescription);
@@ -138,7 +137,7 @@ public class ReleaseStack_MediaXmlRpcTest extends ReleaseStack_Base {
         pushMedia(site, testMedia, TEST_EVENTS.PUSHED_MEDIA);
 
         // verify restored media properties
-        final MediaModel restoredMedia = mMediaStore.getSiteMediaWithId(siteId, testId);
+        final MediaModel restoredMedia = mMediaStore.getSiteMediaWithId(site, testId);
         assertEquals(restoredMedia.getTitle(), mediaTitle);
         assertEquals(restoredMedia.getDescription(), mediaDescription);
         assertEquals(restoredMedia.getCaption(), mediaCaption);
@@ -232,7 +231,7 @@ public class ReleaseStack_MediaXmlRpcTest extends ReleaseStack_Base {
         SiteModel site = mSiteStore.getSites().get(0);
         fetchAllMedia(site);
 
-        final List<MediaModel> siteMedia = mMediaStore.getAllSiteMedia(site.getSiteId());
+        final List<MediaModel> siteMedia = mMediaStore.getAllSiteMedia(site);
         assertFalse(siteMedia.isEmpty());
 
         // fetch half of the media

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -14,6 +14,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.persistence.MediaSqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.utils.MediaUtils;
@@ -42,7 +43,7 @@ public class MediaSqlUtilsTest {
     @Test
     public void testInsertNullMedia() {
         Assert.assertEquals(0, MediaSqlUtils.insertOrUpdateMedia(null));
-        Assert.assertTrue(MediaSqlUtils.getAllSiteMedia(TEST_SITE_ID).isEmpty());
+        Assert.assertTrue(MediaSqlUtils.getAllSiteMedia(getTestSiteWithId(TEST_SITE_ID)).isEmpty());
     }
 
     // Inserts a media item with various known fields then retrieves and validates those fields
@@ -54,7 +55,7 @@ public class MediaSqlUtilsTest {
         String testCaption = getTestString();
         MediaModel testMedia = getTestMedia(testId, testTitle, testDescription, testCaption);
         Assert.assertEquals(0, MediaSqlUtils.insertOrUpdateMedia(testMedia));
-        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(TEST_SITE_ID, testId);
+        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(getTestSiteWithId(TEST_SITE_ID), testId);
         Assert.assertEquals(1, media.size());
         Assert.assertNotNull(media.get(0));
         Assert.assertEquals(testId, media.get(0).getMediaId());
@@ -67,7 +68,7 @@ public class MediaSqlUtilsTest {
     @Test
     public void testGetAllSiteMedia() {
         long[] testIds = insertBasicTestItems(SMALL_TEST_POOL);
-        List<MediaModel> storedMedia = MediaSqlUtils.getAllSiteMedia(TEST_SITE_ID);
+        List<MediaModel> storedMedia = MediaSqlUtils.getAllSiteMedia(getTestSiteWithId(TEST_SITE_ID));
         Assert.assertEquals(testIds.length, storedMedia.size());
         for (int i = 0; i < testIds.length; ++i) {
             Assert.assertNotNull(storedMedia.get(i));
@@ -81,12 +82,12 @@ public class MediaSqlUtilsTest {
         long testId = Math.abs(mRandom.nextLong());
         MediaModel testMedia = getTestMedia(testId);
         Assert.assertEquals(0, MediaSqlUtils.insertOrUpdateMedia(testMedia));
-        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(TEST_SITE_ID, testId);
+        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(getTestSiteWithId(TEST_SITE_ID), testId);
         Assert.assertEquals(1, media.size());
         Assert.assertNotNull(media.get(0));
         Assert.assertEquals(testId, media.get(0).getMediaId());
         Assert.assertEquals(1, MediaSqlUtils.deleteMedia(testMedia));
-        media = MediaSqlUtils.getAllSiteMedia(TEST_SITE_ID);
+        media = MediaSqlUtils.getAllSiteMedia(getTestSiteWithId(TEST_SITE_ID));
         Assert.assertTrue(media.isEmpty());
     }
 
@@ -98,7 +99,7 @@ public class MediaSqlUtilsTest {
         for (int i = 0; i < SMALL_TEST_POOL; i += 2) {
             mediaIds.add(testIds[i]);
         }
-        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithIds(TEST_SITE_ID, mediaIds);
+        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithIds(getTestSiteWithId(TEST_SITE_ID), mediaIds);
         Assert.assertEquals(SMALL_TEST_POOL / 2, media.size());
         for (int i = 0; i < media.size(); ++i) {
             Assert.assertEquals(media.get(i).getMediaId(), testIds[i * 2]);
@@ -120,7 +121,7 @@ public class MediaSqlUtilsTest {
             Assert.assertEquals(0, MediaSqlUtils.insertOrUpdateMedia(image));
             Assert.assertEquals(0, MediaSqlUtils.insertOrUpdateMedia(video));
         }
-        List<MediaModel> images = MediaSqlUtils.getSiteImages(TEST_SITE_ID);
+        List<MediaModel> images = MediaSqlUtils.getSiteImages(getTestSiteWithId(TEST_SITE_ID));
         Assert.assertEquals(imageIds.size(), images.size());
         for (int i = 0; i < imageIds.size(); ++i) {
             Assert.assertTrue(images.get(0).getMimeType().contains(MediaUtils.MIME_TYPE_IMAGE));
@@ -136,7 +137,8 @@ public class MediaSqlUtilsTest {
         for (int i = 0; i < SMALL_TEST_POOL; i += 2) {
             exclusion.add(imageIds[i]);
         }
-        List<MediaModel> includedImages = MediaSqlUtils.getSiteImagesExcluding(TEST_SITE_ID, exclusion);
+        List<MediaModel> includedImages = MediaSqlUtils
+                .getSiteImagesExcluding(getTestSiteWithId(TEST_SITE_ID), exclusion);
         Assert.assertEquals(SMALL_TEST_POOL - exclusion.size(), includedImages.size());
         for (int i = 0; i < includedImages.size(); ++i) {
             Assert.assertFalse(exclusion.contains(includedImages.get(i).getMediaId()));
@@ -154,7 +156,8 @@ public class MediaSqlUtilsTest {
             Assert.assertEquals(0, MediaSqlUtils.insertOrUpdateMedia(getTestMedia(i, testTitles[i], "", "")));
         }
         for (int i = 0; i < testTitles.length; ++i) {
-            List<MediaModel> mediaModels = MediaSqlUtils.searchSiteMedia(TEST_SITE_ID, MediaModelTable.TITLE, testTitles[i]);
+            List<MediaModel> mediaModels = MediaSqlUtils
+                    .searchSiteMedia(getTestSiteWithId(TEST_SITE_ID), MediaModelTable.TITLE, testTitles[i]);
             Assert.assertEquals(SMALL_TEST_POOL - i, mediaModels.size());
         }
     }
@@ -170,7 +173,8 @@ public class MediaSqlUtilsTest {
             Assert.assertEquals(0, MediaSqlUtils.insertOrUpdateMedia(getTestMedia(i, testTitles[i], "", "")));
         }
         for (String testTitle : testTitles) {
-            List<MediaModel> mediaModels = MediaSqlUtils.matchSiteMedia(TEST_SITE_ID, MediaModelTable.TITLE, testTitle);
+            List<MediaModel> mediaModels = MediaSqlUtils
+                    .matchSiteMedia(getTestSiteWithId(TEST_SITE_ID), MediaModelTable.TITLE, testTitle);
             Assert.assertEquals(1, mediaModels.size());
             Assert.assertEquals(testTitle, mediaModels.get(0).getTitle());
         }
@@ -264,7 +268,7 @@ public class MediaSqlUtilsTest {
         testModel.setFeatured(!testFeatured);
         testModel.setFeaturedInPost(!testFeaturedInPost);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testModel));
-        List<MediaModel> media = MediaSqlUtils.getAllSiteMedia(testSiteId);
+        List<MediaModel> media = MediaSqlUtils.getAllSiteMedia(getTestSiteWithId(testSiteId));
         Assert.assertEquals(1, media.size());
         MediaModel testMedia = media.get(0);
         Assert.assertEquals(testId, testMedia.getMediaId());
@@ -302,8 +306,9 @@ public class MediaSqlUtilsTest {
         for (int i = 0; i < SMALL_TEST_POOL; ++i) {
             Assert.assertEquals(0, MediaSqlUtils.insertOrUpdateMedia(getTestMedia(i, testTitle, "", "")));
         }
-        Assert.assertEquals(SMALL_TEST_POOL, MediaSqlUtils.deleteMatchingSiteMedia(TEST_SITE_ID, MediaModelTable.TITLE, testTitle));
-        List<MediaModel> media = MediaSqlUtils.getAllSiteMedia(TEST_SITE_ID);
+        Assert.assertEquals(SMALL_TEST_POOL, MediaSqlUtils
+                .deleteMatchingSiteMedia(getTestSiteWithId(TEST_SITE_ID), MediaModelTable.TITLE, testTitle));
+        List<MediaModel> media = MediaSqlUtils.getAllSiteMedia(getTestSiteWithId(TEST_SITE_ID));
         Assert.assertEquals(1, media.size());
         Assert.assertEquals(SMALL_TEST_POOL + 1, media.get(0).getMediaId());
     }
@@ -349,5 +354,11 @@ public class MediaSqlUtilsTest {
 
     private String getTestString() {
         return "BaseTestString-" + mRandom.nextInt();
+    }
+
+    private SiteModel getTestSiteWithId(long siteId) {
+        SiteModel siteModel = new SiteModel();
+        siteModel.setSiteId(siteId);
+        return siteModel;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -4,71 +4,72 @@ import com.wellsql.generated.MediaModelTable;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 
 import java.util.List;
 
 public class MediaSqlUtils {
-    public static List<MediaModel> getAllSiteMedia(long siteId) {
+    public static List<MediaModel> getAllSiteMedia(SiteModel siteModel) {
         return WellSql.select(MediaModel.class)
-                .where().equals(MediaModelTable.SITE_ID, siteId).endWhere()
+                .where().equals(MediaModelTable.SITE_ID, siteModel.getSiteId()).endWhere()
                 .getAsModel();
     }
 
-    public static List<MediaModel> getSiteMediaWithId(long siteId, long mediaId) {
+    public static List<MediaModel> getSiteMediaWithId(SiteModel siteModel, long mediaId) {
         return WellSql.select(MediaModel.class).where().beginGroup()
-                .equals(MediaModelTable.SITE_ID, siteId)
+                .equals(MediaModelTable.SITE_ID, siteModel.getSiteId())
                 .equals(MediaModelTable.MEDIA_ID, mediaId)
                 .endGroup().endWhere().getAsModel();
     }
 
-    public static List<MediaModel> getSiteMediaWithIds(long siteId, List<Long> mediaIds) {
+    public static List<MediaModel> getSiteMediaWithIds(SiteModel siteModel, List<Long> mediaIds) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.SITE_ID, siteId)
+                .equals(MediaModelTable.SITE_ID, siteModel.getSiteId())
                 .isIn(MediaModelTable.MEDIA_ID, mediaIds)
                 .endGroup().endWhere().getAsModel();
     }
 
-    public static List<MediaModel> searchSiteMedia(long siteId, String column, String searchTerm) {
+    public static List<MediaModel> searchSiteMedia(SiteModel siteModel, String column, String searchTerm) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.SITE_ID, siteId)
+                .equals(MediaModelTable.SITE_ID, siteModel.getSiteId())
                 .contains(column, searchTerm)
                 .endGroup().endWhere().getAsModel();
     }
 
-    public static List<MediaModel> getSiteImages(long siteId) {
+    public static List<MediaModel> getSiteImages(SiteModel siteModel) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.SITE_ID, siteId)
+                .equals(MediaModelTable.SITE_ID, siteModel.getSiteId())
                 .contains(MediaModelTable.MIME_TYPE, MediaUtils.MIME_TYPE_IMAGE)
                 .endGroup().endWhere()
                 .getAsModel();
     }
 
-    public static List<MediaModel> getSiteImagesExcluding(long siteId, List<Long> filter) {
+    public static List<MediaModel> getSiteImagesExcluding(SiteModel siteModel, List<Long> filter) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.SITE_ID, siteId)
+                .equals(MediaModelTable.SITE_ID, siteModel.getSiteId())
                 .contains(MediaModelTable.MIME_TYPE, MediaUtils.MIME_TYPE_IMAGE)
                 .isNotIn(MediaModelTable.MEDIA_ID, filter)
                 .endGroup().endWhere()
                 .getAsModel();
     }
 
-    public static List<MediaModel> getSiteMediaExcluding(long siteId, String column, Object value) {
+    public static List<MediaModel> getSiteMediaExcluding(SiteModel siteModel, String column, Object value) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.SITE_ID, siteId)
+                .equals(MediaModelTable.SITE_ID, siteModel.getSiteId())
                 .notContains(column, value)
                 .endGroup().endWhere().getAsModel();
     }
 
-    public static List<MediaModel> matchSiteMedia(long siteId, String column, Object value) {
+    public static List<MediaModel> matchSiteMedia(SiteModel siteModel, String column, Object value) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.SITE_ID, siteId)
+                .equals(MediaModelTable.SITE_ID, siteModel.getSiteId())
                 .equals(column, value)
                 .endGroup().endWhere().getAsModel();
     }
@@ -107,10 +108,10 @@ public class MediaSqlUtils {
         return WellSql.delete(MediaModel.class).whereId(media.getId());
     }
 
-    public static int deleteMatchingSiteMedia(long siteId, String column, Object value) {
+    public static int deleteMatchingSiteMedia(SiteModel siteModel, String column, Object value) {
         return WellSql.delete(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.SITE_ID, siteId)
+                .equals(MediaModelTable.SITE_ID, siteModel.getSiteId())
                 .equals(column, value)
                 .endGroup().endWhere().execute();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -253,65 +253,65 @@ public class MediaStore extends Store {
     // Media persistence
     //
 
-    public List<MediaModel> getAllSiteMedia(long siteId) {
-        return MediaSqlUtils.getAllSiteMedia(siteId);
+    public List<MediaModel> getAllSiteMedia(SiteModel siteModel) {
+        return MediaSqlUtils.getAllSiteMedia(siteModel);
     }
 
-    public int getSiteMediaCount(long siteId) {
-        return getAllSiteMedia(siteId).size();
+    public int getSiteMediaCount(SiteModel siteModel) {
+        return getAllSiteMedia(siteModel).size();
     }
 
-    public boolean hasSiteMediaWithId(long siteId, long mediaId) {
-        return getSiteMediaWithId(siteId, mediaId) != null;
+    public boolean hasSiteMediaWithId(SiteModel siteModel, long mediaId) {
+        return getSiteMediaWithId(siteModel, mediaId) != null;
     }
 
-    public MediaModel getSiteMediaWithId(long siteId, long mediaId) {
-        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(siteId, mediaId);
+    public MediaModel getSiteMediaWithId(SiteModel siteModel, long mediaId) {
+        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(siteModel, mediaId);
         return media.size() > 0 ? media.get(0) : null;
     }
 
-    public List<MediaModel> getSiteMediaWithIds(long siteId, List<Long> mediaIds) {
-        return MediaSqlUtils.getSiteMediaWithIds(siteId, mediaIds);
+    public List<MediaModel> getSiteMediaWithIds(SiteModel siteModel, List<Long> mediaIds) {
+        return MediaSqlUtils.getSiteMediaWithIds(siteModel, mediaIds);
     }
 
-    public List<MediaModel> getSiteImages(long siteId) {
-        return MediaSqlUtils.getSiteImages(siteId);
+    public List<MediaModel> getSiteImages(SiteModel siteModel) {
+        return MediaSqlUtils.getSiteImages(siteModel);
     }
 
-    public int getSiteImageCount(long siteId) {
-        return getSiteImages(siteId).size();
+    public int getSiteImageCount(SiteModel siteModel) {
+        return getSiteImages(siteModel).size();
     }
 
-    public List<MediaModel> getSiteImagesExcludingIds(long siteId, List<Long> filter) {
-        return MediaSqlUtils.getSiteImagesExcluding(siteId, filter);
+    public List<MediaModel> getSiteImagesExcludingIds(SiteModel siteModel, List<Long> filter) {
+        return MediaSqlUtils.getSiteImagesExcluding(siteModel, filter);
     }
 
-    public List<MediaModel> getUnattachedSiteMedia(long siteId) {
-        return MediaSqlUtils.matchSiteMedia(siteId, MediaModelTable.POST_ID, 0);
+    public List<MediaModel> getUnattachedSiteMedia(SiteModel siteModel) {
+        return MediaSqlUtils.matchSiteMedia(siteModel, MediaModelTable.POST_ID, 0);
     }
 
-    public int getUnattachedSiteMediaCount(long siteId) {
-        return getUnattachedSiteMedia(siteId).size();
+    public int getUnattachedSiteMediaCount(SiteModel siteModel) {
+        return getUnattachedSiteMedia(siteModel).size();
     }
 
-    public List<MediaModel> getLocalSiteMedia(long siteId) {
+    public List<MediaModel> getLocalSiteMedia(SiteModel siteModel) {
         MediaModel.UploadState expectedState = MediaModel.UploadState.UPLOADED;
-        return MediaSqlUtils.getSiteMediaExcluding(siteId, MediaModelTable.UPLOAD_STATE, expectedState);
+        return MediaSqlUtils.getSiteMediaExcluding(siteModel, MediaModelTable.UPLOAD_STATE, expectedState);
     }
 
-    public String getUrlForSiteVideoWithVideoPressGuid(long siteId, String videoPressGuid) {
+    public String getUrlForSiteVideoWithVideoPressGuid(SiteModel siteModel, String videoPressGuid) {
         List<MediaModel> media =
-                MediaSqlUtils.matchSiteMedia(siteId, MediaModelTable.VIDEO_PRESS_GUID, videoPressGuid);
+                MediaSqlUtils.matchSiteMedia(siteModel, MediaModelTable.VIDEO_PRESS_GUID, videoPressGuid);
         return media.size() > 0 ? media.get(0).getUrl() : null;
     }
 
-    public String getThumbnailUrlForSiteMediaWithId(long siteId, long mediaId) {
-        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(siteId, mediaId);
+    public String getThumbnailUrlForSiteMediaWithId(SiteModel siteModel, long mediaId) {
+        List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(siteModel, mediaId);
         return media.size() > 0 ? media.get(0).getThumbnailUrl() : null;
     }
 
-    public List<MediaModel> searchSiteMediaByTitle(long siteId, String titleSearch) {
-        return MediaSqlUtils.searchSiteMedia(siteId, MediaModelTable.TITLE, titleSearch);
+    public List<MediaModel> searchSiteMediaByTitle(SiteModel siteModel, String titleSearch) {
+        return MediaSqlUtils.searchSiteMedia(siteModel, MediaModelTable.TITLE, titleSearch);
     }
 
     public MediaModel getPostMediaWithPath(long postId, String filePath) {
@@ -319,14 +319,14 @@ public class MediaStore extends Store {
         return media.size() > 0 ? media.get(0) : null;
     }
 
-    public MediaModel getNextSiteMediaToDelete(long siteId) {
-        List<MediaModel> media = MediaSqlUtils.matchSiteMedia(siteId,
+    public MediaModel getNextSiteMediaToDelete(SiteModel siteModel) {
+        List<MediaModel> media = MediaSqlUtils.matchSiteMedia(siteModel,
                 MediaModelTable.UPLOAD_STATE, MediaModel.UploadState.DELETE.toString());
         return media.size() > 0 ? media.get(0) : null;
     }
 
-    public boolean hasSiteMediaToDelete(long siteId) {
-        return getNextSiteMediaToDelete(siteId) != null;
+    public boolean hasSiteMediaToDelete(SiteModel siteModel) {
+        return getNextSiteMediaToDelete(siteModel) != null;
     }
 
     //


### PR DESCRIPTION
As per our discussion on Slack with @maxme, it's better to accept a SiteModel as parameter in `MediaStore` methods. Accepting ids is a much more error-prone approach especially since we have both an `id` and a `siteId`. I think it's best to hide the implementation details from the users of this library.

The only downside is you can't do anything with a media if you don't have the `SiteModel` associated with it in your cache/db, but I don't think that'd be ever the case. It's something to watch-out for nevertheless.

This change also required me to update the existing tests to use the `SiteModel` instead of the `siteId`, but I just passed an empty `SiteModel` with just the `siteId` set. I felt that'd be good enough, but curious to see what you guys think.

/cc @tonyr59h 

P.S: I am hoping I didn't miss any files, since test files don't show up as errors if you don't actually run the tests in that file :(