### PR TITLE
Issue #276: Request maximum number of terms from WP.com REST

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -79,7 +79,10 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
     public void fetchTerms(final SiteModel site, final String taxonomyName) {
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomyName).terms.getUrlV1_1();
 
-        final WPComGsonRequest request = WPComGsonRequest.buildGetRequest(url, null,
+        Map<String, String> params = new HashMap<>();
+        params.put("number", "1000");
+
+        final WPComGsonRequest request = WPComGsonRequest.buildGetRequest(url, params,
                 TermsResponse.class,
                 new Listener<TermsResponse>() {
                     @Override


### PR DESCRIPTION
Fixes #276, fetching as many terms at a time as possible from the WP.com REST API ([1000](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/taxonomies/%24taxonomy/terms/)). The previous limit (the default value of the `number` param) was 100.