### PR TITLE
Use ASYNC thread mode for OnCommentInstantiated

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -155,7 +155,7 @@ public class CommentsFragment extends Fragment {
         }
     }
 
-    @Subscribe(threadMode = ThreadMode.MAIN)
+    @Subscribe(threadMode = ThreadMode.ASYNC)
     public void onCommentInstantiated(OnCommentInstantiated event) {
         mNewComment = event.comment;
         mCountDownLatch.countDown();


### PR DESCRIPTION
This fixes an [issue](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/221#discussion_r89929535) raised by @tonyr59h for the taxonomies demo that also applies to comments.

Without this patch, attempting to create a new comment in the example app will cause a crash, as the `CountDownLatch` times out. `ThreadMode.ASYNC` needs to be used to prevent the main thread from being blocked.

cc @maxme