### PR TITLE
Replace deprecated apt plugin by annotationProcessor from the android gradle plugin (2.2)

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.0'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
 
@@ -13,7 +12,6 @@ repositories {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     compileSdkVersion 24
@@ -65,7 +63,7 @@ dependencies {
     compile project(':fluxc');
 
     compile 'com.google.dagger:dagger:2.0.2'
-    apt 'com.google.dagger:dagger-compiler:2.0.2'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
     testCompile 'junit:junit:4.12'
@@ -75,5 +73,5 @@ dependencies {
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestApt 'com.google.dagger:dagger-compiler:2.0'
+    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.0'
 }

--- a/fluxc-annotations/build.gradle
+++ b/fluxc-annotations/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.0'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
 

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.0'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
 

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -4,13 +4,11 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.0'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'checkstyle'
 
@@ -48,11 +46,11 @@ dependencies {
 
     // Custom WellSql version
     compile 'org.wordpress:wellsql:1.1.0'
-    apt 'org.wordpress:wellsql-processor:1.1.0'
+    annotationProcessor 'org.wordpress:wellsql-processor:1.1.0'
 
     // FluxC annotations
     compile project(':fluxc-annotations')
-    apt project(':fluxc-processor')
+    annotationProcessor project(':fluxc-processor')
 
     // External libs
     compile 'org.greenrobot:eventbus:3.0.0'
@@ -61,7 +59,7 @@ dependencies {
     compile 'com.android.volley:volley:1.0.0'
     compile 'com.google.code.gson:gson:2.4'
     compile 'com.google.dagger:dagger:2.0.2'
-    apt 'com.google.dagger:dagger-compiler:2.0.2'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 }
 


### PR DESCRIPTION
The Android Gradle plugin now includes `annotationProcessor`, we don't need the apt plugin anymore - More infos on http://tools.android.com/tech-docs/jackandjill (plugin changelog is not up to date).