### PR TITLE
Tweak uploading posts with no categories/tags over XML-RPC

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -22,6 +22,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -356,6 +357,39 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(date, newPage.getDateCreated());
 
         assertEquals(0, newPage.getFeaturedImageId()); // The page should upload, but have the featured image stripped
+    }
+
+    public void testClearTagsFromPost() throws InterruptedException {
+        createNewPost();
+
+        mPost.setTitle("A post with tags");
+        mPost.setContent("Some content here! <strong>Bold text</strong>.");
+
+        List<Long> categoryIds = new ArrayList<>(1);
+        categoryIds.add((long) 1);
+        mPost.setCategoryIdList(categoryIds);
+
+        List<String> tags = new ArrayList<>(2);
+        tags.add("fluxc");
+        tags.add("generated-" + RandomStringUtils.randomAlphanumeric(8));
+        mPost.setTagNameList(tags);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertFalse(newPost.getTagNameList().isEmpty());
+
+        newPost.setTagNameList(Collections.<String>emptyList());
+        newPost.setIsLocallyChanged(true);
+
+        // Upload edited post
+        uploadPost(newPost);
+
+        PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertTrue(finalPost.getTagNameList().isEmpty());
     }
 
     public void testAddLocationToRemotePost() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -98,6 +98,9 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         assertNotSame(0, uploadedPost.getRemotePostId());
         assertFalse(uploadedPost.isLocalDraft());
+
+        // The site should automatically assign the post the default category
+        assertFalse(uploadedPost.getCategoryIdList().isEmpty());
     }
 
     public void testEditRemotePost() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -23,6 +23,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -344,6 +345,39 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("A fully featured page", newPage.getTitle());
         assertEquals("Some content here! <strong>Bold text</strong>.", newPage.getContent());
         assertEquals(date, newPage.getDateCreated());
+    }
+
+    public void testClearTagsFromPost() throws InterruptedException {
+        createNewPost();
+
+        mPost.setTitle("A post with tags");
+        mPost.setContent("Some content here! <strong>Bold text</strong>.");
+
+        List<Long> categoryIds = new ArrayList<>(1);
+        categoryIds.add((long) 1);
+        mPost.setCategoryIdList(categoryIds);
+
+        List<String> tags = new ArrayList<>(2);
+        tags.add("fluxc");
+        tags.add("generated-" + RandomStringUtils.randomAlphanumeric(8));
+        mPost.setTagNameList(tags);
+
+        uploadPost(mPost);
+
+        // Get the current copy of the post from the PostStore
+        PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertFalse(newPost.getTagNameList().isEmpty());
+
+        newPost.setTagNameList(Collections.<String>emptyList());
+        newPost.setIsLocallyChanged(true);
+
+        // Upload edited post
+        uploadPost(newPost);
+
+        PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
+
+        assertTrue(finalPost.getTagNameList().isEmpty());
     }
 
     public void testAddLocationToRemotePost() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -90,6 +90,9 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         assertNotSame(0, uploadedPost.getRemotePostId());
         assertFalse(uploadedPost.isLocalDraft());
