### PR TITLE
Issue #188: Fix location for posts

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -375,7 +375,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         assertEquals(false, mPost.hasLocation());
 
         // 2. Modify the post, setting some location data
-        mPost.setPostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
+        mPost.setLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
         mPost.setIsLocallyChanged(true);
 
         uploadPost(mPost);
@@ -385,8 +385,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
 
         // The set location should be stored in the remote post
         assertEquals(true, mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
     }
 
     public void testUploadPostWithLocation() throws InterruptedException {
@@ -396,7 +396,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mPost.setTitle("A post with location");
         mPost.setContent("Some content");
 
-        mPost.setPostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
+        mPost.setLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
 
         uploadPost(mPost);
 
@@ -411,8 +411,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
 
         // The set location should be stored in the remote post
         assertEquals(true, mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
 
         // 2. Modify the post without changing the location data and update
         mPost.setTitle("A new title");
@@ -427,8 +427,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
 
         // The location data should not have been altered
         assertEquals(true, mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
 
         // 3. Clear location data from the post and update
         mPost.clearLocation();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -431,7 +431,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
 
         // 3. Clear location data from the post and update
-        mPost.setPostLocation(null);
+        mPost.clearLocation();
         mPost.setIsLocallyChanged(true);
 
         uploadPost(mPost);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -40,6 +40,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
 
     private static final String POST_DEFAULT_TITLE = "PostTestWPCom base post";
     private static final String POST_DEFAULT_DESCRIPTION = "Hi there, I'm a post from FluxC!";
+    private static final double EXAMPLE_LATITUDE = 44.8378;
+    private static final double EXAMPLE_LONGITUDE = 0.5792;
 
     private CountDownLatch mCountDownLatch;
     private PostModel mPost;
@@ -349,6 +351,96 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         assertEquals(date, newPage.getDateCreated());
 
         assertEquals(0, newPage.getFeaturedImageId()); // The page should upload, but have the featured image stripped
+    }
+
+    public void testAddLocationToRemotePost() throws InterruptedException {
+        // 1. Upload a post with no location data
+        createNewPost();
+
+        mPost.setTitle("A post with location");
+        mPost.setContent("Some content");
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+
+        assertEquals("A post with location", mPost.getTitle());
+        assertEquals("Some content", mPost.getContent());
+
+        // The post should not have a location since we never set one
+        assertEquals(false, mPost.hasLocation());
+
+        // 2. Modify the post, setting some location data
+        mPost.setPostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
+        mPost.setIsLocallyChanged(true);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        // The set location should be stored in the remote post
+        assertEquals(true, mPost.hasLocation());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+    }
+
+    public void testUploadPostWithLocation() throws InterruptedException {
+        // 1. Upload a post with location data
+        createNewPost();
+
+        mPost.setTitle("A post with location");
+        mPost.setContent("Some content");
+
+        mPost.setPostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+
+        assertEquals("A post with location", mPost.getTitle());
+        assertEquals("Some content", mPost.getContent());
+
+        // The set location should be stored in the remote post
+        assertEquals(true, mPost.hasLocation());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+
+        // 2. Modify the post without changing the location data and update
+        mPost.setTitle("A new title");
+        mPost.setIsLocallyChanged(true);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertEquals("A new title", mPost.getTitle());
+
+        // The location data should not have been altered
+        assertEquals(true, mPost.hasLocation());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+
+        // 3. Clear location data from the post and update
+        mPost.setPostLocation(null);
+        mPost.setIsLocallyChanged(true);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        // The post should not have a location anymore
+        assertEquals(false, mPost.hasLocation());
     }
 
     public void testDeleteRemotePost() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -41,7 +41,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
     private static final String POST_DEFAULT_TITLE = "PostTestWPCom base post";
     private static final String POST_DEFAULT_DESCRIPTION = "Hi there, I'm a post from FluxC!";
     private static final double EXAMPLE_LATITUDE = 44.8378;
-    private static final double EXAMPLE_LONGITUDE = 0.5792;
+    private static final double EXAMPLE_LONGITUDE = -0.5792;
 
     private CountDownLatch mCountDownLatch;
     private PostModel mPost;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -429,7 +429,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
 
         // 3. Clear location data from the post and update
-        mPost.setPostLocation(null);
+        mPost.clearLocation();
         mPost.setIsLocallyChanged(true);
 
         uploadPost(mPost);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -373,7 +373,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         assertEquals(false, mPost.hasLocation());
 
         // 2. Modify the post, setting some location data
-        mPost.setPostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
+        mPost.setLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
         mPost.setIsLocallyChanged(true);
 
         uploadPost(mPost);
@@ -383,8 +383,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
 
         // The set location should be stored in the remote post
         assertEquals(true, mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
     }
 
     public void testUploadPostWithLocation() throws InterruptedException {
@@ -394,7 +394,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mPost.setTitle("A post with location");
         mPost.setContent("Some content");
 
-        mPost.setPostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
+        mPost.setLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
 
         uploadPost(mPost);
 
@@ -409,8 +409,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
 
         // The set location should be stored in the remote post
         assertEquals(true, mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
 
         // 2. Modify the post without changing the location data and update
         mPost.setTitle("A new title");
@@ -425,8 +425,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
 
         // The location data should not have been altered
         assertEquals(true, mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
 
         // 3. Clear location data from the post and update
         mPost.clearLocation();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -34,6 +34,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
 
     private static final String POST_DEFAULT_TITLE = "PostTestXMLRPC base post";
     private static final String POST_DEFAULT_DESCRIPTION = "Hi there, I'm a post from FluxC!";
+    private static final double EXAMPLE_LATITUDE = 44.8378;
+    private static final double EXAMPLE_LONGITUDE = 0.5792;
 
     private CountDownLatch mCountDownLatch;
     private PostModel mPost;
@@ -347,6 +349,96 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         assertEquals("A fully featured page", newPage.getTitle());
         assertEquals("Some content here! <strong>Bold text</strong>.", newPage.getContent());
         assertEquals(date, newPage.getDateCreated());
+    }
+
+    public void testAddLocationToRemotePost() throws InterruptedException {
+        // 1. Upload a post with no location data
+        createNewPost();
+
+        mPost.setTitle("A post with location");
+        mPost.setContent("Some content");
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+
+        assertEquals("A post with location", mPost.getTitle());
+        assertEquals("Some content", mPost.getContent());
+
+        // The post should not have a location since we never set one
+        assertEquals(false, mPost.hasLocation());
+
+        // 2. Modify the post, setting some location data
+        mPost.setPostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
+        mPost.setIsLocallyChanged(true);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        // The set location should be stored in the remote post
+        assertEquals(true, mPost.hasLocation());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+    }
+
+    public void testUploadPostWithLocation() throws InterruptedException {
+        // 1. Upload a post with location data
+        createNewPost();
+
+        mPost.setTitle("A post with location");
+        mPost.setContent("Some content");
+
+        mPost.setPostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+
+        assertEquals("A post with location", mPost.getTitle());
+        assertEquals("Some content", mPost.getContent());
+
+        // The set location should be stored in the remote post
+        assertEquals(true, mPost.hasLocation());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+
+        // 2. Modify the post without changing the location data and update
+        mPost.setTitle("A new title");
+        mPost.setIsLocallyChanged(true);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertEquals("A new title", mPost.getTitle());
+
+        // The location data should not have been altered
+        assertEquals(true, mPost.hasLocation());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getPostLocation().getLatitude());
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getPostLocation().getLongitude());
+
+        // 3. Clear location data from the post and update
+        mPost.setPostLocation(null);
+        mPost.setIsLocallyChanged(true);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        // The post should not have a location anymore
+        assertEquals(false, mPost.hasLocation());
     }
 
     public void testDeleteRemotePost() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -35,7 +35,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
     private static final String POST_DEFAULT_TITLE = "PostTestXMLRPC base post";
     private static final String POST_DEFAULT_DESCRIPTION = "Hi there, I'm a post from FluxC!";
     private static final double EXAMPLE_LATITUDE = 44.8378;
-    private static final double EXAMPLE_LONGITUDE = 0.5792;
+    private static final double EXAMPLE_LONGITUDE = -0.5792;
 
     private CountDownLatch mCountDownLatch;
     private PostModel mPost;

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.post.PostLocation;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.network.BaseRequest;
 
@@ -13,6 +14,8 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.wordpress.android.fluxc.post.PostTestUtils.EXAMPLE_LATITUDE;
+import static org.wordpress.android.fluxc.post.PostTestUtils.EXAMPLE_LONGITUDE;
 
 @RunWith(RobolectricTestRunner.class)
 public class PostModelTest {
@@ -67,5 +70,44 @@ public class PostModelTest {
         assertEquals(2, testPost.getCategoryIdList().size());
         assertTrue(categoryIds.containsAll(testPost.getCategoryIdList()) &&
                 testPost.getCategoryIdList().containsAll(categoryIds));
+    }
+
+    @Test
+    public void testLocation() {
+        PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
+
+        // Expect no location if none was set
+        assertFalse(testPost.hasLocation());
+        assertFalse(testPost.getLocation().isValid());
+        assertFalse(testPost.shouldDeleteLatitude());
+        assertFalse(testPost.shouldDeleteLongitude());
+
+        // Verify state when location is set
+        testPost.setLocation(new PostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE));
+
+        assertTrue(testPost.hasLocation());
+        assertEquals(EXAMPLE_LATITUDE, testPost.getLatitude(), 0);
+        assertEquals(EXAMPLE_LONGITUDE, testPost.getLongitude(), 0);
+        assertEquals(new PostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE), testPost.getLocation());
+        assertFalse(testPost.shouldDeleteLatitude());
+        assertFalse(testPost.shouldDeleteLongitude());
+
+        // (0, 0) is a valid location
+        testPost.setLocation(0, 0);
+
+        assertTrue(testPost.hasLocation());
+        assertEquals(0, testPost.getLatitude(), 0);
+        assertEquals(0, testPost.getLongitude(), 0);
+        assertEquals(new PostLocation(0, 0), testPost.getLocation());
+        assertFalse(testPost.shouldDeleteLatitude());
+        assertFalse(testPost.shouldDeleteLongitude());
+
+        // Clearing the location should remove the location, and flag it for deletion on the server
+        testPost.clearLocation();
+
+        assertFalse(testPost.hasLocation());
+        assertFalse(testPost.getLocation().isValid());
+        assertTrue(testPost.shouldDeleteLatitude());
+        assertTrue(testPost.shouldDeleteLongitude());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
@@ -7,6 +7,9 @@ import org.wordpress.android.fluxc.model.PostModel;
 import java.util.List;
 
 public class PostTestUtils {
+    public static final double EXAMPLE_LATITUDE = 44.8378;
+    public static final double EXAMPLE_LONGITUDE = 0.5792;
+
     public static PostModel generateSampleUploadedPost() {
         return generateSampleUploadedPost("text");
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class PostTestUtils {
     public static final double EXAMPLE_LATITUDE = 44.8378;
-    public static final double EXAMPLE_LONGITUDE = 0.5792;
+    public static final double EXAMPLE_LONGITUDE = -0.5792;
 
     public static PostModel generateSampleUploadedPost() {
         return generateSampleUploadedPost("text");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -251,7 +251,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         return new PostLocation(mLatitude, mLongitude);
     }
 
-    public void setPostLocation(PostLocation postLocation) {
+    public void setPostLocation(@NonNull PostLocation postLocation) {
         mLatitude = postLocation.getLatitude();
         mLongitude = postLocation.getLongitude();
     }
@@ -413,6 +413,11 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
 
     public boolean hasLocation() {
         return getPostLocation() != null && getPostLocation().isValid();
+    }
+
+    public void clearLocation() {
+        mLatitude = PostLocation.INVALID_LATITUDE;
+        mLongitude = PostLocation.INVALID_LONGITUDE;
     }
 
     public boolean featuredImageHasChanged() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -24,6 +24,8 @@ import java.util.List;
 @Table
 public class PostModel extends Payload implements Cloneable, Identifiable, Serializable {
     private static final long FEATURED_IMAGE_INIT_VALUE = -2;
+    private static final long LATITUDE_REMOVED_VALUE = 8888;
+    private static final long LONGITUDE_REMOVED_VALUE = 8888;
 
     @PrimaryKey
     @Column private int mId;
@@ -415,9 +417,17 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         return getLocation() != null && getLocation().isValid();
     }
 
+    public boolean shouldDeleteLatitude() {
+        return mLatitude == LATITUDE_REMOVED_VALUE;
+    }
+
+    public boolean shouldDeleteLongitude() {
+        return mLongitude == LONGITUDE_REMOVED_VALUE;
+    }
+
     public void clearLocation() {
-        mLatitude = PostLocation.INVALID_LATITUDE;
-        mLongitude = PostLocation.INVALID_LONGITUDE;
+        mLatitude = LATITUDE_REMOVED_VALUE;
+        mLongitude = LONGITUDE_REMOVED_VALUE;
     }
 
     public boolean featuredImageHasChanged() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -247,16 +247,16 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         mLatitude = latitude;
     }
 
-    public PostLocation getPostLocation() {
+    public PostLocation getLocation() {
         return new PostLocation(mLatitude, mLongitude);
     }
 
-    public void setPostLocation(@NonNull PostLocation postLocation) {
+    public void setLocation(@NonNull PostLocation postLocation) {
         mLatitude = postLocation.getLatitude();
         mLongitude = postLocation.getLongitude();
     }
 
-    public void setPostLocation(double latitude, double longitude) {
+    public void setLocation(double latitude, double longitude) {
         mLatitude = latitude;
         mLongitude = longitude;
     }
@@ -412,7 +412,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     }
 
     public boolean hasLocation() {
-        return getPostLocation() != null && getPostLocation().isValid();
+        return getLocation() != null && getLocation().isValid();
     }
 
     public void clearLocation() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -43,8 +43,8 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     @Column private long mFeaturedImageId = FEATURED_IMAGE_INIT_VALUE;
     @Column private String mPostFormat;
     @Column private String mSlug;
-    @Column private double mLatitude;
-    @Column private double mLongitude;
+    @Column private double mLatitude = PostLocation.INVALID_LATITUDE;
+    @Column private double mLongitude = PostLocation.INVALID_LONGITUDE;
 
     // Page specific
     @Column private boolean mIsPage;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostLocation.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostLocation.java
@@ -3,8 +3,8 @@ package org.wordpress.android.fluxc.model.post;
 import java.io.Serializable;
 
 public class PostLocation implements Serializable {
-    static final double INVALID_LATITUDE = 9999;
-    static final double INVALID_LONGITUDE = 9999;
+    public static final double INVALID_LATITUDE = 9999;
+    public static final double INVALID_LONGITUDE = 9999;
     static final double MIN_LATITUDE = -90;
     static final double MAX_LATITUDE = 90;
     static final double MIN_LONGITUDE = -180;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostLocation.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostLocation.java
@@ -16,6 +16,9 @@ public class PostLocation implements Serializable {
     public PostLocation() { }
 
     public PostLocation(double latitude, double longitude) {
+        if (!(isValidLatitude(latitude) && isValidLongitude(longitude))) {
+            return;
+        }
         setLatitude(latitude);
         setLongitude(longitude);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/GeoLocation.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/GeoLocation.java
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.post;
 import org.wordpress.android.fluxc.network.rest.JsonObjectOrFalse;
 
 public class GeoLocation extends JsonObjectOrFalse {
-    public float latitude;
-    public float longitude;
+    public double latitude;
+    public double longitude;
     public String address;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -345,7 +345,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                 }
             }
             if (postLocation.isValid()) {
-                post.setPostLocation(postLocation);
+                post.setLocation(postLocation);
             }
         }
         post.setCustomFields(jsonCustomFieldsArray.toString());
@@ -454,7 +454,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                 }
 
                 if (post.hasLocation()) {
-                    PostLocation location = post.getPostLocation();
+                    PostLocation location = post.getLocation();
                     hLatitude.put("key", "geo_latitude");
                     hLongitude.put("key", "geo_longitude");
                     hPublic.put("key", "geo_public");


### PR DESCRIPTION
Fixes #188 - several issues with post location across XML-RPC and WP.com.

#### Summary of the changes:

* Avoid the need to null `PostLocation` to unset it; instead, get `mLatitude` and `mLongitude` in `PostModel` to reflect an invalid location properly
* Since we need to know the difference between a local removal of post location and a post with no post location to begin with, `mLatitude` and `mLongitude` get a special value when the post's location has been unset (this is similar to what we do for [featured images](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/5a081753d02c8336ccc26c9315dfc99bee6db603/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java#L433-L435))
* The `PostRestClient` now handles adding/removing location data when uploading posts

To test, check out the tests in 708c610 - they should fail. Checking out 8149e48 should fix the XML-RPC tests, and finally checking out the branch should green both sets of tests.

cc @maxme