### PR TITLE
Fix #284 crash adding jetpack site

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
@@ -327,7 +327,8 @@ public class MainFragment extends Fragment {
         }
         if (mSiteStore.hasSite()) {
             SiteModel firstSite = mSiteStore.getSites().get(0);
-            prependToLog("First site name: " + firstSite.getName() + " - Total sites: " + mSiteStore.getSitesCount());
+            prependToLog("First site name: " + firstSite.getName() + " - Total sites: " + mSiteStore.getSitesCount()
+                         + " - rowsAffected: " + event.rowsAffected);
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -60,6 +60,15 @@ public class SitesFragment extends Fragment {
             }
         });
 
+        view.findViewById(R.id.update_all_sites).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                for (SiteModel site: mSiteStore.getSites()) {
+                    mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site));
+                }
+            }
+        });
+
         view.findViewById(R.id.log_sites).setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -122,16 +122,16 @@ public class SitesFragment extends Fragment {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        prependToLog("OnSiteChanged");
         if (event.isError()) {
+            prependToLog("SiteChanged error: " + event.error.type);
             AppLog.e(T.TESTS, "SiteChanged error: " + event.error.type);
-            return;
+        } else {
+            prependToLog("SiteChanged: rowsAffected = " + event.rowsAffected);
         }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onNewSiteCreated(OnNewSiteCreated event) {
-        prependToLog("OnNewSiteCreated");
         String message = event.dryRun ? "validated" : "created";
         if (event.isError()) {
             prependToLog("New site " + message + ": error: " + event.error.type + " - " + event.error.message);

--- a/example/src/main/res/layout/fragment_sites.xml
+++ b/example/src/main/res/layout/fragment_sites.xml
@@ -18,6 +18,12 @@
         android:text="Fetch first site" />
 
     <Button
+        android:id="@+id/update_all_sites"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch all sites" />
+
+    <Button
         android:id="@+id/log_sites"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -25,10 +25,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSite;
+import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSiteOverXMLRPC;
 import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSiteOverRestOnly;
 import static org.wordpress.android.fluxc.utils.SiteUtils.generatePostFormats;
 import static org.wordpress.android.fluxc.utils.SiteUtils.generateSelfHostedNonJPSite;
@@ -100,8 +101,8 @@ public class SiteStoreUnitTest {
         assertEquals(1, mSiteStore.getSelfHostedSitesCount());
 
         // Test counts with one .COM, one self-hosted and one Jetpack site
-        SiteModel jetpackSite = generateJetpackSite();
-        SiteSqlUtils.insertOrUpdateSite(jetpackSite);
+        SiteModel jetpackSiteOverXMLRPC = generateJetpackSiteOverXMLRPC();
+        SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverXMLRPC);
 
         assertTrue(mSiteStore.hasSite());
         assertTrue(mSiteStore.hasWPComSite());
@@ -109,8 +110,8 @@ public class SiteStoreUnitTest {
         assertTrue(mSiteStore.hasJetpackSite());
 
         assertEquals(3, mSiteStore.getSitesCount());
-        assertEquals(2, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
+        assertEquals(1, mSiteStore.getWPComSitesCount());
+        assertEquals(2, mSiteStore.getSelfHostedSitesCount());
         assertEquals(1, mSiteStore.getJetpackSitesCount());
     }
 
@@ -124,7 +125,7 @@ public class SiteStoreUnitTest {
         assertTrue(mSiteStore.hasSelfHostedSiteWithSiteIdAndXmlRpcUrl(selfHostedSite.getSelfHostedSiteId(),
                 selfHostedSite.getXmlRpcUrl()));
 
-        SiteModel jetpackSite = generateJetpackSite();
+        SiteModel jetpackSite = generateJetpackSiteOverXMLRPC();
         SiteSqlUtils.insertOrUpdateSite(jetpackSite);
 
         assertTrue(mSiteStore.hasSelfHostedSiteWithSiteIdAndXmlRpcUrl(jetpackSite.getSelfHostedSiteId(),
@@ -140,7 +141,7 @@ public class SiteStoreUnitTest {
 
         assertTrue(mSiteStore.hasWPComOrJetpackSiteWithSiteId(wpComSite.getSiteId()));
 
-        SiteModel jetpackSite = generateJetpackSite();
+        SiteModel jetpackSite = generateJetpackSiteOverXMLRPC();
         SiteSqlUtils.insertOrUpdateSite(jetpackSite);
 
         // hasWPComOrJetpackSiteWithSiteId() should be able to locate a Jetpack site with either the site id or the
@@ -210,7 +211,7 @@ public class SiteStoreUnitTest {
 
         SiteModel selfHostedSite = generateSelfHostedNonJPSite();
         SiteModel wpComSite = generateWPComSite();
-        SiteModel jetpackSite = generateJetpackSite();
+        SiteModel jetpackSite = generateJetpackSiteOverXMLRPC();
         SiteSqlUtils.insertOrUpdateSite(selfHostedSite);
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
         SiteSqlUtils.insertOrUpdateSite(jetpackSite);
@@ -239,7 +240,7 @@ public class SiteStoreUnitTest {
 
         SiteModel selfHostedSite = generateSelfHostedNonJPSite();
         SiteModel wpComSite = generateWPComSite();
-        SiteModel jetpackSite = generateJetpackSite();
+        SiteModel jetpackSite = generateJetpackSiteOverXMLRPC();
         SiteSqlUtils.insertOrUpdateSite(selfHostedSite);
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
         SiteSqlUtils.insertOrUpdateSite(jetpackSite);
@@ -266,17 +267,19 @@ public class SiteStoreUnitTest {
     @Test
     public void testGetWPComSites() throws DuplicateSiteException {
         SiteModel wpComSite = generateWPComSite();
-        SiteModel jetpackSiteOverSelfHosted = generateJetpackSite();
+        SiteModel jetpackSiteOverXMLRPC = generateJetpackSiteOverXMLRPC();
         SiteModel jetpackSiteOverRestOnly = generateJetpackSiteOverRestOnly();
 
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
-        SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverSelfHosted);
-        SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverRestOnly);
+        SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverXMLRPC);
         SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverRestOnly);
 
         List<SiteModel> wpComSites = SiteSqlUtils.getAllWPComSites();
 
-        assertEquals(3, wpComSites.size());
+        assertEquals(2, wpComSites.size());
+        for (SiteModel site : wpComSites) {
+            assertNotEquals(jetpackSiteOverXMLRPC.getId(), site.getId());
+        }
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -108,8 +108,8 @@ public class SiteStoreUnitTest {
         assertTrue(mSiteStore.hasJetpackSite());
 
         assertEquals(3, mSiteStore.getSitesCount());
-        assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(2, mSiteStore.getSelfHostedSitesCount());
+        assertEquals(2, mSiteStore.getWPComSitesCount());
+        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
         assertEquals(1, mSiteStore.getJetpackSitesCount());
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.SiteStore;
 
@@ -60,7 +61,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testInsertOrUpdateSite() {
+    public void testInsertOrUpdateSite() throws DuplicateSiteException {
         SiteModel site = generateWPComSite();
         SiteSqlUtils.insertOrUpdateSite(site);
 
@@ -69,7 +70,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testHasSiteAndgetCountMethods() {
+    public void testHasSiteAndgetCountMethods() throws DuplicateSiteException {
         assertFalse(mSiteStore.hasSite());
         assertTrue(mSiteStore.getSites().isEmpty());
 
@@ -114,7 +115,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testHasSiteWithSiteIdAndXmlRpcUrl() {
+    public void testHasSiteWithSiteIdAndXmlRpcUrl() throws DuplicateSiteException {
         assertFalse(mSiteStore.hasSelfHostedSiteWithSiteIdAndXmlRpcUrl(124, ""));
 
         SiteModel selfHostedSite = generateSelfHostedNonJPSite();
@@ -131,7 +132,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testHasWPComOrJetpackSiteWithSiteId() {
+    public void testHasWPComOrJetpackSiteWithSiteId() throws DuplicateSiteException {
         assertFalse(mSiteStore.hasWPComOrJetpackSiteWithSiteId(673));
 
         SiteModel wpComSite = generateWPComSite();
@@ -149,7 +150,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testWPComSiteVisibility() {
+    public void testWPComSiteVisibility() throws DuplicateSiteException {
         // Should not cause any errors
         mSiteStore.isWPComSiteVisibleByLocalId(45);
         SiteSqlUtils.setSiteVisibility(null, true);
@@ -173,7 +174,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testSetAllWPComSitesVisibility() {
+    public void testSetAllWPComSitesVisibility() throws DuplicateSiteException {
         SiteModel selfHostedNonJPSite = generateSelfHostedNonJPSite();
         SiteSqlUtils.insertOrUpdateSite(selfHostedNonJPSite);
 
@@ -202,7 +203,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testGetIdForIdMethods() {
+    public void testGetIdForIdMethods() throws DuplicateSiteException {
         assertEquals(0, mSiteStore.getLocalIdForRemoteSiteId(555));
         assertEquals(0, mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(2626, ""));
         assertEquals(0, mSiteStore.getSiteIdForLocalId(5577));
@@ -233,7 +234,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testGetSiteBySiteId() {
+    public void testGetSiteBySiteId() throws DuplicateSiteException {
         assertNull(mSiteStore.getSiteBySiteId(555));
 
         SiteModel selfHostedSite = generateSelfHostedNonJPSite();
@@ -249,7 +250,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testDeleteSite() {
+    public void testDeleteSite() throws DuplicateSiteException {
         SiteModel wpComSite = generateWPComSite();
 
         // Should not cause any errors
@@ -263,7 +264,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testGetWPComSites() {
+    public void testGetWPComSites() throws DuplicateSiteException {
         SiteModel wpComSite = generateWPComSite();
         SiteModel jetpackSiteOverSelfHosted = generateJetpackSite();
         SiteModel jetpackSiteOverRestOnly = generateJetpackSiteOverRestOnly();
@@ -281,7 +282,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testGetPostFormats() {
+    public void testGetPostFormats() throws DuplicateSiteException {
         SiteModel site = generateWPComSite();
         SiteSqlUtils.insertOrUpdateSite(site);
 
@@ -297,7 +298,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testSearchSitesByNameMatching() {
+    public void testSearchSitesByNameMatching() throws DuplicateSiteException {
         SiteModel wpComSite1 = generateWPComSite();
         wpComSite1.setName("Doctor Emmet Brown Homepage");
         SiteModel wpComSite2 = generateWPComSite();
@@ -317,7 +318,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testSearchSitesByNameOrUrlMatching() {
+    public void testSearchSitesByNameOrUrlMatching() throws DuplicateSiteException {
         SiteModel wpComSite1 = generateWPComSite();
         wpComSite1.setName("Doctor Emmet Brown Homepage");
         SiteModel wpComSite2 = generateWPComSite();
@@ -337,7 +338,7 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testSearchWPComSitesByNameOrUrlMatching() {
+    public void testSearchWPComSitesByNameOrUrlMatching() throws DuplicateSiteException {
         SiteModel wpComSite1 = generateWPComSite();
         wpComSite1.setName("Doctor Emmet Brown Homepage");
         SiteModel wpComSite2 = generateWPComSite();

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -29,7 +29,7 @@ public class SiteUtils {
         SiteModel example = new SiteModel();
         example.setSiteId(982);
         example.setSelfHostedSiteId(8);
-        example.setIsWPCom(false);
+        example.setIsWPCom(true);
         example.setIsJetpack(true);
         example.setIsVisible(true);
         example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");
@@ -39,7 +39,7 @@ public class SiteUtils {
     public static SiteModel generateJetpackSiteOverRestOnly() {
         SiteModel example = new SiteModel();
         example.setSiteId(5623);
-        example.setIsWPCom(false);
+        example.setIsWPCom(true);
         example.setIsJetpack(true);
         example.setIsVisible(true);
         example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -42,7 +42,17 @@ public class SiteUtils {
         example.setIsWPCom(true);
         example.setIsJetpack(true);
         example.setIsVisible(true);
-        example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");
+        example.setXmlRpcUrl("http://jetpack2.url/xmlrpc.php");
+        return example;
+    }
+
+    public static SiteModel generateSelfHostedSiteFutureJetpack() {
+        SiteModel example = new SiteModel();
+        example.setSelfHostedSiteId(8);
+        example.setIsWPCom(false);
+        example.setIsJetpack(false);
+        example.setIsVisible(true);
+        example.setXmlRpcUrl("http://jetpack2.url/xmlrpc.php");
         return example;
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -25,11 +25,11 @@ public class SiteUtils {
         return example;
     }
 
-    public static SiteModel generateJetpackSite() {
+    public static SiteModel generateJetpackSiteOverXMLRPC() {
         SiteModel example = new SiteModel();
         example.setSiteId(982);
         example.setSelfHostedSiteId(8);
-        example.setIsWPCom(true);
+        example.setIsWPCom(false);
         example.setIsJetpack(true);
         example.setIsVisible(true);
         example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -79,7 +79,7 @@ public class SiteSqlUtils {
         if (siteResult.isEmpty()) {
             // No site with this local ID, or REMOTE_ID + URL, then insert it
             WellSql.insert(site).asSingleTransaction(true).execute();
-            return 0;
+            return 1;
         } else {
             // Update old site
             int oldId = siteResult.get(0).getId();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -77,7 +77,6 @@ public class SiteSqlUtils {
         // Looks like a new site, make sure we don't already have it.
         if (siteResult.isEmpty()) {
             AppLog.d(T.DB, "Site not found using local id");
-            // TODO: Make the URL enough, we could get surprise with the site id with .org sites becoming jetpack sites
             siteResult = WellSql.select(SiteModel.class)
                     .where().beginGroup()
                     .equals(SiteModelTable.SITE_ID, site.getSiteId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPCo
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -165,6 +166,7 @@ public class SiteStore extends Store {
 
     public enum SiteErrorType {
         INVALID_SITE,
+        DUPLICATE_SITE,
         GENERIC_ERROR
     }
 
@@ -697,27 +699,31 @@ public class SiteStore extends Store {
     }
 
     private void updateSite(SiteModel siteModel) {
-        OnSiteChanged event;
+        OnSiteChanged event = new OnSiteChanged(0);
         if (siteModel.isError()) {
-            event = new OnSiteChanged(0);
             // TODO: what kind of error could we get here?
             event.error = new SiteError(SiteErrorType.GENERIC_ERROR);
         } else {
-            int rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
-            event = new OnSiteChanged(rowsAffected);
+            try {
+                event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
+            } catch (DuplicateSiteException e) {
+                event.error = new SiteError(SiteErrorType.DUPLICATE_SITE);
+            }
         }
         emitChange(event);
     }
 
     private void updateSites(SitesModel sitesModel) {
-        OnSiteChanged event;
+        OnSiteChanged event = new OnSiteChanged(0);
         if (sitesModel.isError()) {
-            event = new OnSiteChanged(0);
             // TODO: what kind of error could we get here?
             event.error = new SiteError(SiteErrorType.GENERIC_ERROR);
         } else {
-            int rowsAffected = createOrUpdateSites(sitesModel);
-            event = new OnSiteChanged(rowsAffected);
+            try {
+                event.rowsAffected = createOrUpdateSites(sitesModel);
+            } catch (DuplicateSiteException e) {
+                event.error = new SiteError(SiteErrorType.DUPLICATE_SITE);
+            }
         }
         emitChange(event);
     }
@@ -765,7 +771,7 @@ public class SiteStore extends Store {
         emitChange(event);
     }
 
-    private int createOrUpdateSites(SitesModel sites) {
+    private int createOrUpdateSites(SitesModel sites) throws DuplicateSiteException {
         int rowsAffected = 0;
         for (SiteModel site : sites.getSites()) {
             rowsAffected += SiteSqlUtils.insertOrUpdateSite(site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -757,7 +757,7 @@ public class SiteStore extends Store {
     private void handleCheckedIsWPComUrl(IsWPComResponsePayload payload) {
         OnURLChecked event = new OnURLChecked(payload.url);
         if (payload.isError()) {
-            // Return invalid site for all errors (this endpoint is not documented and seems a bit drunk).
+            // Return invalid site for all errors (this endpoint seems a bit drunk).
             // Client likely needs to know if there was an error or not.
             event.error = new SiteError(SiteErrorType.INVALID_SITE);
         }


### PR DESCRIPTION
Fix #284 

At least 2 cases to test in the example:

1. Jetpack -> self hosted
    * Clear app data
    * Sign in a .com account with a Jetpack site
    * Try to add that Jetpack site as a self hosted site
    * You should get a "DUPLICATE_SITE" error
1. Self hosted -> Jetpack (with the same account / sites)
    * Clear app data
    * Add that Jetpack site as a self hosted site
    * Sign in a .com account
    * You should get the same number of sites, and the previous self hosted site is now considered a Jetpack

Not easy to test automatically without predefined sites or complex mocks.

I'm not a big fan of [checking for the XMLRPC endpoint ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/8aad65ddc0fa7d458702792aa0df8e47df9bcc18/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java#L87)as a "key", but I don't think we can find anything better.
