### PR TITLE
Fix #206 faster app startup

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
@@ -154,7 +154,9 @@ public class MemorizingTrustManager implements X509TrustManager {
     }
 
     public X509Certificate[] getAcceptedIssuers() {
-        return mDefaultTrustManager.getAcceptedIssuers();
+        // return mDefaultTrustManager.getAcceptedIssuers();
+        // ^ Original code is super slow (~1200 msecs) - Return an empty list since it seems unused by OkHttp.
+        return new X509Certificate[0];
     }
 
     public X509Certificate getLastFailure() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
@@ -32,7 +32,7 @@ import javax.net.ssl.X509TrustManager;
 public class MemorizingTrustManager implements X509TrustManager {
     private static final String KEYSTORE_FILENAME = "wpstore_certs_truststore.bks";
     private static final String KEYSTORE_PASSWORD = "secret";
-    private static final long FUTURE_TASK_TIMEOUT_SECONDS = 5;
+    private static final long FUTURE_TASK_TIMEOUT_SECONDS = 10;
 
     private FutureTask<X509TrustManager> mTrustManagerFutureTask;
     private FutureTask<KeyStore> mLocalKeyStoreFutureTask;
@@ -61,8 +61,7 @@ public class MemorizingTrustManager implements X509TrustManager {
         try {
             return mLocalKeyStoreFutureTask.get(FUTURE_TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            throw new IllegalStateException("Couldn't find X509TrustManager");
-            // no op
+            throw new IllegalStateException("Couldn't find KeyStore");
         }
     }
 
@@ -72,7 +71,6 @@ public class MemorizingTrustManager implements X509TrustManager {
             return mTrustManagerFutureTask.get(FUTURE_TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new IllegalStateException("Couldn't find X509TrustManager");
-            // no op
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
@@ -64,7 +64,8 @@ public class MemorizingTrustManager implements X509TrustManager {
         executorService.execute(mTrustManagerFutureTask);
     }
 
-    private @NonNull X509TrustManager getDefaultTrustManager() {
+    @NonNull
+    private X509TrustManager getDefaultTrustManager() {
         try {
             return mTrustManagerFutureTask.get(TRUST_MANAGER_FUTURE_TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {


### PR DESCRIPTION
Fix #206 faster app startup:

* Return an empty list when `getAcceptedIssuers()` is called (original code takes ~1200ms)
* Wrap the keyStore init (~400ms) in a FutureTask, so the injection itself is pretty fast (that won't make the time to first network call faster but that's not really a problem)