### PR TITLE
Use the empty body when we get the null body in a POST, PUT or PATCH method

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
@@ -151,9 +151,11 @@ public class OkHttpStack implements HttpStack {
     }
 
     private static RequestBody createRequestBody(Request r) throws AuthFailureError {
-        final byte[] body = r.getBody();
-        if (body == null) return null;
-
+        byte[] body = r.getBody();
+        if (body == null) {
+            // Use the empty body when we get the null body
+            body = "".getBytes();
+        }
         return RequestBody.create(MediaType.parse(r.getBodyContentType()), body);
     }
 }


### PR DESCRIPTION
We're using the raw volley request queue in wpandroid, some request are incorrectly passing a null body to a POST call, this patch makes sure null body will be ignored.