### PR TITLE
Emit OnPostChanged event when deleting a local post

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -332,7 +332,7 @@ public class PostStore extends Store {
                 handleDeletePostCompleted((RemotePostPayload) action.getPayload());
                 break;
             case REMOVE_POST:
-                PostSqlUtils.deletePost((PostModel) action.getPayload());
+                removePost((PostModel) action.getPayload());
                 break;
         }
     }
@@ -486,6 +486,14 @@ public class PostStore extends Store {
 
         OnPostChanged onPostChanged = new OnPostChanged(rowsAffected);
         onPostChanged.causeOfChange = PostAction.UPDATE_POST;
+        emitChange(onPostChanged);
+    }
+
+    private void removePost(PostModel post) {
+        int rowsAffected = PostSqlUtils.deletePost(post);
+
+        OnPostChanged onPostChanged = new OnPostChanged(rowsAffected);
+        onPostChanged.causeOfChange = PostAction.REMOVE_POST;
         emitChange(onPostChanged);
     }
 }


### PR DESCRIPTION
Fixes #240, emitting an `OnPostChanged` event in response to `REMOVE_POST` actions.