### PR TITLE
Fix isAdmin flag for .com sites

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -41,6 +41,13 @@ public class SitesFragment extends Fragment {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_sites, container, false);
 
+        view.findViewById(R.id.new_site).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showNewSiteDialog();
+            }
+        });
+
         view.findViewById(R.id.update_first_site).setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -59,13 +66,6 @@ public class SitesFragment extends Fragment {
                     prependToLog(site.getName());
                     AppLog.i(T.API, LogUtils.toString(site));
                 }
-            }
-        });
-
-        view.findViewById(R.id.new_site).setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                showNewSiteDialog();
             }
         });
 

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -202,23 +202,6 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testIsCurrentUserAdminOfSelfHostedSiteId() {
-        assertFalse(mSiteStore.isCurrentUserAdminOfSelfHostedSiteId(0));
-
-        SiteModel site = generateSelfHostedNonJPSite();
-        SiteSqlUtils.insertOrUpdateSite(site);
-
-        assertFalse(mSiteStore.isCurrentUserAdminOfSelfHostedSiteId(site.getSiteId()));
-
-        site.setIsSelfHostedAdmin(true);
-        assertTrue(site.isSelfHostedAdmin());
-        SiteSqlUtils.insertOrUpdateSite(site);
-
-        assertTrue(mSiteStore.getSiteByLocalId(site.getId()).isSelfHostedAdmin());
-        assertTrue(mSiteStore.isCurrentUserAdminOfSelfHostedSiteId(site.getSelfHostedSiteId()));
-    }
-
-    @Test
     public void testGetIdForIdMethods() {
         assertEquals(0, mSiteStore.getLocalIdForRemoteSiteId(555));
         assertEquals(0, mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(2626, ""));

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -202,20 +202,20 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testIsCurrentUserAdminOfSiteId() {
-        assertFalse(mSiteStore.isCurrentUserAdminOfSiteId(0));
+    public void testIsCurrentUserAdminOfSelfHostedSiteId() {
+        assertFalse(mSiteStore.isCurrentUserAdminOfSelfHostedSiteId(0));
 
         SiteModel site = generateSelfHostedNonJPSite();
         SiteSqlUtils.insertOrUpdateSite(site);
 
-        assertFalse(mSiteStore.isCurrentUserAdminOfSiteId(site.getSiteId()));
+        assertFalse(mSiteStore.isCurrentUserAdminOfSelfHostedSiteId(site.getSiteId()));
 
         site.setIsSelfHostedAdmin(true);
         assertTrue(site.isSelfHostedAdmin());
         SiteSqlUtils.insertOrUpdateSite(site);
 
         assertTrue(mSiteStore.getSiteByLocalId(site.getId()).isSelfHostedAdmin());
-        assertTrue(mSiteStore.isCurrentUserAdminOfSiteId(site.getSiteId()));
+        assertTrue(mSiteStore.isCurrentUserAdminOfSelfHostedSiteId(site.getSelfHostedSiteId()));
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -210,11 +210,11 @@ public class SiteStoreUnitTest {
 
         assertFalse(mSiteStore.isCurrentUserAdminOfSiteId(site.getSiteId()));
 
-        site.setIsAdmin(true);
-        assertTrue(site.isAdmin());
+        site.setIsSelfHostedAdmin(true);
+        assertTrue(site.isSelfHostedAdmin());
         SiteSqlUtils.insertOrUpdateSite(site);
 
-        assertTrue(mSiteStore.getSiteByLocalId(site.getId()).isAdmin());
+        assertTrue(mSiteStore.getSiteByLocalId(site.getId()).isSelfHostedAdmin());
         assertTrue(mSiteStore.isCurrentUserAdminOfSiteId(site.getSiteId()));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -29,7 +29,6 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private String mName;
     @Column private String mDescription;
     @Column private boolean mIsWPCom;
-    @Column private boolean mIsAdmin;
     @Column private boolean mIsFeaturedImageSupported;
     @Column private String mDefaultCommentStatus = "open";
     @Column private String mTimezone;
@@ -42,6 +41,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private String mPassword;
     @Column(name = "XMLRPC_URL") private String mXmlRpcUrl;
     @Column private String mSoftwareVersion;
+    @Column private boolean mIsSelfHostedAdmin;
 
     // WPCom specifics
     @Column private boolean mIsJetpack;
@@ -170,12 +170,12 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
         mSelfHostedSiteId = selfHostedSiteId;
     }
 
-    public boolean isAdmin() {
-        return mIsAdmin;
+    public boolean isSelfHostedAdmin() {
+        return mIsSelfHostedAdmin;
     }
 
-    public void setIsAdmin(boolean admin) {
-        mIsAdmin = admin;
+    public void setIsSelfHostedAdmin(boolean selfHostedAdmin) {
+        mIsSelfHostedAdmin = selfHostedAdmin;
     }
 
     public boolean isJetpack() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -233,6 +233,10 @@ public class SiteRestClient extends BaseWPComRestClient {
             }
         }
         site.setIsWPCom(true);
+
+        // On WordPress.com sites only admins have `manage_options` capability
+        // a list of all the roles and its capabilities can be found in: `/v1.1/sites/$site/roles`
+        site.setIsAdmin(site.getHasCapabilityManageOptions());
         return site;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -233,10 +233,6 @@ public class SiteRestClient extends BaseWPComRestClient {
             }
         }
         site.setIsWPCom(true);
-
-        // On WordPress.com sites only admins have `manage_options` capability
-        // a list of all the roles and its capabilities can be found in: `/v1.1/sites/$site/roles`
-        site.setIsAdmin(site.getHasCapabilityManageOptions());
         return site;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -161,7 +161,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             site.setName((String) siteMap.get(SITE_NAME_KEY));
             site.setUrl((String) siteMap.get(SITE_URL_KEY));
             site.setXmlRpcUrl((String) siteMap.get(SITE_XMLRPC_URL_KEY));
-            site.setIsAdmin((Boolean) siteMap.get(SITE_ADMIN_KEY));
+            site.setIsSelfHostedAdmin((Boolean) siteMap.get(SITE_ADMIN_KEY));
             // Self Hosted won't be hidden
             site.setIsVisible(true);
             // From what we know about the host

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -380,14 +380,12 @@ public class SiteStore extends Store {
     }
 
     /**
-     * Checks whether the user is an admin of the given (remote) site id.
+     * Checks whether the user is an admin of the given (remote) self hosted site id.
      */
-    public boolean isCurrentUserAdminOfSiteId(long siteId) {
+    public boolean isCurrentUserAdminOfSelfHostedSiteId(long selfHostedSiteId) {
         return WellSql.select(SiteModel.class)
                 .where().beginGroup().beginGroup()
-                .equals(SiteModelTable.SITE_ID, siteId)
-                .or()
-                .equals(SiteModelTable.SELF_HOSTED_SITE_ID, siteId)
+                .equals(SiteModelTable.SELF_HOSTED_SITE_ID, selfHostedSiteId)
                 .endGroup()
                 .equals(SiteModelTable.IS_SELF_HOSTED_ADMIN, true)
                 .endGroup().endWhere()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -380,19 +380,6 @@ public class SiteStore extends Store {
     }
 
     /**
-     * Checks whether the user is an admin of the given (remote) self hosted site id.
-     */
-    public boolean isCurrentUserAdminOfSelfHostedSiteId(long selfHostedSiteId) {
-        return WellSql.select(SiteModel.class)
-                .where().beginGroup().beginGroup()
-                .equals(SiteModelTable.SELF_HOSTED_SITE_ID, selfHostedSiteId)
-                .endGroup()
-                .equals(SiteModelTable.IS_SELF_HOSTED_ADMIN, true)
-                .endGroup().endWhere()
-                .getAsCursor().getCount() > 0;
-    }
-
-    /**
      * Given a (remote) site id, returns the corresponding (local) id.
      */
     public int getLocalIdForRemoteSiteId(long siteId) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -389,7 +389,7 @@ public class SiteStore extends Store {
                 .or()
                 .equals(SiteModelTable.SELF_HOSTED_SITE_ID, siteId)
                 .endGroup()
-                .equals(SiteModelTable.IS_ADMIN, true)
+                .equals(SiteModelTable.IS_SELF_HOSTED_ADMIN, true)
                 .endGroup().endWhere()
                 .getAsCursor().getCount() > 0;
     }


### PR DESCRIPTION
Fixes #95. The `isAdmin` flag was never set for wp.com sites. As mentioned in the comment, only admins can have `manage_options` capability on wp.com sites, so we can simply use that to set the flag. I also threw in a small code re-order to match the UI.