### PR TITLE
TaxonomyStore implementation

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -22,13 +22,15 @@ import dagger.Component;
 public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_AccountTest test);
     void inject(ReleaseStack_AccountAvailabilityTest test);
-    void inject(ReleaseStack_DiscoveryTest test);
-    void inject(ReleaseStack_PostTestWPCom test);
-    void inject(ReleaseStack_PostTestXMLRPC test);
     void inject(ReleaseStack_CommentTestWPCom test);
     void inject(ReleaseStack_CommentTestXMLRPC test);
-    void inject(ReleaseStack_SiteTestXMLRPC test);
-    void inject(ReleaseStack_SiteTestWPCom test);
+    void inject(ReleaseStack_DiscoveryTest test);
     void inject(ReleaseStack_MediaTestWPCom test);
     void inject(ReleaseStack_MediaTestXMLRPC test);
+    void inject(ReleaseStack_PostTestWPCom test);
+    void inject(ReleaseStack_PostTestXMLRPC test);
+    void inject(ReleaseStack_SiteTestWPCom test);
+    void inject(ReleaseStack_SiteTestXMLRPC test);
+    void inject(ReleaseStack_TaxonomyTestWPCom test);
+    void inject(ReleaseStack_TaxonomyTestXMLRPC test);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -100,14 +100,14 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
 
         TermModel term = new TermModel();
-        term.setTaxonomy("category");
+        term.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
         term.setSlug("uncategorized");
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermAction(new RemoteTermPayload(term, sSite)));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        TermModel fetchedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+        TermModel fetchedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
         assertEquals("uncategorized", fetchedTerm.getSlug());
         assertNotSame(0, fetchedTerm.getRemoteTermId());
@@ -121,10 +121,10 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         // Upload new term to site
         uploadTerm(mTerm);
 
-        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+        TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "category").size());
+        assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
 
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
@@ -137,17 +137,17 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         // Upload new term to site
         uploadTerm(mTerm);
 
-        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "post_tag").get(0);
+        TermModel uploadedTerm = mTaxonomyStore.getTagsForSite(sSite).get(0);
 
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "post_tag").size());
+        assertEquals(1, mTaxonomyStore.getTagsForSite(sSite).size());
 
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
         TaxonomyModel taxonomyModel = new TaxonomyModel();
-        taxonomyModel.setName("category");
+        taxonomyModel.setName(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
 
         // Instantiate new term
         createNewTerm(taxonomyModel);
@@ -156,10 +156,10 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         // Upload new term to site
         uploadTerm(mTerm);
 
-        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+        TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "category").size());
+        assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
 
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -204,6 +204,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     // TODO: Add tests for existing custom taxonomies
 
+    @SuppressWarnings("unused")
     @Subscribe
     public void onTaxonomyChanged(OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
@@ -249,6 +250,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe
     public void onTermUploaded(OnTermUploaded event) {
         AppLog.i(T.API, "Received OnTermUploaded");
@@ -275,6 +277,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch.countDown();
     }
 
+    @SuppressWarnings("unused")
     @Subscribe
     public void onTermInstantiated(OnTermInstantiated event) {
         AppLog.i(T.API, "Received OnTermInstantiated");

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -1,0 +1,179 @@
+package org.wordpress.android.fluxc.release;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TaxonomyModel;
+import org.wordpress.android.fluxc.model.TermModel;
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_Base {
+    @Inject Dispatcher mDispatcher;
+    @Inject AccountStore mAccountStore;
+    @Inject SiteStore mSiteStore;
+    @Inject TaxonomyStore mTaxonomyStore;
+
+    private CountDownLatch mCountDownLatch;
+    private static SiteModel sSite;
+
+    private enum TEST_EVENTS {
+        NONE,
+        SITE_CHANGED,
+        CATEGORIES_FETCHED,
+        TAGS_FETCHED,
+        TERMS_FETCHED,
+        ERROR_INVALID_TAXONOMY,
+        ERROR_UNAUTHORIZED,
+        ERROR_GENERIC
+    }
+    private TEST_EVENTS mNextEvent;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mReleaseStackAppComponent.inject(this);
+        // Register
+        mDispatcher.register(this);
+        // Reset expected test event
+        mNextEvent = TEST_EVENTS.NONE;
+
+        if (mAccountStore.getAccessToken().isEmpty()) {
+            authenticate();
+        }
+
+        if (sSite == null) {
+            fetchSites();
+            sSite = mSiteStore.getSites().get(0);
+        }
+    }
+
+    public void testFetchCategories() throws InterruptedException {
+        mNextEvent = TEST_EVENTS.CATEGORIES_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(sSite));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        List<TermModel> categories = mTaxonomyStore.getCategoriesForSite(sSite);
+        assertTrue(categories.size() > 0);
+    }
+
+    public void testFetchTags() throws InterruptedException {
+        mNextEvent = TEST_EVENTS.TAGS_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTagsAction(sSite));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        List<TermModel> tags = mTaxonomyStore.getTagsForSite(sSite);
+        assertTrue(tags.size() > 0);
+    }
+
+    public void testFetchTermsForInvalidTaxonomy() throws InterruptedException {
+        mNextEvent = TEST_EVENTS.ERROR_INVALID_TAXONOMY;
+        mCountDownLatch = new CountDownLatch(1);
+
+        TaxonomyModel taxonomyModel = new TaxonomyModel();
+        taxonomyModel.setName("roads");
+
+        FetchTermsPayload payload = new FetchTermsPayload(sSite, taxonomyModel);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermsAction(payload));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void authenticate() throws InterruptedException {
+        // Authenticate a test user (actual credentials declared in gradle.properties)
+        AccountStore.AuthenticatePayload payload =
+                new AccountStore.AuthenticatePayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
+                        BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        mCountDownLatch = new CountDownLatch(1);
+
+        // Correct user we should get an OnAuthenticationChanged message
+        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
+        // Wait for a network response / onChanged event
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void fetchSites() throws InterruptedException {
+        // Fetch sites from REST API, and wait for onSiteChanged event
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TEST_EVENTS.SITE_CHANGED;
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Subscribe
+    public void onAuthenticationChanged(AccountStore.OnAuthenticationChanged event) {
+        assertFalse(event.isError());
+        mCountDownLatch.countDown();
+    }
+
+    @Subscribe
+    public void onSiteChanged(SiteStore.OnSiteChanged event) {
+        AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
+        if (event.isError()) {
+            AppLog.i(T.TESTS, "event error type: " + event.error.type);
+            return;
+        }
+        assertTrue(mSiteStore.hasSite());
+        assertTrue(mSiteStore.hasWPComSite());
+        assertEquals(TEST_EVENTS.SITE_CHANGED, mNextEvent);
+        mCountDownLatch.countDown();
+    }
+
+    @Subscribe
+    public void onTaxonomyChanged(TaxonomyStore.OnTaxonomyChanged event) {
+        AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
+        if (event.isError()) {
+            AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);
+            if (mNextEvent.equals(TEST_EVENTS.ERROR_INVALID_TAXONOMY)) {
+                assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                mCountDownLatch.countDown();
+            } else if (mNextEvent.equals(TEST_EVENTS.ERROR_GENERIC)) {
+                assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                mCountDownLatch.countDown();
+            }
+            return;
+        }
+        switch (event.causeOfChange) {
+            case FETCH_CATEGORIES:
+                if (mNextEvent.equals(TEST_EVENTS.CATEGORIES_FETCHED)) {
+                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " categories");
+                    mCountDownLatch.countDown();
+                }
+                break;
+            case FETCH_TAGS:
+                if (mNextEvent.equals(TEST_EVENTS.TAGS_FETCHED)) {
+                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " tags");
+                    mCountDownLatch.countDown();
+                }
+                break;
+            case FETCH_TERMS:
+                if (mNextEvent.equals(TEST_EVENTS.TERMS_FETCHED)) {
+                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " " + event.taxonomyName + " terms");
+                    mCountDownLatch.countDown();
+                }
+        }
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
@@ -7,7 +8,10 @@ import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.InstantiateTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermInstantiated;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
 import org.wordpress.android.fluxc.utils.WellSqlUtils;
@@ -23,18 +27,24 @@ import javax.inject.Inject;
 public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     @Inject TaxonomyStore mTaxonomyStore;
 
+    private static final String TERM_DEFAULT_NAME = "fluxc-example";
+    private static final String TERM_DEFAULT_DESCRIPTION = "A term from FluxC";
+
     private enum TestEvents {
         NONE,
         CATEGORIES_FETCHED,
         TAGS_FETCHED,
         TERMS_FETCHED,
         TERM_UPDATED,
+        TERM_INSTANTIATED,
+        TERM_UPLOADED,
         ERROR_INVALID_TAXONOMY,
         ERROR_UNAUTHORIZED,
         ERROR_GENERIC
     }
 
     private TestEvents mNextEvent;
+    private TermModel mTerm;
 
     @Override
     protected void setUp() throws Exception {
@@ -102,6 +112,57 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, fetchedTerm.getRemoteTermId());
     }
 
+    public void testUploadNewCategory() throws InterruptedException {
+        // Instantiate new category
+        createNewCategory();
+        setupTermAttributes();
+
+        // Upload new term to site
+        uploadTerm(mTerm);
+
+        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "category").size());
+
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+    }
+
+    public void testUploadNewTag() throws InterruptedException {
+        // Instantiate new tag
+        createNewTag();
+        setupTermAttributes();
+
+        // Upload new term to site
+        uploadTerm(mTerm);
+
+        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "post_tag").get(0);
+
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "post_tag").size());
+
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+    }
+
+    public void testUploadNewCategoryAsTerm() throws InterruptedException {
+        TaxonomyModel taxonomyModel = new TaxonomyModel();
+        taxonomyModel.setName("category");
+
+        // Instantiate new term
+        createNewTerm(taxonomyModel);
+        setupTermAttributes();
+
+        // Upload new term to site
+        uploadTerm(mTerm);
+
+        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "category").size());
+
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+    }
+
     @Subscribe
     public void onTaxonomyChanged(OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
@@ -142,5 +203,84 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
                 }
                 break;
         }
