### PR TITLE
Issue #197: Delay OnPostUploaded until post is synced

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -53,6 +53,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         NONE,
         SITE_CHANGED,
         POST_INSTANTIATED,
+        POST_UPLOADED,
         POST_UPDATED,
         POSTS_FETCHED,
         PAGES_FETCHED,
@@ -667,9 +668,12 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
             }
             return;
         }
+        assertEquals(TEST_EVENTS.POST_UPLOADED, mNextEvent);
         assertEquals(false, event.post.isLocalDraft());
         assertEquals(false, event.post.isLocallyChanged());
         assertNotSame(0, event.post.getRemotePostId());
+
+        mCountDownLatch.countDown();
     }
 
     private void setupPostAttributes() {
@@ -689,7 +693,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
     }
 
     private void uploadPost(PostModel post) throws InterruptedException {
-        mNextEvent = TEST_EVENTS.POST_UPDATED;
+        mNextEvent = TEST_EVENTS.POST_UPLOADED;
         mCountDownLatch = new CountDownLatch(1);
 
         RemotePostPayload pushPayload = new RemotePostPayload(post, mSite);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -45,7 +45,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
 
     private CountDownLatch mCountDownLatch;
     private PostModel mPost;
-    private static SiteModel mSite;
+    private static SiteModel sSite;
 
     private boolean mCanLoadMorePosts;
 
@@ -80,9 +80,9 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
             authenticate();
         }
 
-        if (mSite == null) {
+        if (sSite == null) {
             fetchSites();
-            mSite = mSiteStore.getSites().get(0);
+            sSite = mSiteStore.getSites().get(0);
         }
     }
 
@@ -97,7 +97,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertNotSame(0, uploadedPost.getRemotePostId());
         assertEquals(false, uploadedPost.isLocalDraft());
@@ -122,7 +122,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("From testEditingRemotePost", finalPost.getTitle());
 
@@ -152,7 +152,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         PostModel latestPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals(POST_DEFAULT_TITLE, latestPost.getTitle());
         assertEquals(false, latestPost.isLocallyChanged());
@@ -181,7 +181,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("From testChangingLocalDraft, redux", mPost.getTitle());
         assertEquals("Some new content", mPost.getContent());
@@ -218,7 +218,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("From testMultipleLocalChangesToUploadedPost, redux", mPost.getTitle());
         assertEquals("Some different content", mPost.getContent());
@@ -256,11 +256,11 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new PostStore.FetchPostsPayload(mSite, false)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new PostStore.FetchPostsPayload(sSite, false)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        int firstFetchPosts = mPostStore.getPostsCountForSite(mSite);
+        int firstFetchPosts = mPostStore.getPostsCountForSite(sSite);
 
         // Dangerous, will fail for a site with no posts
         assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
@@ -272,11 +272,11 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new PostStore.FetchPostsPayload(mSite, true)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new PostStore.FetchPostsPayload(sSite, true)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        int currentStoredPosts = mPostStore.getPostsCountForSite(mSite);
+        int currentStoredPosts = mPostStore.getPostsCountForSite(sSite);
 
         assertTrue(currentStoredPosts > firstFetchPosts);
         assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
@@ -286,11 +286,11 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.PAGES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPagesAction(new PostStore.FetchPostsPayload(mSite, false)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPagesAction(new PostStore.FetchPostsPayload(sSite, false)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        int firstFetchPosts = mPostStore.getPagesCountForSite(mSite);
+        int firstFetchPosts = mPostStore.getPagesCountForSite(sSite);
 
         // Dangerous, will fail for a site with no pages
         assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
@@ -315,7 +315,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("A fully featured post", newPost.getTitle());
         assertEquals("Some content here! <strong>Bold text</strong>.\r\n\r\nA new paragraph.", newPost.getContent());
@@ -343,7 +343,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         PostModel newPage = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPagesCountForSite(mSite));
+        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
 
         assertNotSame(0, newPage.getRemotePostId());
 
@@ -367,7 +367,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("A post with location", mPost.getTitle());
         assertEquals("Some content", mPost.getContent());
@@ -405,7 +405,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("A post with location", mPost.getTitle());
         assertEquals("Some content", mPost.getContent());
@@ -455,14 +455,14 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POST_DELETED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(uploadedPost, mSite)));
+        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(uploadedPost, sSite)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // The post should be removed from the db (regardless of whether it was deleted or just trashed on the server)
         assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost.getId()));
         assertEquals(0, WellSqlUtils.getTotalPostsCount());
-        assertEquals(0, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
     }
 
     // Error handling tests
