### PR TITLE
Add asc+desc parameters to some getters

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import com.yarolegovich.wellsql.SelectQuery;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.CommentActionBuilder;
@@ -74,7 +76,8 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Verify it was inserted in the DB
-        List<CommentModel> comments = CommentSqlUtils.getCommentsForSite(sSite, CommentStatus.ALL);
+        List<CommentModel> comments = CommentSqlUtils.getCommentsForSite(sSite, SelectQuery.ORDER_ASCENDING,
+                CommentStatus.ALL);
         assertEquals(mNewComment.getId(), comments.get(0).getId());
     }
 
@@ -97,7 +100,8 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check the last comment we get from the DB is the same
-        List<CommentModel> comments = CommentSqlUtils.getCommentsForSite(sSite, CommentStatus.ALL);
+        List<CommentModel> comments = CommentSqlUtils.getCommentsForSite(sSite, SelectQuery.ORDER_ASCENDING,
+                CommentStatus.ALL);
         assertEquals(mNewComment.getContent(), comments.get(0).getContent());
 
         // Remove that comment
@@ -106,7 +110,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check the last comment we get from the DB is different
-        comments = CommentSqlUtils.getCommentsForSite(sSite, CommentStatus.ALL);
+        comments = CommentSqlUtils.getCommentsForSite(sSite, SelectQuery.ORDER_ASCENDING, CommentStatus.ALL);
         if (comments.size() != 0) {
             assertNotSame(mNewComment.getId(), comments.get(0).getId());
         }
@@ -396,7 +400,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     @SuppressWarnings("unused")
     @Subscribe
     public void onCommentChanged(OnCommentChanged event) {
-        List<CommentModel> comments = mCommentStore.getCommentsForSite(sSite, CommentStatus.ALL);
+        List<CommentModel> comments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
         if (event.isError()) {
             AppLog.i(T.TESTS, "event error type: " + event.error.type);
             if (mNextEvent == TestEvents.COMMENT_CHANGED_UNKNOWN_COMMENT) {
@@ -457,7 +461,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        mComments = mCommentStore.getCommentsForSite(sSite, CommentStatus.ALL);
+        mComments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
     }
 
     private void fetchFirstPosts() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -287,7 +287,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @SuppressWarnings("unused")
     @Subscribe
     public void onCommentChanged(OnCommentChanged event) {
-        List<CommentModel> comments = mCommentStore.getCommentsForSite(sSite, CommentStatus.ALL);
+        List<CommentModel> comments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
         if (event.isError()) {
             AppLog.i(T.TESTS, "event error type: " + event.error.type);
             if (mNextEvent == TestEvents.COMMENT_CHANGED_UNKNOWN_COMMENT) {
@@ -335,7 +335,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(payload));
         // Wait for a network response / onChanged event
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        mComments = mCommentStore.getCommentsForSite(sSite, CommentStatus.ALL);
+        mComments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
     }
 
     private void fetchFirstPosts() throws InterruptedException {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -101,12 +101,12 @@ public class CommentsFragment extends Fragment {
     }
 
     private CommentModel getFirstComment() {
-        List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), CommentStatus.ALL);
+        List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), false, CommentStatus.ALL);
         if (comments.size() == 0) {
             prependToLog("There is no comments on this site or comments haven't been fetched.");
             return null;
         }
-        return mCommentStore.getCommentsForSite(getFirstSite(), CommentStatus.ALL).get(0);
+        return mCommentStore.getCommentsForSite(getFirstSite(), false, CommentStatus.ALL).get(0);
     }
 
     private void fetchCommentsFirstSite() {
@@ -147,7 +147,8 @@ public class CommentsFragment extends Fragment {
                 prependToLog("Comment " + (getFirstComment().getILike() ? "liked ツ" : "unliked (ಥ﹏ಥ)"));
             } else {
                 prependToLog("OnCommentChanged: rowsAffected=" + event.rowsAffected);
-                List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), CommentStatus.ALL);
+                List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), false,
+                        CommentStatus.ALL);
                 for (CommentModel comment : comments) {
                     prependToLog(comment.getAuthorName() + " @" + comment.getDatePublished());
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence;
 import com.wellsql.generated.CommentModelTable;
 import com.yarolegovich.wellsql.ConditionClauseBuilder;
 import com.yarolegovich.wellsql.SelectQuery;
+import com.yarolegovich.wellsql.SelectQuery.Order;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.CommentModel;
@@ -106,13 +107,13 @@ public class CommentSqlUtils {
         return selectQueryBuilder.endGroup().endWhere();
     }
 
-    public static List<CommentModel> getCommentsForSite(SiteModel site, CommentStatus... statuses) {
+    public static List<CommentModel> getCommentsForSite(SiteModel site, @Order int order, CommentStatus... statuses) {
         if (site == null) {
             return Collections.emptyList();
         }
 
         return getCommentsQueryForSite(site, statuses)
-                .orderBy(CommentModelTable.DATE_PUBLISHED, SelectQuery.ORDER_ASCENDING)
+                .orderBy(CommentModelTable.DATE_PUBLISHED, order)
                 .getAsModel();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -3,6 +3,9 @@ package org.wordpress.android.fluxc.store;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.yarolegovich.wellsql.SelectQuery;
+import com.yarolegovich.wellsql.SelectQuery.Order;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -188,8 +191,19 @@ public class CommentStore extends Store {
 
     // Getters
 
-    public List<CommentModel> getCommentsForSite(SiteModel site, CommentStatus... statuses) {
-        return CommentSqlUtils.getCommentsForSite(site, statuses);
+    /**
+     * Get a list of comment for a specific site.
+     *
+     * @param site Site model to get comment for.
+     * @param orderByDateAscending If true order the results by ascending published date.
+     *                             If false, order the results by descending published date.
+     * @param statuses Array of status or CommentStatus.ALL to get all of them.
+     * @return
+     */
+    public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending,
+                                                 CommentStatus... statuses) {
+        @Order int order = orderByDateAscending ? SelectQuery.ORDER_ASCENDING : SelectQuery.ORDER_DESCENDING;
+        return CommentSqlUtils.getCommentsForSite(site, order, statuses);
     }
 
     public int getNumberOfCommentsForSite(SiteModel site, CommentStatus... statuses) {


### PR DESCRIPTION
Note: I wanted to add the same parameter to all getters returning a `List<PostModel>` in the `PostStore`, but I noticed local drafts always come first and I want to avoid having a `orderByAscendingPublishingDateExceptForLocalDraftThatComesFirst` parameter ;)
