### PR TITLE
Simplify boolean asserts

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 
 public class CommentsFragment extends Fragment {
     @Inject SiteStore mSiteStore;
@@ -120,7 +120,7 @@ public class CommentsFragment extends Fragment {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newInstantiateCommentAction(payload));
         try {
-            assertEquals(true, mCountDownLatch.await(2, TimeUnit.SECONDS));
+            assertTrue(mCountDownLatch.await(2, TimeUnit.SECONDS));
             mNewComment.setContent("I'm a new comment id: " + new Random().nextLong() + " from FluxC Example App");
             mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(
                     new RemoteCreateCommentPayload(getFirstSite(), getFirstComment(), mNewComment)

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -249,8 +249,8 @@ public class PostStoreUnitTest {
         assertEquals(1, mPostStore.getPostsCountForSite(site));
         assertEquals(1, mPostStore.getPagesCountForSite(site));
 
-        assertEquals(false, PostTestUtils.getPosts().get(0).isPage());
-        assertEquals(true, PostTestUtils.getPosts().get(1).isPage());
+        assertFalse(PostTestUtils.getPosts().get(0).isPage());
+        assertTrue(PostTestUtils.getPosts().get(1).isPage());
 
         assertEquals(1, mPostStore.getUploadedPostsCountForSite(site));
         assertEquals(1, mPostStore.getUploadedPagesCountForSite(site));

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -30,7 +30,6 @@ import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -133,6 +132,6 @@ public class SiteXMLRPCClientTest {
                           + "  </struct>\n"
                           + "</value></param></params></methodResponse>";
         mSiteXMLRPCClient.fetchSite(site);
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }


### PR DESCRIPTION
Eliminates all remaining instances of `assertEquals(true, X)` and `assertEquals(false, Y)`.