### PR TITLE
Don't check for null site and let it crash in media network clients

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -77,7 +77,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     /**
      */
     public void pushMedia(final SiteModel site, final MediaModel media) {
-        if (site == null || media == null) {
+        if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
             notifyMediaPushed(site, media, error);
@@ -124,14 +124,6 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
     public void fetchAllMedia(final SiteModel site) {
-        if (site == null) {
-            AppLog.w(T.MEDIA, "No site given with FETCH_ALL_MEDIA request, dispatching error.");
-            // caller may be expecting a notification
-            MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
-            notifyAllMediaFetched(null, null, error, null);
-            return;
-        }
-
         final MediaFilter filter = new MediaFilter();
         filter.number = MediaFilter.ALL_NUMBER;
         final Map<String, String> params = new HashMap<>();
@@ -174,7 +166,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * Gets a list of media items whose media IDs match the provided list.
      */
     public void fetchMedia(final SiteModel site, final MediaModel media) {
-        if (site == null || media == null) {
+        if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
             notifyMediaFetched(site, media, error);
@@ -211,7 +203,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * Deletes media from a WP.com site whose media ID is in the provided list.
      */
     public void deleteMedia(final SiteModel site, final MediaModel media) {
-        if (site == null || media == null) {
+        if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
             notifyMediaDeleted(site, media, error);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -192,14 +192,6 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
     public void fetchAllMedia(final SiteModel site) {
-        if (site == null) {
-            AppLog.w(T.MEDIA, "No site given with FETCH_ALL_MEDIA request, dispatching error.");
-            // caller may be expecting a notification
-            MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
-            notifyAllMediaFetched(null, null, error, null);
-            return;
-        }
-
         List<Object> params = getBasicParams(site, null);
         final MediaFilter filter = new MediaFilter();
         filter.number = MediaFilter.MAX_NUMBER;
@@ -241,7 +233,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaItem
      */
     public void fetchMedia(final SiteModel site, final MediaModel media) {
-        if (site == null || media == null) {
+        if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
             notifyMediaFetched(site, media, error);
@@ -275,7 +267,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     public void deleteMedia(final SiteModel site, final MediaModel media) {
-        if (site == null || media == null) {
+        if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
             notifyMediaDeleted(site, media, error);


### PR DESCRIPTION
@maxme From our previous conversations, I assume we don't want these `null` checks, so I just quickly removed them.

P.S: I need this change in a separate branch, hence the quick PR for it.