### PR TITLE
Issue #178: Add UNAUTHORIZED error to PostErrorType

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -77,7 +77,16 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                         // 404 - "Invalid post ID."
                         RemotePostPayload payload = new RemotePostPayload(post, site);
                         // TODO: Check the error message and flag this as UNKNOWN_POST if applicable
-                        payload.error = new PostError(PostErrorType.GENERIC_ERROR, error.message);
+                        // Convert GenericErrorType to PostErrorType where applicable
+                        PostError postError;
+                        switch (error.type) {
+                            case AUTHORIZATION_REQUIRED:
+                                postError = new PostError(PostErrorType.UNAUTHORIZED, error.message);
+                                break;
+                            default:
+                                postError = new PostError(PostErrorType.GENERIC_ERROR, error.message);
+                        }
+                        payload.error = postError;
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
                     }
                 });
@@ -129,7 +138,15 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                         // Possible non-generic errors:
                         // 403 - "The post type specified is not valid"
                         // TODO: Check the error message and flag this as INVALID_POST_TYPE if applicable
-                        PostError postError = new PostError(PostErrorType.GENERIC_ERROR, error.message);
+                        // Convert GenericErrorType to PostErrorType where applicable
+                        PostError postError;
+                        switch (error.type) {
+                            case AUTHORIZATION_REQUIRED:
+                                postError = new PostError(PostErrorType.UNAUTHORIZED, error.message);
+                                break;
+                            default:
+                                postError = new PostError(PostErrorType.GENERIC_ERROR, error.message);
+                        }
                         FetchPostsResponsePayload payload = new FetchPostsResponsePayload(postError);
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostsAction(payload));
                     }
@@ -181,7 +198,16 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                         // 404 - "Invalid attachment ID." (invalid featured image)
                         RemotePostPayload payload = new RemotePostPayload(post, site);
                         // TODO: Check the error message and flag this as one of the above specific errors if applicable
-                        payload.error = new PostError(PostErrorType.GENERIC_ERROR, error.message);
+                        // Convert GenericErrorType to PostErrorType where applicable
+                        PostError postError;
+                        switch (error.type) {
+                            case AUTHORIZATION_REQUIRED:
+                                postError = new PostError(PostErrorType.UNAUTHORIZED, error.message);
+                                break;
+                            default:
+                                postError = new PostError(PostErrorType.GENERIC_ERROR, error.message);
+                        }
+                        payload.error = postError;
                         mDispatcher.dispatch(PostActionBuilder.newPushedPostAction(payload));
                     }
                 });
@@ -212,7 +238,16 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                         // 404 - "Invalid post ID."
                         RemotePostPayload payload = new RemotePostPayload(post, site);
                         // TODO: Check the error message and flag this as UNKNOWN_POST if applicable
-                        payload.error = new PostError(PostErrorType.GENERIC_ERROR, error.message);
+                        // Convert GenericErrorType to PostErrorType where applicable
+                        PostError postError;
+                        switch (error.type) {
+                            case AUTHORIZATION_REQUIRED:
+                                postError = new PostError(PostErrorType.UNAUTHORIZED, error.message);
+                                break;
+                            default:
+                                postError = new PostError(PostErrorType.GENERIC_ERROR, error.message);
+                        }
+                        payload.error = postError;
                         mDispatcher.dispatch(PostActionBuilder.newDeletedPostAction(payload));
                     }
                 });

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -174,6 +174,7 @@ public class PostStore extends Store {
     public enum PostErrorType {
         UNKNOWN_POST,
         UNKNOWN_POST_TYPE,
+        UNAUTHORIZED,
         INVALID_RESPONSE,
         GENERIC_ERROR;
 


### PR DESCRIPTION
Fixes #178, allowing FluxC clients to recognize when a post error is caused by the user lacking permissions on that site.

Since our error handling flow is a bit complex, I'll note some of the implementation details here for posterity.

Notes:
* `BaseNetworkError.AUTHORIZATION_REQUIRED` is [already reported](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/9e535369eb7dfef24c844e90443b3c634d3c4bde/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java#L226) to the network clients in `onErrorResponse`, this is just a matter of converting it to a `PostErrorType.UNAUTHORIZED` error instead of `PostErrorType.GENERIC_ERROR` before notifying the `PostStore`
* The REST API posts client already [attempts to convert](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/9e535369eb7dfef24c844e90443b3c634d3c4bde/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java#L75) the (string) error type reported from the server into a `PostErrorType` - `unauthorized` is the string we get in this case, so the conversion happens with no extra work as long as `PostErrorType.UNAUTHORIZED` exists
* XML-RPC post errors have to be [manually classified](https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/issue/178-add-unauthorized-post-error?expand=1#diff-a0608c2f4f3f075943fd592351ca6279R83) as `UNAUTHORIZED`
* There's some code repetition in the XML-RPC case, but since we're going to add more cases in the future when we solve the error string localization problem (https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/129), refactoring this now is probably premature

cc @maxme