### PR TITLE
Issue #189: Support WP.com POST requests with arbitrary JSON

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/RequestQueryParametersTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/RequestQueryParametersTest.java
@@ -18,7 +18,7 @@ public class RequestQueryParametersTest {
     public void testBaseRequestAddQueryParameters() {
         String baseUrl = "https://public-api.wordpress.com/rest/v1.1/sites/56/posts/";
 
-        WPComGsonRequest wpComGsonRequest = new WPComGsonRequest<Object>(Method.HEAD, baseUrl, null, null, null, null);
+        WPComGsonRequest<Object> wpComGsonRequest = WPComGsonRequest.buildGetRequest(baseUrl, null, null, null, null);
 
         wpComGsonRequest.addQueryParameter("type", "post");
         assertEquals(baseUrl + "?type=post", wpComGsonRequest.getUrl());
@@ -45,7 +45,7 @@ public class RequestQueryParametersTest {
         params.put("offset", "20");
         params.put("favorite_pet", "pony");
 
-        WPComGsonRequest wpComGsonRequest = new WPComGsonRequest<>(Method.GET, baseUrl, params, null, null, null);
+        WPComGsonRequest wpComGsonRequest = WPComGsonRequest.buildGetRequest(baseUrl, params, null, null, null);
         assertEquals(baseUrl + "?offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
     }
 
@@ -53,11 +53,11 @@ public class RequestQueryParametersTest {
     public void testWPComGsonRequestConstructorPost() {
         String baseUrl = "https://public-api.wordpress.com/rest/v1.1/sites/56/posts/";
 
-        Map<String, String> params = new HashMap<>();
-        params.put("offset", "20");
-        params.put("favorite_pet", "pony");
+        Map<String, Object> body = new HashMap<>();
+        body.put("offset", "20");
+        body.put("favorite_pet", "pony");
 
-        WPComGsonRequest wpComGsonRequest = new WPComGsonRequest<>(Method.POST, baseUrl, params, null, null, null);
+        WPComGsonRequest wpComGsonRequest = WPComGsonRequest.buildPostRequest(baseUrl, body, null, null, null);
         // No change if the request != GET
         assertEquals(baseUrl, wpComGsonRequest.getUrl());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest;
 
+import com.android.volley.AuthFailureError;
 import com.android.volley.NetworkResponse;
 import com.android.volley.ParseError;
 import com.android.volley.Response;
@@ -12,6 +13,7 @@ import com.google.gson.JsonSyntaxException;
 import org.wordpress.android.fluxc.network.BaseRequest;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Map;
 
 public abstract class GsonRequest<T> extends BaseRequest<T> {
@@ -22,14 +24,16 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
     private final Class<T> mClass;
     private final Listener<T> mListener;
     private final Map<String, String> mParams;
+    private final Map<String, Object> mBody;
 
-    public GsonRequest(int method, Map<String, String> params, String url, Class<T> clazz, Listener<T> listener,
-                       BaseErrorListener errorListener) {
+    public GsonRequest(int method, Map<String, String> params, Map<String, Object> body, String url, Class<T> clazz,
+                       Listener<T> listener, BaseErrorListener errorListener) {
         super(method, url, errorListener);
         mClass = clazz;
         mListener = listener;
         mGson = setupGsonBuilder().create();
         mParams = params;
+        mBody = body;
     }
 
     @Override
@@ -45,6 +49,15 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
     @Override
     protected Map<String, String> getParams() {
         return mParams;
+    }
+
+    @Override
+    public byte[] getBody() throws AuthFailureError {
+        if (mBody == null) {
+            return super.getBody();
+        }
+
+        return mGson.toJson(mBody).getBytes(Charset.forName("UTF-8"));
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -28,13 +28,49 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         }
     }
 
+    /**
+     * Creates a new request with the given method (one of the values from {@link Method Method}).
+     * For a request with a body of arbitrary JSON, use
+     * {@link #buildPostRequest(String, Map, Class, Listener, BaseErrorListener) postRequest}.
+     */
     public WPComGsonRequest(int method, String url, Map<String, String> params, Class<T> clazz,
                             Listener<T> listener, BaseErrorListener errorListener) {
-        super(method, params, null, url, clazz, listener, errorListener);
+        this(method, url, params, null, clazz, listener, errorListener);
+    }
+
+    private WPComGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
+                            Class<T> clazz, Listener<T> listener, BaseErrorListener errorListener) {
+        super(method, params, body, url, clazz, listener, errorListener);
         // If it's a GET request, add the parameters to the URL
         if (method == Method.GET) {
             addQueryParameters(params);
         }
+    }
+
+    /**
+     * Creates a new GET request.
+     * @param url the request URL
+     * @param params the parameters to append to the request URL
+     * @param clazz the class defining the expected response
+     * @param listener the success listener
+     * @param errorListener the error listener
+     */
+    public static <T> WPComGsonRequest<T> buildGetRequest(String url, Map<String, String> params, Class<T> clazz,
+                                                          Listener<T> listener, BaseErrorListener errorListener) {
+        return new WPComGsonRequest<>(Method.GET, url, params, null, clazz, listener, errorListener);
+    }
+
+    /**
+     * Creates a new JSON-formatted POST request.
+     * @param url the request URL
+     * @param body the content body, which will be converted to JSON using {@link com.google.gson.Gson Gson}
+     * @param clazz the class defining the expected response
+     * @param listener the success listener
+     * @param errorListener the error listener
+     */
+    public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, Object> body, Class<T> clazz,
+                                                           Listener<T> listener, BaseErrorListener errorListener) {
+        return new WPComGsonRequest<T>(Method.POST, url, null, body, clazz, listener, errorListener);
     }
 
     private String addDefaultParameters(String url) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
-import com.android.volley.Request;
 import com.android.volley.Response.Listener;
 import com.android.volley.toolbox.HttpHeaderParser;
 
@@ -31,9 +30,9 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
 
     public WPComGsonRequest(int method, String url, Map<String, String> params, Class<T> clazz,
                             Listener<T> listener, BaseErrorListener errorListener) {
-        super(method, params, url, clazz, listener, errorListener);
-        // If it's a GET request, then add the parameters as query Parameters
-        if (method == Request.Method.GET) {
+        super(method, params, null, url, clazz, listener, errorListener);
+        // If it's a GET request, add the parameters to the URL
+        if (method == Method.GET) {
             addQueryParameters(params);
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -28,16 +28,6 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         }
     }
 
-    /**
-     * Creates a new request with the given method (one of the values from {@link Method Method}).
-     * For a request with a body of arbitrary JSON, use
-     * {@link #buildPostRequest(String, Map, Class, Listener, BaseErrorListener) postRequest}.
-     */
-    public WPComGsonRequest(int method, String url, Map<String, String> params, Class<T> clazz,
-                            Listener<T> listener, BaseErrorListener errorListener) {
-        this(method, url, params, null, clazz, listener, errorListener);
-    }
-
     private WPComGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
                             Class<T> clazz, Listener<T> listener, BaseErrorListener errorListener) {
         super(method, params, body, url, clazz, listener, errorListener);
@@ -70,7 +60,7 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
      */
     public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, Object> body, Class<T> clazz,
                                                            Listener<T> listener, BaseErrorListener errorListener) {
-        return new WPComGsonRequest<T>(Method.POST, url, null, body, clazz, listener, errorListener);
+        return new WPComGsonRequest<>(Method.POST, url, null, body, clazz, listener, errorListener);
     }
 
     private String addDefaultParameters(String url) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.account;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
@@ -82,7 +81,7 @@ public class AccountRestClient extends BaseWPComRestClient {
      */
     public void fetchAccount() {
         String url = WPCOMREST.me.getUrlV1_1();
-        add(new WPComGsonRequest<>(Method.GET, url, null, AccountResponse.class,
+        add(WPComGsonRequest.buildGetRequest(url, null, AccountResponse.class,
                 new Listener<AccountResponse>() {
                     @Override
                     public void onResponse(AccountResponse response) {
@@ -109,7 +108,7 @@ public class AccountRestClient extends BaseWPComRestClient {
      */
     public void fetchAccountSettings() {
         String url = WPCOMREST.me.settings.getUrlV1_1();
-        add(new WPComGsonRequest<>(Method.GET, url, null, AccountSettingsResponse.class,
+        add(WPComGsonRequest.buildGetRequest(url, null, AccountSettingsResponse.class,
                 new Listener<AccountSettingsResponse>() {
                     @Override
                     public void onResponse(AccountSettingsResponse response) {
@@ -136,12 +135,12 @@ public class AccountRestClient extends BaseWPComRestClient {
      *
      * No HTTP POST call is made if the given parameter map is null or contains no entries.
      */
-    public void postAccountSettings(Map<String, String> params) {
-        if (params == null || params.isEmpty()) return;
+    public void postAccountSettings(Map<String, Object> body) {
+        if (body == null || body.isEmpty()) return;
         String url = WPCOMREST.me.settings.getUrlV1_1();
         // Note: we have to use a HashMap as a response here because the API response format is different depending
         // of the request we do.
-        add(new WPComGsonRequest<>(Method.POST, url, params, HashMap.class,
+        add(WPComGsonRequest.buildPostRequest(url, body, HashMap.class,
                 new Listener<HashMap>() {
                     @Override
                     public void onResponse(HashMap response) {
@@ -163,15 +162,15 @@ public class AccountRestClient extends BaseWPComRestClient {
     public void newAccount(@NonNull String username, @NonNull String password, @NonNull String email,
                            final boolean dryRun) {
         String url = WPCOMREST.users.new_.getUrlV1();
-        Map<String, String> params = new HashMap<>();
-        params.put("username", username);
-        params.put("password", password);
-        params.put("email", email);
-        params.put("validate", dryRun ? "1" : "0");
-        params.put("client_id", mAppSecrets.getAppId());
-        params.put("client_secret", mAppSecrets.getAppSecret());
+        Map<String, Object> body = new HashMap<>();
+        body.put("username", username);
+        body.put("password", password);
+        body.put("email", email);
+        body.put("validate", dryRun ? "1" : "0");
+        body.put("client_id", mAppSecrets.getAppId());
+        body.put("client_secret", mAppSecrets.getAppSecret());
 
-        WPComGsonRequest<NewAccountResponse> request = new WPComGsonRequest<>(Method.POST, url, params,
+        WPComGsonRequest<NewAccountResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 NewAccountResponse.class,
                 new Listener<NewAccountResponse>() {
                     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
-import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 
@@ -52,8 +51,8 @@ public class PostRestClient extends BaseWPComRestClient {
 
         params.put("context", "edit");
 
-        final WPComGsonRequest<PostWPComRestResponse> request = new WPComGsonRequest<>(Method.GET,
-                url, params, PostWPComRestResponse.class,
+        final WPComGsonRequest<PostWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, params,
+                PostWPComRestResponse.class,
                 new Listener<PostWPComRestResponse>() {
                     @Override
                     public void onResponse(PostWPComRestResponse response) {
@@ -101,8 +100,8 @@ public class PostRestClient extends BaseWPComRestClient {
             params.put("offset", String.valueOf(offset));
         }
 
-        final WPComGsonRequest<PostsResponse> request = new WPComGsonRequest<>(Method.GET,
-                url, params, PostsResponse.class,
+        final WPComGsonRequest<PostsResponse> request = WPComGsonRequest.buildGetRequest(url, params,
+                PostsResponse.class,
                 new Listener<PostsResponse>() {
                     @Override
                     public void onResponse(PostsResponse response) {
@@ -143,10 +142,10 @@ public class PostRestClient extends BaseWPComRestClient {
             url = WPCOMREST.sites.site(site.getSiteId()).posts.post(post.getRemotePostId()).getUrlV1_1();
         }
 
-        Map<String, String> params = postModelToParams(post);
+        Map<String, Object> body = postModelToParams(post);
 
-        final WPComGsonRequest<PostWPComRestResponse> request = new WPComGsonRequest<>(Method.POST,
-                url, params, PostWPComRestResponse.class,
+        final WPComGsonRequest<PostWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, body,
+                PostWPComRestResponse.class,
                 new Listener<PostWPComRestResponse>() {
                     @Override
                     public void onResponse(PostWPComRestResponse response) {
@@ -183,8 +182,8 @@ public class PostRestClient extends BaseWPComRestClient {
     public void deletePost(final PostModel post, final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).posts.post(post.getRemotePostId()).delete.getUrlV1_1();
 
-        final WPComGsonRequest<PostWPComRestResponse> request = new WPComGsonRequest<>(Method.POST,
-                url, null, PostWPComRestResponse.class,
+        final WPComGsonRequest<PostWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
+                PostWPComRestResponse.class,
                 new Listener<PostWPComRestResponse>() {
                     @Override
                     public void onResponse(PostWPComRestResponse response) {
@@ -266,8 +265,8 @@ public class PostRestClient extends BaseWPComRestClient {
         return post;
     }
 
-    private Map<String, String> postModelToParams(PostModel post) {
-        Map<String, String> params = new HashMap<>();
+    private Map<String, Object> postModelToParams(PostModel post) {
+        Map<String, Object> params = new HashMap<>();
 
         params.put("status", StringUtils.notNullStr(post.getStatus()));
         params.put("title", StringUtils.notNullStr(post.getTitle()));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.site;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
@@ -59,8 +58,8 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void pullSites() {
         String url = WPCOMREST.me.sites.getUrlV1_1();
-        final WPComGsonRequest<SitesResponse> request = new WPComGsonRequest<>(Method.GET,
-                url, null, SitesResponse.class,
+        final WPComGsonRequest<SitesResponse> request = WPComGsonRequest.buildGetRequest(url, null,
+                SitesResponse.class,
                 new Listener<SitesResponse>() {
                     @Override
                     public void onResponse(SitesResponse response) {
@@ -86,8 +85,8 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void pullSite(final SiteModel site) {
         String url = WPCOMREST.sites.getUrlV1_1() + site.getSiteId();
-        final WPComGsonRequest<SiteWPComRestResponse> request = new WPComGsonRequest<>(Method.GET,
-                url, null, SiteWPComRestResponse.class,
+        final WPComGsonRequest<SiteWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,
+                SiteWPComRestResponse.class,
                 new Listener<SiteWPComRestResponse>() {
                     @Override
                     public void onResponse(SiteWPComRestResponse response) {
@@ -110,16 +109,16 @@ public class SiteRestClient extends BaseWPComRestClient {
     public void newSite(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
                         @NonNull SiteVisibility visibility, final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1();
-        Map<String, String> params = new HashMap<>();
-        params.put("blog_name", siteName);
-        params.put("blog_title", siteTitle);
-        params.put("lang_id", language);
-        params.put("public", visibility.toString());
-        params.put("validate", dryRun ? "1" : "0");
-        params.put("client_id", mAppSecrets.getAppId());
-        params.put("client_secret", mAppSecrets.getAppSecret());
+        Map<String, Object> body = new HashMap<>();
+        body.put("blog_name", siteName);
+        body.put("blog_title", siteTitle);
+        body.put("lang_id", language);
+        body.put("public", visibility.toString());
+        body.put("validate", dryRun ? "1" : "0");
+        body.put("client_id", mAppSecrets.getAppId());
+        body.put("client_secret", mAppSecrets.getAppSecret());
 
-        WPComGsonRequest<NewAccountResponse> request = new WPComGsonRequest<>(Method.POST, url, params,
+        WPComGsonRequest<NewAccountResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 NewAccountResponse.class,
                 new Listener<NewAccountResponse>() {
                     @Override
@@ -145,8 +144,8 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void pullPostFormats(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).post_formats.getUrlV1_1();
-        final WPComGsonRequest<PostFormatsResponse> request = new WPComGsonRequest<>(Method.GET,
-                url, null, PostFormatsResponse.class,
+        final WPComGsonRequest<PostFormatsResponse> request = WPComGsonRequest.buildGetRequest(url, null,
+                PostFormatsResponse.class,
                 new Listener<PostFormatsResponse>() {
                     @Override
                     public void onResponse(PostFormatsResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -53,7 +53,7 @@ public class AccountStore extends Store {
     }
 
     public static class PushAccountSettingsPayload extends Payload {
-        public Map<String, String> params;
+        public Map<String, Object> params;
         public PushAccountSettingsPayload() {
         }
     }


### PR DESCRIPTION
Addresses #189. Modifies `GsonRequest` to support generating a JSON body from a `Map<String, Object>`, and updates `WPComGsonRequest` with two static factory methods (one for `GET`, and one for `POST`).

I'd like to remove [this method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/issue/189-wpcom-complex-post-requests?expand=1#diff-8aec461b9ea3f73c8e15c4b4a6231f9bR36) entirely, and rely only on factory methods for all calls to `WPComGsonRequest` (this means refactoring all our current REST calls). If we need to support methods other than `POST` or `GET` in the future for WP.com we can expand on this. What do you think @maxme?

#### Aside:

I experimented with using a builder rather than a factory method, but I'm not sure how well it suits us since all but one of the params are required, so the only 'optional' (`setBody()` or `setUrlParams()`) ends up buried under all the listener callback code:

```java
final WPComGsonRequest<PostWPComRestResponse> request = new WPComGsonRequest.WPComGsonRequestBuilder<>(
		Method.POST, url, PostWPComRestResponse.class,
		new Listener<PostWPComRestResponse>() {
			@Override
			public void onResponse(PostWPComRestResponse response) {
				// TODO: Handle response
			}
		},
		new BaseErrorListener() {
			@Override
			public void onErrorResponse(@NonNull BaseNetworkError error) {
				// TODO: Handle error
			}
		})
		.setBody(body)
		.build();

request.addQueryParameter("context", "edit");

request.disableRetries();
add(request);
```

(either `.setBody()` or `.setParams()` would need to be called to access `.build()`)