### PR TITLE
Support mixed endpoints in the endpoint processor

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -22,6 +22,7 @@ public class WPComEndpointTest {
         assertEquals("/sites/56/posts/78/", WPCOMREST.sites.site(56).posts.post(78).getEndpoint());
         assertEquals("/sites/56/posts/78/delete/", WPCOMREST.sites.site(56).posts.post(78).delete.getEndpoint());
         assertEquals("/sites/56/posts/new/", WPCOMREST.sites.site(56).posts.new_.getEndpoint());
+        assertEquals("/sites/56/posts/slug:fluxc/", WPCOMREST.sites.site(56).posts.slug("fluxc").getEndpoint());
 
         // Sites - Media
         assertEquals("/sites/56/media/", WPCOMREST.sites.site(56).media.getEndpoint());
@@ -34,6 +35,8 @@ public class WPComEndpointTest {
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.getEndpoint());
         assertEquals("/sites/56/taxonomies/category/terms/new/",
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.new_.getEndpoint());
+        assertEquals("/sites/56/taxonomies/category/terms/slug:fluxc/",
+                WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.slug("fluxc").getEndpoint());
         assertEquals("/sites/56/taxonomies/post_tag/terms/",
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("post_tag").terms.getEndpoint());
         assertEquals("/sites/56/taxonomies/post_tag/terms/new/",

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
@@ -68,7 +68,12 @@ public class EndpointNode {
     }
 
     public String getCleanEndpointName() {
-        return getLocalEndpoint().replaceAll("/|\\$|#.*|_ID|_id", "").replaceAll("-", "_");
+        if (getLocalEndpoint().contains(":")) {
+            // For 'mixed' endpoints, e.g. item:$theItem, return the label part ('item')
+            return getLocalEndpoint().substring(0, getLocalEndpoint().indexOf(":")).replaceAll("-", "_");
+        } else {
+            return getLocalEndpoint().replaceAll("/|\\$|#.*|_ID|_id", "").replaceAll("-", "_");
+        }
     }
 
     public List<String> getEndpointTypes() {

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -124,7 +124,7 @@ public class RESTPoet {
 
         if (!endpointNode.hasChildren()) {
             // Build annotated accessor method for variable endpoint and add it to the class
-            List<MethodSpec> endpointMethods = generateEndpointMethodsForClass(endpointNode, sBaseEndpointClass);
+            List<MethodSpec> endpointMethods = generateEndpointMethods(endpointNode, sBaseEndpointClass);
 
             for (MethodSpec endpointMethod : endpointMethods) {
                 classBuilder.addMethod(endpointMethod);
@@ -158,7 +158,7 @@ public class RESTPoet {
             TypeName endpointClassName = ClassName.get("", innerClassName);
 
             // Build annotated accessor method for variable endpoint
-            List<MethodSpec> endpointMethods = generateEndpointMethodsForClass(endpointNode, endpointClassName);
+            List<MethodSpec> endpointMethods = generateEndpointMethods(endpointNode, endpointClassName);
 
             for (EndpointNode childEndpoint : endpointNode.getChildren()) {
                 addEndpointToBuilder(childEndpoint, endpointClassBuilder);
@@ -172,7 +172,7 @@ public class RESTPoet {
         }
     }
 
-    private static List<MethodSpec> generateEndpointMethodsForClass(EndpointNode endpointNode, TypeName endpointClassName) {
+    private static List<MethodSpec> generateEndpointMethods(EndpointNode endpointNode, TypeName endpointClassName) {
         List<MethodSpec> endpointMethods = new ArrayList<>();
 
         for (Class endpointType : getVariableEndpointTypes(endpointNode)) {

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -11,6 +11,7 @@
 /sites/$site/posts/$post_ID/delete/
 /sites/$site/posts/$post_ID/replies/new
 /sites/$site/posts/new/
+/sites/$site/posts/slug:$post_slug#String/
 
 /sites/$site/media/
 /sites/$site/media/$media_ID/
@@ -26,5 +27,6 @@
 
 /sites/$site/taxonomies/$taxonomy#String/terms/
 /sites/$site/taxonomies/$taxonomy#String/terms/new/
+/sites/$site/taxonomies/$taxonomy#String/terms/slug:$slug#String/
 
 /users/new/


### PR DESCRIPTION
Addresses item 1 in #128:

> Support endpoints of type `/sites/$site/posts/slug:$post_slug`

I'm implementing this a bit earlier than expected since TaxonomyStore will need the [`/sites/$site/taxonomies/$taxonomy/terms/slug:$slug/` endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/taxonomies/%24taxonomy/terms/slug:%24slug/).

Here are some extra test cases I checked against to verify other possible configurations for mixed endpoints:

```
/other:$otherThing/
/place:$place/unknown/
/magic/pony:$pony/new/
-----------
assertEquals("/other:42/", WPCOMREST.other(42).getEndpoint());
assertEquals("/place:42/unknown/", WPCOMREST.place(42).unknown.getEndpoint());
assertEquals("/magic/pony:42/new/", WPCOMREST.magic.pony(42).new_.getEndpoint());
```

(Those + the real endpoints cover all permutations of root/non-root, and children/no-children - as well as checking that both `String` and `long` are supported for mixed endpoints.)

cc @maxme