### PR TITLE
Allow media uploading on sites with http auth

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
@@ -20,9 +20,9 @@ public class BaseXMLRPCClient {
     private SiteModel mSiteModel;
     private final RequestQueue mRequestQueue;
     protected final Dispatcher mDispatcher;
-    private UserAgent mUserAgent;
+    protected UserAgent mUserAgent;
     protected OnAuthFailedListener mOnAuthFailedListener;
-    private HTTPAuthManager mHTTPAuthManager;
+    protected HTTPAuthManager mHTTPAuthManager;
 
     public BaseXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,
                             UserAgent userAgent, HTTPAuthManager httpAuthManager) {


### PR DESCRIPTION
Reuse HTTPAuthManager and UserAgent in the MediaXMLRPCClient to decorate the okhttp request and allow media uploading on sites with http auth.