### PR TITLE
Use long IDs for all WPCOM REST response IDs

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.java
@@ -27,7 +27,7 @@ public class PostWPComRestResponse extends Payload implements Response {
         public boolean delete_post;
     }
 
-    public int ID;
+    public long ID;
     public long site_ID;
     public String date;
     public String modified;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -53,7 +53,7 @@ public class SiteWPComRestResponse extends Payload implements Response {
         public Links links;
     }
 
-    public int ID;
+    public long ID;
     public String URL;
     public String name;
     public String description;


### PR DESCRIPTION
Use long IDs for all WPCOM REST response IDs