@@ -470,12 +470,12 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
     public void testFetchInvalidPost() throws InterruptedException {
         PostModel post = new PostModel();
         post.setRemotePostId(6420328);
-        post.setRemoteSiteId(mSite.getSiteId());
+        post.setRemoteSiteId(sSite.getSiteId());
 
         mNextEvent = TEST_EVENTS.ERROR_UNKNOWN_POST;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, mSite)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, sSite)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -501,7 +501,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         // Upload edited post
-        RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -509,7 +509,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         PostModel persistedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // The locally saved post should still be marked as locally changed, and local changes should be preserved
         assertEquals("From testEditInvalidPost", persistedPost.getTitle());
@@ -523,12 +523,12 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
     public void testDeleteInvalidRemotePost() throws InterruptedException {
         PostModel invalidPost = new PostModel();
         invalidPost.setRemotePostId(6420328);
-        invalidPost.setRemoteSiteId(mSite.getSiteId());
+        invalidPost.setRemoteSiteId(sSite.getSiteId());
 
         mNextEvent = TEST_EVENTS.ERROR_UNKNOWN_POST;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(invalidPost, mSite)));
+        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(invalidPost, sSite)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -686,7 +686,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POST_INSTANTIATED;
         mCountDownLatch = new CountDownLatch(1);
 
-        InstantiatePostPayload initPayload = new InstantiatePostPayload(mSite, false);
+        InstantiatePostPayload initPayload = new InstantiatePostPayload(sSite, false);
         mDispatcher.dispatch(PostActionBuilder.newInstantiatePostAction(initPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -696,7 +696,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POST_UPLOADED;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemotePostPayload pushPayload = new RemotePostPayload(post, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(post, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -706,7 +706,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POST_UPDATED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, mSite)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, sSite)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -913,11 +913,6 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        mNextEvent = TEST_EVENTS.POST_UPDATED;
-        mCountDownLatch = new CountDownLatch(1);
-
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchPost(PostModel post) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -40,7 +40,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
 
     private CountDownLatch mCountDownLatch;
     private PostModel mPost;
-    private static SiteModel mSite;
+    private static SiteModel sSite;
 
     private boolean mCanLoadMorePosts;
 
@@ -62,12 +62,12 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
     private TEST_EVENTS mNextEvent;
 
     {
-        mSite = new SiteModel();
-        mSite.setId(1);
-        mSite.setSelfHostedSiteId(0);
-        mSite.setUsername(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE);
-        mSite.setPassword(BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE);
-        mSite.setXmlRpcUrl(BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
+        sSite = new SiteModel();
+        sSite.setId(1);
+        sSite.setSelfHostedSiteId(0);
+        sSite.setUsername(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE);
+        sSite.setPassword(BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE);
+        sSite.setXmlRpcUrl(BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
     }
 
     @Override
@@ -96,7 +96,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertNotSame(0, uploadedPost.getRemotePostId());
         assertEquals(false, uploadedPost.isLocalDraft());
@@ -121,7 +121,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("From testEditingRemotePost", finalPost.getTitle());
 
@@ -151,7 +151,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         PostModel latestPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals(POST_DEFAULT_TITLE, latestPost.getTitle());
         assertEquals(false, latestPost.isLocallyChanged());
@@ -180,7 +180,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("From testChangingLocalDraft, redux", mPost.getTitle());
         assertEquals("Some new content", mPost.getContent());
@@ -217,7 +217,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("From testMultipleLocalChangesToUploadedPost, redux", mPost.getTitle());
         assertEquals("Some different content", mPost.getContent());
@@ -255,11 +255,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new PostStore.FetchPostsPayload(mSite, false)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new PostStore.FetchPostsPayload(sSite, false)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        int firstFetchPosts = mPostStore.getPostsCountForSite(mSite);
+        int firstFetchPosts = mPostStore.getPostsCountForSite(sSite);
 
         // Dangerous, will fail for a site with no posts
         assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
@@ -271,11 +271,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new PostStore.FetchPostsPayload(mSite, true)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new PostStore.FetchPostsPayload(sSite, true)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        int currentStoredPosts = mPostStore.getPostsCountForSite(mSite);
+        int currentStoredPosts = mPostStore.getPostsCountForSite(sSite);
 
         assertTrue(currentStoredPosts > firstFetchPosts);
         assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
@@ -285,11 +285,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.PAGES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPagesAction(new PostStore.FetchPostsPayload(mSite, false)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPagesAction(new PostStore.FetchPostsPayload(sSite, false)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        int firstFetchPosts = mPostStore.getPagesCountForSite(mSite);
+        int firstFetchPosts = mPostStore.getPagesCountForSite(sSite);
 
         // Dangerous, will fail for a site with no pages
         assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
@@ -314,7 +314,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("A fully featured post", newPost.getTitle());
         assertEquals("Some content here! <strong>Bold text</strong>.", newPost.getContent());
@@ -340,7 +340,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         PostModel newPage = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPagesCountForSite(mSite));
+        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
 
         assertNotSame(0, newPage.getRemotePostId());
 
@@ -362,7 +362,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("A post with location", mPost.getTitle());
         assertEquals("Some content", mPost.getContent());
@@ -400,7 +400,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         assertEquals("A post with location", mPost.getTitle());
         assertEquals("Some content", mPost.getContent());
@@ -450,14 +450,14 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POST_DELETED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(uploadedPost, mSite)));
+        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(uploadedPost, sSite)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // The post should be removed from the db (regardless of whether it was deleted or just trashed on the server)
         assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost.getId()));
         assertEquals(0, WellSqlUtils.getTotalPostsCount());
-        assertEquals(0, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
     }
 
     // Error handling tests
@@ -469,7 +469,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, mSite)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, sSite)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -499,7 +499,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         // Upload edited post
-        RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -507,7 +507,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         PostModel persistedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // The locally saved post should still be marked as locally changed, and local changes should be preserved
         assertEquals("From testEditInvalidPost", persistedPost.getTitle());