+
+        // The site should automatically assign the post the default category
+        assertFalse(uploadedPost.getCategoryIdList().isEmpty());
     }
 
     public void testEditRemotePost() throws InterruptedException {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -428,26 +428,17 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         contentStruct.put("post_content", content);
 
-        // Handle taxonomies
-        // Add categories by ID to the 'terms' param
-        Map<Object, Object> terms = new HashMap<>();
+        if (!post.isPage()) {
+            // Handle taxonomies
 
-        if (!post.getCategoryIdList().isEmpty()) {
+            // Add categories by ID to the 'terms' param
+            Map<Object, Object> terms = new HashMap<>();
             terms.put("category", post.getCategoryIdList().toArray());
-        }
-
-        if (!terms.isEmpty()) {
             contentStruct.put("terms", terms);
-        }
 
-        // Add tags by name to the 'terms_names' param
-        Map<Object, Object> termsNames = new HashMap<>();
-
-        if (!post.getTagNameList().isEmpty()) {
+            // Add tags by name to the 'terms_names' param
+            Map<Object, Object> termsNames = new HashMap<>();
             termsNames.put("post_tag", post.getTagNameList().toArray());
-        }
-
-        if (!termsNames.isEmpty()) {
             contentStruct.put("terms_names", termsNames);
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -431,22 +431,47 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         if (!post.isPage()) {
             // Handle taxonomies
 
-            // Add categories by ID to the 'terms' param
-            Map<Object, Object> terms = new HashMap<>();
-            terms.put("category", post.getCategoryIdList().toArray());
+            if (post.isLocalDraft()) {
+                // When first time publishing, we only want to send the category and tag arrays if they contain info
+                // For tags it doesn't matter if we send an empty array, but for categories we want WordPress to give
+                // the post the site's default category, and that won't happen if we send an empty category array
+                // (we should send nothing instead)
+                if (!post.getCategoryIdList().isEmpty()) {
+                    // Add categories by ID to the 'terms' param
+                    Map<Object, Object> terms = new HashMap<>();
+                    terms.put("category", post.getCategoryIdList().toArray());
+                    contentStruct.put("terms", terms);
+                }
 
-            if (!post.getTagNameList().isEmpty()) {
-                // Add tags by name to the 'terms_names' param
-                Map<Object, Object> termsNames = new HashMap<>();
-                termsNames.put("post_tag", post.getTagNameList().toArray());
-                contentStruct.put("terms_names", termsNames);
+                if (!post.getTagNameList().isEmpty()) {
+                    // Add tags by name to the 'terms_names' param
+                    Map<Object, Object> termsNames = new HashMap<>();
+                    termsNames.put("post_tag", post.getTagNameList().toArray());
+                    contentStruct.put("terms_names", termsNames);
+                }
             } else {
-                // To clear any existing tags, we must pass an empty 'post_tag' array in the 'terms' param
-                // (this won't work in the 'terms_names' param)
-                terms.put("post_tag", post.getTagNameList().toArray());
-            }
+                // When editing existing posts, we want to explicitly tell the server that tags or categories are now
+                // empty, as it might be because the user removed them from the post
 
-            contentStruct.put("terms", terms);
+                // Add categories by ID to the 'terms' param
+                Map<Object, Object> terms = new HashMap<>();
+                if (post.getCategoryIdList().size() > 0 || !post.isLocalDraft()) {
+                    terms.put("category", post.getCategoryIdList().toArray());
+                }
+
+                if (!post.getTagNameList().isEmpty()) {
+                    // Add tags by name to the 'terms_names' param
+                    Map<Object, Object> termsNames = new HashMap<>();
+                    termsNames.put("post_tag", post.getTagNameList().toArray());
+                    contentStruct.put("terms_names", termsNames);
+                } else {
+                    // To clear any existing tags, we must pass an empty 'post_tag' array in the 'terms' param
+                    // (this won't work in the 'terms_names' param)
+                    terms.put("post_tag", post.getTagNameList().toArray());
+                }
+
+                contentStruct.put("terms", terms);
+            }
         }
 
         contentStruct.put("post_excerpt", post.getExcerpt());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -434,12 +434,19 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             // Add categories by ID to the 'terms' param
             Map<Object, Object> terms = new HashMap<>();
             terms.put("category", post.getCategoryIdList().toArray());
-            contentStruct.put("terms", terms);
 
-            // Add tags by name to the 'terms_names' param
-            Map<Object, Object> termsNames = new HashMap<>();
-            termsNames.put("post_tag", post.getTagNameList().toArray());
-            contentStruct.put("terms_names", termsNames);
+            if (!post.getTagNameList().isEmpty()) {
+                // Add tags by name to the 'terms_names' param
+                Map<Object, Object> termsNames = new HashMap<>();
+                termsNames.put("post_tag", post.getTagNameList().toArray());
+                contentStruct.put("terms_names", termsNames);
+            } else {
+                // To clear any existing tags, we must pass an empty 'post_tag' array in the 'terms' param
+                // (this won't work in the 'terms_names' param)
+                terms.put("post_tag", post.getTagNameList().toArray());
+            }
+
+            contentStruct.put("terms", terms);
         }
 
         contentStruct.put("post_excerpt", post.getExcerpt());


### PR DESCRIPTION
Introduces a few fixes to handling terms (categories and tags) during XML-RPC post uploads.

* Separates the logic for first-time publishing VS editing a post for readability
* Fixes an issue where it wasn't possible to remove all tags from a post that previously had tags (we need to use the `terms` param instead of the `terms_names` param in this specific case)
* Fixes an issue that prevented category-less first-time published posts from receiving the site's default category automatically server-side (this is how it works in wp-admin, and also in pre-FluxC WPAndroid)
* Re-restrict the login to posts only (not pages)