### PR TITLE
Reuse UserAgent in the MediaRESTClient to decorate the okhttp request used for upload

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -18,7 +18,7 @@ public class BaseWPComRestClient {
     private final RequestQueue mRequestQueue;
     protected final Dispatcher mDispatcher;
     protected final Context mAppContext;
-    private UserAgent mUserAgent;
+    protected UserAgent mUserAgent;
 
     protected OnAuthFailedListener mOnAuthFailedListener;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -228,6 +228,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
 
         okhttp3.Request request = new okhttp3.Request.Builder()
                 .addHeader(WPComGsonRequest.REST_AUTHORIZATION_HEADER, authHeader)
+                .addHeader("User-Agent", mUserAgent.toString())
                 .url(url)
                 .post(body)
                 .build();


### PR DESCRIPTION
Reuse UserAgent in the MediaRESTClient to decorate the okhttp request used for upload

I forgot this in #183 