### PR TITLE
Group actions together by type

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -128,7 +128,7 @@ public class SiteXMLRPCClientTest {
                 "    </param>\n" +
                 "  </params>\n" +
                 "</methodResponse>\n";
-        mSiteXMLRPCClient.pullSite(site);
+        mSiteXMLRPCClient.fetchSite(site);
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.action;
 
+import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountPushSettingsResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountRestPayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.NewAccountResponsePayload;
@@ -11,27 +12,32 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.model.AccountModel;
 
 @ActionEnum
-public enum AccountAction implements org.wordpress.android.fluxc.annotations.action.IAction {
+public enum AccountAction implements IAction {
+    // Remote actions
     @Action
     FETCH_ACCOUNT,          // request fetch of Account information
-    @Action(payloadType = AccountRestPayload.class)
-    FETCHED_ACCOUNT,        // response received from Account fetch request
     @Action
     FETCH_SETTINGS,         // request fetch of Account Settings
-    @Action(payloadType = AccountRestPayload.class)
-    FETCHED_SETTINGS,       // response received from Account Settings fetch
     @Action(payloadType = PushAccountSettingsPayload.class)
     PUSH_SETTINGS,          // request saving Account Settings remotely
+    @Action(payloadType = NewAccountPayload.class)
+    CREATE_NEW_ACCOUNT,     // create a new account (can be used to validate the account before creating it)
+
+    // Remote responses
+    @Action(payloadType = AccountRestPayload.class)
+    FETCHED_ACCOUNT,        // response received from Account fetch request
+    @Action(payloadType = AccountRestPayload.class)
+    FETCHED_SETTINGS,       // response received from Account Settings fetch
     @Action(payloadType = AccountPushSettingsResponsePayload.class)
     PUSHED_SETTINGS,        // response received from Account Settings post
+    @Action(payloadType = NewAccountResponsePayload.class)
+    CREATED_NEW_ACCOUNT,    // create a new account response
+
+    // Local actions
     @Action(payloadType = AccountModel.class)
-    UPDATE_ACCOUNT,                 // update in-memory and persisted Account in AccountStore
+    UPDATE_ACCOUNT,         // update in-memory and persisted Account in AccountStore
     @Action(payloadType = UpdateTokenPayload.class)
     UPDATE_ACCESS_TOKEN,    // update in-memory and persisted Access Token
     @Action
-    SIGN_OUT,               // delete persisted Account, reset in-memory Account, delete access token
-    @Action(payloadType = NewAccountPayload.class)
-    CREATE_NEW_ACCOUNT,     // create a new account (can be used to validate the account before creating it)
-    @Action(payloadType = NewAccountResponsePayload.class)
-    CREATED_NEW_ACCOUNT,    // create a new account response
+    SIGN_OUT                // delete persisted Account, reset in-memory Account, delete access token
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AuthenticationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AuthenticationAction.java
@@ -10,12 +10,15 @@ import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 
 @ActionEnum
 public enum AuthenticationAction implements IAction {
+    // Remote actions
     @Action(payloadType = AuthenticatePayload.class)
     AUTHENTICATE,
-    @Action(payloadType = AuthenticateErrorPayload.class)
-    AUTHENTICATE_ERROR,
     @Action(payloadType = RefreshSitesXMLRPCPayload.class)
     DISCOVER_ENDPOINT,
+
+    // Remote responses
+    @Action(payloadType = AuthenticateErrorPayload.class)
+    AUTHENTICATE_ERROR,
     @Action(payloadType = DiscoveryResultPayload.class)
-    DISCOVERY_RESULT,
+    DISCOVERY_RESULT
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -12,28 +12,33 @@ import org.wordpress.android.fluxc.store.PostStore.InstantiatePostPayload;
 
 @ActionEnum
 public enum PostAction implements IAction {
+    // Remote actions
     @Action(payloadType = FetchPostsPayload.class)
     FETCH_POSTS,
     @Action(payloadType = FetchPostsPayload.class)
     FETCH_PAGES,
-    @Action(payloadType = FetchPostsResponsePayload.class)
-    FETCHED_POSTS,
     @Action(payloadType = RemotePostPayload.class)
     FETCH_POST,
-    @Action(payloadType = FetchPostResponsePayload.class)
-    FETCHED_POST,
-    @Action(payloadType = InstantiatePostPayload.class)
-    INSTANTIATE_POST,
     @Action(payloadType = RemotePostPayload.class)
     PUSH_POST,
     @Action(payloadType = RemotePostPayload.class)
-    PUSHED_POST,
-    @Action(payloadType = PostModel.class)
-    UPDATE_POST,
-    @Action(payloadType = RemotePostPayload.class)
     DELETE_POST,
+
+    // Remote responses
+    @Action(payloadType = FetchPostsResponsePayload.class)
+    FETCHED_POSTS,
+    @Action(payloadType = FetchPostResponsePayload.class)
+    FETCHED_POST,
+    @Action(payloadType = RemotePostPayload.class)
+    PUSHED_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETED_POST,
+
+    // Local actions
+    @Action(payloadType = InstantiatePostPayload.class)
+    INSTANTIATE_POST,
+    @Action(payloadType = PostModel.class)
+    UPDATE_POST,
     @Action(payloadType = PostModel.class)
     REMOVE_POST
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.action;
 
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
+import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
@@ -10,13 +11,26 @@ import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 
 @ActionEnum
-public enum SiteAction implements org.wordpress.android.fluxc.annotations.action.IAction {
+public enum SiteAction implements IAction {
+    // Remote actions
     @Action(payloadType = SiteModel.class)
     FETCH_SITE,
     @Action
     FETCH_SITES,
     @Action(payloadType = RefreshSitesXMLRPCPayload.class)
     FETCH_SITES_XML_RPC,
+    @Action(payloadType = NewSitePayload.class)
+    CREATE_NEW_SITE,
+    @Action(payloadType = SiteModel.class)
+    FETCH_POST_FORMATS,
+
+    // Remote responses
+    @Action(payloadType = NewSiteResponsePayload.class)
+    CREATED_NEW_SITE,
+    @Action(payloadType = FetchedPostFormatsPayload.class)
+    FETCHED_POST_FORMATS,
+
+    // Local actions
     @Action(payloadType = SiteModel.class)
     UPDATE_SITE,
     @Action(payloadType = SitesModel.class)
@@ -29,12 +43,4 @@ public enum SiteAction implements org.wordpress.android.fluxc.annotations.action
     SHOW_SITES,
     @Action(payloadType = SitesModel.class)
     HIDE_SITES,
-    @Action(payloadType = NewSitePayload.class)
-    CREATE_NEW_SITE,
-    @Action(payloadType = NewSiteResponsePayload.class)
-    CREATED_NEW_SITE,
-    @Action(payloadType = SiteModel.class)
-    FETCH_POST_FORMATS,
-    @Action(payloadType = FetchedPostFormatsPayload.class)
-    FETCHED_POST_FORMATS,
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -135,7 +135,7 @@ public class AccountRestClient extends BaseWPComRestClient {
      *
      * No HTTP POST call is made if the given parameter map is null or contains no entries.
      */
-    public void postAccountSettings(Map<String, Object> body) {
+    public void pushAccountSettings(Map<String, Object> body) {
         if (body == null || body.isEmpty()) return;
         String url = WPCOMREST.me.settings.getUrlV1_1();
         // Note: we have to use a HashMap as a response here because the API response format is different depending

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -56,7 +56,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         mAppSecrets = appSecrets;
     }
 
-    public void pullSites() {
+    public void fetchSites() {
         String url = WPCOMREST.me.sites.getUrlV1_1();
         final WPComGsonRequest<SitesResponse> request = WPComGsonRequest.buildGetRequest(url, null,
                 SitesResponse.class,
@@ -83,7 +83,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void pullSite(final SiteModel site) {
+    public void fetchSite(final SiteModel site) {
         String url = WPCOMREST.sites.getUrlV1_1() + site.getSiteId();
         final WPComGsonRequest<SiteWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,
                 SiteWPComRestResponse.class,
@@ -142,7 +142,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void pullPostFormats(@NonNull final SiteModel site) {
+    public void fetchPostFormats(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).post_formats.getUrlV1_1();
         final WPComGsonRequest<PostFormatsResponse> request = WPComGsonRequest.buildGetRequest(url, null,
                 PostFormatsResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -33,7 +33,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
     }
 
-    public void pullSites(final String xmlrpcUrl, final String username, final String password) {
+    public void fetchSites(final String xmlrpcUrl, final String username, final String password) {
         List<Object> params = new ArrayList<>(2);
         params.add(username);
         params.add(password);
@@ -78,7 +78,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         XMLRPC_BLOG_OPTIONS.put("time_zone", "time_zone");
     }
 
-    public void pullSite(final SiteModel site) {
+    public void fetchSite(final SiteModel site) {
         List<Object> params = new ArrayList<>(2);
         params.add(site.getSiteId());
         params.add(site.getUsername());
@@ -105,8 +105,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    // TODO: rename s/pull/fetch/ methods in this file
-    public void pullPostFormats(final SiteModel site) {
+    public void fetchPostFormats(final SiteModel site) {
         List<Object> params = new ArrayList<>(2);
         params.add(site.getSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -246,7 +246,7 @@ public class AccountStore extends Store {
                 mAccountRestClient.fetchAccountSettings();
                 break;
             case PUSH_SETTINGS:
-                mAccountRestClient.postAccountSettings(((PushAccountSettingsPayload) payload).params);
+                mAccountRestClient.pushAccountSettings(((PushAccountSettingsPayload) payload).params);
                 break;
             case UPDATE_ACCOUNT:
                 updateDefaultAccount((AccountModel) payload, AccountAction.UPDATE_ACCOUNT);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -513,7 +513,7 @@ public class SiteStore extends Store {
                 fetchSite((SiteModel) action.getPayload());
                 break;
             case FETCH_SITES:
-                mSiteRestClient.pullSites();
+                mSiteRestClient.fetchSites();
                 break;
             case FETCH_SITES_XML_RPC:
                 fetchSitesXmlRpc((RefreshSitesXMLRPCPayload) action.getPayload());
@@ -560,7 +560,7 @@ public class SiteStore extends Store {
     }
 
     private void removeWPComSites() {
-        // Logging out of WP.com. Drop all WP.com sites, and all Jetpack sites that were pulled over the WP.com
+        // Logging out of WP.com. Drop all WP.com sites, and all Jetpack sites that were fetched over the WP.com
         // REST API only (they don't have a .org site id)
         List<SiteModel> wpcomSites = SiteSqlUtils.getAllWPComSites();
         int rowsAffected = removeSites(wpcomSites);
@@ -582,21 +582,21 @@ public class SiteStore extends Store {
 
     private void fetchSite(SiteModel site) {
         if (site.isWPCom()) {
-            mSiteRestClient.pullSite(site);
+            mSiteRestClient.fetchSite(site);
         } else {
-            mSiteXMLRPCClient.pullSite(site);
+            mSiteXMLRPCClient.fetchSite(site);
         }
     }
 
     private void fetchSitesXmlRpc(RefreshSitesXMLRPCPayload payload) {
-        mSiteXMLRPCClient.pullSites(payload.url, payload.username, payload.password);
+        mSiteXMLRPCClient.fetchSites(payload.url, payload.username, payload.password);
     }
 
     private void fetchPostFormats(SiteModel site) {
         if (site.isWPCom()) {
-            mSiteRestClient.pullPostFormats(site);
+            mSiteRestClient.fetchPostFormats(site);
         } else {
-            mSiteXMLRPCClient.pullPostFormats(site);
+            mSiteXMLRPCClient.fetchPostFormats(site);
         }
     }
 


### PR DESCRIPTION
Groups actions together into remote actions, remote responses, and local actions, following the style we're using for [`MediaStore`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/6ebb6642f930a9efe790db56acdf55f784917d18/fluxc/src/main/java/org/wordpress/android/fluxc/action/MediaAction.java).

The 'remote responses' are the actions we'd like to move to separate, internal-only events, so they're not exposed to FluxC clients. (https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/53)

Also renamed some `pull` methods to `fetch` and a `post` method to `push` for consistency across all network methods.