### PR TITLE
Issue #223: Set comment_status when uploading XML-RPC posts

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -31,6 +31,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private boolean mIsWPCom;
     @Column private boolean mIsAdmin;
     @Column private boolean mIsFeaturedImageSupported;
+    @Column private String mDefaultCommentStatus = "open";
     @Column private String mTimezone;
 
 
@@ -207,6 +208,14 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
 
     public void setIsFeaturedImageSupported(boolean featuredImageSupported) {
         mIsFeaturedImageSupported = featuredImageSupported;
+    }
+
+    public String getDefaultCommentStatus() {
+        return mDefaultCommentStatus;
+    }
+
+    public void setDefaultCommentStatus(String defaultCommentStatus) {
+        mDefaultCommentStatus = defaultCommentStatus;
     }
 
     public String getSoftwareVersion() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -175,6 +175,12 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         Map<String, Object> contentStruct = postModelToContentStruct(post);
 
+        if (post.isLocalDraft()) {
+            // For first time publishing, set the comment status (open or closed) to the default value for the site
+            // (respect the existing comment status when editing posts)
+            contentStruct.put("comment_status", site.getDefaultCommentStatus());
+        }
+
         List<Object> params = new ArrayList<>(5);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -33,6 +33,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
     //
     public static final String SOFTWARE_VERSION_KEY = "software_version";
     public static final String POST_THUMBNAIL_KEY = "post_thumbnail";
+    public static final String DEFAULT_COMMENT_STATUS_KEY = "default_comment_status";
     public static final String JETPACK_CLIENT_ID_KEY = "jetpack_client_id";
     public static final String SITE_PUBLIC_KEY = "blog_public";
     public static final String HOME_URL_KEY = "home_url";
@@ -106,8 +107,8 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         params.add(site.getUsername());
         params.add(site.getPassword());
         params.add(new String[] {
-                SOFTWARE_VERSION_KEY, POST_THUMBNAIL_KEY, JETPACK_CLIENT_ID_KEY, SITE_PUBLIC_KEY,
-                HOME_URL_KEY, ADMIN_URL_KEY, LOGIN_URL_KEY, SITE_TITLE_KEY, TIME_ZONE_KEY });
+                SOFTWARE_VERSION_KEY, POST_THUMBNAIL_KEY, DEFAULT_COMMENT_STATUS_KEY, JETPACK_CLIENT_ID_KEY,
+                SITE_PUBLIC_KEY, HOME_URL_KEY, ADMIN_URL_KEY, LOGIN_URL_KEY, SITE_TITLE_KEY, TIME_ZONE_KEY });
         final XMLRPCRequest request = new XMLRPCRequest(
                 site.getXmlRpcUrl(), XMLRPC.GET_OPTIONS, params,
                 new Listener<Object>() {
@@ -207,6 +208,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         oldModel.setSoftwareVersion(getOption(siteOptions, SOFTWARE_VERSION_KEY, String.class));
         Boolean postThumbnail = getOption(siteOptions, POST_THUMBNAIL_KEY, Boolean.class);
         oldModel.setIsFeaturedImageSupported((postThumbnail != null) && postThumbnail);
+        oldModel.setDefaultCommentStatus(getOption(siteOptions, DEFAULT_COMMENT_STATUS_KEY, String.class));
         oldModel.setTimezone(getOption(siteOptions, TIME_ZONE_KEY, String.class));
         oldModel.setLoginUrl(getOption(siteOptions, LOGIN_URL_KEY, String.class));
         oldModel.setAdminUrl(getOption(siteOptions, ADMIN_URL_KEY, String.class));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -87,20 +87,6 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public static final Map<String, String> XMLRPC_BLOG_OPTIONS = new HashMap<>();
-
-    static {
-        XMLRPC_BLOG_OPTIONS.put("software_version", "software_version");
-        XMLRPC_BLOG_OPTIONS.put("post_thumbnail", "post_thumbnail");
-        XMLRPC_BLOG_OPTIONS.put("jetpack_client_id", "jetpack_client_id");
-        XMLRPC_BLOG_OPTIONS.put("blog_public", "blog_public");
-        XMLRPC_BLOG_OPTIONS.put("home_url", "home_url");
-        XMLRPC_BLOG_OPTIONS.put("admin_url", "admin_url");
-        XMLRPC_BLOG_OPTIONS.put("login_url", "login_url");
-        XMLRPC_BLOG_OPTIONS.put("blog_title", "blog_title");
-        XMLRPC_BLOG_OPTIONS.put("time_zone", "time_zone");
-    }
-
     public void fetchSite(final SiteModel site) {
         List<Object> params = new ArrayList<>(2);
         params.add(site.getSiteId());


### PR DESCRIPTION
Fixes #223. It seems XML-RPC's `wp.newPost` will always create posts with comments disabled, regardless of the default setting for the site.

To fix this, I added `default_comment_status` to the options we retrieve with `wp.getOptions`, and use that value for the post's `comment_status` param on every new upload.

In the future we could add a toggle for this in the post settings screen, so it can be changed for individual posts like on the web.

There's one small hiccup with this approach: if we publish a post without having called `wp.getOptions` beforehand we won't have the real default comment status for that site. Comments are enabled by default on first install, so I opted for the default value if we haven't called `wp.getOptions` to be `open`.

To test (on self-hosted site):
1. Make sure comments are enabled by default for the test site (`Settings` -> `Discussion` - > `Allow people to post comments on new articles` in wp-admin)
2. Publish a new post with FluxC (tests or example app) without this branch
3. Notice that the post has comments disabled
4. Switch to this branch and try again
5. The new post should have comments enabled
6. Try editing an existing post - the comment status shouldn't be changed by the edit