### PR TITLE
WP-API Endpoint support

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/WPAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPAPIEndpointTest.java
@@ -1,0 +1,42 @@
+package org.wordpress.android.fluxc;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.wordpress.android.fluxc.generated.endpoint.WPAPI;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class WPAPIEndpointTest {
+    @Test
+    public void testAllEndpoints() {
+        // Posts
+        assertEquals("/posts/", WPAPI.posts.getEndpoint());
+        assertEquals("/posts/56/", WPAPI.posts.id(56).getEndpoint());
+
+        // Pages
+        assertEquals("/pages/", WPAPI.pages.getEndpoint());
+        assertEquals("/pages/56/", WPAPI.pages.id(56).getEndpoint());
+
+        // Media
+        assertEquals("/media/", WPAPI.media.getEndpoint());
+        assertEquals("/media/56/", WPAPI.media.id(56).getEndpoint());
+
+        // Comments
+        assertEquals("/comments/", WPAPI.comments.getEndpoint());
+        assertEquals("/comments/56/", WPAPI.comments.id(56).getEndpoint());
+
+        // Settings
+        assertEquals("/settings/", WPAPI.settings.getEndpoint());
+    }
+
+    @Test
+    public void testUrls() {
+        assertEquals("wp/v2/posts/", WPAPI.posts.getUrlV2());
+        assertEquals("wp/v2/pages/", WPAPI.pages.getUrlV2());
+        assertEquals("wp/v2/media/", WPAPI.media.getUrlV2());
+        assertEquals("wp/v2/comments/", WPAPI.comments.getUrlV2());
+        assertEquals("wp/v2/settings/", WPAPI.settings.getUrlV2());
+    }
+}

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
@@ -72,7 +72,7 @@ public class EndpointNode {
             // For 'mixed' endpoints, e.g. item:$theItem, return the label part ('item')
             return getLocalEndpoint().substring(0, getLocalEndpoint().indexOf(":")).replaceAll("-", "_");
         } else {
-            return getLocalEndpoint().replaceAll("/|\\$|#.*|_ID|_id", "").replaceAll("-", "_");
+            return getLocalEndpoint().replaceAll("/|\\$|#.*|_ID|_id|<|>", "").replaceAll("-", "_");
         }
     }
 

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPAPIEndpoint.java
@@ -1,0 +1,27 @@
+package org.wordpress.android.fluxc.annotations.endpoint;
+
+public class WPAPIEndpoint {
+    private static final String WPAPI_PREFIX_V2 = "wp/v2";
+
+    private final String mEndpoint;
+
+    public WPAPIEndpoint(String endpoint) {
+        mEndpoint = endpoint;
+    }
+
+    public WPAPIEndpoint(String endpoint, long id) {
+        this(endpoint + id + "/");
+    }
+
+    public WPAPIEndpoint(String endpoint, String value) {
+        this(endpoint + value + "/");
+    }
+
+    public String getEndpoint() {
+        return mEndpoint;
+    }
+
+    public String getUrlV2() {
+        return WPAPI_PREFIX_V2 + mEndpoint;
+    }
+}

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -7,6 +7,7 @@ import com.squareup.javapoet.TypeSpec;
 import org.wordpress.android.fluxc.annotations.AnnotationConfig;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointNode;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointTreeGenerator;
+import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint;
 import org.wordpress.android.fluxc.annotations.endpoint.WPComEndpoint;
 
 import java.io.File;
