### PR TITLE
Default jetpack id to 0

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -198,7 +198,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         oldModel.setTimezone(getOption(siteOptions, TIME_ZONE_KEY, String.class));
         oldModel.setLoginUrl(getOption(siteOptions, LOGIN_URL_KEY, String.class));
         oldModel.setAdminUrl(getOption(siteOptions, ADMIN_URL_KEY, String.class));
-        long wpComIdForJetpack = string2Long(getOption(siteOptions, JETPACK_CLIENT_ID_KEY, String.class), -1);
+        long wpComIdForJetpack = string2Long(getOption(siteOptions, JETPACK_CLIENT_ID_KEY, String.class), 0);
         oldModel.setSiteId(wpComIdForJetpack);
         // If the site is not public, it's private. Note: this field doesn't always exist.
         oldModel.setIsPrivate(false);


### PR DESCRIPTION
I'm not sure why I used -1 in the first place, especially with that check [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7fd7a800ac3900d3a95a430fbe86de7e03ba00cd/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java#L211-L213).