### PR TITLE
Support typed endpoints in the endpoint processor

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/EndpointNodeTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/EndpointNodeTest.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class EndpointNodeTest {
@@ -48,12 +48,13 @@ public class EndpointNodeTest {
     }
 
     @Test
-    public void testGetEndpointType() {
+    public void testGetEndpointTypes() {
         EndpointNode typedNode = new EndpointNode("$taxonomy#String/");
-        assertEquals("String", typedNode.getEndpointType());
+        assertEquals(1, typedNode.getEndpointTypes().size());
+        assertEquals("String", typedNode.getEndpointTypes().get(0));
 
         EndpointNode normalNode = new EndpointNode("$post_ID/");
-        assertNull(normalNode.getEndpointType());
+        assertTrue(normalNode.getEndpointTypes().isEmpty());
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/EndpointNodeTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/EndpointNodeTest.java
@@ -11,8 +11,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class EndpointNodeTest {
@@ -39,8 +40,20 @@ public class EndpointNodeTest {
         EndpointNode node = new EndpointNode("$post_ID/");
         assertEquals("post", node.getCleanEndpointName());
 
-        node.setLocalEndpoint("");
-        assertEquals("", node.getCleanEndpointName());
+        EndpointNode nodeWithType = new EndpointNode("$taxonomy#String/");
+        assertEquals("taxonomy", nodeWithType.getCleanEndpointName());
+
+        EndpointNode emptyNode = new EndpointNode("");
+        assertEquals("", emptyNode.getCleanEndpointName());
+    }
+
+    @Test
+    public void testGetEndpointType() {
+        EndpointNode typedNode = new EndpointNode("$taxonomy#String/");
+        assertEquals("String", typedNode.getEndpointType());
+
+        EndpointNode normalNode = new EndpointNode("$post_ID/");
+        assertNull(normalNode.getEndpointType());
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -29,6 +29,16 @@ public class WPComEndpointTest {
         assertEquals("/sites/56/media/78/delete/", WPCOMREST.sites.site(56).media.item(78).delete.getEndpoint());
         assertEquals("/sites/56/media/new/", WPCOMREST.sites.site(56).media.new_.getEndpoint());
 
+        // Sites - Taxonomies
+        assertEquals("/sites/56/taxonomies/category/terms/",
+                WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.getEndpoint());
+        assertEquals("/sites/56/taxonomies/category/terms/new/",
+                WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.new_.getEndpoint());
+        assertEquals("/sites/56/taxonomies/post_tag/terms/",
+                WPCOMREST.sites.site(56).taxonomies.taxonomy("post_tag").terms.getEndpoint());
+        assertEquals("/sites/56/taxonomies/post_tag/terms/new/",
+                WPCOMREST.sites.site(56).taxonomies.taxonomy("post_tag").terms.new_.getEndpoint());
+
         // Me
         assertEquals("/me/", WPCOMREST.me.getEndpoint());
         assertEquals("/me/settings/", WPCOMREST.me.settings.getEndpoint());

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.annotations.endpoint;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -69,14 +71,15 @@ public class EndpointNode {
         return getLocalEndpoint().replaceAll("/|\\$|#.*|_ID|_id", "").replaceAll("-", "_");
     }
 
-    public String getEndpointType() {
+    public List<String> getEndpointTypes() {
         Pattern pattern = Pattern.compile("#([^\\/]*)");
         Matcher matcher = pattern.matcher(getLocalEndpoint());
 
         if (matcher.find()) {
-            return matcher.group(1);
+            return Arrays.asList(matcher.group(1).split(","));
         }
-        return null;
+
+        return Collections.emptyList();
     }
 
     public boolean isRoot() {

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.annotations.endpoint;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class EndpointNode {
     private String mLocalEndpoint;
@@ -56,15 +58,25 @@ public class EndpointNode {
     }
 
     public String getFullEndpoint() {
-        String fullEndpoint = getLocalEndpoint();
+        String fullEndpoint = getLocalEndpoint().replaceAll("#[^/]*", ""); // Strip any type metadata, e.g. $name#String
         if (getParent() == null) {
             return fullEndpoint;
         }
-       return getParent().getFullEndpoint() + fullEndpoint;
+        return getParent().getFullEndpoint() + fullEndpoint;
     }
 
     public String getCleanEndpointName() {
-        return getLocalEndpoint().replaceAll("/|\\$|_ID|_id", "").replaceAll("-", "_");
+        return getLocalEndpoint().replaceAll("/|\\$|#.*|_ID|_id", "").replaceAll("-", "_");
+    }
+
+    public String getEndpointType() {
+        Pattern pattern = Pattern.compile("#([^\\/]*)");
+        Matcher matcher = pattern.matcher(getLocalEndpoint());
+
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
     }
 
     public boolean isRoot() {

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPComEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPComEndpoint.java
@@ -17,6 +17,10 @@ public class WPComEndpoint {
         this(endpoint + id + "/");
     }
 
+    public WPComEndpoint(String endpoint, String value) {
+        this(endpoint + value + "/");
+    }
+
     public String getEndpoint() {
         return mEndpoint;
     }

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -10,6 +10,8 @@ import com.squareup.javapoet.TypeSpec;
 import org.wordpress.android.fluxc.annotations.Endpoint;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointNode;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import javax.lang.model.element.Modifier;
@@ -122,15 +124,12 @@ public class RESTPoet {
 
         if (!endpointNode.hasChildren()) {
             // Build annotated accessor method for variable endpoint and add it to the class
-            classBuilder.addMethod(generateEndpointMethodForClass(endpointNode, sBaseEndpointClass));
-        } else {
-            MethodSpec endpointConstructor = MethodSpec.constructorBuilder()
-                    .addModifiers(Modifier.PRIVATE)
-                    .addParameter(String.class, "previousEndpoint")
-                    .addParameter(getVariableEndpointType(endpointNode), endpointName + "Id")
-                    .addStatement("super($L, $L)", "previousEndpoint", endpointName + "Id")
-                    .build();
+            List<MethodSpec> endpointMethods = generateEndpointMethodsForClass(endpointNode, sBaseEndpointClass);
 
+            for (MethodSpec endpointMethod : endpointMethods) {
+                classBuilder.addMethod(endpointMethod);
+            }
+        } else {
             String innerClassName;
             if (endpointNode.getParent().getCleanEndpointName().equals(endpointName)) {
                 // Special rule for situations like '.../media/$media_ID/` where the inner class needs to be renamed
@@ -141,49 +140,67 @@ public class RESTPoet {
 
             TypeSpec.Builder endpointClassBuilder = TypeSpec.classBuilder(innerClassName)
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                    .superclass(sBaseEndpointClass)
-                    .addMethod(endpointConstructor);
+                    .superclass(sBaseEndpointClass);
+
+            // Add a constructor for each type this endpoint accepts (usually long)
+            for (Class endpointType : getVariableEndpointTypes(endpointNode)) {
+                MethodSpec endpointConstructor = MethodSpec.constructorBuilder()
+                        .addModifiers(Modifier.PRIVATE)
+                        .addParameter(String.class, "previousEndpoint")
+                        .addParameter(endpointType, endpointName + "Id")
+                        .addStatement("super($L, $L)", "previousEndpoint", endpointName + "Id")
+                        .build();
+                endpointClassBuilder.addMethod(endpointConstructor);
+            }
 
             TypeName endpointClassName = ClassName.get("", innerClassName);
 
             // Build annotated accessor method for variable endpoint
-            MethodSpec endpointMethod = generateEndpointMethodForClass(endpointNode, endpointClassName);
+            List<MethodSpec> endpointMethods = generateEndpointMethodsForClass(endpointNode, endpointClassName);
 
             for (EndpointNode childEndpoint : endpointNode.getChildren()) {
                 addEndpointToBuilder(childEndpoint, endpointClassBuilder);
             }
 
-            classBuilder.addMethod(endpointMethod)
-                    .addType(endpointClassBuilder.build());
+            for (MethodSpec endpointMethod : endpointMethods) {
+                classBuilder.addMethod(endpointMethod);
+            }
+
+            classBuilder.addType(endpointClassBuilder.build());
         }
     }
 
-    private static MethodSpec generateEndpointMethodForClass(EndpointNode endpointNode, TypeName endpointClassName) {
-        String endpointName = endpointNode.getCleanEndpointName();
+    private static List<MethodSpec> generateEndpointMethodsForClass(EndpointNode endpointNode, TypeName endpointClassName) {
+        List<MethodSpec> endpointMethods = new ArrayList<>();
 
-        String methodName = endpointName;
-        if (endpointNode.getParent().getCleanEndpointName().equals(endpointName)) {
-            // Special rule for situations like '.../media/$media_ID/`
-            methodName = "item";
+        for (Class endpointType : getVariableEndpointTypes(endpointNode)) {
+            String endpointName = endpointNode.getCleanEndpointName();
+
+            String methodName = endpointName;
+            if (endpointNode.getParent().getCleanEndpointName().equals(endpointName)) {
+                // Special rule for situations like '.../media/$media_ID/`
+                methodName = "item";
+            }
+
+            MethodSpec.Builder endpointMethodBuilder = MethodSpec.methodBuilder(methodName)
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(endpointClassName)
+                    .addParameter(endpointType, endpointName + "Id")
+                    .addAnnotation(AnnotationSpec.builder(Endpoint.class)
+                            .addMember("value", "$S", endpointNode.getFullEndpoint())
+                            .build());
+
+            if (endpointNode.getParent().isRoot()) {
+                endpointMethodBuilder.addModifiers(Modifier.STATIC)
+                        .addStatement("return new $T($S, $L)", endpointClassName, "/", endpointName + "Id");
+            } else {
+                endpointMethodBuilder
+                        .addStatement("return new $T(getEndpoint(), $L)", endpointClassName, endpointName + "Id");
+            }
+            endpointMethods.add(endpointMethodBuilder.build());
         }
 
-        MethodSpec.Builder endpointMethodBuilder = MethodSpec.methodBuilder(methodName)
-                .addModifiers(Modifier.PUBLIC)
-                .returns(endpointClassName)
-                .addParameter(getVariableEndpointType(endpointNode), endpointName + "Id")
-                .addAnnotation(AnnotationSpec.builder(Endpoint.class)
-                        .addMember("value", "$S", endpointNode.getFullEndpoint())
-                        .build());
-
-        if (endpointNode.getParent().isRoot()) {
-            endpointMethodBuilder.addModifiers(Modifier.STATIC)
-                    .addStatement("return new $T($S, $L)", endpointClassName, "/", endpointName + "Id");
-        } else {
-            endpointMethodBuilder
-                    .addStatement("return new $T(getEndpoint(), $L)", endpointClassName, endpointName + "Id");
-        }
-
-        return endpointMethodBuilder.build();
+        return endpointMethods;
     }
 
     private static String capitalize(String endpoint) {
@@ -199,19 +216,24 @@ public class RESTPoet {
         return string;
     }
 
-    private static Class getVariableEndpointType(EndpointNode endpointNode) {
-        Class paramType = long.class;
+    private static List<Class> getVariableEndpointTypes(EndpointNode endpointNode) {
+        List<Class> endpointTypes = new ArrayList<>();
 
-        String endpointType = endpointNode.getEndpointType();
-
-        if (endpointType != null) {
+        for (String endpointType : endpointNode.getEndpointTypes()) {
             switch (endpointType) {
                 case "String":
-                    paramType = String.class;
+                    endpointTypes.add(String.class);
+                    break;
+                case "long":
+                    endpointTypes.add(long.class);
                     break;
             }
         }
 
-        return paramType;
+        if (endpointTypes.isEmpty()) {
+            endpointTypes.add(long.class);
+        }
+
+        return endpointTypes;
     }
 }

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -127,7 +127,7 @@ public class RESTPoet {
             MethodSpec endpointConstructor = MethodSpec.constructorBuilder()
                     .addModifiers(Modifier.PRIVATE)
                     .addParameter(String.class, "previousEndpoint")
-                    .addParameter(long.class, endpointName + "Id")
+                    .addParameter(getVariableEndpointType(endpointNode), endpointName + "Id")
                     .addStatement("super($L, $L)", "previousEndpoint", endpointName + "Id")
                     .build();
 
@@ -170,7 +170,7 @@ public class RESTPoet {
         MethodSpec.Builder endpointMethodBuilder = MethodSpec.methodBuilder(methodName)
                 .addModifiers(Modifier.PUBLIC)
                 .returns(endpointClassName)
-                .addParameter(long.class, endpointName + "Id")
+                .addParameter(getVariableEndpointType(endpointNode), endpointName + "Id")
                 .addAnnotation(AnnotationSpec.builder(Endpoint.class)
                         .addMember("value", "$S", endpointNode.getFullEndpoint())
                         .build());
@@ -197,5 +197,21 @@ public class RESTPoet {
             }
         }
         return string;
+    }
+
+    private static Class getVariableEndpointType(EndpointNode endpointNode) {
+        Class paramType = long.class;
+
+        String endpointType = endpointNode.getEndpointType();
+
+        if (endpointType != null) {
+            switch (endpointType) {
+                case "String":
+                    paramType = String.class;
+                    break;
+            }
+        }
+
+        return paramType;
     }
 }

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -144,11 +144,13 @@ public class RESTPoet {
 
             // Add a constructor for each type this endpoint accepts (usually long)
             for (Class endpointType : getVariableEndpointTypes(endpointNode)) {
+                String variableName = endpointType.equals(String.class) ? endpointName : endpointName + "Id";
+
                 MethodSpec endpointConstructor = MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PRIVATE)
                         .addParameter(String.class, "previousEndpoint")
-                        .addParameter(endpointType, endpointName + "Id")
-                        .addStatement("super($L, $L)", "previousEndpoint", endpointName + "Id")
+                        .addParameter(endpointType, variableName)
+                        .addStatement("super($L, $L)", "previousEndpoint", variableName)
                         .build();
                 endpointClassBuilder.addMethod(endpointConstructor);
             }
@@ -182,20 +184,22 @@ public class RESTPoet {
                 methodName = "item";
             }
 
+            String variableName = endpointType.equals(String.class) ? endpointName : endpointName + "Id";
+
             MethodSpec.Builder endpointMethodBuilder = MethodSpec.methodBuilder(methodName)
                     .addModifiers(Modifier.PUBLIC)
                     .returns(endpointClassName)
-                    .addParameter(endpointType, endpointName + "Id")
+                    .addParameter(endpointType, variableName)
                     .addAnnotation(AnnotationSpec.builder(Endpoint.class)
                             .addMember("value", "$S", endpointNode.getFullEndpoint())
                             .build());
 
             if (endpointNode.getParent().isRoot()) {
                 endpointMethodBuilder.addModifiers(Modifier.STATIC)
-                        .addStatement("return new $T($S, $L)", endpointClassName, "/", endpointName + "Id");
+                        .addStatement("return new $T($S, $L)", endpointClassName, "/", variableName);
             } else {
                 endpointMethodBuilder
-                        .addStatement("return new $T(getEndpoint(), $L)", endpointClassName, endpointName + "Id");
+                        .addStatement("return new $T(getEndpoint(), $L)", endpointClassName, variableName);
             }
             endpointMethods.add(endpointMethodBuilder.build());
         }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -16,4 +16,6 @@
 /sites/$site/media/$media_ID/delete/
 /sites/$site/media/new/
 
+/sites/$site/taxonomies/$taxonomy#String/terms/
+/sites/$site/taxonomies/$taxonomy#String/terms/new/
 /users/new/


### PR DESCRIPTION
Addresses item 3 in https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/128:

> Allow setting types when defining endpoints in the text file

With this change, you can specify a type for a variable endpoint when adding it to [`wp-com-endpoints.txt`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/324af44323c2d784ec7efad6584b31907e52194f/fluxc/src/main/tools/wp-com-endpoints.txt).

For example,

```java
/sites/$site/taxonomies/$taxonomy#String/terms/
```

will make the generated `taxonomy()` method accept a `String` (instead of the default `long`).

Though we don't need it yet, I also added support for multiple types, e.g.:

```java
/sites/$site#long,String
```

will create two methods, accepting `long` and `String` values for `sites.site()`.

This will come in handy if we ever need to support domains for the [`$site` endpoint](https://developer.wordpress.com/docs/api/1.2/get/sites/%24site/). Also for the `/read/feed/$feed_url_or_id` endpoint which is mentioned in #128 (but needs an additional fix for the `_id` part which we'll address separately).

cc @maxme 