@@ -30,8 +31,10 @@ import javax.lang.model.element.TypeElement;
 public class EndpointProcessor extends AbstractProcessor {
     private static final String WPCOMREST_ENDPOINT_FILE = "fluxc/src/main/tools/wp-com-endpoints.txt";
     private static final String XMLRPC_ENDPOINT_FILE = "fluxc/src/main/tools/xmlrpc-endpoints.txt";
+    private static final String WPAPI_ENDPOINT_FILE = "fluxc/src/main/tools/wp-api-endpoints.txt";
 
     private static final Pattern WPCOMREST_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("\\$");
+    private static final Pattern WPAPI_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("^<.*>/$");
 
     private static final Map<String, List<String>> XML_RPC_ALIASES;
     static {
@@ -58,6 +61,7 @@ public class EndpointProcessor extends AbstractProcessor {
         try {
             generateWPCOMRESTEndpointFile();
             generateXMLRPCEndpointFile();
+            generateWPAPIEndpointFile();
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -81,6 +85,15 @@ public class EndpointProcessor extends AbstractProcessor {
         File file = new File(XMLRPC_ENDPOINT_FILE);
 
         TypeSpec endpointClass = XMLRPCPoet.generate(file, "XMLRPC", XML_RPC_ALIASES);
+        writeEndpointClassToFile(endpointClass);
+    }
+
+    private void generateWPAPIEndpointFile() throws IOException {
+        File file = new File(WPAPI_ENDPOINT_FILE);
+        EndpointNode rootNode = EndpointTreeGenerator.process(file);
+
+        TypeSpec endpointClass = RESTPoet.generate(rootNode, "WPAPI", WPAPIEndpoint.class,
+                WPAPI_VARIABLE_ENDPOINT_PATTERN);
         writeEndpointClassToFile(endpointClass);
     }
 

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
@@ -29,6 +30,8 @@ import javax.lang.model.element.TypeElement;
 public class EndpointProcessor extends AbstractProcessor {
     private static final String WPCOMREST_ENDPOINT_FILE = "fluxc/src/main/tools/wp-com-endpoints.txt";
     private static final String XMLRPC_ENDPOINT_FILE = "fluxc/src/main/tools/xmlrpc-endpoints.txt";
+
+    private static final Pattern WPCOMREST_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("\\$");
 
     private static final Map<String, List<String>> XML_RPC_ALIASES;
     static {
@@ -69,7 +72,8 @@ public class EndpointProcessor extends AbstractProcessor {
         File file = new File(WPCOMREST_ENDPOINT_FILE);
         EndpointNode rootNode = EndpointTreeGenerator.process(file);
 
-        TypeSpec endpointClass = RESTPoet.generate(rootNode, "WPCOMREST", WPComEndpoint.class);
+        TypeSpec endpointClass = RESTPoet.generate(rootNode, "WPCOMREST", WPComEndpoint.class,
+                WPCOMREST_VARIABLE_ENDPOINT_PATTERN);
         writeEndpointClassToFile(endpointClass);
     }
 

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -17,7 +17,6 @@ import java.util.Locale;
 import javax.lang.model.element.Modifier;
 
 public class RESTPoet {
-    // TODO: Need to support "/sites/$site/posts/slug:$post_slug"-type endpoints
     private static final String[] JAVA_KEYWORDS = {
             "new", "abstract", "assert", "boolean",
             "break", "byte", "case", "catch", "char", "class", "const",

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -73,7 +73,7 @@ public class RESTPoet {
 
             if (endpointNode.getParent().isRoot()) {
                 endpointFieldBuilder.addModifiers(Modifier.STATIC)
-                        .initializer("new $T($S)", sBaseEndpointClass, endpointNode.getLocalEndpoint());
+                        .initializer("new $T($S)", sBaseEndpointClass, "/" + endpointNode.getLocalEndpoint());
             } else {
                 endpointFieldBuilder
                         .initializer("new $T(getEndpoint() + $S)", sBaseEndpointClass, endpointNode.getLocalEndpoint());

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -150,7 +150,10 @@ public class RESTPoet {
 
             // Add a constructor for each type this endpoint accepts (usually long)
             for (Class endpointType : getVariableEndpointTypes(endpointNode)) {
-                String variableName = endpointType.equals(String.class) ? endpointName : endpointName + "Id";
+                String variableName = endpointName;
+                if (endpointType.equals(long.class) && !endpointName.equals("id")) {
+                    variableName = endpointName + "Id";
+                }
 
                 MethodSpec.Builder endpointConstructorBuilder = MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PRIVATE)
@@ -196,7 +199,10 @@ public class RESTPoet {
                 methodName = "item";
             }
 
-            String variableName = endpointType.equals(String.class) ? endpointName : endpointName + "Id";
+            String variableName = endpointName;
+            if (endpointType.equals(long.class) && !endpointName.equals("id")) {
+                variableName = endpointName + "Id";
+            }
 
             MethodSpec.Builder endpointMethodBuilder = MethodSpec.methodBuilder(methodName)
                     .addModifiers(Modifier.PUBLIC)

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -13,6 +13,8 @@ import org.wordpress.android.fluxc.annotations.endpoint.EndpointNode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.lang.model.element.Modifier;
 
@@ -30,9 +32,12 @@ public class RESTPoet {
     };
 
     private static TypeName sBaseEndpointClass;
+    private static Pattern sVariableEndpointPattern;
 
-    public static TypeSpec generate(EndpointNode rootNode, String fileName, Class baseEndpointClass) {
+    public static TypeSpec generate(EndpointNode rootNode, String fileName, Class baseEndpointClass,
+                                    Pattern variableEndpointPattern) {
         sBaseEndpointClass = ClassName.get(baseEndpointClass);
+        sVariableEndpointPattern = variableEndpointPattern;
 
         TypeSpec.Builder wpcomRestBuilder = TypeSpec.classBuilder(fileName)
                 .addModifiers(Modifier.PUBLIC);
@@ -45,7 +50,9 @@ public class RESTPoet {
     }
 
     private static void addEndpointToBuilder(EndpointNode endpointNode, TypeSpec.Builder classBuilder) {
-        if (endpointNode.getLocalEndpoint().contains("$")) {
+        Matcher variableEndpointMatcher = sVariableEndpointPattern.matcher(endpointNode.getLocalEndpoint());
+
+        if (variableEndpointMatcher.find()) {
             processVariableEndpointNode(endpointNode, classBuilder);
         } else {
             processStaticEndpointNode(endpointNode, classBuilder);

--- a/fluxc/src/main/tools/wp-api-endpoints.txt
+++ b/fluxc/src/main/tools/wp-api-endpoints.txt
@@ -1,0 +1,13 @@
+/posts/
+/posts/<id>/
+
+/pages/
+/pages/<id>/
+
+/media/
+/media/<id>/
+
+/comments/
+/comments/<id>/
+
+/settings/


### PR DESCRIPTION
Updates the `EndpointProcessor` to generate `WPAPI.java` from a list of WP-API endpoints for future use by FluxC.