### PR TITLE
Issue #258: Restrict term lookup from list by site

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -130,6 +130,13 @@ public class TaxonomyStoreUnitTest {
         TaxonomySqlUtils.insertOrUpdateTerm(category);
 
         assertEquals(category, mTaxonomyStore.getCategoryByRemoteId(site, category.getRemoteTermId()));
+
+        // An identical category on a different site should be ignored in the match
+        TermModel otherSiteIdenticalCategory = TaxonomyTestUtils.generateSampleCategory();
+        otherSiteIdenticalCategory.setLocalSiteId(7);
+        TaxonomySqlUtils.insertOrUpdateTerm(otherSiteIdenticalCategory);
+
+        assertEquals(category, mTaxonomyStore.getCategoryByRemoteId(site, category.getRemoteTermId()));
     }
 
     @Test
@@ -196,5 +203,16 @@ public class TaxonomyStoreUnitTest {
         idList.add(unsyncedCategory.getRemoteTermId());
 
         assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, DEFAULT_TAXONOMY_CATEGORY).size());
+
+        // An identical category on a different site should be ignored in the match
+        TermModel otherSiteIdenticalCategory = TaxonomyTestUtils.generateSampleCategory();
+        otherSiteIdenticalCategory.setLocalSiteId(7);
+        TaxonomySqlUtils.insertOrUpdateTerm(otherSiteIdenticalCategory);
+
+        idList.clear();
+        idList.add(category.getRemoteTermId());
+        idList.add(category2.getRemoteTermId());
+
+        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, DEFAULT_TAXONOMY_CATEGORY).size());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -184,7 +184,7 @@ public class TaxonomyStoreUnitTest {
         idList.add(category.getRemoteTermId());
         idList.add(category2.getRemoteTermId());
 
-        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, DEFAULT_TAXONOMY_CATEGORY).size());
+        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
 
         // Unsynced category ID should be ignored in the final list
         TermModel unsyncedCategory = TaxonomyTestUtils.generateSampleCategory();
@@ -192,17 +192,17 @@ public class TaxonomyStoreUnitTest {
         unsyncedCategory.setName("More");
         idList.add(unsyncedCategory.getRemoteTermId());
 
-        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, DEFAULT_TAXONOMY_CATEGORY).size());
+        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
 
         // Empty list should return empty category list
         idList.clear();
 
-        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, DEFAULT_TAXONOMY_CATEGORY).size());
+        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
 
         // List with only unsynced categories should return empty category list
         idList.add(unsyncedCategory.getRemoteTermId());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, DEFAULT_TAXONOMY_CATEGORY).size());
+        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
 
         // An identical category on a different site should be ignored in the match
         TermModel otherSiteIdenticalCategory = TaxonomyTestUtils.generateSampleCategory();
@@ -213,6 +213,6 @@ public class TaxonomyStoreUnitTest {
         idList.add(category.getRemoteTermId());
         idList.add(category2.getRemoteTermId());
 
-        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, DEFAULT_TAXONOMY_CATEGORY).size());
+        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -74,7 +74,8 @@ public class TaxonomySqlUtils {
         return null;
     }
 
-    public static List<TermModel> getTermsFromRemoteIdList(List<Long> remoteTermIds, String taxonomyName) {
+    public static List<TermModel> getTermsFromRemoteIdList(List<Long> remoteTermIds, SiteModel site,
+                                                           String taxonomyName) {
         if (taxonomyName == null || remoteTermIds == null || remoteTermIds.isEmpty()) {
             return Collections.emptyList();
         }
@@ -82,6 +83,7 @@ public class TaxonomySqlUtils {
         return WellSql.select(TermModel.class)
                 .where().beginGroup()
                 .equals(TermModelTable.TAXONOMY, taxonomyName)
+                .equals(TermModelTable.LOCAL_SITE_ID, site.getId())
                 .isIn(TermModelTable.REMOTE_TERM_ID, remoteTermIds)
                 .endGroup().endWhere()
                 .getAsModel();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -221,15 +221,15 @@ public class TaxonomyStore extends Store {
     /**
      * Returns all the categories for the given post as a {@link TermModel} list.
      */
-    public List<TermModel> getCategoriesForPost(PostModel post) {
-        return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getCategoryIdList(), DEFAULT_TAXONOMY_CATEGORY);
+    public List<TermModel> getCategoriesForPost(PostModel post, SiteModel site) {
+        return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getCategoryIdList(), site, DEFAULT_TAXONOMY_CATEGORY);
     }
 
     /**
      * Returns all the tags for the given post as a {@link TermModel} list.
      */
-    public List<TermModel> getTagsForPost(PostModel post) {
-        return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getTagIdList(), DEFAULT_TAXONOMY_TAG);
+    public List<TermModel> getTagsForPost(PostModel post, SiteModel site) {
+        return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getTagIdList(), site, DEFAULT_TAXONOMY_TAG);
     }
 
     @Subscribe(threadMode = ThreadMode.ASYNC)


### PR DESCRIPTION
Fixes #258, limiting the results of `getTermsFromRemoteIdList()` to the given site.