### PR TITLE
Update okhttp libs to 3.4.1

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -56,8 +56,8 @@ dependencies {
 
     // External libs
     compile 'org.greenrobot:eventbus:3.0.0'
-    compile 'com.squareup.okhttp3:okhttp:3.2.0'
-    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.2.0'
+    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.4.1'
     compile 'com.android.volley:volley:1.0.0'
     compile 'com.google.code.gson:gson:2.4'
     compile 'com.google.dagger:dagger:2.0.2'


### PR DESCRIPTION
Updates the `okhttp` and `okhttp-urlconnection` libs to `3.4.1`.

This fixes a version conflict when using FluxC in WPAndroid.