### PR TITLE
Support imports for Javadoc comments in checkstyle

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -103,7 +103,9 @@
         <module name="AvoidStarImport"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
-        <module name="UnusedImports"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
 
         <module name="ImportOrder">
             <property name="groups" value="android,com,junit,net,org,java,javax"/>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.android.volley.Response.Listener;
 
+import org.wordpress.android.fluxc.action.AuthenticationAction;
 import org.wordpress.android.fluxc.generated.endpoint.XMLRPC;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -11,6 +11,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.AccountModel;


### PR DESCRIPTION
Updated our checkstyle config to allow imports that are only used by Javadocs (previously, this would trigger an 'unused import' warning). I also added the imports in a few places where they were needed by Javadocs.