### PR TITLE
Fix #247: Check if the email address is _false_ and init the email field with the empty string instead

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -280,7 +280,11 @@ public class CommentRestClient extends BaseWPComRestClient {
         if (response.author != null) {
             comment.setAuthorUrl(response.author.URL);
             comment.setAuthorName(response.author.name);
-            comment.setAuthorEmail(response.author.email);
+            if ("false".equals(response.author.email)) {
+                comment.setAuthorEmail("");
+            } else {
+                comment.setAuthorEmail(response.author.email);
+            }
             comment.setAuthorProfileImageUrl(response.author.avatar_URL);
         }
 


### PR DESCRIPTION
Fix #247: Check if the email address is _false_ and init the email field with the empty string instead

Would be cleaner to check the `response.author.email` type instead, but we can't and "false" is an invalid email address anyway.