### PR TITLE
Issue #307: Add support for Automated Transfers

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -439,6 +439,7 @@ public class SiteStoreUnitTest {
         automatedTransferSite.setIsJetpackInstalled(true);
         automatedTransferSite.setIsJetpackConnected(true);
         automatedTransferSite.setIsWPCom(false);
+        automatedTransferSite.setIsAutomatedTransfer(true);
 
         SiteSqlUtils.insertOrUpdateSite(automatedTransferSite);
 

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -426,4 +426,22 @@ public class SiteStoreUnitTest {
 
         assertEquals(0, mSiteStore.getSitesCount());
     }
+
+    @Test
+    public void testWPComAutomatedTransfer() throws DuplicateSiteException {
+        SiteModel wpComSite = generateWPComSite();
+        SiteSqlUtils.insertOrUpdateSite(wpComSite);
+
+        // Turn WP.com site into an Automated Transfer (Jetpack) site
+        SiteModel automatedTransferSite = generateWPComSite();
+        automatedTransferSite.setIsJetpackInstalled(true);
+        automatedTransferSite.setIsJetpackConnected(true);
+        automatedTransferSite.setIsWPCom(false);
+
+        SiteSqlUtils.insertOrUpdateSite(automatedTransferSite);
+
+        assertEquals(1, mSiteStore.getSitesCount());
+        assertEquals(0, mSiteStore.getWPComSitesCount());
+        assertEquals(1, mSiteStore.getJetpackSitesCount());
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -353,8 +353,10 @@ public class SiteStoreUnitTest {
         wpComSite1.setName("Doctor Emmet Brown Homepage");
         SiteModel wpComSite2 = generateWPComSite();
         wpComSite2.setName("Shield Eyes from light");
+        wpComSite2.setSiteId(557);
         SiteModel wpComSite3 = generateWPComSite();
         wpComSite3.setName("I remember when this was all farmland as far as the eye could see");
+        wpComSite2.setSiteId(558);
 
         SiteSqlUtils.insertOrUpdateSite(wpComSite1);
         SiteSqlUtils.insertOrUpdateSite(wpComSite2);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -46,6 +46,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private boolean mIsJetpackInstalled;
     // mIsJetpackConnected is true if Jetpack is installed, activated and connected to a WordPress.com account.
     @Column private boolean mIsJetpackConnected;
+    @Column private boolean mIsAutomatedTransfer;
 
     // WPCom specifics
     @Column private boolean mIsVisible;
@@ -419,5 +420,13 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
 
     public void setIsJetpackConnected(boolean jetpackConnected) {
         mIsJetpackConnected = jetpackConnected;
+    }
+
+    public boolean isAutomatedTransfer() {
+        return mIsAutomatedTransfer;
+    }
+
+    public void setIsAutomatedTransfer(boolean automatedTransfer) {
+        mIsAutomatedTransfer = automatedTransfer;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -304,6 +304,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         if (from.options != null) {
             site.setIsFeaturedImageSupported(from.options.featured_images_enabled);
             site.setIsVideoPressSupported(from.options.videopress_enabled);
+            site.setIsAutomatedTransfer(from.options.is_automated_transfer);
             site.setAdminUrl(from.options.admin_url);
             site.setLoginUrl(from.options.login_url);
             site.setTimezone(from.options.timezone);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -13,6 +13,7 @@ public class SiteWPComRestResponse extends Payload implements Response {
     public class Options {
         public boolean videopress_enabled;
         public boolean featured_images_enabled;
+        public boolean is_automated_transfer;
         public String admin_url;
         public String login_url;
         public String timezone;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -51,6 +51,17 @@ public class SiteSqlUtils {
                 .endWhere().getAsModel();
     }
 
+    /**
+     * Inserts the given SiteModel into the DB, or updates an existing entry where sites match.
+     *
+     * Possible cases:
+     * 1. Exists in the DB already and matches by local id (simple update) -> UPDATE
+     * 2. Exists in the DB, is a Jetpack or WordPress site and matches by remote id (SITE_ID) -> UPDATE
+     * 3. Exists in the DB, is a pure self hosted and matches by remote id (SITE_ID) + URL -> UPDATE
+     * 4. Exists in the DB, was not a Jetpack site but is now a Jetpack site, and matches by XMLRPC_URL -> UPDATE
+     * 5. Exists in the DB, and matches by XMLRPC_URL -> THROW a DuplicateSiteException
+     * 6. Not matching any previous cases -> INSERT
+     */
     public static int insertOrUpdateSite(SiteModel site) throws DuplicateSiteException {
         if (site == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -68,13 +68,20 @@ public class SiteSqlUtils {
         // Looks like a new site, make sure we don't already have it.
         if (siteResult.isEmpty()) {
             AppLog.d(T.DB, "Site not found using local id");
-            siteResult = WellSql.select(SiteModel.class)
-                    .where().beginGroup()
-                    .equals(SiteModelTable.SITE_ID, site.getSiteId())
-                    .equals(SiteModelTable.URL, site.getUrl())
-                    .endGroup().endWhere().getAsModel();
+            if (site.getSiteId() > 0) {
+                // For WordPress.com and Jetpack sites, the WP.com ID is a unique enough identifier
+                siteResult = WellSql.select(SiteModel.class)
+                        .where().beginGroup()
+                        .equals(SiteModelTable.SITE_ID, site.getSiteId())
+                        .endGroup().endWhere().getAsModel();
+            } else {
+                siteResult = WellSql.select(SiteModel.class)
+                        .where().beginGroup()
+                        .equals(SiteModelTable.SITE_ID, site.getSiteId())
+                        .equals(SiteModelTable.URL, site.getUrl())
+                        .endGroup().endWhere().getAsModel();
+            }
         }
-
 
         // If the site is a self hosted, maybe it's already in the DB as a Jetpack site, and we don't want to create
         // a duplicate.


### PR DESCRIPTION
Fixes #307.

1. Modifies `insertOrUpdateSite()` to consider sites the same if they have the same WP.com site ID

    The reason for this is that AT sites might begin as `*.wordpress.com` sites, but they will definitely have a TLD after AT, because having a domain is a requirement for AT. If we force a match with ID and URL, we end up with a duplicate site after AT.

    Incidentally, this should fix a case I don't think we considered before - a user changing the primary domain for their WordPress.com site would end up with a duplicate.

2. Adds a unit test to simulate AT (a WordPress.com site becoming a Jetpack site)

    I decided against a mock network test for now - I think the unit test + some manual checks of a transition provide the same value a mock test would in this case.

3. Adds `SiteModel.isAutomatedTransfer()` so we can identify ATs in the app

cc @maxme