### PR TITLE
Feature/okhttpstack+stetho

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -67,8 +67,6 @@ android.buildTypes.all { buildType ->
 dependencies {
     compile project(':fluxc');
 
-
-
     compile 'com.google.dagger:dagger:2.0.2'
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.support:support-v4:25.1.0'
@@ -81,4 +79,8 @@ dependencies {
     androidTestApt 'com.google.dagger:dagger-compiler:2.0'
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
+
+    // Debug dependencies
+    debugCompile 'com.facebook.stetho:stetho:1.4.2'
+    debugCompile 'com.facebook.stetho:stetho-okhttp3:1.4.2'
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -21,10 +21,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.ErrorLi
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Listener;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Token;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 
@@ -34,7 +34,6 @@ import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
 import okhttp3.OkHttpClient;
-import okhttp3.OkUrlFactory;
 
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.any;
@@ -47,19 +46,13 @@ import static org.mockito.Mockito.spy;
 public class MockedNetworkModule {
     @Singleton
     @Provides
-    public OkHttpClient provideOkHttpClient() {
-        return new OkHttpClient();
+    public OkHttpClient.Builder provideOkHttpClient() {
+        return new OkHttpClient.Builder();
     }
 
     @Singleton
     @Provides
-    public OkUrlFactory provideOkUrlFactory(OkHttpClient okHttpClient) {
-        return new OkUrlFactory(okHttpClient);
-    }
-
-    @Singleton
-    @Provides
-    public RequestQueue provideRequestQueue(OkHttpClient okHttpClient, Context appContext) {
+    public RequestQueue provideRequestQueue(OkHttpClient.Builder okHttpClient, Context appContext) {
         return Volley.newRequestQueue(appContext, new OkHttpStack(okHttpClient));
     }
 
@@ -129,14 +122,14 @@ public class MockedNetworkModule {
     @Provides
     public MediaRestClient provideMediaRestClient(Dispatcher dispatcher, Context appContext,
                                                   @Named("regular") RequestQueue requestQueue,
-                                                  @Named("regular") OkHttpClient okHttpClient,
+                                                  @Named("regular") OkHttpClient.Builder okHttpClient,
                                                   AccessToken token, UserAgent userAgent) {
         return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClient, token, userAgent);
     }
 
     @Singleton
     @Provides
-    public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher, OkHttpClient okClient,
+    public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher, OkHttpClient.Builder okClient,
                                                       @Named("regular") RequestQueue requestQueue,
                                                       AccessToken token, UserAgent userAgent,
                                                       HTTPAuthManager httpAuthManager) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -59,8 +59,8 @@ public class MockedNetworkModule {
 
     @Singleton
     @Provides
-    public RequestQueue provideRequestQueue(OkUrlFactory okUrlFactory, Context appContext) {
-        return Volley.newRequestQueue(appContext, new OkHttpStack(okUrlFactory));
+    public RequestQueue provideRequestQueue(OkHttpClient okHttpClient, Context appContext) {
+        return Volley.newRequestQueue(appContext, new OkHttpStack(okHttpClient));
     }
 
     @Singleton

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -46,14 +46,14 @@ import static org.mockito.Mockito.spy;
 public class MockedNetworkModule {
     @Singleton
     @Provides
-    public OkHttpClient.Builder provideOkHttpClient() {
+    public OkHttpClient.Builder provideOkHttpClientBuilder() {
         return new OkHttpClient.Builder();
     }
 
     @Singleton
     @Provides
-    public RequestQueue provideRequestQueue(OkHttpClient.Builder okHttpClient, Context appContext) {
-        return Volley.newRequestQueue(appContext, new OkHttpStack(okHttpClient));
+    public RequestQueue provideRequestQueue(OkHttpClient.Builder okHttpClientBuilder, Context appContext) {
+        return Volley.newRequestQueue(appContext, new OkHttpStack(okHttpClientBuilder));
     }
 
     @Singleton
@@ -122,18 +122,18 @@ public class MockedNetworkModule {
     @Provides
     public MediaRestClient provideMediaRestClient(Dispatcher dispatcher, Context appContext,
                                                   @Named("regular") RequestQueue requestQueue,
-                                                  @Named("regular") OkHttpClient.Builder okHttpClient,
+                                                  @Named("regular") OkHttpClient.Builder okHttpClientBuilder,
                                                   AccessToken token, UserAgent userAgent) {
-        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClient, token, userAgent);
+        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClientBuilder, token, userAgent);
     }
 
     @Singleton
     @Provides
-    public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher, OkHttpClient.Builder okClient,
+    public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher, OkHttpClient.Builder okHttpClientBuilder,
                                                       @Named("regular") RequestQueue requestQueue,
                                                       AccessToken token, UserAgent userAgent,
                                                       HTTPAuthManager httpAuthManager) {
-        return new MediaXMLRPCClient(dispatcher, requestQueue, okClient, token, userAgent, httpAuthManager);
+        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClientBuilder, token, userAgent, httpAuthManager);
     }
 
     @Singleton

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.example.AppSecretsModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
+import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseStoreModule;
 
 import javax.inject.Singleton;
@@ -15,6 +16,7 @@ import dagger.Component;
 @Component(modules = {
         AppContextModule.class,
         AppSecretsModule.class,
+        ReleaseOkHttpClientModule.class,
         ReleaseBaseModule.class,
         ReleaseNetworkModule.class,
         ReleaseStoreModule.class

--- a/example/src/debug/AndroidManifest.xml
+++ b/example/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest package="org.wordpress.android.fluxc.example"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:name=".ExampleDebugApp"
+        tools:replace="android:name" />
+
+</manifest>

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/AppComponentDebug.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/AppComponentDebug.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.example;
 
 import org.wordpress.android.fluxc.module.AppContextModule;
-import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseStoreModule;
@@ -14,20 +13,10 @@ import dagger.Component;
 @Component(modules = {
         AppContextModule.class,
         AppSecretsModule.class,
-        ReleaseOkHttpClientModule.class,
+        DebugOkHttpClientModule.class,
         ReleaseBaseModule.class,
         ReleaseNetworkModule.class,
         ReleaseStoreModule.class
 })
-public interface AppComponent {
-    void inject(ExampleApp object);
-    void inject(MainExampleActivity object);
-    void inject(SitesFragment object);
-    void inject(MainFragment object);
-    void inject(MediaFragment object);
-    void inject(CommentsFragment object);
-    void inject(PostsFragment object);
-    void inject(AccountFragment object);
-    void inject(SignedOutActionsFragment object);
-    void inject(TaxonomiesFragment object);
+public interface AppComponentDebug extends AppComponent {
 }

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
@@ -22,13 +22,13 @@ import okhttp3.OkHttpClient;
 public class DebugOkHttpClientModule {
     @Provides
     @Named("regular")
-    public OkHttpClient.Builder provideOkHttpClient() {
+    public OkHttpClient.Builder provideOkHttpClientBuilder() {
         return new OkHttpClient.Builder().addNetworkInterceptor(new StethoInterceptor());
     }
 
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient.Builder provideOkHttpClientCustomSSL(MemorizingTrustManager memorizingTrustManager) {
+    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(MemorizingTrustManager memorizingTrustManager) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
@@ -1,0 +1,44 @@
+package org.wordpress.android.fluxc.example;
+
+import com.facebook.stetho.okhttp3.StethoInterceptor;
+
+import org.wordpress.android.fluxc.network.MemorizingTrustManager;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.inject.Named;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+import dagger.Module;
+import dagger.Provides;
+import okhttp3.OkHttpClient;
+
+@Module
+public class DebugOkHttpClientModule {
+    @Provides
+    @Named("regular")
+    public OkHttpClient.Builder provideOkHttpClient() {
+        return new OkHttpClient.Builder().addNetworkInterceptor(new StethoInterceptor());
+    }
+
+    @Provides
+    @Named("custom-ssl")
+    public OkHttpClient.Builder provideOkHttpClientCustomSSL(MemorizingTrustManager memorizingTrustManager) {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        try {
+            final SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new java.security.SecureRandom());
+            final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+            builder.sslSocketFactory(sslSocketFactory);
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            AppLog.e(T.API, e);
+        }
+        builder.addNetworkInterceptor(new StethoInterceptor());
+        return builder;
+    }
+}

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/ExampleDebugApp.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/ExampleDebugApp.java
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.example;
+
+import com.facebook.stetho.Stetho;
+
+import org.wordpress.android.fluxc.module.AppContextModule;
+
+public class ExampleDebugApp extends ExampleApp {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        initDaggerComponent();
+        Stetho.initializeWithDefaults(this);
+    }
+
+    protected void initDaggerComponent() {
+        mComponent = DaggerAppComponentDebug.builder()
+                .appContextModule(new AppContextModule(getApplicationContext()))
+                .build();
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.java
@@ -8,19 +8,23 @@ import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 
 public class ExampleApp extends Application {
-    private AppComponent mComponent;
+    protected AppComponent mComponent;
 
     @Override
     public void onCreate() {
         super.onCreate();
-        mComponent = DaggerAppComponent.builder()
-                .appContextModule(new AppContextModule(getApplicationContext()))
-                .build();
+        initDaggerComponent();
         component().inject(this);
         WellSql.init(new WellSqlConfig(getApplicationContext()));
     }
 
     public AppComponent component() {
         return mComponent;
+    }
+
+    protected void initDaggerComponent() {
+        mComponent = DaggerAppComponent.builder()
+                .appContextModule(new AppContextModule(getApplicationContext()))
+                .build();
     }
 }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -18,6 +18,8 @@ repositories {
 }
 
 android {
+    useLibrary 'org.apache.http.legacy'
+
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -29,85 +29,42 @@ import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
-import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 
 import java.io.File;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
 
 import dagger.Module;
 import dagger.Provides;
 import okhttp3.OkHttpClient;
-import okhttp3.OkUrlFactory;
 
 @Module
 public class ReleaseNetworkModule {
     private static final String DEFAULT_CACHE_DIR = "volley-fluxc";
     private static final int NETWORK_THREAD_POOL_SIZE = 10;
 
-    private RequestQueue newRequestQueue(OkUrlFactory okUrlFactory, Context appContext) {
+    private RequestQueue newRequestQueue(OkHttpClient.Builder okHttpClientBuilder, Context appContext) {
         File cacheDir = new File(appContext.getCacheDir(), DEFAULT_CACHE_DIR);
-        Network network = new BasicNetwork(new OkHttpStack(okUrlFactory));
+        Network network = new BasicNetwork(new OkHttpStack(okHttpClientBuilder));
         RequestQueue queue = new RequestQueue(new DiskBasedCache(cacheDir), network, NETWORK_THREAD_POOL_SIZE);
         queue.start();
         return queue;
     }
 
-    @Provides
-    @Named("regular")
-    public OkHttpClient provideOkHttpClient() {
-        return new OkHttpClient.Builder().build();
-    }
-
     @Singleton
     @Named("regular")
     @Provides
-    public OkUrlFactory provideOkUrlFactory(@Named("regular") OkHttpClient okHttpClient) {
-        return new OkUrlFactory(okHttpClient);
-    }
-
-    @Singleton
-    @Named("regular")
-    @Provides
-    public RequestQueue provideRequestQueue(@Named("regular") OkUrlFactory okUrlFactory, Context appContext) {
-        return newRequestQueue(okUrlFactory, appContext);
-    }
-
-    @Provides
-    @Named("custom-ssl")
-    public OkHttpClient provideOkHttpClientCustomSSL(MemorizingTrustManager memorizingTrustManager) {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder();
-        try {
-            final SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new java.security.SecureRandom());
-            final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
-            builder.sslSocketFactory(sslSocketFactory);
-        } catch (NoSuchAlgorithmException | KeyManagementException e) {
-            AppLog.e(T.API, e);
-        }
-        return builder.build();
+    public RequestQueue provideRequestQueue(@Named("regular") OkHttpClient.Builder okHttpClient, Context appContext) {
+        return newRequestQueue(okHttpClient, appContext);
     }
 
     @Singleton
     @Named("custom-ssl")
     @Provides
-    public OkUrlFactory provideOkUrlFactoryCustomSSL(@Named("custom-ssl") OkHttpClient okHttpClient) {
-        return new OkUrlFactory(okHttpClient);
-    }
-
-    @Singleton
-    @Named("custom-ssl")
-    @Provides
-    public RequestQueue provideRequestQueueCustomSSL(@Named("custom-ssl") OkUrlFactory okUrlFactory,
+    public RequestQueue provideRequestQueueCustomSSL(@Named("custom-ssl") OkHttpClient.Builder okHttpClient,
                                                      Context appContext) {
-        return newRequestQueue(okUrlFactory, appContext);
+        return newRequestQueue(okHttpClient, appContext);
     }
 
     @Singleton
@@ -162,7 +119,7 @@ public class ReleaseNetworkModule {
     @Provides
     public MediaRestClient provideMediaRestClient(Context appContext, Dispatcher dispatcher,
                                                   @Named("regular") RequestQueue requestQueue,
-                                                  @Named("regular") OkHttpClient okHttpClient,
+                                                  @Named("regular") OkHttpClient.Builder okHttpClient,
                                                   AccessToken token, UserAgent userAgent) {
         return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClient, token, userAgent);
     }
@@ -171,7 +128,7 @@ public class ReleaseNetworkModule {
     @Provides
     public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher,
                                                       @Named("custom-ssl") RequestQueue requestQueue,
-                                                      @Named("custom-ssl") OkHttpClient okClient,
+                                                      @Named("custom-ssl") OkHttpClient.Builder okClient,
                                                       AccessToken token, UserAgent userAgent,
                                                       HTTPAuthManager httpAuthManager) {
         return new MediaXMLRPCClient(dispatcher, requestQueue, okClient, token, userAgent, httpAuthManager);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -55,16 +55,17 @@ public class ReleaseNetworkModule {
     @Singleton
     @Named("regular")
     @Provides
-    public RequestQueue provideRequestQueue(@Named("regular") OkHttpClient.Builder okHttpClient, Context appContext) {
-        return newRequestQueue(okHttpClient, appContext);
+    public RequestQueue provideRequestQueue(@Named("regular") OkHttpClient.Builder okHttpClientBuilder,
+                                            Context appContext) {
+        return newRequestQueue(okHttpClientBuilder, appContext);
     }
 
     @Singleton
     @Named("custom-ssl")
     @Provides
-    public RequestQueue provideRequestQueueCustomSSL(@Named("custom-ssl") OkHttpClient.Builder okHttpClient,
+    public RequestQueue provideRequestQueueCustomSSL(@Named("custom-ssl") OkHttpClient.Builder okHttpClientBuilder,
                                                      Context appContext) {
-        return newRequestQueue(okHttpClient, appContext);
+        return newRequestQueue(okHttpClientBuilder, appContext);
     }
 
     @Singleton
@@ -119,19 +120,19 @@ public class ReleaseNetworkModule {
     @Provides
     public MediaRestClient provideMediaRestClient(Context appContext, Dispatcher dispatcher,
                                                   @Named("regular") RequestQueue requestQueue,
-                                                  @Named("regular") OkHttpClient.Builder okHttpClient,
+                                                  @Named("regular") OkHttpClient.Builder okHttpClientBuilder,
                                                   AccessToken token, UserAgent userAgent) {
-        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClient, token, userAgent);
+        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClientBuilder, token, userAgent);
     }
 
     @Singleton
     @Provides
     public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher,
                                                       @Named("custom-ssl") RequestQueue requestQueue,
-                                                      @Named("custom-ssl") OkHttpClient.Builder okClient,
+                                                      @Named("custom-ssl") OkHttpClient.Builder okHttpClientBuilder,
                                                       AccessToken token, UserAgent userAgent,
                                                       HTTPAuthManager httpAuthManager) {
-        return new MediaXMLRPCClient(dispatcher, requestQueue, okClient, token, userAgent, httpAuthManager);
+        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClientBuilder, token, userAgent, httpAuthManager);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -1,0 +1,41 @@
+package org.wordpress.android.fluxc.module;
+
+import org.wordpress.android.fluxc.network.MemorizingTrustManager;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.inject.Named;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+import dagger.Module;
+import dagger.Provides;
+import okhttp3.OkHttpClient;
+
+@Module
+public class ReleaseOkHttpClientModule {
+    @Provides
+    @Named("regular")
+    public OkHttpClient.Builder provideOkHttpClient() {
+        return new OkHttpClient.Builder();
+    }
+
+    @Provides
+    @Named("custom-ssl")
+    public OkHttpClient.Builder provideOkHttpClientCustomSSL(MemorizingTrustManager memorizingTrustManager) {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        try {
+            final SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new java.security.SecureRandom());
+            final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+            builder.sslSocketFactory(sslSocketFactory);
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            AppLog.e(T.API, e);
+        }
+        return builder;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -20,13 +20,13 @@ import okhttp3.OkHttpClient;
 public class ReleaseOkHttpClientModule {
     @Provides
     @Named("regular")
-    public OkHttpClient.Builder provideOkHttpClient() {
+    public OkHttpClient.Builder provideOkHttpClientBuilder() {
         return new OkHttpClient.Builder();
     }
 
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient.Builder provideOkHttpClientCustomSSL(MemorizingTrustManager memorizingTrustManager) {
+    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(MemorizingTrustManager memorizingTrustManager) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
@@ -27,11 +27,12 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 
 /**
+ * Modified version of https://gist.github.com/alashow/c96c09320899e4caa06b
+ *
  * OkHttp backed {@link com.android.volley.toolbox.HttpStack HttpStack} that does not
  * use okhttp-urlconnection
  */
 public class OkHttpStack implements HttpStack {
-
     private final OkHttpClient.Builder mClientBuilder;
 
     public OkHttpStack(OkHttpClient.Builder clientBuilder) {
@@ -41,7 +42,6 @@ public class OkHttpStack implements HttpStack {
     @Override
     public HttpResponse performRequest(com.android.volley.Request<?> request, Map<String, String> additionalHeaders)
             throws IOException, AuthFailureError {
-
         int timeoutMs = request.getTimeoutMs();
         mClientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);
         mClientBuilder.readTimeout(timeoutMs, TimeUnit.MILLISECONDS);
@@ -65,7 +65,8 @@ public class OkHttpStack implements HttpStack {
         Call okHttpCall = client.newCall(okHttpRequest);
         okhttp3.Response okHttpResponse = okHttpCall.execute();
 
-        StatusLine responseStatus = new BasicStatusLine(parseProtocol(okHttpResponse.protocol()), okHttpResponse.code(), okHttpResponse.message());
+        StatusLine responseStatus = new BasicStatusLine(parseProtocol(okHttpResponse.protocol()),
+                okHttpResponse.code(), okHttpResponse.message());
         BasicHttpResponse response = new BasicHttpResponse(responseStatus);
         response.setEntity(entityFromOkHttpResponse(okHttpResponse));
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
@@ -1,25 +1,158 @@
 package org.wordpress.android.fluxc.network;
 
-import com.android.volley.toolbox.HurlStack;
+import com.android.volley.AuthFailureError;
+import com.android.volley.Request;
+import com.android.volley.toolbox.HttpStack;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-import okhttp3.OkUrlFactory;
+import okhttp3.Call;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request.Builder;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
 
-public class OkHttpStack extends HurlStack {
-    private final OkUrlFactory mOkUrlFactory;
+/**
+ * OkHttp backed {@link com.android.volley.toolbox.HttpStack HttpStack} that does not
+ * use okhttp-urlconnection
+ */
+public class OkHttpStack implements HttpStack {
 
-    public OkHttpStack(OkUrlFactory okUrlFactory) {
-        if (okUrlFactory == null) {
-            throw new NullPointerException("Client must not be null.");
-        }
-        mOkUrlFactory = okUrlFactory;
+    private final OkHttpClient.Builder mClientBuilder;
+
+    public OkHttpStack(OkHttpClient.Builder clientBuilder) {
+        this.mClientBuilder = clientBuilder;
     }
 
     @Override
-    protected HttpURLConnection createConnection(URL url) throws IOException {
-        return mOkUrlFactory.open(url);
+    public HttpResponse performRequest(com.android.volley.Request<?> request, Map<String, String> additionalHeaders)
+            throws IOException, AuthFailureError {
+
+        int timeoutMs = request.getTimeoutMs();
+        mClientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+        mClientBuilder.readTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+        mClientBuilder.writeTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+
+        Builder okHttpRequestBuilder = new okhttp3.Request.Builder();
+        okHttpRequestBuilder.url(request.getUrl());
+
+        Map<String, String> headers = request.getHeaders();
+        for (final String name : headers.keySet()) {
+            okHttpRequestBuilder.addHeader(name, headers.get(name));
+        }
+        for (final String name : additionalHeaders.keySet()) {
+            okHttpRequestBuilder.addHeader(name, additionalHeaders.get(name));
+        }
+
+        setConnectionParametersForRequest(okHttpRequestBuilder, request);
+
+        OkHttpClient client = mClientBuilder.build();
+        okhttp3.Request okHttpRequest = okHttpRequestBuilder.build();
+        Call okHttpCall = client.newCall(okHttpRequest);
+        okhttp3.Response okHttpResponse = okHttpCall.execute();
+
+        StatusLine responseStatus = new BasicStatusLine(parseProtocol(okHttpResponse.protocol()), okHttpResponse.code(), okHttpResponse.message());
+        BasicHttpResponse response = new BasicHttpResponse(responseStatus);
+        response.setEntity(entityFromOkHttpResponse(okHttpResponse));
+
+        Headers responseHeaders = okHttpResponse.headers();
+        for (int i = 0, len = responseHeaders.size(); i < len; i++) {
+            final String name = responseHeaders.name(i), value = responseHeaders.value(i);
+            if (name != null) {
+                response.addHeader(new BasicHeader(name, value));
+            }
+        }
+
+        return response;
+    }
+
+    private static HttpEntity entityFromOkHttpResponse(okhttp3.Response r) throws IOException {
+        BasicHttpEntity entity = new BasicHttpEntity();
+        ResponseBody body = r.body();
+
+        entity.setContent(body.byteStream());
+        entity.setContentLength(body.contentLength());
+        entity.setContentEncoding(r.header("Content-Encoding"));
+
+        if (body.contentType() != null) {
+            entity.setContentType(body.contentType().type());
+        }
+        return entity;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void setConnectionParametersForRequest(Builder builder, Request<?> request)
+            throws IOException, AuthFailureError {
+        switch (request.getMethod()) {
+            case Request.Method.DEPRECATED_GET_OR_POST:
+                // Ensure backwards compatibility.  Volley assumes a request with a null body is a GET.
+                byte[] postBody = request.getPostBody();
+                if (postBody != null) {
+                    builder.post(RequestBody.create(MediaType.parse(request.getPostBodyContentType()), postBody));
+                }
+                break;
+            case Request.Method.GET:
+                builder.get();
+                break;
+            case Request.Method.DELETE:
+                builder.delete();
+                break;
+            case Request.Method.POST:
+                builder.post(createRequestBody(request));
+                break;
+            case Request.Method.PUT:
+                builder.put(createRequestBody(request));
+                break;
+            case Request.Method.HEAD:
+                builder.head();
+                break;
+            case Request.Method.OPTIONS:
+                builder.method("OPTIONS", null);
+                break;
+            case Request.Method.TRACE:
+                builder.method("TRACE", null);
+                break;
+            case Request.Method.PATCH:
+                builder.patch(createRequestBody(request));
+                break;
+            default:
+                throw new IllegalStateException("Unknown method type.");
+        }
+    }
+
+    private static ProtocolVersion parseProtocol(final Protocol p) {
+        switch (p) {
+            case HTTP_1_0:
+                return new ProtocolVersion("HTTP", 1, 0);
+            case HTTP_1_1:
+                return new ProtocolVersion("HTTP", 1, 1);
+            case SPDY_3:
+                return new ProtocolVersion("SPDY", 3, 1);
+            case HTTP_2:
+                return new ProtocolVersion("HTTP", 2, 0);
+        }
+
+        throw new IllegalAccessError("Unkwown protocol");
+    }
+
+    private static RequestBody createRequestBody(Request r) throws AuthFailureError {
+        final byte[] body = r.getBody();
+        if (body == null) return null;
+
+        return RequestBody.create(MediaType.parse(r.getBodyContentType()), body);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError;
 
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class WPComGsonRequest<T> extends GsonRequest<T> {
@@ -60,6 +61,10 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
      */
     public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, Object> body, Class<T> clazz,
                                                            Listener<T> listener, BaseErrorListener errorListener) {
+        // HTTP RFC requires a body (even empty) for all POST requests.
+        if (body == null) {
+            body = new HashMap<>();
+        }
         return new WPComGsonRequest<>(Method.POST, url, null, body, clazz, listener, errorListener);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -59,9 +59,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     private OkHttpClient mOkHttpClient;
 
     public MediaRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
-                           OkHttpClient okClient, AccessToken accessToken, UserAgent userAgent) {
+                           OkHttpClient.Builder okClientBuilder, AccessToken accessToken, UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
-        mOkHttpClient = okClient;
+        mOkHttpClient = okClientBuilder.build();
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -56,11 +56,11 @@ import okhttp3.Request.Builder;
 public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListener {
     private OkHttpClient mOkHttpClient;
 
-    public MediaXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, OkHttpClient okClient,
+    public MediaXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, OkHttpClient.Builder okClientBuilder,
                              AccessToken accessToken, UserAgent userAgent,
                              HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
-        mOkHttpClient = okClient;
+        mOkHttpClient = okClientBuilder.build();
     }
 
     @Override

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppComponent.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppComponent.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.instaflux;
 
 import org.wordpress.android.fluxc.module.AppContextModule;
+import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseStoreModule;
@@ -13,6 +14,7 @@ import dagger.Component;
 @Component(modules = {
         AppContextModule.class,
         AppSecretsModule.class,
+        ReleaseOkHttpClientModule.class,
         ReleaseBaseModule.class,
         ReleaseNetworkModule.class,
         ReleaseStoreModule.class


### PR DESCRIPTION
* Add [Stetho](https://facebook.github.io/stetho/) to our example app debug builds.
* Move OkHttp client providers to their own dagger module (so we can replace them in the debug app).
* Replace the old OkHttpStack using the deprecated OkUrlFactory.
* Fixed an issue with empty bodies for certain POST requests.