### PR TITLE
New IS_WPCOM_URL Site action

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -97,7 +97,8 @@ public class SignedOutActionsFragment extends Fragment {
         AlertDialog.Builder alert = new AlertDialog.Builder(getActivity());
         final EditText editText = new EditText(getActivity());
         editText.setSingleLine();
-        alert.setMessage("Check if the following URL is wpcom or jetpack (and can be contacted via wpcom credentials):");
+        alert.setMessage("Check if the following URL is wpcom or jetpack"
+                + " (and can be contacted via wpcom credentials):");
         alert.setView(editText);
         alert.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {

--- a/example/src/main/res/layout/fragment_signed_out_actions.xml
+++ b/example/src/main/res/layout/fragment_signed_out_actions.xml
@@ -17,4 +17,10 @@
         android:layout_height="wrap_content"
         android:text="Send Magic Link E-mail" />
 
+    <Button
+        android:id="@+id/check_url_wpcom"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Check if URL is WPCom site (or Jetpack)" />
+
 </LinearLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -6,10 +6,11 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.DeleteSiteResponsePayload;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPComResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
-import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 
 @ActionEnum
 public enum SiteAction implements IAction {
@@ -26,6 +27,8 @@ public enum SiteAction implements IAction {
     FETCH_POST_FORMATS,
     @Action(payloadType = SiteModel.class)
     DELETE_SITE,
+    @Action(payloadType = String.class)
+    IS_WPCOM_URL,
 
     // Remote responses
     @Action(payloadType = NewSiteResponsePayload.class)
@@ -48,4 +51,6 @@ public enum SiteAction implements IAction {
     SHOW_SITES,
     @Action(payloadType = SitesModel.class)
     HIDE_SITES,
+    @Action(payloadType = IsWPComResponsePayload.class)
+    CHECKED_IS_WPCOM_URL
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -69,6 +69,14 @@ public class SiteRestClient extends BaseWPComRestClient {
         public DeleteSiteError error;
     }
 
+    public static class IsWPComResponsePayload extends Payload {
+        public IsWPComResponsePayload() {
+        }
+        public String url;
+        public BaseNetworkError error;
+        public boolean isWPCom;
+    }
+
     @Inject
     public SiteRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue, AppSecrets appSecrets,
                           AccessToken accessToken, UserAgent userAgent) {
@@ -97,6 +105,40 @@ public class SiteRestClient extends BaseWPComRestClient {
                         SitesModel payload = new SitesModel(new ArrayList<SiteModel>());
                         payload.error = error;
                         mDispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(payload));
+                    }
+                }
+        );
+        add(request);
+    }
+
+    public void checkUrlIsWPCom(@NonNull final String testedUrl) {
+        String url = WPCOMREST.sites.getUrlV1_1() + testedUrl;
+        final WPComGsonRequest<SiteWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,
+                SiteWPComRestResponse.class,
+                new Listener<SiteWPComRestResponse>() {
+                    @Override
+                    public void onResponse(SiteWPComRestResponse response) {
+                        IsWPComResponsePayload payload = new IsWPComResponsePayload();
+                        payload.url = testedUrl;
+                        payload.isWPCom = true;
+                        mDispatcher.dispatch(SiteActionBuilder.newCheckedIsWpcomUrlAction(payload));
+                    }
+                },
+                new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        IsWPComResponsePayload payload = new IsWPComResponsePayload();
+                        payload.url = testedUrl;
+                        // "unauthorized" and "unknown_blog" errors expected if the site is not accessible via
+                        // the WPCom REST API.
+                        if (error instanceof WPComGsonNetworkError
+                            && ("unauthorized".equals(((WPComGsonNetworkError) error).apiError) ||
+                                "unknown_blog".equals(((WPComGsonNetworkError) error).apiError))) {
+                            payload.isWPCom = false;
+                        } else {
+                            payload.error = error;
+                        }
+                        mDispatcher.dispatch(SiteActionBuilder.newCheckedIsWpcomUrlAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -73,7 +73,6 @@ public class SiteRestClient extends BaseWPComRestClient {
         public IsWPComResponsePayload() {
         }
         public String url;
-        public BaseNetworkError error;
         public boolean isWPCom;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -132,8 +132,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                         // "unauthorized" and "unknown_blog" errors expected if the site is not accessible via
                         // the WPCom REST API.
                         if (error instanceof WPComGsonNetworkError
-                            && ("unauthorized".equals(((WPComGsonNetworkError) error).apiError) ||
-                                "unknown_blog".equals(((WPComGsonNetworkError) error).apiError))) {
+                            && ("unauthorized".equals(((WPComGsonNetworkError) error).apiError)
+                                || "unknown_blog".equals(((WPComGsonNetworkError) error).apiError))) {
                             payload.isWPCom = false;
                         } else {
                             payload.error = error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -580,6 +580,9 @@ public class SiteStore extends Store {
             case DELETED_SITE:
                 handleDeletedSite((SiteRestClient.DeleteSiteResponsePayload) action.getPayload());
                 break;
+            case CHECKED_IS_WPCOM_URL:
+                handleCheckedIsWPComUrl((IsWPComResponsePayload) action.getPayload());
+                break;
         }
     }
 


### PR DESCRIPTION
That checks if the url is accessible via the WordPress.com REST API (likely a wordpress.com hosted site or a jetpack site or "test.com").

Known issue: test.com