### PR TITLE
Issue #232: Fix XML-RPC site tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -108,6 +108,8 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
     }
 
     public void testXMLRPCSelfSignedSSLFetchSites() throws InterruptedException {
+        mMemorizingTrustManager.clearLocalTrustStore();
+
         RefreshSitesXMLRPCPayload payload = new RefreshSitesXMLRPCPayload();
         payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_SELFSIGNED_SSL;
         payload.password = BuildConfig.TEST_WPORG_PASSWORD_SH_SELFSIGNED_SSL;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -226,7 +226,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
     @SuppressWarnings("unused")
     @Subscribe
     public void onSiteChanged(OnSiteChanged event) {
-        AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
+        AppLog.i(T.TESTS, "Received OnSiteChanged, site count: " + mSiteStore.getSitesCount());
         if (event.isError()) {
             AppLog.i(T.TESTS, "OnSiteChanged has error: " + event.error.type);
             if (mNextEvent.equals(TEST_EVENTS.HTTP_AUTH_ERROR)) {
@@ -250,7 +250,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
     @SuppressWarnings("unused")
     @Subscribe
     public void OnSiteRemoved(SiteStore.OnSiteRemoved event) {
-        AppLog.e(T.TESTS, "site count " + mSiteStore.getSitesCount());
+        AppLog.i(T.TESTS, "Received OnSiteRemoved, site count: " + mSiteStore.getSitesCount());
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -264,7 +264,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
         if (event.isError()) {
-            AppLog.i(T.TESTS, "error " + event.error.type + " - " + event.error.message);
+            AppLog.i(T.TESTS, "OnAuthenticationChanged has error: " + event.error.type + " - " + event.error.message);
             if (event.error.type == AuthenticationErrorType.HTTP_AUTH_ERROR) {
                 assertEquals(TEST_EVENTS.HTTP_AUTH_ERROR, mNextEvent);
             } else if (event.error.type == AuthenticationErrorType.INVALID_SSL_CERTIFICATE) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -249,7 +249,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
         if (event.isError()) {
             AppLog.i(T.TESTS, "error " + event.error.type + " - " + event.error.message);
-            if (event.error.type == AuthenticationErrorType.GENERIC_ERROR) {
+            if (event.error.type == AuthenticationErrorType.HTTP_AUTH_ERROR) {
                 assertEquals(TEST_EVENTS.HTTP_AUTH_ERROR, mNextEvent);
             } else if (event.error.type == AuthenticationErrorType.INVALID_SSL_CERTIFICATE) {
                 assertEquals(TEST_EVENTS.INVALID_SSL_CERTIFICATE, mNextEvent);


### PR DESCRIPTION
Fixes #232, repairing two tests in `ReleaseStack_SiteTestXMLRPC` that were broken by test changes in #214 (`testXMLRPCHTTPAuthFetchSites()` and `testXMLRPCSelfSignedSSLFetchSites()`).

With stricter identification of errors in tests to avoid false positives, we now need to be more specific with the site tests. The issue was that SSL and HTTP AUTH failures generate *two* `OnChanged` events, but the tests expected one.

When an SSL or HTTP AUTH error is encountered, an `OnAuthenticationChanged` event is always dispatched with the error. The failed action, however, can also dispatch its own event (here, `OnSiteChanged`), reporting a `GENERIC_ERROR`.

The fix was to specify that there are two errors expected in those tests, and allow `OnSiteChanged` to count down the latch if the tests are expecting an HTTP AUTH or SSL error.

@tonyr59h and I had some discussion about the deeper implications here. I'm not sure that `SiteErrorType`, for example, needs to contain an `HTTP_AUTH_ERROR` and `INVALID_SSL_CERTIFICATE` error, since it's not up to `OnSiteChanged` to handle this - this is a deeper problem with the site itself that needs to be handled in `OnAuthenticationChanged`.

If this is the case, then it seems good enough that `OnSiteChanged` reports a `GENERIC_ERROR`, signaling to the UI to stop showing loading screens/animations, while `OnAuthenticationChanged` takes care of prompting the HTTP AUTH screen/SSL popup. cc @maxme on whether this makes sense or not.