### PR TITLE
Add methods for obtaining a TermModel given a name

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -140,6 +140,17 @@ public class TaxonomyStoreUnitTest {
     }
 
     @Test
+    public void testGetTermByName() {
+        SiteModel site = new SiteModel();
+        site.setId(6);
+
+        TermModel category = TaxonomyTestUtils.generateSampleCategory();
+        TaxonomySqlUtils.insertOrUpdateTerm(category);
+
+        assertEquals(category, mTaxonomyStore.getCategoryByName(site, category.getName()));
+    }
+
+    @Test
     public void testClearTaxonomy() {
         SiteModel site = new SiteModel();
         site.setId(6);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -74,6 +74,25 @@ public class TaxonomySqlUtils {
         return null;
     }
 
+    public static TermModel getTermByName(SiteModel site, String termName, String taxonomyName) {
+        if (site == null || taxonomyName == null) {
+            return null;
+        }
+
+        List<TermModel> termResult = WellSql.select(TermModel.class)
+                .where().beginGroup()
+                .equals(TermModelTable.LOCAL_SITE_ID, site.getId())
+                .equals(TermModelTable.NAME, termName)
+                .equals(TermModelTable.TAXONOMY, taxonomyName)
+                .endGroup().endWhere()
+                .getAsModel();
+
+        if (!termResult.isEmpty()) {
+            return termResult.get(0);
+        }
+        return null;
+    }
+
     public static List<TermModel> getTermsFromRemoteIdList(List<Long> remoteTermIds, SiteModel site,
                                                            String taxonomyName) {
         if (taxonomyName == null || remoteTermIds == null || remoteTermIds.isEmpty()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -205,14 +205,14 @@ public class TaxonomyStore extends Store {
     }
 
     /**
-     * Returns a category as a {@link TermModel} given its remote id.
+     * Returns a tag as a {@link TermModel} given its remote id.
      */
     public TermModel getTagByRemoteId(SiteModel site, long remoteId) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, DEFAULT_TAXONOMY_TAG);
     }
 
     /**
-     * Returns a category as a {@link TermModel} given its remote id.
+     * Returns a term as a {@link TermModel} given its remote id.
      */
     public TermModel getTermByRemoteId(SiteModel site, long remoteId, String taxonomyName) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, taxonomyName);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -219,6 +219,27 @@ public class TaxonomyStore extends Store {
     }
 
     /**
+     * Returns a category as a {@link TermModel} given its name.
+     */
+    public TermModel getCategoryByName(SiteModel site, String categoryName) {
+        return TaxonomySqlUtils.getTermByName(site, categoryName, DEFAULT_TAXONOMY_CATEGORY);
+    }
+
+    /**
+     * Returns a tag as a {@link TermModel} given its name.
+     */
+    public TermModel getTagByName(SiteModel site, String tagName) {
+        return TaxonomySqlUtils.getTermByName(site, tagName, DEFAULT_TAXONOMY_TAG);
+    }
+
+    /**
+     * Returns a term as a {@link TermModel} given its name.
+     */
+    public TermModel getTermByName(SiteModel site, String termName, String taxonomyName) {
+        return TaxonomySqlUtils.getTermByName(site, termName, taxonomyName);
+    }
+
+    /**
      * Returns all the categories for the given post as a {@link TermModel} list.
      */
     public List<TermModel> getCategoriesForPost(PostModel post, SiteModel site) {


### PR DESCRIPTION
Adds methods for getting a `TermModel` given the name of a term. This is not yet needed by WPAndroid, but might be needed in the future to e.g. obtain `TermModel`s given tag names from a `PostModel` (see #267).

Note: This PR was originally intended to be used to interface with the site settings component in WPAndroid. Site settings [provides the default category name](https://github.com/wordpress-mobile/WordPress-Android/blob/8b3a35d2db44fd840e02fb121a9771bea01331c1/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L259), which we need to turn into a remote term ID. I found a better way of doing this, so this PR is now unnecessary, but the methods used might still be needed in the future.