@@ -529,7 +529,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(invalidPost, mSite)));
+        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(invalidPost, sSite)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -551,7 +551,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         // Upload edited post
-        RemotePostPayload pushPayload = new RemotePostPayload(mPost, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(mPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -574,7 +574,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         // Upload edited post
-        RemotePostPayload pushPayload = new RemotePostPayload(mPost, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(mPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -608,7 +608,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         // Upload edited post
-        RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -616,7 +616,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         PostModel persistedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // The locally saved post should still be marked as locally changed, and local changes should be preserved
         assertEquals("From testEditInvalidPost", persistedPost.getTitle());
@@ -641,7 +641,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         // Upload edited post
-        RemotePostPayload pushPayload = new RemotePostPayload(mPost, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(mPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -672,7 +672,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         // Upload edited post
-        RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -680,7 +680,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         PostModel persistedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
+        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // The locally saved post should still be marked as locally changed, and local changes should be preserved
         assertEquals("From testEditInvalidPost", persistedPost.getTitle());
@@ -897,7 +897,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POST_INSTANTIATED;
         mCountDownLatch = new CountDownLatch(1);
 
-        InstantiatePostPayload initPayload = new InstantiatePostPayload(mSite, false);
+        InstantiatePostPayload initPayload = new InstantiatePostPayload(sSite, false);
         mDispatcher.dispatch(PostActionBuilder.newInstantiatePostAction(initPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -907,7 +907,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POST_UPLOADED;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemotePostPayload pushPayload = new RemotePostPayload(post, mSite);
+        RemotePostPayload pushPayload = new RemotePostPayload(post, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -917,7 +917,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TEST_EVENTS.POST_UPDATED;
         mCountDownLatch = new CountDownLatch(1);
 
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, mSite)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, sSite)));
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostInstantiated;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
+import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.fluxc.utils.WellSqlUtils;
 import org.wordpress.android.util.AppLog;
@@ -39,7 +40,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
 
     private CountDownLatch mCountDownLatch;
     private PostModel mPost;
-    private SiteModel mSite;
+    private static SiteModel mSite;
 
     private boolean mCanLoadMorePosts;
 
@@ -126,9 +127,6 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
 
         // The post should no longer be flagged as having local changes
         assertFalse(finalPost.isLocallyChanged());
-
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(mSite));
 
         // The date created should not have been altered by the edits
         assertFalse(finalPost.getDateCreated().isEmpty());
@@ -804,16 +802,16 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
             AppLog.i(T.API, "OnPostChanged has error: " + event.error.type + " - " + event.error.message);
             mLastPostError = event.error;
             if (mNextEvent.equals(TEST_EVENTS.ERROR_UNKNOWN_POST)) {
-                assertEquals(PostStore.PostErrorType.UNKNOWN_POST, event.error.type);
+                assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TEST_EVENTS.ERROR_UNKNOWN_POST_TYPE)) {
-                assertEquals(PostStore.PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
+                assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TEST_EVENTS.ERROR_UNAUTHORIZED)) {
-                assertEquals(PostStore.PostErrorType.UNAUTHORIZED, event.error.type);
+                assertEquals(PostErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TEST_EVENTS.ERROR_GENERIC)) {
-                assertEquals(PostStore.PostErrorType.GENERIC_ERROR, event.error.type);
+                assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             }
             return;
@@ -867,16 +865,16 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_Base {
             AppLog.i(T.API, "OnPostUploaded has error: " + event.error.type + " - " + event.error.message);
             mLastPostError = event.error;
             if (mNextEvent.equals(TEST_EVENTS.ERROR_UNKNOWN_POST)) {
-                assertEquals(PostStore.PostErrorType.UNKNOWN_POST, event.error.type);
+                assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TEST_EVENTS.ERROR_UNKNOWN_POST_TYPE)) {
-                assertEquals(PostStore.PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
+                assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TEST_EVENTS.ERROR_UNAUTHORIZED)) {
-                assertEquals(PostStore.PostErrorType.UNAUTHORIZED, event.error.type);
+                assertEquals(PostErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TEST_EVENTS.ERROR_GENERIC)) {
-                assertEquals(PostStore.PostErrorType.GENERIC_ERROR, event.error.type);
+                assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             }
             return;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
@@ -19,7 +20,7 @@ public enum PostAction implements IAction {
     FETCHED_POSTS,
     @Action(payloadType = RemotePostPayload.class)
     FETCH_POST,
-    @Action(payloadType = RemotePostPayload.class)
+    @Action(payloadType = FetchPostResponsePayload.class)
     FETCHED_POST,
     @Action(payloadType = InstantiatePostPayload.class)
     INSTANTIATE_POST,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostsResponse;
 import org.wordpress.android.fluxc.store.PostStore;
+import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
@@ -61,7 +62,7 @@ public class PostRestClient extends BaseWPComRestClient {
                         fetchedPost.setId(post.getId());
                         fetchedPost.setLocalSiteId(site.getId());
 
-                        RemotePostPayload payload = new RemotePostPayload();
+                        FetchPostResponsePayload payload = new FetchPostResponsePayload(fetchedPost, site);
                         payload.post = fetchedPost;
 
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
@@ -71,7 +72,7 @@ public class PostRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         // Possible non-generic errors: 404 unknown_post (invalid post ID)
-                        RemotePostPayload payload = new RemotePostPayload(post, site);
+                        FetchPostResponsePayload payload = new FetchPostResponsePayload(post, site);
                         payload.error = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -68,6 +68,9 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                             PostModel postModel = postResponseObjectToPostModel(response, site, post.isPage());
                             FetchPostResponsePayload payload;
                             if (postModel != null) {
+                                if (origin == PostAction.PUSH_POST) {
+                                    postModel.setId(post.getId());
+                                }
                                 payload = new FetchPostResponsePayload(postModel, site);
                             } else {
                                 payload = new FetchPostResponsePayload(post, site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -10,6 +10,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.PostAction;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.XMLRPC;
 import org.wordpress.android.fluxc.model.PostModel;
@@ -26,6 +27,7 @@ import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCUtils;
 import org.wordpress.android.fluxc.store.PostStore;
+import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
@@ -48,6 +50,10 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
     }
 
     public void fetchPost(final PostModel post, final SiteModel site) {
+        fetchPost(post, site, PostAction.FETCH_POST);
+    }
+
+    public void fetchPost(final PostModel post, final SiteModel site, final PostAction origin) {
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());
@@ -60,14 +66,16 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                     public void onResponse(Object response) {
                         if (response != null && response instanceof Map) {
                             PostModel postModel = postResponseObjectToPostModel(response, site, post.isPage());
+                            FetchPostResponsePayload payload;
                             if (postModel != null) {
-                                RemotePostPayload payload = new RemotePostPayload(postModel, site);
-                                mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
+                                payload = new FetchPostResponsePayload(postModel, site);
                             } else {
-                                RemotePostPayload payload = new RemotePostPayload(post, site);
+                                payload = new FetchPostResponsePayload(post, site);
                                 payload.error = new PostError(PostErrorType.INVALID_RESPONSE);
-                                mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
                             }
+                            payload.origin = origin;
+
+                            mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
                         }
                     }
                 }, new BaseErrorListener() {
@@ -75,7 +83,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         // Possible non-generic errors:
                         // 404 - "Invalid post ID."
-                        RemotePostPayload payload = new RemotePostPayload(post, site);
+                        FetchPostResponsePayload payload = new FetchPostResponsePayload(post, site);
                         // TODO: Check the error message and flag this as UNKNOWN_POST if applicable
                         // Convert GenericErrorType to PostErrorType where applicable
                         PostError postError;
@@ -87,6 +95,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                                 postError = new PostError(PostErrorType.GENERIC_ERROR, error.message);
                         }
                         payload.error = postError;
+                        payload.origin = origin;
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
                     }
                 });


### PR DESCRIPTION
Fixes #197, delaying the emission of `OnPostUploaded` until the db has been updated with the server's latest version of the uploaded post.

This means:

1. For XML-RPC, the `PostStore` will wait for a second server call, which fetches the uploaded post from the server, and store the result in the db before emitting `OnPostUploaded`
2. For WP.com, the `PostStore` will save the post to the db first, then emit `OnPostUploaded`

(#197 has a full breakdown of the change and the motivation behind it)

cc @maxme