### PR TITLE
Export Content

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -23,6 +23,8 @@ public enum SiteAction implements IAction {
     CREATE_NEW_SITE,
     @Action(payloadType = SiteModel.class)
     FETCH_POST_FORMATS,
+    @Action(payloadType = SiteModel.class)
+    EXPORT_SITE,
 
     // Remote responses
     @Action(payloadType = NewSiteResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.DeleteSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.ExportSiteResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
@@ -36,6 +37,8 @@ public enum SiteAction implements IAction {
     FETCHED_POST_FORMATS,
     @Action(payloadType = DeleteSiteResponsePayload.class)
     DELETED_SITE,
+    @Action(payloadType = ExportSiteResponsePayload.class)
+    EXPORTED_SITE,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/ExportSiteResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/ExportSiteResponse.java
@@ -1,0 +1,5 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+public class ExportSiteResponse {
+    public String status;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -228,7 +228,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void exportSite(@NonNull final SiteModel site) {
-        String url = WPCOMREST.sites.site(site.getSiteId()).exports.getUrlV1_1();
+        String url = WPCOMREST.sites.site(site.getSiteId()).exports.start.getUrlV1_1();
         final WPComGsonRequest<ExportSiteResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 ExportSiteResponse.class,
                 new Listener<ExportSiteResponse>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -186,6 +186,24 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void exportSite(@NonNull final SiteModel site) {
+        String url = WPCOMREST.sites.site(site.getSiteId()).exports.getUrlV1_1();
+        final WPComGsonRequest<ExportSiteResponse> request = WPComGsonRequest.buildPostRequest(url, null,
+                ExportSiteResponse.class,
+                new Listener<ExportSiteResponse>() {
+                    @Override
+                    public void onResponse(ExportSiteResponse response) {
+                    }
+                },
+                new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    }
+                }
+        );
+        add(request);
+    }
+
     private SiteModel siteResponseToSiteModel(SiteWPComRestResponse from) {
         SiteModel site = new SiteModel();
         site.setSiteId(from.ID);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -69,6 +69,12 @@ public class SiteRestClient extends BaseWPComRestClient {
         public DeleteSiteError error;
     }
 
+    public static class ExportSiteResponsePayload extends Payload {
+        public ExportSiteResponsePayload() {
+        }
+        public SiteModel site;
+    }
+
     @Inject
     public SiteRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue, AppSecrets appSecrets,
                           AccessToken accessToken, UserAgent userAgent) {
@@ -228,11 +234,16 @@ public class SiteRestClient extends BaseWPComRestClient {
                 new Listener<ExportSiteResponse>() {
                     @Override
                     public void onResponse(ExportSiteResponse response) {
+                        ExportSiteResponsePayload payload = new ExportSiteResponsePayload();
+                        mDispatcher.dispatch(SiteActionBuilder.newExportedSiteAction(payload));
                     }
                 },
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        ExportSiteResponsePayload payload = new ExportSiteResponsePayload();
+                        payload.error = error;
+                        mDispatcher.dispatch(SiteActionBuilder.newExportedSiteAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -72,7 +72,6 @@ public class SiteRestClient extends BaseWPComRestClient {
     public static class ExportSiteResponsePayload extends Payload {
         public ExportSiteResponsePayload() {
         }
-        public SiteModel site;
     }
 
     @Inject

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -665,7 +665,10 @@ public class SiteStore extends Store {
     }
 
     private void exportSite(SiteModel site) {
-        if (site == null || !site.isWPCom()) {
+        if (!site.isWPCom()) {
+            OnSiteExported event = new OnSiteExported();
+            event.error = new ExportSiteError(ExportSiteErrorType.INVALID_SITE);
+            emitChange(event);
             return;
         }
         mSiteRestClient.exportSite(site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -517,6 +517,9 @@ public class SiteStore extends Store {
             case UPDATE_SITES:
                 updateSites((SitesModel) action.getPayload());
                 break;
+            case EXPORT_SITE:
+                exportSite((SiteModel) action.getPayload());
+                break;
             case REMOVE_SITE:
                 removeSite((SiteModel) action.getPayload());
                 break;
@@ -617,6 +620,13 @@ public class SiteStore extends Store {
             event = new OnSiteChanged(rowsAffected);
         }
         emitChange(event);
+    }
+
+    private void exportSite(SiteModel site) {
+        if (site == null || !site.isWPCom()) {
+            return;
+        }
+        mSiteRestClient.exportSite(site);
     }
 
     private void updatePostFormats(FetchedPostFormatsPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -617,10 +617,10 @@ public class SiteStore extends Store {
                 updatePostFormats((FetchedPostFormatsPayload) action.getPayload());
                 break;
             case DELETED_SITE:
-                handleDeletedSite((SiteRestClient.DeleteSiteResponsePayload) action.getPayload());
+                handleDeletedSite((DeleteSiteResponsePayload) action.getPayload());
                 break;
             case EXPORTED_SITE:
-                handleExportedSite((SiteRestClient.ExportSiteResponsePayload) action.getPayload());
+                handleExportedSite((ExportSiteResponsePayload) action.getPayload());
                 break;
             case CHECKED_IS_WPCOM_URL:
                 handleCheckedIsWPComUrl((IsWPComResponsePayload) action.getPayload());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -20,8 +20,8 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.DeleteSiteResponsePayload;
-import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.ExportSiteResponsePayload;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.util.AppLog;
@@ -719,11 +719,8 @@ public class SiteStore extends Store {
     private void handleExportedSite(ExportSiteResponsePayload payload) {
         OnSiteExported event = new OnSiteExported();
         if (payload.isError()) {
-            if (payload.error.type.equals("unknown_blog")) {
-                event.error = new ExportSiteError(ExportSiteErrorType.INVALID_SITE);
-            } else {
-                event.error = new ExportSiteError(ExportSiteErrorType.GENERIC_ERROR);
-            }
+            // TODO: what kind of error could we get here?
+            event.error = new ExportSiteError(ExportSiteErrorType.GENERIC_ERROR);
         }
         emitChange(event);
     }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -5,6 +5,7 @@
 /sites/
 /sites/new/
 /sites/$site/post-formats/
+/sites/$site/exports/start
 
 /sites/$site/posts/
 /sites/$site/posts/$post_ID/


### PR DESCRIPTION
Closes #268. This PR adds the network call for exporting the content of a site. I skipped the error handling part since we have a todo for other endpoints as well. However, as far as I can tell there are 2 errors, unknown blog & auth error. The call will just trigger a backend event which once completed will send an email with a link to download the exported content.

The following diff can be used for easy testing; Just put a correct and incorrect site id to test both paths:

```
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
index c9b8570..45b9799 100644
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -33,6 +33,11 @@ public class SitesFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((ExampleApp) getActivity().getApplication()).component().inject(this);
+
+        SiteModel s = new SiteModel();
+        s.setSiteId("site id here!");
+        s.setIsWPCom(true);
+        mDispatcher.dispatch(SiteActionBuilder.newExportSiteAction(s));
     }
 
     @Override

```
