### PR TITLE
Issue #265: Track post tags by name instead of by ID

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
@@ -304,6 +305,11 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         categoryIds.add((long) 1);
         mPost.setCategoryIdList(categoryIds);
 
+        List<String> tags = new ArrayList<>(2);
+        tags.add("fluxc");
+        tags.add("generated-" + RandomStringUtils.randomAlphanumeric(8));
+        mPost.setTagNameList(tags);
+
         uploadPost(mPost);
 
         // Get the current copy of the post from the PostStore
@@ -318,6 +324,9 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         assertTrue(categoryIds.containsAll(newPost.getCategoryIdList())
                 && newPost.getCategoryIdList().containsAll(categoryIds));
+
+        assertTrue(tags.containsAll(newPost.getTagNameList())
+                && newPost.getTagNameList().containsAll(tags));
     }
 
     public void testFullFeaturedPageUpload() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -296,6 +297,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         categoryIds.add((long) 1);
         mPost.setCategoryIdList(categoryIds);
 
+        List<String> tags = new ArrayList<>(2);
+        tags.add("fluxc");
+        tags.add("generated-" + RandomStringUtils.randomAlphanumeric(8));
+        mPost.setTagNameList(tags);
+
         uploadPost(mPost);
 
         // Get the current copy of the post from the PostStore
@@ -310,6 +316,9 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         assertTrue(categoryIds.containsAll(newPost.getCategoryIdList())
                 && newPost.getCategoryIdList().containsAll(categoryIds));
