### PR TITLE
Allow date changes for published WP.com posts

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCOM.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCOM.java
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.InstantiatePostPayload;
@@ -221,6 +222,31 @@ public class ReleaseStack_PostTestWPCOM extends ReleaseStack_Base {
         assertEquals(5, mPost.getFeaturedImageId());
         assertEquals(true, mPost.isLocallyChanged());
         assertEquals(false, mPost.isLocalDraft());
+    }
+
+    public void testChangePublishedPostToScheduled() throws InterruptedException {
+        createNewPost();
+        setupPostAttributes();
+
+        uploadPost(mPost);
+
+        PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        String futureDate = "2075-10-14T10:51:11+00:00";
+        uploadedPost.setDateCreated(futureDate);
+        uploadedPost.setIsLocallyChanged(true);
+
+        // Upload edited post
+        uploadPost(uploadedPost);
+
+        PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        // The post should no longer be flagged as having local changes
+        assertFalse(finalPost.isLocallyChanged());
+
+        // The post should now have a future created date and should have 'future' status
+        assertEquals(futureDate, finalPost.getDateCreated());
+        assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
     }
 
     public void testFetchPosts() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.InstantiatePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
@@ -223,6 +224,31 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         assertEquals(5, mPost.getFeaturedImageId());
         assertEquals(true, mPost.isLocallyChanged());
         assertEquals(false, mPost.isLocalDraft());
+    }
+
+    public void testChangePublishedPostToScheduled() throws InterruptedException {
+        createNewPost();
+        setupPostAttributes();
+
+        uploadPost(mPost);
+
+        PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        String futureDate = "2075-10-14T10:51:11+00:00";
+        uploadedPost.setDateCreated(futureDate);
+        uploadedPost.setIsLocallyChanged(true);
+
+        // Upload edited post
+        uploadPost(uploadedPost);
+
+        PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        // The post should no longer be flagged as having local changes
+        assertFalse(finalPost.isLocallyChanged());
+
+        // The post should now have a future created date and should have 'future' status
+        assertEquals(futureDate, finalPost.getDateCreated());
+        assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
     }
 
     public void testFetchPosts() throws InterruptedException {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -274,7 +274,7 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("content", StringUtils.notNullStr(post.getContent()));
         params.put("excerpt", StringUtils.notNullStr(post.getExcerpt()));
 
-        if (post.isLocalDraft() && !TextUtils.isEmpty(post.getDateCreated())) {
+        if (!TextUtils.isEmpty(post.getDateCreated())) {
             params.put("date", post.getDateCreated());
         }
 


### PR DESCRIPTION
Fixes as issue where it was impossible to change the published date for a post over the REST API (this also made it impossible to change status from `'publish'` to `'future'`).

To test, the new WPCOM test added in 8da752a should fail when checking out that commit (while the XML-RPC one works). Checking out the branch should fix the test.

cc @maxme