### PR TITLE
Issue/memorizing trust manager fix

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
@@ -61,6 +61,7 @@ public class MemorizingTrustManager implements X509TrustManager {
         try {
             return mLocalKeyStoreFutureTask.get(FUTURE_TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            AppLog.e(T.API, e);
             throw new IllegalStateException("Couldn't find KeyStore");
         }
     }
@@ -70,6 +71,7 @@ public class MemorizingTrustManager implements X509TrustManager {
         try {
             return mTrustManagerFutureTask.get(FUTURE_TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            AppLog.e(T.API, e);
             throw new IllegalStateException("Couldn't find X509TrustManager");
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
@@ -83,8 +83,7 @@ public class MemorizingTrustManager implements X509TrustManager {
         } catch (FileNotFoundException e) {
             // Init the key store for the first time
             try {
-                initLocalKeyStoreFile();
-                localKeyStore = loadTrustStore();
+                localKeyStore = initLocalKeyStoreFile();
             } catch (IOException | GeneralSecurityException e1) {
                 throw new IllegalStateException(e1);
             }
@@ -139,7 +138,7 @@ public class MemorizingTrustManager implements X509TrustManager {
         }
     }
 
-    private void initLocalKeyStoreFile() throws GeneralSecurityException, IOException {
+    private KeyStore initLocalKeyStoreFile() throws GeneralSecurityException, IOException {
         FileOutputStream out = null;
         try {
             File localKeyStoreFile = new File(mContext.getFilesDir(), KEYSTORE_FILENAME);
@@ -147,6 +146,7 @@ public class MemorizingTrustManager implements X509TrustManager {
             KeyStore localTrustStore = KeyStore.getInstance(KeyStore.getDefaultType());
             localTrustStore.load(null, KEYSTORE_PASSWORD.toCharArray());
             localTrustStore.store(out, KEYSTORE_PASSWORD.toCharArray());
+            return localTrustStore;
         } finally {
             if (out != null) {
                 try {


### PR DESCRIPTION
Found a weird issue when reviewing #234 - looks like the ".store()" call is asynchronous. Don't try to reload the keystore after the init fixes the problem.

```
java.lang.IllegalStateException: Couldn't find KeyStore
at org.wordpress.android.fluxc.network.MemorizingTrustManager.getLocalKeyStore(MemorizingTrustManager.java:64)
at org.wordpress.android.fluxc.network.MemorizingTrustManager.storeCert(MemorizingTrustManager.java:173)
at org.wordpress.android.fluxc.network.MemorizingTrustManager.storeLastFailure(MemorizingTrustManager.java:168)
at org.wordpress.android.fluxc.release.ReleaseStack_SiteTestXMLRPC.testXMLRPCSelfSignedSSLFetchSites(ReleaseStack_SiteTestXMLRPC.java:127)
at
```