### PR TITLE
Emit an invalid site error for deleting non-wpcom site

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -104,6 +104,7 @@ public class SiteStore extends Store {
         }
         public DeleteSiteError(DeleteSiteErrorType errorType) {
             this.type = errorType;
+            this.message = "";
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -102,6 +102,9 @@ public class SiteStore extends Store {
             this.type = DeleteSiteErrorType.fromString(errorType);
             this.message = message;
         }
+        public DeleteSiteError(DeleteSiteErrorType errorType) {
+            this.type = errorType;
+        }
     }
 
     // OnChanged Events
@@ -147,6 +150,7 @@ public class SiteStore extends Store {
     }
 
     public enum DeleteSiteErrorType {
+        INVALID_SITE,
         UNAUTHORIZED, // user don't have permission to delete
         AUTHORIZATION_REQUIRED, // missing access token
         GENERIC_ERROR;
@@ -633,7 +637,9 @@ public class SiteStore extends Store {
     }
 
     private void deleteSite(SiteModel site) {
-        if (site == null || !site.isWPCom()) {
+        if (!site.isWPCom()) {
+            OnSiteDeleted event = new OnSiteDeleted(new DeleteSiteError(DeleteSiteErrorType.INVALID_SITE));
+            emitChange(event);
             return;
         }
         mSiteRestClient.deleteSite(site);


### PR DESCRIPTION
As discussed [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/273#discussion_r95595240) we'll throw an `INVALID_SITE` error if the site is not wpcom and crash if it's null. Since there is no error message, I am just setting the type for the error. This makes me a bit uneasy since we take a `@NonNull` error message otherwise.

/cc @maxme 