### PR TITLE
 Example app: add some comment actions

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -89,6 +89,11 @@ public class CommentsFragment extends Fragment {
     }
 
     private CommentModel getFirstComment() {
+        List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), CommentStatus.ALL);
+        if (comments.size() == 0) {
+            prependToLog("There is no comments on this site or comments haven't been fetched.");
+            return null;
+        }
         return mCommentStore.getCommentsForSite(getFirstSite(), CommentStatus.ALL).get(0);
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -25,6 +25,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ToastUtils;
 
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -102,7 +103,7 @@ public class CommentsFragment extends Fragment {
         mDispatcher.dispatch(CommentActionBuilder.newInstantiateCommentAction(payload));
         try {
             assertEquals(true, mCountDownLatch.await(2, TimeUnit.SECONDS));
-            mNewComment.setContent("I'm a new comment from the FluxC example app.");
+            mNewComment.setContent("I'm a new comment id: " + new Random().nextLong() + " from FluxC Example App");
             mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(
                     new RemoteCreateCommentPayload(getFirstSite(), getFirstComment(), mNewComment)
             ));

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -4,19 +4,44 @@ import android.app.Fragment;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 
 import org.greenrobot.eventbus.Subscribe;
-import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.CommentActionBuilder;
+import org.wordpress.android.fluxc.model.CommentModel;
+import org.wordpress.android.fluxc.model.CommentStatus;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.CommentStore;
+import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsPayload;
+import org.wordpress.android.fluxc.store.CommentStore.InstantiateCommentPayload;
+import org.wordpress.android.fluxc.store.CommentStore.OnCommentChanged;
+import org.wordpress.android.fluxc.store.CommentStore.OnCommentInstantiated;
+import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
-import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.ToastUtils;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static junit.framework.Assert.assertEquals;
+
 public class CommentsFragment extends Fragment {
     @Inject SiteStore mSiteStore;
+    @Inject CommentStore mCommentStore;
     @Inject Dispatcher mDispatcher;
+
+    private CommentModel mFirstComment;
+
+    // Needed for instantiate action :/
+    private CommentModel mNewComment;
+    private CountDownLatch mCountDownLatch;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -29,6 +54,22 @@ public class CommentsFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_comments, container, false);
+        view.findViewById(R.id.fetch_comments).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                fetchCommentsFirstSite();
+            }
+        });
+        view.findViewById(R.id.reply_to_comment).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mFirstComment == null) {
+                    ToastUtils.showToast(getActivity(), "Fetch comments first");
+                    return;
+                }
+                replyToFirstComment();
+            }
+        });
         return view;
     }
 
@@ -44,8 +85,52 @@ public class CommentsFragment extends Fragment {
         mDispatcher.unregister(this);
     }
 
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSiteChanged(OnSiteChanged event) {
+    private SiteModel getFirstSite() {
+        return mSiteStore.getSites().get(0);
+    }
+
+    private void fetchCommentsFirstSite() {
+        mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(
+                new FetchCommentsPayload(getFirstSite(), 5, 0)));
+    }
+
+    private void replyToFirstComment() {
+        InstantiateCommentPayload payload = new InstantiateCommentPayload(getFirstSite());
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(CommentActionBuilder.newInstantiateCommentAction(payload));
+        try {
+            assertEquals(true, mCountDownLatch.await(2, TimeUnit.SECONDS));
+            mNewComment.setContent("I'm a new comment from the FluxC example app.");
+            mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(
+                    new RemoteCreateCommentPayload(getFirstSite(), mFirstComment, mNewComment)
+            ));
+        } catch (Exception e) {
+            // noop
+        }
+    }
+
+    @Subscribe
+    public void onCommentChanged(OnCommentChanged event) {
+        prependToLog("OnCommentChanged: rowsAffected=" + event.rowsAffected);
+        if (event.isError()) {
+            String error = "Error: " + event.error.type + " - " + event.error.message;
+            prependToLog(error);
+            AppLog.i(T.TESTS, error);
+        } else {
+            List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), CommentStatus.ALL);
+            for (CommentModel comment : comments) {
+                if (mFirstComment == null) {
+                    mFirstComment = comment;
+                }
+                prependToLog(comment.getAuthorName() + " @" + comment.getDatePublished());
+            }
+        }
+    }
+
+    @Subscribe
+    public void onCommentInstantiated(OnCommentInstantiated event) {
+        mNewComment = event.comment;
+        mCountDownLatch.countDown();
     }
 
     private void prependToLog(final String s) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -37,8 +37,6 @@ public class CommentsFragment extends Fragment {
     @Inject CommentStore mCommentStore;
     @Inject Dispatcher mDispatcher;
 
-    private CommentModel mFirstComment;
-
     // Needed for instantiate action :/
     private CommentModel mNewComment;
     private CountDownLatch mCountDownLatch;
@@ -63,7 +61,7 @@ public class CommentsFragment extends Fragment {
         view.findViewById(R.id.reply_to_comment).setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (mFirstComment == null) {
+                if (getFirstComment() == null) {
                     ToastUtils.showToast(getActivity(), "Fetch comments first");
                     return;
                 }
@@ -89,6 +87,10 @@ public class CommentsFragment extends Fragment {
         return mSiteStore.getSites().get(0);
     }
 
+    private CommentModel getFirstComment() {
+        return mCommentStore.getCommentsForSite(getFirstSite(), CommentStatus.ALL).get(0);
+    }
+
     private void fetchCommentsFirstSite() {
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(
                 new FetchCommentsPayload(getFirstSite(), 5, 0)));
@@ -102,7 +104,7 @@ public class CommentsFragment extends Fragment {
             assertEquals(true, mCountDownLatch.await(2, TimeUnit.SECONDS));
             mNewComment.setContent("I'm a new comment from the FluxC example app.");
             mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(
-                    new RemoteCreateCommentPayload(getFirstSite(), mFirstComment, mNewComment)
+                    new RemoteCreateCommentPayload(getFirstSite(), getFirstComment(), mNewComment)
             ));
         } catch (Exception e) {
             // noop
@@ -119,9 +121,6 @@ public class CommentsFragment extends Fragment {
         } else {
             List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), CommentStatus.ALL);
             for (CommentModel comment : comments) {
-                if (mFirstComment == null) {
-                    mFirstComment = comment;
-                }
                 prependToLog(comment.getAuthorName() + " @" + comment.getDatePublished());
             }
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.text.method.ScrollingMovementMethod;
 import android.widget.TextView;
 
-
 public class MainExampleActivity extends Activity {
     private TextView mLogView;
 

--- a/example/src/main/res/layout/fragment_comments.xml
+++ b/example/src/main/res/layout/fragment_comments.xml
@@ -5,5 +5,16 @@
               android:orientation="vertical"
               tools:context="org.wordpress.android.fluxc.example.CommentsFragment">
 
+    <Button
+        android:id="@+id/fetch_comments"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch comments from first site" />
+
+    <Button
+        android:id="@+id/reply_to_comment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Reply to first comment" />
 
 </LinearLayout>


### PR DESCRIPTION
Add comment actions to the example app.

@oguzkocer I fixed your comments on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/202