+    }
+
+    @Subscribe
+    public void onTermUploaded(OnTermUploaded event) {
+        AppLog.i(T.API, "Received OnTermUploaded");
+        if (event.isError()) {
+            AppLog.i(T.API, "OnTermUploaded has error: " + event.error.type + " - " + event.error.message);
+            if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
+                assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                mCountDownLatch.countDown();
+            } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
+                assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                mCountDownLatch.countDown();
+            }
+            return;
+        }
+        assertEquals(TestEvents.TERM_UPLOADED, mNextEvent);
+        assertNotSame(0, event.term.getRemoteTermId());
+
+        mCountDownLatch.countDown();
+    }
+
+    @Subscribe
+    public void onTermInstantiated(OnTermInstantiated event) {
+        AppLog.i(T.API, "Received OnTermInstantiated");
+        assertEquals(TestEvents.TERM_INSTANTIATED, mNextEvent);
+
+        assertEquals(0, event.term.getRemoteTermId());
+        assertNotSame(0, event.term.getId());
+        assertNotSame(0, event.term.getLocalSiteId());
+
+        mTerm = event.term;
+        mCountDownLatch.countDown();
+    }
+
+    private void setupTermAttributes() {
+        mTerm.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
+        mTerm.setDescription(TERM_DEFAULT_DESCRIPTION);
+    }
+
+    private void createNewCategory() throws InterruptedException {
+        // Instantiate new category
+        mNextEvent = TestEvents.TERM_INSTANTIATED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateCategoryAction(sSite));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void createNewTag() throws InterruptedException {
+        // Instantiate new tag
+        mNextEvent = TestEvents.TERM_INSTANTIATED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTagAction(sSite));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
+        // Instantiate new term
+        mNextEvent = TestEvents.TERM_INSTANTIATED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        InstantiateTermPayload payload = new InstantiateTermPayload(sSite, taxonomy);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTermAction(payload));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void uploadTerm(TermModel term) throws InterruptedException {
+        mNextEvent = TestEvents.TERM_UPLOADED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -1,19 +1,13 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
-import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
-import org.wordpress.android.fluxc.example.BuildConfig;
-import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
-import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
-import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
-import org.wordpress.android.fluxc.store.AccountStore;
-import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
 import org.wordpress.android.fluxc.utils.WellSqlUtils;
@@ -26,18 +20,11 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_Base {
-    @Inject Dispatcher mDispatcher;
-    @Inject AccountStore mAccountStore;
-    @Inject SiteStore mSiteStore;
+public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     @Inject TaxonomyStore mTaxonomyStore;
 
-    private CountDownLatch mCountDownLatch;
-    private static SiteModel sSite;
-
-    private enum TEST_EVENTS {
+    private enum TestEvents {
         NONE,
-        SITE_CHANGED,
         CATEGORIES_FETCHED,
         TAGS_FETCHED,
         TERMS_FETCHED,
@@ -46,29 +33,22 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_Base {
         ERROR_UNAUTHORIZED,
         ERROR_GENERIC
     }
-    private TEST_EVENTS mNextEvent;
+
+    private TestEvents mNextEvent;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
-        // Register
-        mDispatcher.register(this);
-        // Reset expected test event
-        mNextEvent = TEST_EVENTS.NONE;
 
-        if (mAccountStore.getAccessToken().isEmpty()) {
-            authenticate();
-        }
-
-        if (sSite == null) {
-            fetchSites();
-            sSite = mSiteStore.getSites().get(0);
-        }
+        // Authenticate, fetch sites and initialize sSite
+        init();
+        // Init mNextEvent
+        mNextEvent = TestEvents.NONE;
     }
 
     public void testFetchCategories() throws InterruptedException {
-        mNextEvent = TEST_EVENTS.CATEGORIES_FETCHED;
+        mNextEvent = TestEvents.CATEGORIES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(sSite));
@@ -80,7 +60,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_Base {
     }
 
     public void testFetchTags() throws InterruptedException {
-        mNextEvent = TEST_EVENTS.TAGS_FETCHED;
+        mNextEvent = TestEvents.TAGS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTagsAction(sSite));
@@ -92,7 +72,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_Base {
     }
 
     public void testFetchTermsForInvalidTaxonomy() throws InterruptedException {
-        mNextEvent = TEST_EVENTS.ERROR_INVALID_TAXONOMY;
+        mNextEvent = TestEvents.ERROR_INVALID_TAXONOMY;
         mCountDownLatch = new CountDownLatch(1);
 
         TaxonomyModel taxonomyModel = new TaxonomyModel();
@@ -105,7 +85,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_Base {
     }
 
     public void testFetchSingleCategory() throws InterruptedException {
-        mNextEvent = TEST_EVENTS.TERM_UPDATED;
+        mNextEvent = TestEvents.TERM_UPDATED;
         mCountDownLatch = new CountDownLatch(1);
 
         TermModel term = new TermModel();
@@ -122,56 +102,15 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_Base {
         assertNotSame(0, fetchedTerm.getRemoteTermId());
     }
 
-    private void authenticate() throws InterruptedException {
-        // Authenticate a test user (actual credentials declared in gradle.properties)
-        AccountStore.AuthenticatePayload payload =
-                new AccountStore.AuthenticatePayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
-                        BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
-        mCountDownLatch = new CountDownLatch(1);
-
-        // Correct user we should get an OnAuthenticationChanged message
-        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
-        // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    private void fetchSites() throws InterruptedException {
-        // Fetch sites from REST API, and wait for onSiteChanged event
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TEST_EVENTS.SITE_CHANGED;
-        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
     @Subscribe
-    public void onAuthenticationChanged(AccountStore.OnAuthenticationChanged event) {
-        assertFalse(event.isError());
-        mCountDownLatch.countDown();
-    }
-
-    @Subscribe
-    public void onSiteChanged(SiteStore.OnSiteChanged event) {
-        AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
-        if (event.isError()) {
-            AppLog.i(T.TESTS, "event error type: " + event.error.type);
-            return;
-        }
-        assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasWPComSite());
-        assertEquals(TEST_EVENTS.SITE_CHANGED, mNextEvent);
-        mCountDownLatch.countDown();
-    }
-
-    @Subscribe
-    public void onTaxonomyChanged(TaxonomyStore.OnTaxonomyChanged event) {
+    public void onTaxonomyChanged(OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
         if (event.isError()) {
             AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);
-            if (mNextEvent.equals(TEST_EVENTS.ERROR_INVALID_TAXONOMY)) {
+            if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
                 assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
-            } else if (mNextEvent.equals(TEST_EVENTS.ERROR_GENERIC)) {
+            } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
                 assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             }
@@ -179,25 +118,25 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_Base {
         }
         switch (event.causeOfChange) {
             case FETCH_CATEGORIES:
-                if (mNextEvent.equals(TEST_EVENTS.CATEGORIES_FETCHED)) {
+                if (mNextEvent.equals(TestEvents.CATEGORIES_FETCHED)) {
                     AppLog.i(T.API, "Fetched " + event.rowsAffected + " categories");
                     mCountDownLatch.countDown();
                 }
                 break;
             case FETCH_TAGS:
-                if (mNextEvent.equals(TEST_EVENTS.TAGS_FETCHED)) {
+                if (mNextEvent.equals(TestEvents.TAGS_FETCHED)) {
                     AppLog.i(T.API, "Fetched " + event.rowsAffected + " tags");
                     mCountDownLatch.countDown();
                 }
                 break;
             case FETCH_TERMS:
-                if (mNextEvent.equals(TEST_EVENTS.TERMS_FETCHED)) {
+                if (mNextEvent.equals(TestEvents.TERMS_FETCHED)) {
                     AppLog.i(T.API, "Fetched " + event.rowsAffected + " " + event.taxonomyName + " terms");
                     mCountDownLatch.countDown();
                 }
                 break;
             case UPDATE_TERM:
-                if (mNextEvent.equals(TEST_EVENTS.TERM_UPDATED)) {
+                if (mNextEvent.equals(TestEvents.TERM_UPDATED)) {
                     AppLog.i(T.API, "Fetched " + event.rowsAffected + " term");
                     mCountDownLatch.countDown();
                 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -178,7 +178,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         TermModel failedTerm = mTaxonomyStore.getTermsForSite(sSite, "roads").get(0);
         assertEquals(0, failedTerm.getRemoteTermId());
@@ -199,7 +199,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     // TODO: Add tests for existing custom taxonomies
@@ -300,7 +300,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateCategoryAction(sSite));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void createNewTag() throws InterruptedException {
@@ -310,7 +310,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTagAction(sSite));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
@@ -321,7 +321,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         InstantiateTermPayload payload = new InstantiateTermPayload(sSite, taxonomy);
         mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTermAction(payload));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void uploadTerm(TermModel term) throws InterruptedException {
@@ -331,6 +331,6 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -163,6 +163,28 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    public void testUploadTermForInvalidTaxonomy() throws InterruptedException {
+        TaxonomyModel taxonomyModel = new TaxonomyModel();
+        taxonomyModel.setName("roads");
+
+        // Instantiate new term
+        createNewTerm(taxonomyModel);
+        setupTermAttributes();
+
+        mNextEvent = TestEvents.ERROR_INVALID_TAXONOMY;
+        mCountDownLatch = new CountDownLatch(1);
+
+        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        TermModel failedTerm = mTaxonomyStore.getTermsForSite(sSite, "roads").get(0);
+        assertEquals(0, failedTerm.getRemoteTermId());
+    }
+
+    // TODO: Add tests for existing custom taxonomies
+
     @Subscribe
     public void onTaxonomyChanged(OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -1,14 +1,12 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
-import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
-import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
-import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
 import org.wordpress.android.fluxc.utils.WellSqlUtils;
@@ -21,16 +19,10 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_Base {
-    @Inject Dispatcher mDispatcher;
+public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Inject TaxonomyStore mTaxonomyStore;
 
-    private CountDownLatch mCountDownLatch;
-    private static SiteModel sSite;
-
-    private TaxonomyError mLastTaxonomyError;
-
-    private enum TEST_EVENTS {
+    private enum TestEvents {
         NONE,
         CATEGORIES_FETCHED,
         TAGS_FETCHED,
@@ -40,31 +32,25 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_Base {
         ERROR_UNAUTHORIZED,
         ERROR_GENERIC
     }
-    private TEST_EVENTS mNextEvent;
 
-    {
-        sSite = new SiteModel();
-        sSite.setId(1);
-        sSite.setSelfHostedSiteId(0);
-        sSite.setUsername(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE);
-        sSite.setPassword(BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE);
-        sSite.setXmlRpcUrl(BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
-    }
+    private TestEvents mNextEvent;
+    private TaxonomyError mLastTaxonomyError;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
-        // Register
-        mDispatcher.register(this);
+
+        // Fetch sites and initialize sSite
+        init();
         // Reset expected test event
-        mNextEvent = TEST_EVENTS.NONE;
+        mNextEvent = TestEvents.NONE;
 
         mLastTaxonomyError = null;
     }
 
     public void testFetchCategories() throws InterruptedException {
-        mNextEvent = TEST_EVENTS.CATEGORIES_FETCHED;
+        mNextEvent = TestEvents.CATEGORIES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(sSite));
@@ -76,7 +62,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_Base {
     }
 
     public void testFetchTags() throws InterruptedException {
-        mNextEvent = TEST_EVENTS.TAGS_FETCHED;
+        mNextEvent = TestEvents.TAGS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTagsAction(sSite));
@@ -88,7 +74,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_Base {
     }
 
     public void testFetchTermsForInvalidTaxonomy() throws InterruptedException {
-        mNextEvent = TEST_EVENTS.ERROR_GENERIC;
+        mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 
         TaxonomyModel taxonomyModel = new TaxonomyModel();
@@ -105,7 +91,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_Base {
     }
 
     public void testFetchSingleCategory() throws InterruptedException {
-        mNextEvent = TEST_EVENTS.TERM_UPDATED;
+        mNextEvent = TestEvents.TERM_UPDATED;
         mCountDownLatch = new CountDownLatch(1);
 
         TermModel term = new TermModel();
@@ -124,15 +110,15 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_Base {
     }
 
     @Subscribe
-    public void onTaxonomyChanged(TaxonomyStore.OnTaxonomyChanged event) {
+    public void onTaxonomyChanged(OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
         if (event.isError()) {
             AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);
             mLastTaxonomyError = event.error;
-            if (mNextEvent.equals(TEST_EVENTS.ERROR_INVALID_TAXONOMY)) {
+            if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
                 assertEquals(TaxonomyStore.TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
-            } else if (mNextEvent.equals(TEST_EVENTS.ERROR_GENERIC)) {
+            } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
                 assertEquals(TaxonomyStore.TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             }
@@ -140,24 +126,25 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_Base {
         }
         switch (event.causeOfChange) {
             case FETCH_CATEGORIES:
-                if (mNextEvent.equals(TEST_EVENTS.CATEGORIES_FETCHED)) {
+                if (mNextEvent.equals(TestEvents.CATEGORIES_FETCHED)) {
                     AppLog.i(T.API, "Fetched " + event.rowsAffected + " categories");
                     mCountDownLatch.countDown();
                 }
                 break;
             case FETCH_TAGS:
-                if (mNextEvent.equals(TEST_EVENTS.TAGS_FETCHED)) {
+                if (mNextEvent.equals(TestEvents.TAGS_FETCHED)) {
                     AppLog.i(T.API, "Fetched " + event.rowsAffected + " tags");
                     mCountDownLatch.countDown();
                 }
                 break;
             case FETCH_TERMS:
-                if (mNextEvent.equals(TEST_EVENTS.TERMS_FETCHED)) {
+                if (mNextEvent.equals(TestEvents.TERMS_FETCHED)) {
                     AppLog.i(T.API, "Fetched " + event.rowsAffected + " " + event.taxonomyName + " terms");
                     mCountDownLatch.countDown();
                 }
+                break;
             case UPDATE_TERM:
-                if (mNextEvent.equals(TEST_EVENTS.TERM_UPDATED)) {
+                if (mNextEvent.equals(TestEvents.TERM_UPDATED)) {
                     AppLog.i(T.API, "Fetched " + event.rowsAffected + " term");
                     mCountDownLatch.countDown();
                 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -219,6 +219,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("A term with the name provided already exists with this parent.", mLastTaxonomyError.message);
     }
 
+    @SuppressWarnings("unused")
     @Subscribe
     public void onTaxonomyChanged(OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
@@ -265,6 +266,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe
     public void onTermUploaded(OnTermUploaded event) {
         AppLog.i(T.API, "Received OnTermUploaded");
@@ -292,6 +294,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch.countDown();
     }
 
+    @SuppressWarnings("unused")
     @Subscribe
     public void onTermInstantiated(OnTermInstantiated event) {
         AppLog.i(T.API, "Received OnTermInstantiated");

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -187,7 +187,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         TermModel failedTerm = mTaxonomyStore.getTermsForSite(sSite, "roads").get(0);
         assertEquals(0, failedTerm.getRemoteTermId());
@@ -212,7 +212,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // TODO: This will fail for non-English sites - we should be checking for a DUPLICATE error instead
         // (once we make the fixes needed for TaxonomyXMLRPCClient to correctly identify taxonomy errors)
@@ -317,7 +317,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateCategoryAction(sSite));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void createNewTag() throws InterruptedException {
@@ -327,7 +327,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTagAction(sSite));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
@@ -338,7 +338,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         InstantiateTermPayload payload = new InstantiateTermPayload(sSite, taxonomy);
         mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTermAction(payload));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void uploadTerm(TermModel term) throws InterruptedException {
@@ -348,6 +348,6 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -1,14 +1,20 @@
 package org.wordpress.android.fluxc.release;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.InstantiateTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermInstantiated;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
+import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
 import org.wordpress.android.fluxc.utils.WellSqlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -22,12 +28,17 @@ import javax.inject.Inject;
 public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Inject TaxonomyStore mTaxonomyStore;
 
+    private static final String TERM_DEFAULT_NAME = "fluxc-example";
+    private static final String TERM_DEFAULT_DESCRIPTION = "A term from FluxC";
+
     private enum TestEvents {
         NONE,
         CATEGORIES_FETCHED,
         TAGS_FETCHED,
         TERMS_FETCHED,
         TERM_UPDATED,
+        TERM_INSTANTIATED,
+        TERM_UPLOADED,
         ERROR_INVALID_TAXONOMY,
         ERROR_UNAUTHORIZED,
         ERROR_GENERIC
@@ -35,6 +46,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     private TestEvents mNextEvent;
     private TaxonomyError mLastTaxonomyError;
+    private TermModel mTerm;
 
     @Override
     protected void setUp() throws Exception {
@@ -80,7 +92,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         TaxonomyModel taxonomyModel = new TaxonomyModel();
         taxonomyModel.setName("roads");
 
-        TaxonomyStore.FetchTermsPayload payload = new TaxonomyStore.FetchTermsPayload(sSite, taxonomyModel);
+        FetchTermsPayload payload = new FetchTermsPayload(sSite, taxonomyModel);
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermsAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -109,6 +121,57 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, fetchedTerm.getRemoteTermId());
     }
 
+    public void testUploadNewCategory() throws InterruptedException {
+        // Instantiate new category
+        createNewCategory();
+        setupTermAttributes();
+
+        // Upload new term to site
+        uploadTerm(mTerm);
+
+        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "category").size());
+
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+    }
+
+    public void testUploadNewTag() throws InterruptedException {
+        // Instantiate new tag
+        createNewTag();
+        setupTermAttributes();
+
+        // Upload new term to site
+        uploadTerm(mTerm);
+
+        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "post_tag").get(0);
+
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "post_tag").size());
+
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+    }
+
+    public void testUploadNewCategoryAsTerm() throws InterruptedException {
+        TaxonomyModel taxonomyModel = new TaxonomyModel();
+        taxonomyModel.setName("category");
+
+        // Instantiate new term
+        createNewTerm(taxonomyModel);
+        setupTermAttributes();
+
+        // Upload new term to site
+        uploadTerm(mTerm);
+
+        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "category").size());
+
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+    }
+
     @Subscribe
     public void onTaxonomyChanged(OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
@@ -116,10 +179,10 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
             AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);
             mLastTaxonomyError = event.error;
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
-                assertEquals(TaxonomyStore.TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(TaxonomyStore.TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             }
             return;
@@ -150,5 +213,86 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 }
                 break;
         }
+    }
+
+    @Subscribe
+    public void onTermUploaded(OnTermUploaded event) {
+        AppLog.i(T.API, "Received OnTermUploaded");
+        if (event.isError()) {
+            AppLog.i(T.API, "OnTermUploaded has error: " + event.error.type + " - " + event.error.message);
+            mLastTaxonomyError = event.error;
+            // TODO this case can't happen at the moment...but maybe should leave it in for future anyway
+            if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
+                assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                mCountDownLatch.countDown();
+            } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
+                assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                mCountDownLatch.countDown();
+            }
+            return;
+        }
+        assertEquals(TestEvents.TERM_UPLOADED, mNextEvent);
+        assertNotSame(0, event.term.getRemoteTermId());
+
+        mCountDownLatch.countDown();
+    }
+
+    @Subscribe
+    public void onTermInstantiated(OnTermInstantiated event) {
+        AppLog.i(T.API, "Received OnTermInstantiated");
+        assertEquals(TestEvents.TERM_INSTANTIATED, mNextEvent);
+
+        assertEquals(0, event.term.getRemoteTermId());
+        assertNotSame(0, event.term.getId());
+        assertNotSame(0, event.term.getLocalSiteId());
+
+        mTerm = event.term;
+        mCountDownLatch.countDown();
+    }
+
+    private void setupTermAttributes() {
+        mTerm.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
+        mTerm.setDescription(TERM_DEFAULT_DESCRIPTION);
+    }
+
+    private void createNewCategory() throws InterruptedException {
+        // Instantiate new category
+        mNextEvent = TestEvents.TERM_INSTANTIATED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateCategoryAction(sSite));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void createNewTag() throws InterruptedException {
+        // Instantiate new tag
+        mNextEvent = TestEvents.TERM_INSTANTIATED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTagAction(sSite));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
+        // Instantiate new term
+        mNextEvent = TestEvents.TERM_INSTANTIATED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        InstantiateTermPayload payload = new InstantiateTermPayload(sSite, taxonomy);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTermAction(payload));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void uploadTerm(TermModel term) throws InterruptedException {
+        mNextEvent = TestEvents.TERM_UPLOADED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
+
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -1,0 +1,139 @@
+package org.wordpress.android.fluxc.release;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TaxonomyModel;
+import org.wordpress.android.fluxc.model.TermModel;
+import org.wordpress.android.fluxc.store.TaxonomyStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_Base {
+    @Inject Dispatcher mDispatcher;
+    @Inject TaxonomyStore mTaxonomyStore;
+
+    private CountDownLatch mCountDownLatch;
+    private static SiteModel sSite;
+
+    private TaxonomyError mLastTaxonomyError;
+
+    private enum TEST_EVENTS {
+        NONE,
+        CATEGORIES_FETCHED,
+        TAGS_FETCHED,
+        TERMS_FETCHED,
+        ERROR_INVALID_TAXONOMY,
+        ERROR_UNAUTHORIZED,
+        ERROR_GENERIC
+    }
+    private TEST_EVENTS mNextEvent;
+
+    {
+        sSite = new SiteModel();
+        sSite.setId(1);
+        sSite.setSelfHostedSiteId(0);
+        sSite.setUsername(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE);
+        sSite.setPassword(BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE);
+        sSite.setXmlRpcUrl(BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mReleaseStackAppComponent.inject(this);
+        // Register
+        mDispatcher.register(this);
+        // Reset expected test event
+        mNextEvent = TEST_EVENTS.NONE;
+
+        mLastTaxonomyError = null;
+    }
+
+    public void testFetchCategories() throws InterruptedException {
+        mNextEvent = TEST_EVENTS.CATEGORIES_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(sSite));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        List<TermModel> categories = mTaxonomyStore.getCategoriesForSite(sSite);
+        assertTrue(categories.size() > 0);
+    }
+
+    public void testFetchTags() throws InterruptedException {
+        mNextEvent = TEST_EVENTS.TAGS_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTagsAction(sSite));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        List<TermModel> tags = mTaxonomyStore.getTagsForSite(sSite);
+        assertTrue(tags.size() > 0);
+    }
+
+    public void testFetchTermsForInvalidTaxonomy() throws InterruptedException {
+        mNextEvent = TEST_EVENTS.ERROR_GENERIC;
+        mCountDownLatch = new CountDownLatch(1);
+
+        TaxonomyModel taxonomyModel = new TaxonomyModel();
+        taxonomyModel.setName("roads");
+
+        TaxonomyStore.FetchTermsPayload payload = new TaxonomyStore.FetchTermsPayload(sSite, taxonomyModel);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermsAction(payload));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // TODO: This will fail for non-English sites - we should be checking for an INVALID_TAXONOMY error instead
+        // (once we make the fixes needed for TaxonomyXMLRPCClient to correctly identify taxonomy errors)
+        assertEquals("Invalid taxonomy.", mLastTaxonomyError.message);
+    }
+
+    @Subscribe
+    public void onTaxonomyChanged(TaxonomyStore.OnTaxonomyChanged event) {
+        AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
+        if (event.isError()) {
+            AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);
+            mLastTaxonomyError = event.error;
+            if (mNextEvent.equals(TEST_EVENTS.ERROR_INVALID_TAXONOMY)) {
+                assertEquals(TaxonomyStore.TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                mCountDownLatch.countDown();
+            } else if (mNextEvent.equals(TEST_EVENTS.ERROR_GENERIC)) {
+                assertEquals(TaxonomyStore.TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                mCountDownLatch.countDown();
+            }
+            return;
+        }
+        switch (event.causeOfChange) {
+            case FETCH_CATEGORIES:
+                if (mNextEvent.equals(TEST_EVENTS.CATEGORIES_FETCHED)) {
+                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " categories");
+                    mCountDownLatch.countDown();
+                }
+                break;
+            case FETCH_TAGS:
+                if (mNextEvent.equals(TEST_EVENTS.TAGS_FETCHED)) {
+                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " tags");
+                    mCountDownLatch.countDown();
+                }
+                break;
+            case FETCH_TERMS:
+                if (mNextEvent.equals(TEST_EVENTS.TERMS_FETCHED)) {
+                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " " + event.taxonomyName + " terms");
+                    mCountDownLatch.countDown();
+                }
+        }
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -108,7 +108,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
 
         TermModel term = new TermModel();
-        term.setTaxonomy("category");
+        term.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
         term.setSlug("uncategorized");
         term.setRemoteTermId(1);
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermAction(new RemoteTermPayload(term, sSite)));
@@ -116,7 +116,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        TermModel fetchedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+        TermModel fetchedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
         assertEquals("uncategorized", fetchedTerm.getSlug());
         assertNotSame(0, fetchedTerm.getRemoteTermId());
@@ -130,10 +130,10 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Upload new term to site
         uploadTerm(mTerm);
 
-        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+        TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "category").size());
+        assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
 
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
@@ -146,17 +146,17 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Upload new term to site
         uploadTerm(mTerm);
 
-        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "post_tag").get(0);
+        TermModel uploadedTerm = mTaxonomyStore.getTagsForSite(sSite).get(0);
 
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "post_tag").size());
+        assertEquals(1, mTaxonomyStore.getTagsForSite(sSite).size());
 
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
         TaxonomyModel taxonomyModel = new TaxonomyModel();
-        taxonomyModel.setName("category");
+        taxonomyModel.setName(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
 
         // Instantiate new term
         createNewTerm(taxonomyModel);
@@ -165,10 +165,10 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Upload new term to site
         uploadTerm(mTerm);
 
-        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, "category").get(0);
+        TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getTermsForSite(sSite, "category").size());
+        assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
 
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
@@ -271,7 +271,6 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         if (event.isError()) {
             AppLog.i(T.API, "OnTermUploaded has error: " + event.error.type + " - " + event.error.message);
             mLastTaxonomyError = event.error;
-            // TODO this case can't happen at the moment...but maybe should leave it in for future anyway
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
                 assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/utils/WellSqlUtils.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/utils/WellSqlUtils.java
@@ -3,9 +3,14 @@ package org.wordpress.android.fluxc.utils;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.TermModel;
 
 public class WellSqlUtils {
     public static int getTotalPostsCount() {
         return WellSql.select(PostModel.class).getAsCursor().getCount();
+    }
+
+    public static int getTotalTermsCount() {
+        return WellSql.select(TermModel.class).getAsCursor().getCount();
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/AppComponent.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/AppComponent.java
@@ -27,4 +27,5 @@ public interface AppComponent {
     void inject(PostsFragment object);
     void inject(AccountFragment object);
     void inject(SignedOutActionsFragment object);
+    void inject(TaxonomiesFragment object);
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
@@ -108,6 +108,7 @@ public class MainFragment extends Fragment {
         view.findViewById(R.id.posts).setOnClickListener(getOnClickListener(new PostsFragment()));
         view.findViewById(R.id.comments).setOnClickListener(getOnClickListener(new CommentsFragment()));
         view.findViewById(R.id.media).setOnClickListener(getOnClickListener(new MediaFragment()));
+        view.findViewById(R.id.taxonomies).setOnClickListener(getOnClickListener(new TaxonomiesFragment()));
 
         return view;
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -1,0 +1,142 @@
+package org.wordpress.android.fluxc.example;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TermModel;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermInstantiated;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import static junit.framework.Assert.assertEquals;
+
+public class TaxonomiesFragment extends Fragment {
+    @Inject SiteStore mSiteStore;
+    @Inject TaxonomyStore mTaxonomyStore;
+    @Inject Dispatcher mDispatcher;
+
+    // Needed for instantiate action :/
+    private TermModel mNewTerm;
+    private CountDownLatch mCountDownLatch;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((ExampleApp) getActivity().getApplication()).component().inject(this);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        View view = inflater.inflate(R.layout.fragment_taxonomies, container, false);
+        view.findViewById(R.id.fetch_categories).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                fetchCategoriesFirstSite();
+            }
+        });
+        view.findViewById(R.id.fetch_tags).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                fetchTagsFirstSite();
+            }
+        });
+        view.findViewById(R.id.create_category).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                createCategory();
+            }
+        });
+        return view;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        mDispatcher.register(this);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mDispatcher.unregister(this);
+    }
+
+    private SiteModel getFirstSite() {
+        return mSiteStore.getSites().get(0);
+    }
+
+    private void fetchCategoriesFirstSite() {
+        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(getFirstSite()));
+    }
+
+    private void fetchTagsFirstSite() {
+        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTagsAction(getFirstSite()));
+    }
+
+    private void createCategory() {
+        // Count down latch used for waiting for the asynchronous Instantiate action.
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateCategoryAction(getFirstSite()));
+        try {
+            assertEquals(true, mCountDownLatch.await(2, TimeUnit.SECONDS));
+            mNewTerm.setName("FluxC-category-" + new Random().nextLong());
+            mNewTerm.setDescription("From FluxC example app");
+            TaxonomyStore.RemoteTermPayload payload = new TaxonomyStore.RemoteTermPayload(mNewTerm, getFirstSite());
+            mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload));
+        } catch (Exception e) {
+            // noop
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onTaxonomyChanged(OnTaxonomyChanged event) {
+        AppLog.i(T.API, "OnTaxonomyChanged: rowsAffected=" + event.rowsAffected);
+        if (event.isError()) {
+            String error = "Error: " + event.error.type + " - " + event.error.message;
+            prependToLog(error);
+            AppLog.i(T.TESTS, error);
+        } else {
+            List<TermModel> terms = mTaxonomyStore.getTermsForSite(getFirstSite(), event.taxonomyName);
+            for (TermModel term : terms) {
+                prependToLog(event.taxonomyName + " " + term.getRemoteTermId() + ": " + term.getName());
+            }
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onTermInstantiated(OnTermInstantiated event) {
+        mNewTerm = event.term;
+        mCountDownLatch.countDown();
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onCategoryUploaded(OnTermUploaded event) {
+        prependToLog("Term uploaded! Remote category id: " + event.term.getRemoteTermId());
+    }
+
+    private void prependToLog(final String s) {
+        ((MainExampleActivity) getActivity()).prependToLog(s);
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 
 public class TaxonomiesFragment extends Fragment {
     @Inject SiteStore mSiteStore;
@@ -100,7 +100,7 @@ public class TaxonomiesFragment extends Fragment {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateCategoryAction(getFirstSite()));
         try {
-            assertEquals(true, mCountDownLatch.await(2, TimeUnit.SECONDS));
+            assertTrue(mCountDownLatch.await(2, TimeUnit.SECONDS));
             mNewTerm.setName("FluxC-category-" + new Random().nextLong());
             mNewTerm.setDescription("From FluxC example app");
             TaxonomyStore.RemoteTermPayload payload = new TaxonomyStore.RemoteTermPayload(mNewTerm, getFirstSite());

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermInstantiated;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
+import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -103,13 +104,14 @@ public class TaxonomiesFragment extends Fragment {
             assertTrue(mCountDownLatch.await(2, TimeUnit.SECONDS));
             mNewTerm.setName("FluxC-category-" + new Random().nextLong());
             mNewTerm.setDescription("From FluxC example app");
-            TaxonomyStore.RemoteTermPayload payload = new TaxonomyStore.RemoteTermPayload(mNewTerm, getFirstSite());
+            RemoteTermPayload payload = new RemoteTermPayload(mNewTerm, getFirstSite());
             mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload));
         } catch (Exception e) {
             // noop
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onTaxonomyChanged(OnTaxonomyChanged event) {
         AppLog.i(T.API, "OnTaxonomyChanged: rowsAffected=" + event.rowsAffected);
@@ -125,14 +127,16 @@ public class TaxonomiesFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onTermInstantiated(OnTermInstantiated event) {
         mNewTerm = event.term;
         mCountDownLatch.countDown();
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onCategoryUploaded(OnTermUploaded event) {
+    public void onTermUploaded(OnTermUploaded event) {
         prependToLog("Term uploaded! Remote category id: " + event.term.getRemoteTermId());
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -128,7 +128,7 @@ public class TaxonomiesFragment extends Fragment {
     }
 
     @SuppressWarnings("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
+    @Subscribe(threadMode = ThreadMode.ASYNC)
     public void onTermInstantiated(OnTermInstantiated event) {
         mNewTerm = event.term;
         mCountDownLatch.countDown();

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -71,4 +71,10 @@
         android:layout_height="wrap_content"
         android:text="Media" />
 
+    <Button
+        android:id="@+id/taxonomies"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Taxonomies" />
+
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_taxonomies.xml
+++ b/example/src/main/res/layout/fragment_taxonomies.xml
@@ -3,7 +3,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
-              tools:context="org.wordpress.android.fluxc.example.CommentsFragment">
+              tools:context="org.wordpress.android.fluxc.example.TaxonomiesFragment">
 
     <Button
         android:id="@+id/fetch_categories"

--- a/example/src/main/res/layout/fragment_taxonomies.xml
+++ b/example/src/main/res/layout/fragment_taxonomies.xml
@@ -1,0 +1,26 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical"
+              tools:context="org.wordpress.android.fluxc.example.CommentsFragment">
+
+    <Button
+        android:id="@+id/fetch_categories"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch categories from first site" />
+
+    <Button
+        android:id="@+id/fetch_tags"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch tags from first site" />
+
+    <Button
+        android:id="@+id/create_category"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Create new category on first site" />
+
+</LinearLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -126,4 +126,32 @@ public class TaxonomyStoreUnitTest {
 
         assertEquals(category, mTaxonomyStore.getCategoryByRemoteId(site, category.getRemoteTermId()));
     }
+
+    @Test
+    public void testClearTaxonomy() {
+        SiteModel site = new SiteModel();
+        site.setId(6);
+
+        TermModel category = TaxonomyTestUtils.generateSampleCategory();
+        TaxonomySqlUtils.insertOrUpdateTerm(category);
+
+        TermModel category2 = TaxonomyTestUtils.generateSampleCategory();
+        category2.setRemoteTermId(6);
+        category2.setName("Something");
+        TaxonomySqlUtils.insertOrUpdateTerm(category2);
+
+        TermModel tag = TaxonomyTestUtils.generateSampleTag();
+        TaxonomySqlUtils.insertOrUpdateTerm(tag);
+
+        TermModel author = TaxonomyTestUtils.generateSampleAuthor();
+        TaxonomySqlUtils.insertOrUpdateTerm(author);
+
+        assertEquals(4, TaxonomyTestUtils.getTermsCount());
+        assertEquals(2, mTaxonomyStore.getCategoriesForSite(site).size());
+
+        TaxonomySqlUtils.clearTaxonomyForSite(site, TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
+
+        assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
+        assertEquals(2, TaxonomyTestUtils.getTermsCount());
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -1,0 +1,129 @@
+package org.wordpress.android.fluxc.taxonomy;
+
+import android.content.Context;
+
+import com.yarolegovich.wellsql.WellSql;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TermModel;
+import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
+import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
+import org.wordpress.android.fluxc.persistence.TaxonomySqlUtils;
+import org.wordpress.android.fluxc.persistence.WellSqlConfig;
+import org.wordpress.android.fluxc.store.TaxonomyStore;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class TaxonomyStoreUnitTest {
+    private TaxonomyStore mTaxonomyStore = new TaxonomyStore(new Dispatcher(), Mockito.mock(TaxonomyRestClient.class),
+            Mockito.mock(TaxonomyXMLRPCClient.class));
+
+    @Before
+    public void setUp() {
+        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+
+        WellSqlConfig config = new SingleStoreWellSqlConfigForTests(appContext, TermModel.class);
+        WellSql.init(config);
+        config.reset();
+    }
+
+    @Test
+    public void testInsertNullTerm() {
+        assertEquals(0, TaxonomySqlUtils.insertOrUpdateTerm(null));
+
+        assertEquals(0, TaxonomyTestUtils.getTermsCount());
+    }
+
+    @Test
+    public void testSimpleInsertionAndRetrieval() {
+        TermModel termModel = new TermModel();
+        termModel.setRemoteTermId(42);
+        TaxonomySqlUtils.insertOrUpdateTerm(termModel);
+
+        assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        assertEquals(termModel, TaxonomyTestUtils.getTerms().get(0));
+    }
+
+    @Test
+    public void testCategoryInsertionAndRetrieval() {
+        SiteModel site = new SiteModel();
+        site.setId(6);
+
+        TermModel category = TaxonomyTestUtils.generateSampleCategory();
+        TaxonomySqlUtils.insertOrUpdateTerm(category);
+
+        assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        assertEquals(category, TaxonomyTestUtils.getTerms().get(0));
+
+        assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY).size());
+        assertEquals(1, mTaxonomyStore.getCategoriesForSite(site).size());
+
+        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, TaxonomyStore.DEFAULT_TAXONOMY_TAG).size());
+        assertEquals(0, mTaxonomyStore.getTagsForSite(site).size());
+
+        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, "author").size());
+        assertEquals(0, mTaxonomyStore.getTermsForSite(site, "author").size());
+    }
+
+    @Test
+    public void testTagInsertionAndRetrieval() {
+        SiteModel site = new SiteModel();
+        site.setId(6);
+
+        TermModel tag = TaxonomyTestUtils.generateSampleTag();
+        TaxonomySqlUtils.insertOrUpdateTerm(tag);
+
+        assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        assertEquals(tag, TaxonomyTestUtils.getTerms().get(0));
+
+        assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, TaxonomyStore.DEFAULT_TAXONOMY_TAG).size());
+        assertEquals(1, mTaxonomyStore.getTagsForSite(site).size());
+
+        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY).size());
+        assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
+
+        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, "author").size());
+        assertEquals(0, mTaxonomyStore.getTermsForSite(site, "author").size());
+    }
+
+    @Test
+    public void testCustomTaxonomyTermInsertionAndRetrieval() {
+        SiteModel site = new SiteModel();
+        site.setId(6);
+
+        TermModel author = TaxonomyTestUtils.generateSampleAuthor();
+        TaxonomySqlUtils.insertOrUpdateTerm(author);
+
+        assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        assertEquals(author, TaxonomyTestUtils.getTerms().get(0));
+
+        assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, "author").size());
+        assertEquals(1, mTaxonomyStore.getTermsForSite(site, "author").size());
+
+        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY).size());
+        assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
+
+        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, TaxonomyStore.DEFAULT_TAXONOMY_TAG).size());
+        assertEquals(0, mTaxonomyStore.getTagsForSite(site).size());
+    }
+
+    @Test
+    public void testGetTermByRemoteId() {
+        SiteModel site = new SiteModel();
+        site.setId(6);
+
+        TermModel category = TaxonomyTestUtils.generateSampleCategory();
+        TaxonomySqlUtils.insertOrUpdateTerm(category);
+
+        assertEquals(category, mTaxonomyStore.getCategoryByRemoteId(site, category.getRemoteTermId()));
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyTestUtils.java
@@ -1,0 +1,46 @@
+package org.wordpress.android.fluxc.taxonomy;
+
+import com.yarolegovich.wellsql.WellSql;
+
+import org.wordpress.android.fluxc.model.TermModel;
+import org.wordpress.android.fluxc.store.TaxonomyStore;
+
+import java.util.List;
+
+class TaxonomyTestUtils {
+    private static TermModel generateSampleTerm() {
+        TermModel example = new TermModel();
+        example.setLocalSiteId(6);
+        example.setRemoteTermId(5);
+        example.setSlug("travel");
+        example.setName("Travel");
+        example.setDescription("Post about travelling");
+        return example;
+    }
+
+    public static TermModel generateSampleCategory() {
+        TermModel exampleCategory = generateSampleTerm();
+        exampleCategory.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
+        return exampleCategory;
+    }
+
+    public static TermModel generateSampleTag() {
+        TermModel exampleTag = generateSampleTerm();
+        exampleTag.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_TAG);
+        return exampleTag;
+    }
+
+    public static TermModel generateSampleAuthor() {
+        TermModel exampleAuthor = generateSampleTerm();
+        exampleAuthor.setTaxonomy("author");
+        return exampleAuthor;
+    }
+
+    static List<TermModel> getTerms() {
+        return WellSql.select(TermModel.class).getAsModel();
+    }
+
+    static int getTermsCount() {
+        return getTerms().size();
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TermModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TermModelTest.java
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.taxonomy;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.wordpress.android.fluxc.model.TermModel;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class TermModelTest {
+    @Test
+    public void testEquals() {
+        TermModel testCategory = TaxonomyTestUtils.generateSampleCategory();
+        TermModel testCategory2 = TaxonomyTestUtils.generateSampleCategory();
+
+        testCategory2.setRemoteTermId(testCategory.getRemoteTermId() + 1);
+        assertFalse(testCategory.equals(testCategory2));
+        testCategory2.setRemoteTermId(testCategory.getRemoteTermId());
+        assertTrue(testCategory.equals(testCategory2));
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -4,8 +4,11 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TermModel;
+import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 
 @ActionEnum
 public enum TaxonomyAction implements IAction {
@@ -16,11 +19,17 @@ public enum TaxonomyAction implements IAction {
     FETCH_TAGS,
     @Action(payloadType = FetchTermsPayload.class)
     FETCH_TERMS,
+    @Action(payloadType = RemoteTermPayload.class)
+    FETCH_TERM,
 
     // Remote responses
     @Action(payloadType = FetchTermsResponsePayload.class)
-    FETCHED_TERMS
+    FETCHED_TERMS,
+    @Action(payloadType = FetchTermResponsePayload.class)
+    FETCHED_TERM,
 
     // Local actions
+    @Action(payloadType = TermModel.class)
+    UPDATE_TERM
 }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.InstantiateTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 
 @ActionEnum
@@ -29,6 +30,12 @@ public enum TaxonomyAction implements IAction {
     FETCHED_TERM,
 
     // Local actions
+    @Action(payloadType = SiteModel.class)
+    INSTANTIATE_CATEGORY,
+    @Action(payloadType = SiteModel.class)
+    INSTANTIATE_TAG,
+    @Action(payloadType = InstantiateTermPayload.class)
+    INSTANTIATE_TERM,
     @Action(payloadType = TermModel.class)
     UPDATE_TERM
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -1,0 +1,26 @@
+package org.wordpress.android.fluxc.action;
+
+import org.wordpress.android.fluxc.annotations.Action;
+import org.wordpress.android.fluxc.annotations.ActionEnum;
+import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
+
+@ActionEnum
+public enum TaxonomyAction implements IAction {
+    // Remote actions
+    @Action(payloadType = SiteModel.class)
+    FETCH_CATEGORIES,
+    @Action(payloadType = SiteModel.class)
+    FETCH_TAGS,
+    @Action(payloadType = FetchTermsPayload.class)
+    FETCH_TERMS,
+
+    // Remote responses
+    @Action(payloadType = FetchTermsResponsePayload.class)
+    FETCHED_TERMS
+
+    // Local actions
+}
+

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -22,12 +22,16 @@ public enum TaxonomyAction implements IAction {
     FETCH_TERMS,
     @Action(payloadType = RemoteTermPayload.class)
     FETCH_TERM,
+    @Action(payloadType = RemoteTermPayload.class)
+    PUSH_TERM,
 
     // Remote responses
     @Action(payloadType = FetchTermsResponsePayload.class)
     FETCHED_TERMS,
     @Action(payloadType = FetchTermResponsePayload.class)
     FETCHED_TERM,
+    @Action(payloadType = RemoteTermPayload.class)
+    PUSHED_TERM,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
@@ -6,6 +6,7 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.util.StringUtils;
 
 import java.io.Serializable;
 
@@ -81,7 +82,7 @@ public class TaxonomyModel extends Payload implements Identifiable, Serializable
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;
-        if (other == null || getClass() != other.getClass()) return false;
+        if (other == null || !(other instanceof TaxonomyModel)) return false;
 
         TaxonomyModel otherTaxonomy = (TaxonomyModel) other;
 
@@ -89,9 +90,8 @@ public class TaxonomyModel extends Payload implements Identifiable, Serializable
                 && getLocalSiteId() == otherTaxonomy.getLocalSiteId()
                 && isHierarchical() == otherTaxonomy.isHierarchical()
                 && isPublic() == otherTaxonomy.isPublic()
-                && (getName() != null ? getName().equals(otherTaxonomy.getName()) : otherTaxonomy.getName() == null)
-                && (getLabel() != null ? getLabel().equals(otherTaxonomy.getLabel()) : otherTaxonomy.getLabel() == null)
-                && (getDescription() != null
-                 ? getDescription().equals(otherTaxonomy.getDescription()) : otherTaxonomy.getDescription() == null);
+                && StringUtils.equals(getName(), otherTaxonomy.getName())
+                && StringUtils.equals(getLabel(), otherTaxonomy.getLabel())
+                && StringUtils.equals(getDescription(), otherTaxonomy.getDescription());
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
@@ -77,4 +77,21 @@ public class TaxonomyModel extends Payload implements Identifiable, Serializable
     public void setIsPublic(boolean isPublic) {
         mIsPublic = isPublic;
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+
+        TaxonomyModel otherTaxonomy = (TaxonomyModel) other;
+
+        return getId() == otherTaxonomy.getId()
+                && getLocalSiteId() == otherTaxonomy.getLocalSiteId()
+                && isHierarchical() == otherTaxonomy.isHierarchical()
+                && isPublic() == otherTaxonomy.isPublic()
+                && (getName() != null ? getName().equals(otherTaxonomy.getName()) : otherTaxonomy.getName() == null)
+                && (getLabel() != null ? getLabel().equals(otherTaxonomy.getLabel()) : otherTaxonomy.getLabel() == null)
+                && (getDescription() != null
+                 ? getDescription().equals(otherTaxonomy.getDescription()) : otherTaxonomy.getDescription() == null);
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
@@ -1,0 +1,80 @@
+package org.wordpress.android.fluxc.model;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.Table;
+
+import org.wordpress.android.fluxc.Payload;
+
+import java.io.Serializable;
+
+@Table
+public class TaxonomyModel extends Payload implements Identifiable, Serializable {
+    @PrimaryKey
+    @Column private int mId;
+    @Column private int mLocalSiteId;
+    @Column private String mName;
+    @Column private String mLabel;
+    @Column private String mDescription;
+    @Column private boolean mIsHierarchical;
+    @Column private boolean mIsPublic;
+
+    @Override
+    public int getId() {
+        return mId;
+    }
+
+    @Override
+    public void setId(int id) {
+        mId = id;
+    }
+
+    public int getLocalSiteId() {
+        return mLocalSiteId;
+    }
+
+    public void setLocalSiteId(int localSiteId) {
+        mLocalSiteId = localSiteId;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public void setName(String name) {
+        mName = name;
+    }
+
+    public String getLabel() {
+        return mLabel;
+    }
+
+    public void setLabel(String label) {
+        mLabel = label;
+    }
+
+    public String getDescription() {
+        return mDescription;
+    }
+
+    public void setDescription(String description) {
+        mDescription = description;
+    }
+
+    public boolean isHierarchical() {
+        return mIsHierarchical;
+    }
+
+    public void setIsHierarchical(boolean isHierarchical) {
+        mIsHierarchical = isHierarchical;
+    }
+
+    public boolean isPublic() {
+        return mIsPublic;
+    }
+
+    public void setIsPublic(boolean isPublic) {
+        mIsPublic = isPublic;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
@@ -86,4 +86,23 @@ public class TermModel extends Payload implements Identifiable, Serializable {
     public void setParentRemoteId(long parentRemoteId) {
         mParentRemoteId = parentRemoteId;
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+
+        TermModel otherTerm = (TermModel) other;
+
+        return getId() == otherTerm.getId()
+                && getLocalSiteId() == otherTerm.getLocalSiteId()
+                && getRemoteTermId() == otherTerm.getRemoteTermId()
+                && getParentRemoteId() == otherTerm.getParentRemoteId()
+                && (getSlug() != null ? getSlug().equals(otherTerm.getSlug()) : otherTerm.getSlug() == null)
+                && (getName() != null ? getName().equals(otherTerm.getName()) : otherTerm.getName() == null)
+                && (getTaxonomy() != null
+                 ? getTaxonomy().equals(otherTerm.getTaxonomy()) : otherTerm.getTaxonomy() == null)
+                && (getDescription() != null
+                 ? getDescription().equals(otherTerm.getDescription()) : otherTerm.getDescription() == null);
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
@@ -1,0 +1,89 @@
+package org.wordpress.android.fluxc.model;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.Table;
+
+import org.wordpress.android.fluxc.Payload;
+
+import java.io.Serializable;
+
+@Table
+public class TermModel extends Payload implements Identifiable, Serializable {
+    @PrimaryKey
+    @Column private int mId;
+    @Column private int mLocalSiteId;
+    @Column private long mRemoteTermId;
+    @Column private String mTaxonomy;
+    @Column private String mName;
+    @Column private String mSlug;
+    @Column private String mDescription;
+    @Column private long mParentRemoteId;
+
+    @Override
+    public int getId() {
+        return mId;
+    }
+
+    @Override
+    public void setId(int id) {
+        mId = id;
+    }
+
+    public int getLocalSiteId() {
+        return mLocalSiteId;
+    }
+
+    public void setLocalSiteId(int localSiteId) {
+        mLocalSiteId = localSiteId;
+    }
+
+    public long getRemoteTermId() {
+        return mRemoteTermId;
+    }
+
+    public void setRemoteTermId(long remoteTermId) {
+        mRemoteTermId = remoteTermId;
+    }
+
+    public String getTaxonomy() {
+        return mTaxonomy;
+    }
+
+    public void setTaxonomy(String taxonomy) {
+        mTaxonomy = taxonomy;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public void setName(String name) {
+        mName = name;
+    }
+
+    public String getSlug() {
+        return mSlug;
+    }
+
+    public void setSlug(String slug) {
+        mSlug = slug;
+    }
+
+    public String getDescription() {
+        return mDescription;
+    }
+
+    public void setDescription(String description) {
+        mDescription = description;
+    }
+
+    public long getParentRemoteId() {
+        return mParentRemoteId;
+    }
+
+    public void setParentRemoteId(long parentRemoteId) {
+        mParentRemoteId = parentRemoteId;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
@@ -6,6 +6,7 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.util.StringUtils;
 
 import java.io.Serializable;
 
@@ -90,7 +91,7 @@ public class TermModel extends Payload implements Identifiable, Serializable {
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;
-        if (other == null || getClass() != other.getClass()) return false;
+        if (other == null || !(other instanceof TermModel)) return false;
 
         TermModel otherTerm = (TermModel) other;
 
@@ -98,11 +99,9 @@ public class TermModel extends Payload implements Identifiable, Serializable {
                 && getLocalSiteId() == otherTerm.getLocalSiteId()
                 && getRemoteTermId() == otherTerm.getRemoteTermId()
                 && getParentRemoteId() == otherTerm.getParentRemoteId()
-                && (getSlug() != null ? getSlug().equals(otherTerm.getSlug()) : otherTerm.getSlug() == null)
-                && (getName() != null ? getName().equals(otherTerm.getName()) : otherTerm.getName() == null)
-                && (getTaxonomy() != null
-                 ? getTaxonomy().equals(otherTerm.getTaxonomy()) : otherTerm.getTaxonomy() == null)
-                && (getDescription() != null
-                 ? getDescription().equals(otherTerm.getDescription()) : otherTerm.getDescription() == null);
+                && StringUtils.equals(getSlug(), otherTerm.getSlug())
+                && StringUtils.equals(getName(), otherTerm.getName())
+                && StringUtils.equals(getTaxonomy(), otherTerm.getTaxonomy())
+                && StringUtils.equals(getDescription(), otherTerm.getDescription());
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermsModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermsModel.java
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.model;
+
+import android.support.annotation.NonNull;
+
+import org.wordpress.android.fluxc.Payload;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TermsModel extends Payload {
+    private List<TermModel> mTerms;
+
+    public TermsModel() {
+        mTerms = new ArrayList<>();
+    }
+
+    public TermsModel(@NonNull List<TermModel> terms) {
+        mTerms = terms;
+    }
+
+    public List<TermModel> getTerms() {
+        return mTerms;
+    }
+
+    public void setTerms(List<TermModel> terms) {
+        this.mTerms = terms;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -7,25 +7,27 @@ import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.BasicNetwork;
 import com.android.volley.toolbox.DiskBasedCache;
 
-import org.wordpress.android.fluxc.network.MemorizingTrustManager;
-import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder;
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
-import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
+import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.fluxc.network.OkHttpStack;
 import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
-import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentXMLRPCClient;
+import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
+import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -207,6 +209,24 @@ public class ReleaseNetworkModule {
                                                        AccessToken token,
                                                        UserAgent userAgent, HTTPAuthManager httpAuthManager) {
         return new CommentXMLRPCClient(dispatcher, requestQueue, token, userAgent, httpAuthManager);
+    }
+
+    @Singleton
+    @Provides
+    public TaxonomyRestClient provideTaxonomyRestClient(Context appContext, Dispatcher dispatcher,
+                                                        @Named("regular") RequestQueue requestQueue,
+                                                        AppSecrets appSecrets,
+                                                        AccessToken token, UserAgent userAgent) {
+        return new TaxonomyRestClient(appContext, dispatcher, requestQueue, token, userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public TaxonomyXMLRPCClient provideTaxonomyXMLRPCClient(Dispatcher dispatcher,
+                                                            @Named("custom-ssl") RequestQueue requestQueue,
+                                                            AccessToken token,
+                                                            UserAgent userAgent, HTTPAuthManager httpAuthManager) {
+        return new TaxonomyXMLRPCClient(dispatcher, requestQueue, token, userAgent, httpAuthManager);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -215,7 +215,6 @@ public class ReleaseNetworkModule {
     @Provides
     public TaxonomyRestClient provideTaxonomyRestClient(Context appContext, Dispatcher dispatcher,
                                                         @Named("regular") RequestQueue requestQueue,
-                                                        AppSecrets appSecrets,
                                                         AccessToken token, UserAgent userAgent) {
         return new TaxonomyRestClient(appContext, dispatcher, requestQueue, token, userAgent);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseStoreModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseStoreModule.java
@@ -6,18 +6,21 @@ import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
-import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
-import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
-import org.wordpress.android.fluxc.store.AccountStore;
-import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentXMLRPCClient;
+import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
+import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
+import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
+import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
+import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.CommentStore;
+import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore;
 
 import javax.inject.Singleton;
 
@@ -60,5 +63,12 @@ public class ReleaseStoreModule {
     public CommentStore provideCommentStore(Dispatcher dispatcher, CommentRestClient restClient,
                                             CommentXMLRPCClient xmlrpcClient) {
         return new CommentStore(dispatcher, restClient, xmlrpcClient);
+    }
+
+    @Provides
+    @Singleton
+    public TaxonomyStore provideTaxonomyStore(Dispatcher dispatcher, TaxonomyRestClient taxonomyRestClient,
+                                              TaxonomyXMLRPCClient taxonomyXMLRPCClient) {
+        return new TaxonomyStore(dispatcher, taxonomyRestClient, taxonomyXMLRPCClient);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostsResponse;
+import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
@@ -239,7 +240,7 @@ public class PostRestClient extends BaseWPComRestClient {
 
         if (from.categories != null) {
             List<Long> categoryIds = new ArrayList<>();
-            for (PostWPComRestResponse.Taxonomy value : from.categories.values()) {
+            for (TermWPComRestResponse value : from.categories.values()) {
                 categoryIds.add(value.ID);
             }
             post.setCategoryIdList(categoryIds);
@@ -247,7 +248,7 @@ public class PostRestClient extends BaseWPComRestClient {
 
         if (from.tags != null) {
             List<Long> tagIds = new ArrayList<>();
-            for (PostWPComRestResponse.Taxonomy value : from.tags.values()) {
+            for (TermWPComRestResponse value : from.tags.values()) {
                 tagIds.add(value.ID);
             }
             post.setTagIdList(tagIds);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.post;
 
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.network.Response;
+import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -18,26 +19,6 @@ public class PostWPComRestResponse extends Payload implements Response {
         public String mime_type;
         public int width;
         public int height;
-    }
-
-    public class Taxonomy {
-        public long ID;
-        public String name;
-        public String slug;
-        public String description;
-        public long post_count;
-        public long parent;
-        public Meta meta;
-
-        public class Meta {
-            public Links links;
-
-            public class Links {
-                public String self;
-                public String help;
-                public String site;
-            }
-        }
     }
 
     public class Capabilities {
@@ -69,7 +50,7 @@ public class PostWPComRestResponse extends Payload implements Response {
     public PostThumbnail post_thumbnail;
     public String format;
     public GeoLocation geo;
-    public Map<String, Taxonomy> tags;
-    public Map<String, Taxonomy> categories;
+    public Map<String, TermWPComRestResponse> tags;
+    public Map<String, TermWPComRestResponse> categories;
     public Capabilities capabilities;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.taxonomy;
+
+import android.content.Context;
+
+import com.android.volley.RequestQueue;
+
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class TaxonomyRestClient extends BaseWPComRestClient {
+    @Inject
+    public TaxonomyRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
+                              AccessToken accessToken, UserAgent userAgent) {
+        super(appContext, dispatcher, requestQueue, accessToken, userAgent);
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
@@ -1,0 +1,30 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.taxonomy;
+
+import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.Response;
+
+import java.util.List;
+
+public class TermWPComRestResponse extends Payload implements Response {
+    public class TermsResponse {
+        public List<TermWPComRestResponse> terms;
+    }
+
+    public long ID;
+    public String name;
+    public String slug;
+    public String description;
+    public long post_count;
+    public long parent;
+    public Meta meta;
+
+    public class Meta {
+        public Links links;
+
+        public class Links {
+            public String self;
+            public String help;
+            public String site;
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.network.xmlrpc.taxonomy;
+
+import com.android.volley.RequestQueue;
+
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.network.HTTPAuthManager;
+import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
+import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
+
+public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
+    public TaxonomyXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,
+                                UserAgent userAgent, HTTPAuthManager httpAuthManager) {
+        super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -1,16 +1,133 @@
 package org.wordpress.android.fluxc.network.xmlrpc.taxonomy;
 
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+
 import com.android.volley.RequestQueue;
+import com.android.volley.Response;
 
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
+import org.wordpress.android.fluxc.generated.endpoint.XMLRPC;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TermModel;
+import org.wordpress.android.fluxc.model.TermsModel;
+import org.wordpress.android.fluxc.network.BaseRequest;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
+import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
+import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
+import org.wordpress.android.util.MapUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
     public TaxonomyXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,
                                 UserAgent userAgent, HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
+    }
+
+    public void fetchTerms(final SiteModel site, final String taxonomyName) {
+        List<Object> params = new ArrayList<>(4);
+        params.add(site.getSelfHostedSiteId());
+        params.add(site.getUsername());
+        params.add(site.getPassword());
+        params.add(taxonomyName);
+
+        final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_TERMS, params,
+                new Response.Listener<Object[]>() {
+                    @Override
+                    public void onResponse(Object[] response) {
+                        TermsModel terms = termsResponseToTermsModel(response, site);
+
+                        FetchTermsResponsePayload payload = new FetchTermsResponsePayload(terms, site, taxonomyName);
+
+                        if (terms != null) {
+                            mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
+                        } else {
+                            payload.error = new TaxonomyError(TaxonomyErrorType.INVALID_RESPONSE);
+                            mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
+                        }
+                    }
+                },
+                new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseRequest.BaseNetworkError error) {
+                        // Possible non-generic errors:
+                        // 403 - Invalid taxonomy
+                        // TODO: Check the error message and flag this as INVALID_TAXONOMY if applicable
+                        // Convert GenericErrorType to TaxonomyErrorType where applicable
+                        TaxonomyError taxonomyError;
+                        switch (error.type) {
+                            case AUTHORIZATION_REQUIRED:
+                                taxonomyError = new TaxonomyError(TaxonomyErrorType.UNAUTHORIZED, error.message);
+                                break;
+                            default:
+                                taxonomyError = new TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, error.message);
+                        }
+                        FetchTermsResponsePayload payload = new FetchTermsResponsePayload(taxonomyError, taxonomyName);
+                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
+                    }
+                }
+        );
+
+        add(request);
+    }
+
+    private TermsModel termsResponseToTermsModel(Object[] response, SiteModel site) {
+        List<Map<?, ?>> termsList = new ArrayList<>();
+        for (Object responseObject : response) {
+            Map<?, ?> termMap = (Map<?, ?>) responseObject;
+            termsList.add(termMap);
+        }
+
+        List<TermModel> termArray = new ArrayList<>();
+        TermModel term;
+
+        for (Object termObject : termsList) {
+            term = termResponseObjectToTermModel(termObject, site);
+            if (term != null) {
+                termArray.add(term);
+            }
+        }
+
+        if (termArray.isEmpty()) {
+            return null;
+        }
+
+        return new TermsModel(termArray);
+    }
+
+    private TermModel termResponseObjectToTermModel(Object termObject, SiteModel site) {
+        // Sanity checks
+        if (!(termObject instanceof Map)) {
+            return null;
+        }
+
+        Map<?, ?> termMap = (Map<?, ?>) termObject;
+        TermModel term = new TermModel();
+
+        String termId = MapUtils.getMapStr(termMap, "term_id");
+        if (TextUtils.isEmpty(termId)) {
+            // If we don't have a term ID, move on
+            return null;
+        }
+
+        term.setLocalSiteId(site.getId());
+        term.setRemoteTermId(Integer.valueOf(termId));
+        term.setSlug(MapUtils.getMapStr(termMap, "slug"));
+        term.setName(MapUtils.getMapStr(termMap, "name"));
+        term.setDescription(MapUtils.getMapStr(termMap, "description"));
+        term.setParentRemoteId(MapUtils.getMapLong(termMap, "parent"));
+        term.setTaxonomy(MapUtils.getMapStr(termMap, "taxonomy"));
+
+        return term;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -43,7 +43,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
     }
 
     public void fetchTerm(final TermModel term, final SiteModel site, final TaxonomyAction origin) {
-        List<Object> params = new ArrayList<>(4);
+        List<Object> params = new ArrayList<>(5);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());
         params.add(site.getPassword());
@@ -54,44 +54,44 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                 new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
-                        if (response != null && response instanceof Map) {
-                            TermModel termModel = termResponseObjectToTermModel(response, site);
-                            FetchTermResponsePayload payload;
-                            if (termModel != null) {
-                                if (origin == TaxonomyAction.PUSH_TERM) {
-                                    termModel.setId(term.getId());
-                                }
-                                payload = new FetchTermResponsePayload(termModel, site);
-                            } else {
-                                payload = new FetchTermResponsePayload(term, site);
-                                payload.error = new TaxonomyError(TaxonomyErrorType.INVALID_RESPONSE);
+                    if (response != null && response instanceof Map) {
+                        TermModel termModel = termResponseObjectToTermModel(response, site);
+                        FetchTermResponsePayload payload;
+                        if (termModel != null) {
+                            if (origin == TaxonomyAction.PUSH_TERM) {
+                                termModel.setId(term.getId());
                             }
-                            payload.origin = origin;
-
-                            mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
+                            payload = new FetchTermResponsePayload(termModel, site);
+                        } else {
+                            payload = new FetchTermResponsePayload(term, site);
+                            payload.error = new TaxonomyError(TaxonomyErrorType.INVALID_RESPONSE);
                         }
+                        payload.origin = origin;
+
+                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
+                    }
                     }
                 },
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                            // Possible non-generic errors:
-                            // 403 - "Invalid taxonomy."
-                            // 404 - "Invalid term ID."
-                            FetchTermResponsePayload payload = new FetchTermResponsePayload(term, site);
-                            // TODO: Check the error message and flag this as INVALID_TAXONOMY or UNKNOWN_TERM
-                            // Convert GenericErrorType to TaxonomyErrorType where applicable
-                            TaxonomyError taxonomyError;
-                            switch (error.type) {
-                                case AUTHORIZATION_REQUIRED:
-                                    taxonomyError = new TaxonomyError(TaxonomyErrorType.UNAUTHORIZED, error.message);
-                                    break;
-                                default:
-                                    taxonomyError = new TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, error.message);
-                            }
-                            payload.error = taxonomyError;
-                            payload.origin = origin;
-                            mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
+                        // Possible non-generic errors:
+                        // 403 - "Invalid taxonomy."
+                        // 404 - "Invalid term ID."
+                        FetchTermResponsePayload payload = new FetchTermResponsePayload(term, site);
+                        // TODO: Check the error message and flag this as INVALID_TAXONOMY or UNKNOWN_TERM
+                        // Convert GenericErrorType to TaxonomyErrorType where applicable
+                        TaxonomyError taxonomyError;
+                        switch (error.type) {
+                            case AUTHORIZATION_REQUIRED:
+                                taxonomyError = new TaxonomyError(TaxonomyErrorType.UNAUTHORIZED, error.message);
+                                break;
+                            default:
+                                taxonomyError = new TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, error.message);
+                        }
+                        payload.error = taxonomyError;
+                        payload.origin = origin;
+                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
                     }
                 }
         );
@@ -187,7 +187,8 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                         payload.error = taxonomyError;
                         mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                     }
-                });
+                }
+        );
 
         request.disableRetries();
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -22,6 +22,7 @@ public class TaxonomySqlUtils {
                 .beginGroup()
                 .equals(TermModelTable.REMOTE_TERM_ID, term.getRemoteTermId())
                 .equals(TermModelTable.LOCAL_SITE_ID, term.getLocalSiteId())
+                .equals(TermModelTable.TAXONOMY, term.getTaxonomy())
                 .endGroup()
                 .endGroup().endWhere().getAsModel();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -48,6 +48,25 @@ public class TaxonomySqlUtils {
                 .getAsModel();
     }
 
+    public static TermModel getTermByRemoteId(SiteModel site, long remoteTermId, String taxonomyName) {
+        if (site == null) {
+            return null;
+        }
+
+        List<TermModel> termResult = WellSql.select(TermModel.class)
+                .where().beginGroup()
+                .equals(TermModelTable.LOCAL_SITE_ID, site.getId())
+                .equals(TermModelTable.REMOTE_TERM_ID, remoteTermId)
+                .equals(TermModelTable.TAXONOMY, taxonomyName)
+                .endGroup().endWhere()
+                .getAsModel();
+
+        if (!termResult.isEmpty()) {
+            return termResult.get(0);
+        }
+        return null;
+    }
+
     public static int clearTaxonomyForSite(SiteModel site, String taxonomyName) {
         if (site == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -43,7 +43,7 @@ public class TaxonomySqlUtils {
     }
 
     public static List<TermModel> getTermsForSite(SiteModel site, String taxonomyName) {
-        if (site == null) {
+        if (site == null || taxonomyName == null) {
             return Collections.emptyList();
         }
 
@@ -56,7 +56,7 @@ public class TaxonomySqlUtils {
     }
 
     public static TermModel getTermByRemoteId(SiteModel site, long remoteTermId, String taxonomyName) {
-        if (site == null) {
+        if (site == null || taxonomyName == null) {
             return null;
         }
 
@@ -75,7 +75,7 @@ public class TaxonomySqlUtils {
     }
 
     public static List<TermModel> getTermsFromRemoteIdList(List<Long> remoteTermIds, String taxonomyName) {
-        if (remoteTermIds == null || remoteTermIds.isEmpty()) {
+        if (taxonomyName == null || remoteTermIds == null || remoteTermIds.isEmpty()) {
             return Collections.emptyList();
         }
 
@@ -88,7 +88,7 @@ public class TaxonomySqlUtils {
     }
 
     public static int clearTaxonomyForSite(SiteModel site, String taxonomyName) {
-        if (site == null) {
+        if (site == null || taxonomyName == null) {
             return 0;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -35,6 +35,12 @@ public class TaxonomySqlUtils {
         }
     }
 
+    public static TermModel insertTermForResult(TermModel term) {
+        WellSql.insert(term).asSingleTransaction(true).execute();
+
+        return term;
+    }
+
     public static List<TermModel> getTermsForSite(SiteModel site, String taxonomyName) {
         if (site == null) {
             return Collections.emptyList();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -74,6 +74,19 @@ public class TaxonomySqlUtils {
         return null;
     }
 
+    public static List<TermModel> getTermsFromRemoteIdList(List<Long> remoteTermIds, String taxonomyName) {
+        if (remoteTermIds == null || remoteTermIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return WellSql.select(TermModel.class)
+                .where().beginGroup()
+                .equals(TermModelTable.TAXONOMY, taxonomyName)
+                .isIn(TermModelTable.REMOTE_TERM_ID, remoteTermIds)
+                .endGroup().endWhere()
+                .getAsModel();
+    }
+
     public static int clearTaxonomyForSite(SiteModel site, String taxonomyName) {
         if (site == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -1,0 +1,63 @@
+package org.wordpress.android.fluxc.persistence;
+
+import com.wellsql.generated.TermModelTable;
+import com.yarolegovich.wellsql.WellSql;
+
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TermModel;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TaxonomySqlUtils {
+    public static int insertOrUpdateTerm(TermModel term) {
+        if (term == null) {
+            return 0;
+        }
+
+        List<TermModel> termResult = WellSql.select(TermModel.class)
+                .where().beginGroup()
+                .equals(TermModelTable.ID, term.getId())
+                .or()
+                .beginGroup()
+                .equals(TermModelTable.REMOTE_TERM_ID, term.getRemoteTermId())
+                .equals(TermModelTable.LOCAL_SITE_ID, term.getLocalSiteId())
+                .endGroup()
+                .endGroup().endWhere().getAsModel();
+
+        if (termResult.isEmpty()) {
+            // insert
+            WellSql.insert(term).asSingleTransaction(true).execute();
+            return 1;
+        } else {
+            return WellSql.update(TermModel.class).whereId(termResult.get(0).getId())
+                    .put(term, new UpdateAllExceptId<TermModel>()).execute();
+        }
+    }
+
+    public static List<TermModel> getTermsForSite(SiteModel site, String taxonomyName) {
+        if (site == null) {
+            return Collections.emptyList();
+        }
+
+        return WellSql.select(TermModel.class)
+                .where().beginGroup()
+                .equals(TermModelTable.LOCAL_SITE_ID, site.getId())
+                .equals(TermModelTable.TAXONOMY, taxonomyName)
+                .endGroup().endWhere()
+                .getAsModel();
+    }
+
+    public static int clearTaxonomyForSite(SiteModel site, String taxonomyName) {
+        if (site == null) {
+            return 0;
+        }
+
+        return WellSql.delete(TermModel.class)
+                .where().beginGroup()
+                .equals(TermModelTable.LOCAL_SITE_ID, site.getId())
+                .equals(TermModelTable.TAXONOMY, taxonomyName)
+                .endGroup().endWhere()
+                .execute();
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -10,11 +10,12 @@ import com.yarolegovich.wellsql.core.TableClass;
 import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 
 import org.wordpress.android.fluxc.model.AccountModel;
-import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.CommentModel;
+import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.network.HTTPAuthModel;
 
@@ -32,6 +33,7 @@ public class WellSqlConfig extends DefaultWellConfig {
             PostFormatModel.class,
             PostModel.class,
             CommentModel.class,
+            TaxonomyModel.class,
             TermModel.class,
             HTTPAuthModel.class
     };

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.network.HTTPAuthModel;
 
 import java.util.Map;
@@ -31,6 +32,7 @@ public class WellSqlConfig extends DefaultWellConfig {
             PostFormatModel.class,
             PostModel.class,
             CommentModel.class,
+            TermModel.class,
             HTTPAuthModel.class
     };
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -11,14 +11,21 @@ import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
+import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.model.TermsModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
+import org.wordpress.android.fluxc.persistence.TaxonomySqlUtils;
 import org.wordpress.android.util.AppLog;
+
+import java.util.List;
 
 import javax.inject.Inject;
 
 public class TaxonomyStore extends Store {
+    public static final String DEFAULT_TAXONOMY_CATEGORY = "category";
+    public static final String DEFAULT_TAXONOMY_TAG = "post_tag";
+
     public static class FetchTermsPayload extends Payload {
         public SiteModel site;
         public TaxonomyModel taxonomy;
@@ -52,6 +59,18 @@ public class TaxonomyStore extends Store {
         }
     }
 
+    // OnChanged events
+    public class OnTaxonomyChanged extends OnChanged<TaxonomyError> {
+        public int rowsAffected;
+        public String taxonomyName;
+        public TaxonomyAction causeOfChange;
+
+        public OnTaxonomyChanged(int rowsAffected, String taxonomyName) {
+            this.rowsAffected = rowsAffected;
+            this.taxonomyName = taxonomyName;
+        }
+    }
+
     public static class TaxonomyError implements OnChangedError {
         public TaxonomyErrorType type;
         public String message;
@@ -73,6 +92,8 @@ public class TaxonomyStore extends Store {
 
     public enum TaxonomyErrorType {
         // TODO: Fill in
+        INVALID_TAXONOMY,
+        UNAUTHORIZED,
         INVALID_RESPONSE,
         GENERIC_ERROR;
 
@@ -104,6 +125,27 @@ public class TaxonomyStore extends Store {
         AppLog.d(AppLog.T.API, "TaxonomyStore onRegister");
     }
 
+    /**
+     * Returns all categories for the given site as a {@link TermModel} list.
+     */
+    public List<TermModel> getCategoriesForSite(SiteModel site) {
+        return TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY);
+    }
+
+    /**
+     * Returns all tags for the given site as a {@link TermModel} list.
+     */
+    public List<TermModel> getTagsForSite(SiteModel site) {
+        return TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG);
+    }
+
+    /**
+     * Returns all the terms of a taxonomy for the given site as a {@link TermModel} list.
+     */
+    public List<TermModel> getTermsForSite(SiteModel site, String taxonomyName) {
+        return TaxonomySqlUtils.getTermsForSite(site, taxonomyName);
+    }
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
     public void onAction(Action action) {
@@ -114,13 +156,66 @@ public class TaxonomyStore extends Store {
 
         switch ((TaxonomyAction) actionType) {
             case FETCH_CATEGORIES:
+                fetchTerms(((SiteModel) action.getPayload()), DEFAULT_TAXONOMY_CATEGORY);
                 break;
             case FETCH_TAGS:
+                fetchTerms(((SiteModel) action.getPayload()), DEFAULT_TAXONOMY_TAG);
                 break;
             case FETCH_TERMS:
+                fetchTerms((FetchTermsPayload) action.getPayload());
                 break;
             case FETCHED_TERMS:
+                handleFetchTermsCompleted((FetchTermsResponsePayload) action.getPayload());
                 break;
         }
+    }
+
+    private void fetchTerms(SiteModel site, String taxonomyName) {
+        // TODO: Support large number of terms (currently pulling 100 from REST, and ? from XML-RPC) - pagination?
+        if (site.isWPCom()) {
+            mTaxonomyRestClient.fetchTerms(site, taxonomyName);
+        } else {
+            // TODO: check for WP-REST-API plugin and use it here
+             mTaxonomyXMLRPCClient.fetchTerms(site, taxonomyName);
+        }
+    }
+
+    private void fetchTerms(FetchTermsPayload payload) {
+        fetchTerms(payload.site, payload.taxonomy.getName());
+    }
+
+    private void handleFetchTermsCompleted(FetchTermsResponsePayload payload) {
+        OnTaxonomyChanged onTaxonomyChanged;
+
+        if (payload.isError()) {
+            onTaxonomyChanged = new OnTaxonomyChanged(0, payload.taxonomy);
+            onTaxonomyChanged.error = payload.error;
+        } else {
+            // Clear existing terms for this taxonomy
+            // This is the simplest way of keeping our local terms in sync with their remote versions
+            // (in case of deletions,or if the user manually changed some term IDs)
+            // TODO: This may have to change when we support large numbers of terms and require multiple requests
+            TaxonomySqlUtils.clearTaxonomyForSite(payload.site, payload.taxonomy);
+
+            int rowsAffected = 0;
+            for (TermModel term : payload.terms.getTerms()) {
+                rowsAffected += TaxonomySqlUtils.insertOrUpdateTerm(term);
+            }
+
+            onTaxonomyChanged = new OnTaxonomyChanged(rowsAffected, payload.taxonomy);
+        }
+
+        switch (payload.taxonomy) {
+            case DEFAULT_TAXONOMY_CATEGORY:
+                onTaxonomyChanged.causeOfChange = TaxonomyAction.FETCH_CATEGORIES;
+                break;
+            case DEFAULT_TAXONOMY_TAG:
+                onTaxonomyChanged.causeOfChange = TaxonomyAction.FETCH_TAGS;
+                break;
+            default:
+                onTaxonomyChanged.causeOfChange = TaxonomyAction.FETCH_TERMS;
+        }
+
+        emitChange(onTaxonomyChanged);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -146,6 +146,27 @@ public class TaxonomyStore extends Store {
         return TaxonomySqlUtils.getTermsForSite(site, taxonomyName);
     }
 
+    /**
+     * Returns a category as a {@link TermModel} given its remote id.
+     */
+    public TermModel getCategoryByRemoteId(SiteModel site, long remoteId) {
+        return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, DEFAULT_TAXONOMY_CATEGORY);
+    }
+
+    /**
+     * Returns a category as a {@link TermModel} given its remote id.
+     */
+    public TermModel getTagByRemoteId(SiteModel site, long remoteId) {
+        return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, DEFAULT_TAXONOMY_TAG);
+    }
+
+    /**
+     * Returns a category as a {@link TermModel} given its remote id.
+     */
+    public TermModel getTermByRemoteId(SiteModel site, long remoteId, String taxonomyName) {
+        return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, taxonomyName);
+    }
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
     public void onAction(Action action) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -65,8 +65,6 @@ public class TaxonomyStore extends Store {
         public TermModel term;
         public SiteModel site;
 
-        public RemoteTermPayload() {}
-
         public RemoteTermPayload(TermModel term, SiteModel site) {
             this.term = term;
             this.site = site;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -1,0 +1,125 @@
+package org.wordpress.android.fluxc.store;
+
+import android.support.annotation.NonNull;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.action.TaxonomyAction;
+import org.wordpress.android.fluxc.annotations.action.Action;
+import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TermsModel;
+import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
+import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
+import org.wordpress.android.util.AppLog;
+
+import javax.inject.Inject;
+
+public class TaxonomyStore extends Store {
+    public static class FetchTermsPayload extends Payload {
+        public SiteModel site;
+        public String taxonomy;
+
+        public FetchTermsPayload(SiteModel site, String taxonomy) {
+            this.site = site;
+            this.taxonomy = taxonomy;
+        }
+    }
+
+    public static class FetchTermsResponsePayload extends Payload {
+        public TaxonomyError error;
+        public TermsModel terms;
+        public SiteModel site;
+        public String taxonomy;
+
+        public FetchTermsResponsePayload(TermsModel terms, SiteModel site, String taxonomy) {
+            this.terms = terms;
+            this.site = site;
+            this.taxonomy = taxonomy;
+        }
+
+        public FetchTermsResponsePayload(TaxonomyError error, String taxonomy) {
+            this.error = error;
+            this.taxonomy = taxonomy;
+        }
+
+        @Override
+        public boolean isError() {
+            return error != null;
+        }
+    }
+
+    public static class TaxonomyError implements OnChangedError {
+        public TaxonomyErrorType type;
+        public String message;
+
+        public TaxonomyError(TaxonomyErrorType type, @NonNull String message) {
+            this.type = type;
+            this.message = message;
+        }
+
+        public TaxonomyError(@NonNull String type, @NonNull String message) {
+            this.type = TaxonomyErrorType.fromString(type);
+            this.message = message;
+        }
+
+        public TaxonomyError(TaxonomyErrorType type) {
+            this(type, "");
+        }
+    }
+
+    public enum TaxonomyErrorType {
+        // TODO: Fill in
+        INVALID_RESPONSE,
+        GENERIC_ERROR;
+
+        public static TaxonomyErrorType fromString(String string) {
+            if (string != null) {
+                for (TaxonomyErrorType v : TaxonomyErrorType.values()) {
+                    if (string.equalsIgnoreCase(v.name())) {
+                        return v;
+                    }
+                }
+            }
+            return GENERIC_ERROR;
+        }
+    }
+
+    private final TaxonomyRestClient mTaxonomyRestClient;
+    private final TaxonomyXMLRPCClient mTaxonomyXMLRPCClient;
+
+    @Inject
+    public TaxonomyStore(Dispatcher dispatcher, TaxonomyRestClient taxonomyRestClient,
+                         TaxonomyXMLRPCClient taxonomyXMLRPCClient) {
+        super(dispatcher);
+        mTaxonomyRestClient = taxonomyRestClient;
+        mTaxonomyXMLRPCClient = taxonomyXMLRPCClient;
+    }
+
+    @Override
+    public void onRegister() {
+        AppLog.d(AppLog.T.API, "TaxonomyStore onRegister");
+    }
+
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    @Override
+    public void onAction(Action action) {
+        IAction actionType = action.getType();
+        if (!(actionType instanceof TaxonomyAction)) {
+            return;
+        }
+
+        switch ((TaxonomyAction) actionType) {
+            case FETCH_CATEGORIES:
+                break;
+            case FETCH_TAGS:
+                break;
+            case FETCH_TERMS:
+                break;
+            case FETCHED_TERMS:
+                break;
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.action.TaxonomyAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermsModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
@@ -20,9 +21,9 @@ import javax.inject.Inject;
 public class TaxonomyStore extends Store {
     public static class FetchTermsPayload extends Payload {
         public SiteModel site;
-        public String taxonomy;
+        public TaxonomyModel taxonomy;
 
-        public FetchTermsPayload(SiteModel site, String taxonomy) {
+        public FetchTermsPayload(SiteModel site, TaxonomyModel taxonomy) {
             this.site = site;
             this.taxonomy = taxonomy;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -225,7 +225,8 @@ public class TaxonomyStore extends Store {
         if (payload.site.isWPCom()) {
             mTaxonomyRestClient.fetchTerm(payload.term, payload.site);
         } else {
-            // TODO: XML-RPC support
+            // TODO: check for WP-REST-API plugin and use it here
+            mTaxonomyXMLRPCClient.fetchTerm(payload.term, payload.site);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.TaxonomyAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
@@ -217,6 +218,20 @@ public class TaxonomyStore extends Store {
      */
     public TermModel getTermByRemoteId(SiteModel site, long remoteId, String taxonomyName) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, taxonomyName);
+    }
+
+    /**
+     * Returns all the categories for the given post as a {@link TermModel} list.
+     */
+    public List<TermModel> getCategoriesForPost(PostModel post) {
+        return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getCategoryIdList(), DEFAULT_TAXONOMY_CATEGORY);
+    }
+
+    /**
+     * Returns all the tags for the given post as a {@link TermModel} list.
+     */
+    public List<TermModel> getTagsForPost(PostModel post) {
+        return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getTagIdList(), DEFAULT_TAXONOMY_TAG);
     }
 
     @Subscribe(threadMode = ThreadMode.ASYNC)

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -8,6 +8,7 @@ wp.getPosts
 wp.newPost
 wp.editPost
 wp.deletePost
+wp.getTerms
 wp.uploadFile
 wp.newComment
 wp.getComment

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -8,6 +8,7 @@ wp.getPosts
 wp.newPost
 wp.editPost
 wp.deletePost
+wp.getTerm
 wp.getTerms
 wp.uploadFile
 wp.newComment

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -10,6 +10,7 @@ wp.editPost
 wp.deletePost
 wp.getTerm
 wp.getTerms
+wp.newTerm
 wp.uploadFile
 wp.newComment
 wp.getComment


### PR DESCRIPTION
Addresses #160, adding a TaxonomyStore.

Work in progress!

### Notes:
* I added some provisions for supporting generic taxonomies (e.g. `TaxonomyModel`), but no taxonomies other than categories and tags are actually supported at this time
* Editing and deleting terms is unsupported for now, since we don't currently offer those operations in WPAndroid

### Features
- [x] Instantiate a term (local)
- [x] Update a term (local)
- [x] Remove all categories or tags or terms for a site (local)
- [x] Fetch all categories for site (REST & XMLRPC)
- [x] Fetch all tags for site (REST & XMLRPC)
- [x] Fetch all terms for generic taxonomy for site (REST & XMLRPC)
- [x] Fetch single category/tag/term (refresh) (REST & XMLRPC)
- [x] Create category/tag/term (REST & XMLRPC)
- [x] Retrieve full details on categories or tags given a `PostModel` (local)

### Tests
#### Local tests
- [x] Term equality
- [x] Term insertion/retrieval
- [x] Separation of categories/tags/terms
- [x] Clearing all terms for a taxonomy from the db
#### REST
- [x] Fetch categories REST
- [x] Fetch tags REST
- [x] Fetch terms for taxonomy REST
- [x] Attempt to fetch terms for invalid taxonomy REST
- [x] Fetch single term by slug REST
- [x] Create category/tag/term REST
- [x] Attempt to upload term for invalid taxonomy REST
- [x] Attempt to upload a duplicate term REST
#### XML-RPC
- [x] Fetch categories XML-RPC
- [x] Fetch tags XML-RPC
- [x] Fetch terms for taxonomy XML-RPC
- [x] Attempt to fetch terms for invalid taxonomy XML-RPC
- [x] Fetch single term by ID XML-RPC
- [x] Create category/tag/term XML-RPC
- [x] Attempt to upload term for invalid taxonomy XML-RPC
- [x] Attempt to upload a duplicate term XML-RPC