### PR TITLE
Only use selfHostedId in XMLRPC clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-23.0.2
+    - build-tools-25.0.1
     - android-24
 
 env:
@@ -24,4 +24,4 @@ script:
   - ./gradlew assembleDebug assembleRelease
   - ./gradlew lint || (grep -A20 -B2 'severity="Error"' */build/outputs/*.xml; exit 1)
   - ./gradlew checkstyle
-  - find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1)
+  - find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || return 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ script:
   - ./gradlew assembleDebug assembleRelease
   - ./gradlew lint || (grep -A20 -B2 'severity="Error"' */build/outputs/*.xml; exit 1)
   - ./gradlew checkstyle
+  - find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1)

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     }
 
     checkstyle {
-        toolVersion = '6.9'
+        toolVersion = '7.3'
         configFile file("${project.rootDir}/config/checkstyle.xml")
     }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.1'
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.example"

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -19,13 +19,13 @@ repositories {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         versionCode 4
         versionName "0.1"
         minSdkVersion 14
-        targetSdkVersion 24
+        targetSdkVersion 25
     }
     buildTypes {
         release {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -115,7 +115,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         add(new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_MEDIA_LIBRARY, params, new Listener() {
             @Override
             public void onResponse(Object response) {
-                List<MediaModel> media = getMediaListFromXmlrpcResponse(response, site.getSiteId());
+                List<MediaModel> media = getMediaListFromXmlrpcResponse(response, site.getSelfHostedSiteId());
                 if (media != null) {
                     AppLog.v(T.MEDIA, "Fetched all media for site via XMLRPC.GET_MEDIA_LIBRARY");
                     notifyMediaFetched(MediaAction.FETCH_ALL_MEDIA, site, media, null);
@@ -147,7 +147,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                     MediaModel responseMedia = getMediaFromXmlrpcResponse((HashMap) response);
                     if (responseMedia != null) {
                         AppLog.v(T.MEDIA, "Fetched media with ID: " + media.getMediaId());
-                        responseMedia.setSiteId(site.getSiteId());
+                        responseMedia.setSiteId(site.getSelfHostedSiteId());
                         notifyMediaFetched(MediaAction.FETCH_MEDIA, site, responseMedia, null);
                     } else {
                         AppLog.w(T.MEDIA, "could not parse Fetch media response, ID: " + media.getMediaId());
@@ -346,7 +346,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     public static final String CAPTION_EDIT_KEY     = "post_excerpt";
 
     // media list responses should be of type Object[] with each media item in the array represented by a HashMap
-    private List<MediaModel> getMediaListFromXmlrpcResponse(Object response, long siteId) {
+    private List<MediaModel> getMediaListFromXmlrpcResponse(Object response, long selfHostedSiteId) {
         if (response == null || !(response instanceof Object[])) return null;
 
         Object[] responseArray = (Object[]) response;
@@ -355,7 +355,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             if (!(mediaObject instanceof HashMap)) continue;
             MediaModel media = getMediaFromXmlrpcResponse((HashMap) mediaObject);
             if (media != null) {
-                media.setSiteId(siteId);
+                media.setSiteId(selfHostedSiteId);
                 responseMedia.add(media);
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -89,7 +89,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchSite(final SiteModel site) {
         List<Object> params = new ArrayList<>(2);
-        params.add(site.getSiteId());
+        params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());
         params.add(site.getPassword());
         params.add(new String[] {
@@ -118,7 +118,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchPostFormats(final SiteModel site) {
         List<Object> params = new ArrayList<>(2);
-        params.add(site.getSiteId());
+        params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());
         params.add(site.getPassword());
         final XMLRPCRequest request = new XMLRPCRequest(


### PR DESCRIPTION
Also added a shell check in travis in https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/b2f09a7ba593ac8b3e9aa7c5a760a20051ce07e8 (not super proud of this, we can drop it if it reports false positive)