+
+        assertTrue(tags.containsAll(newPost.getTagNameList())
+                && newPost.getTagNameList().containsAll(tags));
     }
 
     public void testFullFeaturedPageUpload() throws InterruptedException {
@@ -534,29 +543,6 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         categories.add((long) 999999);
 
         mPost.setCategoryIdList(categories);
-
-        mNextEvent = TestEvents.ERROR_GENERIC;
-        mCountDownLatch = new CountDownLatch(1);
-
-        // Upload edited post
-        RemotePostPayload pushPayload = new RemotePostPayload(mPost, sSite);
-        mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        // TODO: This will fail for non-English sites - we should be checking for an UNKNOWN_TERM error instead
-        // (once we make the fixes needed for PostXMLRPCClient to correctly identify post errors)
-        assertEquals("Invalid term ID.", mLastPostError.message);
-    }
-
-    public void testCreateNewPostWithInvalidTag() throws InterruptedException {
-        createNewPost();
-        setupPostAttributes();
-
-        List<Long> tags = new ArrayList<>();
-        tags.add((long) 999999);
-
-        mPost.setTagIdList(tags);
 
         mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -215,4 +215,42 @@ public class TaxonomyStoreUnitTest {
 
         assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
     }
+
+    @Test
+    public void testGetTagsFromPost() {
+        SiteModel site = new SiteModel();
+        site.setId(6);
+
+        TermModel tag = TaxonomyTestUtils.generateSampleTag();
+        TaxonomySqlUtils.insertOrUpdateTerm(tag);
+
+        TermModel tag2 = TaxonomyTestUtils.generateSampleTag();
+        tag2.setRemoteTermId(6);
+        tag2.setName("Something");
+        TaxonomySqlUtils.insertOrUpdateTerm(tag2);
+
+        List<String> nameList = new ArrayList<>();
+        nameList.add(tag.getName());
+        nameList.add(tag2.getName());
+
+        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
+
+        // Unsynced tag ID should be ignored in the final list
+        TermModel unsyncedTag = TaxonomyTestUtils.generateSampleTag();
+        unsyncedTag.setRemoteTermId(66);
+        unsyncedTag.setName("More");
+        nameList.add(unsyncedTag.getName());
+
+        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
+
+        // Empty list should return empty tag list
+        nameList.clear();
+
+        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
+
+        // List with only unsynced tags should return empty tag list
+        nameList.add(unsyncedTag.getName());
+
+        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -39,7 +39,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     @Column private String mCustomFields;
     @Column private String mLink;
     @Column private String mExcerpt;
-    @Column private String mTagIds;
+    @Column private String mTagNames;
     @Column private String mStatus;
     @Column private String mPassword;
     @Column private long mFeaturedImageId = FEATURED_IMAGE_INIT_VALUE;
@@ -168,21 +168,21 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         mExcerpt = excerpt;
     }
 
-    public String getTagIds() {
-        return StringUtils.notNullStr(mTagIds);
+    public String getTagNames() {
+        return StringUtils.notNullStr(mTagNames);
     }
 
-    public void setTagIds(String tagIds) {
-        mTagIds = tagIds;
+    public void setTagNames(String tags) {
+        mTagNames = tags;
     }
 
     @NonNull
-    public List<Long> getTagIdList() {
-        return taxonomyIdStringToList(mTagIds);
+    public List<String> getTagNameList() {
+        return termNameStringToList(mTagNames);
     }
 
-    public void setTagIdList(List<Long> tags) {
-        mTagIds = taxonomyIdListToString(tags);
+    public void setTagNameList(List<String> tags) {
+        mTagNames = termNameListToString(tags);
     }
 
     public String getStatus() {
@@ -365,7 +365,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
                && StringUtils.equals(getCustomFields(), otherPost.getCustomFields())
                && StringUtils.equals(getLink(), otherPost.getLink())
                && StringUtils.equals(getExcerpt(), otherPost.getExcerpt())
-               && StringUtils.equals(getTagIds(), otherPost.getTagIds())
+               && StringUtils.equals(getTagNames(), otherPost.getTagNames())
                && StringUtils.equals(getStatus(), otherPost.getStatus())
                && StringUtils.equals(getPassword(), otherPost.getPassword())
                && StringUtils.equals(getPostFormat(), otherPost.getPostFormat())
@@ -449,6 +449,23 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
             return "";
         }
         return TextUtils.join(",", ids);
+    }
+
+    private static List<String> termNameStringToList(String terms) {
+        if (terms == null || terms.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String[] stringArray = terms.split(",");
+        List<String> stringList = new ArrayList<>();
+        Collections.addAll(stringList, stringArray);
+        return stringList;
+    }
+
+    private static String termNameListToString(List<String> termNames) {
+        if (termNames == null || termNames.isEmpty()) {
+            return "";
+        }
+        return TextUtils.join(",", termNames);
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -137,11 +137,11 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
 
     @NonNull
     public List<Long> getCategoryIdList() {
-        return taxonomyIdStringToList(mCategoryIds);
+        return termIdStringToList(mCategoryIds);
     }
 
     public void setCategoryIdList(List<Long> categories) {
-        mCategoryIds = taxonomyIdListToString(categories);
+        mCategoryIds = termIdListToString(categories);
     }
 
     public String getCustomFields() {
@@ -432,7 +432,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         return (mLastKnownRemoteFeaturedImageId != mFeaturedImageId);
     }
 
-    private static List<Long> taxonomyIdStringToList(String ids) {
+    private static List<Long> termIdStringToList(String ids) {
         if (ids == null || ids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -444,7 +444,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         return longList;
     }
 
-    private static String taxonomyIdListToString(List<Long> ids) {
+    private static String termIdListToString(List<Long> ids) {
         if (ids == null || ids.isEmpty()) {
             return "";
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -247,11 +247,11 @@ public class PostRestClient extends BaseWPComRestClient {
         }
 
         if (from.tags != null) {
-            List<Long> tagIds = new ArrayList<>();
+            List<String> tagNames = new ArrayList<>();
             for (TermWPComRestResponse value : from.tags.values()) {
-                tagIds.add(value.ID);
+                tagNames.add(value.name);
             }
-            post.setTagIdList(tagIds);
+            post.setTagNameList(tagNames);
         }
 
         if (from.capabilities != null) {
@@ -291,7 +291,7 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("password", StringUtils.notNullStr(post.getPassword()));
 
         params.put("categories", TextUtils.join(",", post.getCategoryIdList()));
-        params.put("tags", TextUtils.join(",", post.getTagIdList()));
+        params.put("tags", TextUtils.join(",", post.getTagNameList()));
 
         // Will remove any existing featured image if the empty string is sent
         if (post.featuredImageHasChanged()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -326,7 +326,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         Object[] terms = (Object[]) postMap.get("terms");
         List<Long> categoryIds = new ArrayList<>();
-        List<Long> tagIds = new ArrayList<>();
+        List<String> tagNames = new ArrayList<>();
         for (Object term : terms) {
             if (!(term instanceof Map)) {
                 continue;
@@ -336,11 +336,11 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             if (taxonomy.equals("category")) {
                 categoryIds.add(MapUtils.getMapLong(termMap, "term_id"));
             } else if (taxonomy.equals("post_tag")) {
-                tagIds.add(MapUtils.getMapLong(termMap, "term_id"));
+                tagNames.add(MapUtils.getMapStr(termMap, "name"));
             }
         }
         post.setCategoryIdList(categoryIds);
-        post.setTagIdList(tagIds);
+        post.setTagNameList(tagNames);
 
         Object[] customFields = (Object[]) postMap.get("custom_fields");
         JSONArray jsonCustomFieldsArray = new JSONArray();
@@ -428,21 +428,27 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         contentStruct.put("post_content", content);
 
-        // Handle taxonomies (currently supporting categories and tags)
+        // Handle taxonomies
+        // Add categories by ID to the 'terms' param
         Map<Object, Object> terms = new HashMap<>();
 
         if (!post.getCategoryIdList().isEmpty()) {
             terms.put("category", post.getCategoryIdList().toArray());
         }
 
-        if (!post.isPage()) {
-            if (!post.getTagIdList().isEmpty()) {
-                terms.put("post_tag", post.getTagIdList().toArray());
-            }
-        }
-
         if (!terms.isEmpty()) {
             contentStruct.put("terms", terms);
+        }
+
+        // Add tags by name to the 'terms_names' param
+        Map<Object, Object> termsNames = new HashMap<>();
+
+        if (!post.getTagNameList().isEmpty()) {
+            termsNames.put("post_tag", post.getTagNameList().toArray());
+        }
+
+        if (!termsNames.isEmpty()) {
+            contentStruct.put("terms_names", termsNames);
         }
 
         contentStruct.put("post_excerpt", post.getExcerpt());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -89,6 +89,21 @@ public class TaxonomySqlUtils {
                 .getAsModel();
     }
 
+    public static List<TermModel> getTermsFromRemoteNameList(List<String> remoteTermNames, SiteModel site,
+                                                             String taxonomyName) {
+        if (taxonomyName == null || remoteTermNames == null || remoteTermNames.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return WellSql.select(TermModel.class)
+                .where().beginGroup()
+                .equals(TermModelTable.TAXONOMY, taxonomyName)
+                .equals(TermModelTable.LOCAL_SITE_ID, site.getId())
+                .isIn(TermModelTable.NAME, remoteTermNames)
+                .endGroup().endWhere()
+                .getAsModel();
+    }
+
     public static int clearTaxonomyForSite(SiteModel site, String taxonomyName) {
         if (site == null || taxonomyName == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -229,7 +229,7 @@ public class TaxonomyStore extends Store {
      * Returns all the tags for the given post as a {@link TermModel} list.
      */
     public List<TermModel> getTagsForPost(PostModel post, SiteModel site) {
-        return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getTagIdList(), site, DEFAULT_TAXONOMY_TAG);
+        return TaxonomySqlUtils.getTermsFromRemoteNameList(post.getTagNameList(), site, DEFAULT_TAXONOMY_TAG);
     }
 
     @Subscribe(threadMode = ThreadMode.ASYNC)


### PR DESCRIPTION
Fixes #265. ~#259 should be merged first.~

This changes tag handling to use tag names instead of IDs, which is how WPAndroid currently works with tags. This means we won't be storing tags in `TaxonomyStore` for now, though I left the provisions for that in as we might change this in the future.

As a point of interest, both XML-RPC and the .com REST API allow uploading posts with a mix of names and IDs for categories and tags. This might be useful to us if we implement something like ID-based tag management but still want/need to maintain current tags for a post as names.