### PR TITLE
Fix #227: Add has_unseen_notes to the AccountModel and AccountResponse

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -23,6 +23,7 @@ public class AccountModel extends Payload implements Identifiable {
     @Column private int mSiteCount;
     @Column private int mVisibleSiteCount;
     @Column private String mEmail;
+    @Column private boolean mHasUnseenNotes;
 
     // Account Settings attributes
     @Column private String mFirstName;
@@ -66,7 +67,8 @@ public class AccountModel extends Payload implements Identifiable {
                && StringUtils.equals(getDate(), otherAccount.getDate())
                && StringUtils.equals(getNewEmail(), otherAccount.getNewEmail())
                && getPendingEmailChange() == otherAccount.getPendingEmailChange()
-               && StringUtils.equals(getWebAddress(), otherAccount.getWebAddress());
+               && StringUtils.equals(getWebAddress(), otherAccount.getWebAddress())
+               && getHasUnseenNotes() == otherAccount.getHasUnseenNotes();
     }
 
     public void init() {
@@ -102,6 +104,7 @@ public class AccountModel extends Payload implements Identifiable {
         setSiteCount(other.getSiteCount());
         setVisibleSiteCount(other.getVisibleSiteCount());
         setEmail(other.getEmail());
+        setHasUnseenNotes(other.getHasUnseenNotes());
     }
 
     /**
@@ -247,5 +250,13 @@ public class AccountModel extends Payload implements Identifiable {
 
     public String getWebAddress() {
         return mWebAddress;
+    }
+
+    public boolean getHasUnseenNotes() {
+        return mHasUnseenNotes;
+    }
+
+    public void setHasUnseenNotes(boolean hasUnseenNotes) {
+        mHasUnseenNotes = hasUnseenNotes;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountResponse.java
@@ -19,4 +19,5 @@ public class AccountResponse implements Response {
     public String date;
     public int site_count;
     public int visible_site_count;
+    public boolean has_unseen_notes;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -314,6 +314,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         account.setDate(from.date);
         account.setSiteCount(from.site_count);
         account.setVisibleSiteCount(from.visible_site_count);
+        account.setHasUnseenNotes(from.has_unseen_notes);
         return account;
     }
 


### PR DESCRIPTION
Fix #227: Add has_unseen_notes to the AccountModel and AccountResponse