### PR TITLE
Fix #281: Override Payload.isError() where needed

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -47,12 +47,6 @@ public class AccountRestClient extends BaseWPComRestClient {
             this.account = account;
             this.error = error;
         }
-
-        public boolean isError() {
-            return error != null;
-        }
-
-        public BaseNetworkError error;
     }
 
     public static class AccountPushSettingsResponsePayload extends Payload {
@@ -61,10 +55,6 @@ public class AccountRestClient extends BaseWPComRestClient {
         public AccountPushSettingsResponsePayload(BaseNetworkError error) {
             this.error = error;
         }
-        public boolean isError() {
-            return error != null;
-        }
-        public BaseNetworkError error;
     }
 
     public static class NewAccountResponsePayload extends Payload {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -41,6 +41,8 @@ public class AccountRestClient extends BaseWPComRestClient {
     private final AppSecrets mAppSecrets;
 
     public static class AccountRestPayload extends Payload {
+        public AccountModel account;
+
         public AccountRestPayload(AccountModel account, BaseNetworkError error) {
             this.account = account;
             this.error = error;
@@ -51,10 +53,11 @@ public class AccountRestClient extends BaseWPComRestClient {
         }
 
         public BaseNetworkError error;
-        public AccountModel account;
     }
 
     public static class AccountPushSettingsResponsePayload extends Payload {
+        public Map<String, Object> settings;
+
         public AccountPushSettingsResponsePayload(BaseNetworkError error) {
             this.error = error;
         }
@@ -62,12 +65,16 @@ public class AccountRestClient extends BaseWPComRestClient {
             return error != null;
         }
         public BaseNetworkError error;
-        public Map<String, Object> settings;
     }
 
     public static class NewAccountResponsePayload extends Payload {
-        public NewUserError error;
         public boolean dryRun;
+        public NewUserError error;
+
+        @Override
+        public boolean isError() {
+            return error != null;
+        }
     }
 
     public static class IsAvailableResponsePayload extends Payload {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -56,29 +56,38 @@ public class SiteRestClient extends BaseWPComRestClient {
     private final AppSecrets mAppSecrets;
 
     public static class NewSiteResponsePayload extends Payload {
-        public NewSiteResponsePayload() {
-        }
-        public NewSiteError error;
         public boolean dryRun;
+        public NewSiteError error;
+
+        public NewSiteResponsePayload() {}
+
+        @Override
+        public boolean isError() {
+            return error != null;
+        }
     }
 
     public static class DeleteSiteResponsePayload extends Payload {
-        public DeleteSiteResponsePayload() {
-        }
         public SiteModel site;
         public DeleteSiteError error;
+
+        public DeleteSiteResponsePayload() {}
+
+        @Override
+        public boolean isError() {
+            return error != null;
+        }
     }
 
     public static class ExportSiteResponsePayload extends Payload {
-        public ExportSiteResponsePayload() {
-        }
+        public ExportSiteResponsePayload() {}
     }
 
     public static class IsWPComResponsePayload extends Payload {
-        public IsWPComResponsePayload() {
-        }
         public String url;
         public boolean isWPCom;
+
+        public IsWPComResponsePayload() {}
     }
 
     @Inject

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -57,11 +57,17 @@ public class AccountStore extends Store {
 
     public static class AuthenticateErrorPayload extends Payload {
         public AuthenticationError error;
+
         public AuthenticateErrorPayload(@NonNull AuthenticationError error) {
             this.error = error;
         }
         public AuthenticateErrorPayload(@NonNull AuthenticationErrorType errorType) {
             this.error = new AuthenticationError(errorType, "");
+        }
+
+        @Override
+        public boolean isError() {
+            return error != null;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -76,6 +76,7 @@ public class CommentStore extends Store {
 
     public static class RemoteLikeCommentPayload extends RemoteCommentPayload {
         public final boolean like;
+
         public RemoteLikeCommentPayload(@NonNull SiteModel site, @NonNull CommentModel comment, boolean like) {
             super(site, comment);
             this.like = like;
@@ -109,13 +110,24 @@ public class CommentStore extends Store {
             this.number = number;
             this.offset = offset;
         }
+
+        @Override
+        public boolean isError() {
+            return error != null;
+        }
     }
 
     public static class RemoteCommentResponsePayload extends Payload {
         @Nullable public final CommentModel comment;
         public CommentError error;
+
         public RemoteCommentResponsePayload(@Nullable CommentModel comment) {
             this.comment = comment;
+        }
+
+        @Override
+        public boolean isError() {
+            return error != null;
         }
     }
 
@@ -124,8 +136,8 @@ public class CommentStore extends Store {
         public final CommentModel comment;
         public final CommentModel reply;
         public final PostModel post;
-
         public CommentError error;
+
         public RemoteCreateCommentPayload(@NonNull SiteModel site, @NonNull PostModel post,
                                           @NonNull CommentModel comment) {
             this.site = site;
@@ -140,6 +152,11 @@ public class CommentStore extends Store {
             this.comment = comment;
             this.reply = reply;
             this.post = null;
+        }
+
+        @Override
+        public boolean isError() {
+            return error != null;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -136,7 +136,6 @@ public class CommentStore extends Store {
         public final CommentModel comment;
         public final CommentModel reply;
         public final PostModel post;
-        public CommentError error;
 
         public RemoteCreateCommentPayload(@NonNull SiteModel site, @NonNull PostModel post,
                                           @NonNull CommentModel comment) {
@@ -152,11 +151,6 @@ public class CommentStore extends Store {
             this.comment = comment;
             this.reply = reply;
             this.post = null;
-        }
-
-        @Override
-        public boolean isError() {
-            return error != null;
         }
     }
 


### PR DESCRIPTION
Fixes #281 - in all Payloads that were missing it, `isError()` would always return `false`.

An ideal fix would be to make it impossible for this to happen in the first place. Because of the way we're using `Payload`s, there's not really a neat fix for this with no side effects.

Probably the most effective thing would be to rip out `isError()` entirely, and go back to relying on `error != null` instead. But we can visit that later.