### PR TITLE
Media Store Pagination

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -63,7 +63,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         assertNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
     }
 
-    public void testFetchAllMedia() throws InterruptedException {
+    public void testFetchMediaList() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
         mNextEvent = TestEvents.UPLOADED_MEDIA;
@@ -79,7 +79,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         removeAllSiteMedia();
         assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
-        // fetch all media and verify store is not empty
+        // fetch media list and verify store is not empty
         mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
         fetchMediaList();
         assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -225,6 +225,16 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch.countDown();
     }
 
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onMediaListFetched(MediaStore.OnMediaListFetched event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
+        mCountDownLatch.countDown();
+    }
+
     private boolean eventHasKnownImages(OnMediaChanged event) {
         if (event == null || event.mediaList == null || event.mediaList.isEmpty()) return false;
         String[] splitIds = BuildConfig.TEST_WPCOM_IMAGE_IDS_TEST1.split(",");

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -10,9 +10,9 @@ import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
-import org.wordpress.android.fluxc.store.MediaStore.MediaListPayload;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 
 import java.util.List;
@@ -26,7 +26,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
     private enum TestEvents {
         DELETED_MEDIA,
-        FETCHED_ALL_MEDIA,
+        FETCHED_MEDIA_LIST,
         FETCHED_KNOWN_IMAGES,
         PUSHED_MEDIA,
         UPLOADED_MEDIA,
@@ -80,8 +80,8 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // fetch all media and verify store is not empty
-        mNextEvent = TestEvents.FETCHED_ALL_MEDIA;
-        fetchAllMedia();
+        mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
+        fetchMediaList();
         assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // delete test image
@@ -209,8 +209,8 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
             mCountDownLatch.countDown();
             return;
         }
-        if (event.cause == MediaAction.FETCH_ALL_MEDIA) {
-            assertEquals(TestEvents.FETCHED_ALL_MEDIA, mNextEvent);
+        if (event.cause == MediaAction.FETCHED_MEDIA_LIST) {
+            assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
         } else if (event.cause == MediaAction.FETCH_MEDIA) {
             if (eventHasKnownImages(event)) {
                 assertEquals(TestEvents.FETCHED_KNOWN_IMAGES, mNextEvent);
@@ -262,10 +262,10 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
-    private void fetchAllMedia() throws InterruptedException {
-        MediaListPayload fetchPayload = new MediaListPayload(sSite, null, null);
+    private void fetchMediaList() throws InterruptedException {
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(MediaActionBuilder.newFetchAllMediaAction(fetchPayload));
+        mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -233,9 +233,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
         } else {
-            if (event.cause == MediaAction.FETCH_MEDIA_LIST) {
-                assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
-            } else if (event.cause == MediaAction.FETCH_MEDIA) {
+            if (event.cause == MediaAction.FETCH_MEDIA) {
                 assertEquals(TestEvents.FETCHED_MEDIA, mNextEvent);
             } else if (event.cause == MediaAction.PUSH_MEDIA) {
                 assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
@@ -243,6 +241,16 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
             }
         }
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onMediaListFetched(MediaStore.OnMediaListFetched event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
         mCountDownLatch.countDown();
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -83,7 +83,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
-    public void testFetchAllMedia() throws InterruptedException {
+    public void testFetchMediaList() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
         mNextEvent = TestEvents.UPLOADED_MEDIA;
@@ -99,7 +99,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         removeAllSiteMedia();
         assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
-        // fetch all media and verify store is not empty
+        // fetch media list and verify store is not empty
         mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
         fetchMediaList();
         assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
-import org.wordpress.android.fluxc.store.MediaStore.MediaListPayload;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
 
@@ -36,7 +36,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private enum TestEvents {
         NONE,
         PUSHED_MEDIA,
-        FETCHED_ALL_MEDIA,
+        FETCHED_MEDIA_LIST,
         FETCHED_MEDIA,
         DELETED_MEDIA,
         UPLOADED_MEDIA,
@@ -100,8 +100,8 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // fetch all media and verify store is not empty
-        mNextEvent = TestEvents.FETCHED_ALL_MEDIA;
-        fetchAllMedia();
+        mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
+        fetchMediaList();
         assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // delete test image
@@ -233,8 +233,8 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
         } else {
-            if (event.cause == MediaAction.FETCH_ALL_MEDIA) {
-                assertEquals(TestEvents.FETCHED_ALL_MEDIA, mNextEvent);
+            if (event.cause == MediaAction.FETCH_MEDIA_LIST) {
+                assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
             } else if (event.cause == MediaAction.FETCH_MEDIA) {
                 assertEquals(TestEvents.FETCHED_MEDIA, mNextEvent);
             } else if (event.cause == MediaAction.PUSH_MEDIA) {
@@ -273,10 +273,10 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
-    private void fetchAllMedia() throws InterruptedException {
-        MediaListPayload fetchPayload = new MediaListPayload(sSite, null, null);
+    private void fetchMediaList() throws InterruptedException {
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(MediaActionBuilder.newFetchAllMediaAction(fetchPayload));
+        mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
@@ -227,7 +228,7 @@ public class MediaFragment extends Fragment {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onMediaListFetched(OnMediaChanged event) {
+    public void onMediaListFetched(OnMediaListFetched event) {
         if (!event.isError()) {
             prependToLog("Received successful response for media list fetch.");
             prependToLog(event.mediaList == null ? "0" : event.mediaList.size() + " media items fetched.");

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -214,11 +214,7 @@ public class MediaFragment extends Fragment {
     public void onMediaChanged(OnMediaChanged event) {
         if (!event.isError()) {
             prependToLog("Received successful response for " + event.cause + " event.");
-            if (event.cause == MediaAction.FETCHED_MEDIA_LIST) {
-                prependToLog(event.mediaList == null ? "0" : event.mediaList.size() + " media items fetched.");
-                mMedia = mMediaStore.getAllSiteMedia(mSite);
-                mMediaList.setAdapter(new MediaAdapter(getActivity(), R.layout.media_list_item, mMedia));
-            } else if (event.cause == MediaAction.FETCH_MEDIA) {
+            if (event.cause == MediaAction.FETCH_MEDIA) {
                 prependToLog(event.mediaList.size() + " media items fetched.");
             } else if (event.cause == MediaAction.DELETE_MEDIA) {
                 prependToLog("Successfully deleted " + event.mediaList.get(0).getTitle() + ".");

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.store.MediaStore.MediaListPayload;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
@@ -94,7 +94,7 @@ public class MediaFragment extends Fragment {
                     prependToLog("Site is null, cannot request all media.");
                     return;
                 }
-                fetchAllMedia(mSite);
+                fetchMediaList(mSite);
             }
         });
 
@@ -213,7 +213,7 @@ public class MediaFragment extends Fragment {
     public void onMediaChanged(OnMediaChanged event) {
         if (!event.isError()) {
             prependToLog("Received successful response for " + event.cause + " event.");
-            if (event.cause == MediaAction.FETCH_ALL_MEDIA) {
+            if (event.cause == MediaAction.FETCHED_MEDIA_LIST) {
                 prependToLog(event.mediaList == null ? "0" : event.mediaList.size() + " media items fetched.");
                 mMedia = mMediaStore.getAllSiteMedia(mSite);
                 mMediaList.setAdapter(new MediaAdapter(getActivity(), R.layout.media_list_item, mMedia));
@@ -250,9 +250,9 @@ public class MediaFragment extends Fragment {
         ((MainExampleActivity) getActivity()).prependToLog(s);
     }
 
-    private void fetchAllMedia(@NonNull SiteModel site) {
-        MediaListPayload payload = new MediaListPayload(site, null, null);
-        mDispatcher.dispatch(MediaActionBuilder.newFetchAllMediaAction(payload));
+    private void fetchMediaList(@NonNull SiteModel site) {
+        FetchMediaListPayload payload = new FetchMediaListPayload(site, false);
+        mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload));
     }
 
     private void fetchMedia(@NonNull final SiteModel site, @NonNull MediaModel media) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -87,11 +87,11 @@ public class MediaFragment extends Fragment {
             }
         });
 
-        view.findViewById(R.id.fetch_all_media).setOnClickListener(new View.OnClickListener() {
+        view.findViewById(R.id.fetch_media_list).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 if (mSite == null) {
-                    prependToLog("Site is null, cannot request all media.");
+                    prependToLog("Site is null, cannot request first media page.");
                     return;
                 }
                 fetchMediaList(mSite);

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -227,6 +227,18 @@ public class MediaFragment extends Fragment {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onMediaListFetched(OnMediaChanged event) {
+        if (!event.isError()) {
+            prependToLog("Received successful response for media list fetch.");
+            prependToLog(event.mediaList == null ? "0" : event.mediaList.size() + " media items fetched.");
+            mMedia = mMediaStore.getAllSiteMedia(mSite);
+            mMediaList.setAdapter(new MediaAdapter(getActivity(), R.layout.media_list_item, mMedia));
+        }
+    }
+
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaUploaded(OnMediaUploaded event) {
         if (!event.isError()) {
             if (event.progress < 0.f) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -231,7 +231,6 @@ public class MediaFragment extends Fragment {
     public void onMediaListFetched(OnMediaListFetched event) {
         if (!event.isError()) {
             prependToLog("Received successful response for media list fetch.");
-            prependToLog(event.mediaList == null ? "0" : event.mediaList.size() + " media items fetched.");
             mMedia = mMediaStore.getAllSiteMedia(mSite);
             mMediaList.setAdapter(new MediaAdapter(getActivity(), R.layout.media_list_item, mMedia));
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -203,14 +203,6 @@ public class MediaFragment extends Fragment {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onMediaError(OnMediaChanged event) {
-        if (event.isError()) {
-            prependToLog(event.error.message);
-        }
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaChanged(OnMediaChanged event) {
         if (!event.isError()) {
             prependToLog("Received successful response for " + event.cause + " event.");
@@ -219,6 +211,8 @@ public class MediaFragment extends Fragment {
             } else if (event.cause == MediaAction.DELETE_MEDIA) {
                 prependToLog("Successfully deleted " + event.mediaList.get(0).getTitle() + ".");
             }
+        } else {
+            prependToLog(event.error.message);
         }
     }
 

--- a/example/src/main/res/layout/fragment_media.xml
+++ b/example/src/main/res/layout/fragment_media.xml
@@ -7,10 +7,10 @@
     tools:context="org.wordpress.android.fluxc.example.MediaFragment">
 
     <Button
-        android:id="@+id/fetch_all_media"
+        android:id="@+id/fetch_media_list"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Fetch All" />
+        android:text="Fetch First Page" />
 
     <Button
         android:id="@+id/fetch_specified_media"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/MediaAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/MediaAction.java
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
-import org.wordpress.android.fluxc.store.MediaStore.FetchedMediaListPayload;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload;
 
 @ActionEnum
 public enum MediaAction implements IAction {
@@ -30,7 +30,7 @@ public enum MediaAction implements IAction {
     PUSHED_MEDIA,
     @Action(payloadType = ProgressPayload.class)
     UPLOADED_MEDIA,
-    @Action(payloadType = FetchedMediaListPayload.class)
+    @Action(payloadType = FetchMediaListResponsePayload.class)
     FETCHED_MEDIA_LIST,
     @Action(payloadType = MediaPayload.class)
     FETCHED_MEDIA,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/MediaAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/MediaAction.java
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
-import org.wordpress.android.fluxc.store.MediaStore.MediaListPayload;
+import org.wordpress.android.fluxc.store.MediaStore.FetchedMediaListPayload;
 
 @ActionEnum
 public enum MediaAction implements IAction {
@@ -30,8 +30,8 @@ public enum MediaAction implements IAction {
     PUSHED_MEDIA,
     @Action(payloadType = ProgressPayload.class)
     UPLOADED_MEDIA,
-    @Action(payloadType = MediaListPayload.class)
-    FETCHED_ALL_MEDIA,
+    @Action(payloadType = FetchedMediaListPayload.class)
+    FETCHED_MEDIA_LIST,
     @Action(payloadType = MediaPayload.class)
     FETCHED_MEDIA,
     @Action(payloadType = MediaPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/MediaAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/MediaAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaListPayload;
@@ -15,8 +16,8 @@ public enum MediaAction implements IAction {
     PUSH_MEDIA,
     @Action(payloadType = MediaPayload.class)
     UPLOAD_MEDIA,
-    @Action(payloadType = MediaListPayload.class)
-    FETCH_ALL_MEDIA,
+    @Action(payloadType = FetchMediaListPayload.class)
+    FETCH_MEDIA_LIST,
     @Action(payloadType = MediaPayload.class)
     FETCH_MEDIA,
     @Action(payloadType = MediaPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -46,7 +46,7 @@ import okhttp3.OkHttpClient;
  *
  * <ul>
  *     <li>Fetch existing media from a WP.com site
- *     (via {@link #fetchAllMedia(SiteModel, int)} and {@link #fetchMedia(SiteModel, MediaModel)}</li>
+ *     (via {@link #fetchMediaList(SiteModel, int)} and {@link #fetchMedia(SiteModel, MediaModel)}</li>
  *     <li>Push new media to a WP.com site
  *     (via {@link #uploadMedia(SiteModel, MediaModel)})</li>
  *     <li>Push updates to existing media to a WP.com site
@@ -121,10 +121,10 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      */
     public void fetchMediaList(final SiteModel site, final int offset) {
         if (site == null) {
-            AppLog.w(T.MEDIA, "No site given with FETCH_ALL_MEDIA request, dispatching error.");
+            AppLog.w(T.MEDIA, "No site given with FETCH_MEDIA_LIST request, dispatching error.");
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
-            notifyMediaListFetched(site, error);
+            notifyMediaListFetched(null, error);
             return;
         }
 
@@ -140,7 +140,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                     public void onResponse(MultipleMediaResponse response) {
                         List<MediaModel> mediaList = getMediaListFromRestResponse(response, site.getId());
                         if (mediaList != null) {
-                            AppLog.v(T.MEDIA, "Fetched all media for site. count=" + mediaList.size());
+                            AppLog.v(T.MEDIA, "Fetched media list for site with size: " + mediaList.size());
                             boolean canLoadMore = mediaList.size() == MediaStore.NUM_MEDIA_PER_FETCH;
                             notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore);
                         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -158,7 +158,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
-            notifyMediaFetched(site, media, error);
+            notifyMediaFetched(site, null, error);
             return;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -317,7 +317,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, List<MediaModel> media,
+    private void notifyMediaListFetched(SiteModel site, @NonNull List<MediaModel> media,
                                         boolean loadedMore, boolean canLoadMore) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
                 loadedMore, canLoadMore);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -317,8 +317,10 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, List<MediaModel> media, boolean loadedMore, boolean canLoadMore) {
-        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media, loadedMore, canLoadMore);
+    private void notifyMediaListFetched(SiteModel site, List<MediaModel> media,
+                                        boolean loadedMore, boolean canLoadMore) {
+        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
+                loadedMore, canLoadMore);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -119,7 +119,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * NOTE: Only media item data is gathered, the actual media file can be downloaded from the URL
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
-    public void fetchAllMedia(final SiteModel site, final int offset) {
+    public void fetchMediaList(final SiteModel site, final int offset) {
         if (site == null) {
             AppLog.w(T.MEDIA, "No site given with FETCH_ALL_MEDIA request, dispatching error.");
             // caller may be expecting a notification

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -114,7 +114,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     }
 
     /**
-     * Gets a list of all media items on a WP.com site.
+     * Gets a list of media items given the offset on a WP.com site.
      *
      * NOTE: Only media item data is gathered, the actual media file can be downloaded from the URL
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -186,7 +186,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     /**
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
-    public void fetchAllMedia(final SiteModel site, final int offset) {
+    public void fetchMediaList(final SiteModel site, final int offset) {
         if (site == null) {
             AppLog.w(T.MEDIA, "No site given with FETCH_ALL_MEDIA request, dispatching error.");
             // caller may be expecting a notification

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -318,8 +318,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, List<MediaModel> media, boolean loadedMore, boolean canLoadMore) {
-        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media, loadedMore, canLoadMore);
+    private void notifyMediaListFetched(SiteModel site, List<MediaModel> media,
+                                        boolean loadedMore, boolean canLoadMore) {
+        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
+                loadedMore, canLoadMore);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network.xmlrpc.media;
 
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
 import android.util.Base64;
 
 import com.android.volley.RequestQueue;
@@ -25,12 +24,11 @@ import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCFault;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLSerializerUtils;
 import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
-import org.wordpress.android.fluxc.store.MediaStore.MediaListPayload;
-import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
-import org.wordpress.android.fluxc.store.MediaStore.MediaFilter;
+import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
+import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -61,9 +59,6 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     private OkHttpClient mOkHttpClient;
     // track the network call to support cancelling
     private Call mCurrentUploadCall;
-
-    private int mFetchAllOffset = 0;
-    private List<MediaModel> mFetchedMedia = new ArrayList<>();
 
     public MediaXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, OkHttpClient.Builder okClientBuilder,
                              AccessToken accessToken, UserAgent userAgent,
@@ -191,40 +186,35 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     /**
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
-    public void fetchAllMedia(final SiteModel site) {
+    public void fetchAllMedia(final SiteModel site, final int offset) {
         if (site == null) {
             AppLog.w(T.MEDIA, "No site given with FETCH_ALL_MEDIA request, dispatching error.");
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
-            notifyAllMediaFetched(null, null, error, null);
+            notifyMediaListFetched(null, error);
             return;
         }
 
         List<Object> params = getBasicParams(site, null);
-        final MediaFilter filter = new MediaFilter();
-        filter.number = MediaFilter.MAX_NUMBER;
-        filter.offset = mFetchAllOffset;
-        params.add(getQueryParams(filter));
+        Map<String, Object> queryParams = new HashMap<>();
+        queryParams.put("number", MediaStore.NUM_MEDIA_PER_FETCH);
+        if (offset > 0) {
+            queryParams.put("offset", offset);
+        }
+        params.add(queryParams);
 
         add(new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_MEDIA_LIBRARY, params, new Listener() {
             @Override
             public void onResponse(Object response) {
-                List<MediaModel> responseMedia = getMediaListFromXmlrpcResponse(response, site.getId());
-                if (responseMedia != null) {
-                    mFetchedMedia.addAll(responseMedia);
-                    if (responseMedia.size() < MediaFilter.MAX_NUMBER) {
-                        AppLog.v(T.MEDIA, "Fetched all media for site via XMLRPC.GET_MEDIA_LIBRARY");
-                        notifyAllMediaFetched(site, mFetchedMedia, null, filter);
-                        mFetchAllOffset = 0;
-                        mFetchedMedia = new ArrayList<>();
-                    } else {
-                        mFetchAllOffset += MediaFilter.MAX_NUMBER;
-                        fetchAllMedia(site);
-                    }
+                List<MediaModel> mediaList = getMediaListFromXmlrpcResponse(response, site.getId());
+                if (mediaList != null) {
+                    AppLog.v(T.MEDIA, "Fetched all media for site via XMLRPC.GET_MEDIA_LIBRARY");
+                    boolean canLoadMore = mediaList.size() == MediaStore.NUM_MEDIA_PER_FETCH;
+                    notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore);
                 } else {
                     AppLog.w(T.MEDIA, "could not parse XMLRPC.GET_MEDIA_LIBRARY response: " + response);
                     MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
-                    notifyAllMediaFetched(site, null, error, filter);
+                    notifyMediaListFetched(site, error);
                 }
             }
         }, new BaseRequest.BaseErrorListener() {
@@ -232,7 +222,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             public void onErrorResponse(@NonNull BaseRequest.BaseNetworkError error) {
                 AppLog.e(T.MEDIA, "XMLRPC.GET_MEDIA_LIBRARY error response:", error.volleyError);
                 MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
-                notifyAllMediaFetched(site, null, mediaError, filter);
+                notifyMediaListFetched(site, mediaError);
             }
         }));
     }
@@ -336,9 +326,14 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyAllMediaFetched(SiteModel site, List<MediaModel> media, MediaError error, MediaFilter filter) {
-        MediaListPayload payload = new MediaListPayload(site, media, error, filter);
-        mDispatcher.dispatch(MediaActionBuilder.newFetchedAllMediaAction(payload));
+    private void notifyMediaListFetched(SiteModel site, List<MediaModel> media, boolean loadedMore, boolean canLoadMore) {
+        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media, loadedMore, canLoadMore);
+        mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
+    }
+
+    private void notifyMediaListFetched(SiteModel site, MediaError error) {
+        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, error);
+        mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 
     private void notifyMediaFetched(SiteModel site, MediaModel media, MediaError error) {
@@ -454,26 +449,6 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         }
 
         return false;
-    }
-
-    private Map<String, Object> getQueryParams(final MediaFilter filter) {
-        Map<String, Object> queryParams = null;
-        if (filter != null) {
-            queryParams = new HashMap<>();
-            if (filter.number > 0) {
-                queryParams.put("number", Math.min(filter.number, MediaFilter.MAX_NUMBER));
-            }
-            if (filter.offset > 0) {
-                queryParams.put("offset", filter.offset);
-            }
-            if (filter.postId > 0) {
-                queryParams.put("parent_id", filter.postId);
-            }
-            if (!TextUtils.isEmpty(filter.mimeType)) {
-                queryParams.put("mime_type", filter.mimeType);
-            }
-        }
-        return queryParams;
     }
 
     @NonNull

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -226,7 +226,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
-            notifyMediaFetched(site, media, error);
+            notifyMediaFetched(site, null, error);
             return;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -188,7 +188,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
      */
     public void fetchMediaList(final SiteModel site, final int offset) {
         if (site == null) {
-            AppLog.w(T.MEDIA, "No site given with FETCH_ALL_MEDIA request, dispatching error.");
+            AppLog.w(T.MEDIA, "No site given with FETCH_MEDIA_LIST request, dispatching error.");
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
             notifyMediaListFetched(null, error);
@@ -208,7 +208,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             public void onResponse(Object response) {
                 List<MediaModel> mediaList = getMediaListFromXmlrpcResponse(response, site.getId());
                 if (mediaList != null) {
-                    AppLog.v(T.MEDIA, "Fetched all media for site via XMLRPC.GET_MEDIA_LIBRARY");
+                    AppLog.v(T.MEDIA, "Fetched media list for site via XMLRPC.GET_MEDIA_LIBRARY");
                     boolean canLoadMore = mediaList.size() == MediaStore.NUM_MEDIA_PER_FETCH;
                     notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore);
                 } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -20,14 +20,12 @@ public class MediaSqlUtils {
         return getAllSiteMediaQuery(siteModel).getAsCursor();
     }
 
+    public static List<MediaModel> getMediaWithStates(SiteModel site, List<String> uploadStates) {
+        return getMediaWithStatesQuery(site, uploadStates).getAsModel();
+    }
+
     public static WellCursor<MediaModel> getMediaWithStatesAsCursor(SiteModel site, List<String> uploadStates) {
-        return WellSql.select(MediaModel.class)
-                .where().beginGroup()
-                .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
-                .isIn(MediaModelTable.UPLOAD_STATE, uploadStates)
-                .endGroup().endWhere()
-                .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING)
-                .getAsCursor();
+        return getMediaWithStatesQuery(site, uploadStates).getAsCursor();
     }
 
     public static WellCursor<MediaModel> getImagesWithStatesAsCursor(SiteModel site, List<String> uploadStates) {
@@ -55,6 +53,15 @@ public class MediaSqlUtils {
     private static SelectQuery<MediaModel> getAllSiteMediaQuery(SiteModel siteModel) {
         return WellSql.select(MediaModel.class)
                 .where().equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId()).endWhere()
+                .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
+    }
+
+    private static SelectQuery<MediaModel> getMediaWithStatesQuery(SiteModel site, List<String> uploadStates) {
+        return WellSql.select(MediaModel.class)
+                .where().beginGroup()
+                .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
+                .isIn(MediaModelTable.UPLOAD_STATE, uploadStates)
+                .endGroup().endWhere()
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -6,6 +6,7 @@ import com.yarolegovich.wellsql.WellCursor;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.MediaModel.UploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 
@@ -236,6 +237,14 @@ public class MediaSqlUtils {
         return WellSql.delete(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
+                .endGroup().endWhere().execute();
+    }
+
+    public static int deleteAllUploadedSiteMedia(SiteModel siteModel) {
+        return WellSql.delete(MediaModel.class)
+                .where().beginGroup()
+                .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getSiteId())
+                .equals(MediaModelTable.UPLOAD_STATE, UploadState.UPLOADED.toString())
                 .endGroup().endWhere().execute();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -243,7 +243,7 @@ public class MediaSqlUtils {
     public static int deleteAllUploadedSiteMedia(SiteModel siteModel) {
         return WellSql.delete(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getSiteId())
+                .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
                 .equals(MediaModelTable.UPLOAD_STATE, UploadState.UPLOADED.toString())
                 .endGroup().endWhere().execute();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -30,32 +30,6 @@ import javax.inject.Singleton;
 
 @Singleton
 public class MediaStore extends Store {
-    public static class MediaFilter {
-        public static final int NUMBER = 20;
-        public static final int ALL_NUMBER = -1;
-        public static final int MAX_NUMBER = 100;
-
-        public enum SortOrder {
-            DESCENDING, ASCENDING
-        }
-
-        public enum SortField {
-            DATE, TITLE, ID
-        }
-
-        public List<String> fields;
-        public int number;
-        public long postId;
-        public int offset;
-        public int page;
-        public SortOrder sortOrder;
-        public SortField sortField;
-        public String searchQuery;
-        public String after;
-        public String before;
-        public String mimeType;
-    }
-
     //
     // Payloads
     //
@@ -106,13 +80,15 @@ public class MediaStore extends Store {
         public SiteModel site;
         public MediaError error;
         public List<MediaModel> mediaList;
-        public MediaFilter filter;
+        public boolean loadedMore;
+        public boolean canLoadMore;
         public FetchMediaListResponsePayload(SiteModel site, List<MediaModel> mediaList, MediaError error,
-                                             MediaFilter filter) {
+                                             boolean loadedMore, boolean canLoadMore) {
             this.site = site;
             this.mediaList = mediaList;
             this.error = error;
-            this.filter = filter;
+            this.loadedMore = loadedMore;
+            this.canLoadMore = canLoadMore;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -496,7 +496,9 @@ public class MediaStore extends Store {
     private void performFetchMediaList(FetchMediaListPayload payload) {
         int offset = 0;
         if (payload.loadMore) {
-            offset = getAllSiteMedia(payload.site).size();
+            List<String> list = new ArrayList<>();
+            list.add(UploadState.UPLOADED.toString());
+            offset = MediaSqlUtils.getMediaWithStates(payload.site, list).size();
         }
         if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
             mMediaRestClient.fetchMediaList(payload.site, offset);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -83,6 +83,23 @@ public class MediaStore extends Store {
     }
 
     /**
+     * Actions: FETCH_MEDIA_LIST
+     */
+    public static class FetchMediaListPayload extends Payload {
+        public SiteModel site;
+        public boolean loadMore;
+
+        public FetchMediaListPayload(SiteModel site) {
+            this.site = site;
+        }
+
+        public FetchMediaListPayload(SiteModel site, boolean loadMore) {
+            this.site = site;
+            this.loadMore = loadMore;
+        }
+    }
+
+    /**
      * Actions: FETCH(ED)_ALL_MEDIA, PUSH(ED)_MEDIA, DELETE(D)_MEDIA, and REMOVE_MEDIA
      */
     public static class MediaListPayload extends Payload {
@@ -243,8 +260,8 @@ public class MediaStore extends Store {
             case UPLOAD_MEDIA:
                 performUploadMedia((MediaPayload) action.getPayload());
                 break;
-            case FETCH_ALL_MEDIA:
-                performFetchAllMedia((MediaListPayload) action.getPayload());
+            case FETCH_MEDIA_LIST:
+                performFetchMediaList((FetchMediaListPayload) action.getPayload());
                 break;
             case FETCH_MEDIA:
                 performFetchMedia((MediaPayload) action.getPayload());
@@ -501,10 +518,13 @@ public class MediaStore extends Store {
         }
     }
 
-    private void performFetchAllMedia(MediaListPayload payload) {
-        List<MediaModel> mediaList = getAllSiteMedia(payload.site);
+    private void performFetchMediaList(FetchMediaListPayload payload) {
+        int offset = 0;
+        if (payload.loadMore) {
+            offset = getAllSiteMedia(payload.site).size();
+        }
         if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
-            mMediaRestClient.fetchAllMedia(payload.site, mediaList.size());
+            mMediaRestClient.fetchAllMedia(payload.site, offset);
         } else {
             mMediaXmlrpcClient.fetchAllMedia(payload.site);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -30,6 +30,8 @@ import javax.inject.Singleton;
 
 @Singleton
 public class MediaStore extends Store {
+    public static final int NUM_MEDIA_PER_FETCH = 20;
+
     //
     // Payloads
     //
@@ -82,13 +84,17 @@ public class MediaStore extends Store {
         public List<MediaModel> mediaList;
         public boolean loadedMore;
         public boolean canLoadMore;
-        public FetchMediaListResponsePayload(SiteModel site, List<MediaModel> mediaList, MediaError error,
-                                             boolean loadedMore, boolean canLoadMore) {
+        public FetchMediaListResponsePayload(SiteModel site, List<MediaModel> mediaList, boolean loadedMore,
+                                             boolean canLoadMore) {
             this.site = site;
             this.mediaList = mediaList;
-            this.error = error;
             this.loadedMore = loadedMore;
             this.canLoadMore = canLoadMore;
+        }
+
+        public FetchMediaListResponsePayload(SiteModel site, MediaError error) {
+            this.site = site;
+            this.error = error;
         }
     }
 
@@ -495,7 +501,7 @@ public class MediaStore extends Store {
         if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
             mMediaRestClient.fetchAllMedia(payload.site, offset);
         } else {
-            mMediaXmlrpcClient.fetchAllMedia(payload.site);
+            mMediaXmlrpcClient.fetchAllMedia(payload.site, offset);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -30,7 +30,7 @@ import javax.inject.Singleton;
 
 @Singleton
 public class MediaStore extends Store {
-    public static final int NUM_MEDIA_PER_FETCH = 20;
+    public static final int NUM_MEDIA_PER_FETCH = 50;
 
     //
     // Payloads

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -100,7 +100,7 @@ public class MediaStore extends Store {
     }
 
     /**
-     * Actions: FETCH(ED)_ALL_MEDIA, PUSH(ED)_MEDIA, DELETE(D)_MEDIA, and REMOVE_MEDIA
+     * Actions: FETCH_MEDIA_LIST
      */
     public static class FetchedMediaListPayload extends Payload {
         public SiteModel site;
@@ -115,11 +115,6 @@ public class MediaStore extends Store {
             this.mediaList = mediaList;
             this.error = error;
             this.filter = filter;
-        }
-
-        @Override
-        public boolean isError() {
-            return error != null;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -254,7 +254,7 @@ public class MediaStore extends Store {
                 handleMediaUploaded((ProgressPayload) action.getPayload());
                 break;
             case FETCHED_MEDIA_LIST:
-                handleAllMediaFetched((FetchMediaListResponsePayload) action.getPayload());
+                handleMediaListFetched((FetchMediaListResponsePayload) action.getPayload());
                 break;
             case FETCHED_MEDIA:
                 handleMediaFetched((MediaPayload) action.getPayload());
@@ -499,9 +499,9 @@ public class MediaStore extends Store {
             offset = getAllSiteMedia(payload.site).size();
         }
         if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
-            mMediaRestClient.fetchAllMedia(payload.site, offset);
+            mMediaRestClient.fetchMediaList(payload.site, offset);
         } else {
-            mMediaXmlrpcClient.fetchAllMedia(payload.site, offset);
+            mMediaXmlrpcClient.fetchMediaList(payload.site, offset);
         }
     }
 
@@ -562,7 +562,7 @@ public class MediaStore extends Store {
         emitChange(onMediaUploaded);
     }
 
-    private void handleAllMediaFetched(@NonNull FetchMediaListResponsePayload payload) {
+    private void handleMediaListFetched(@NonNull FetchMediaListResponsePayload payload) {
         OnMediaChanged onMediaChanged = new OnMediaChanged(MediaAction.FETCHED_MEDIA_LIST, payload.mediaList);
 
         if (!payload.isError()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -102,15 +102,15 @@ public class MediaStore extends Store {
     /**
      * Actions: FETCH(ED)_ALL_MEDIA, PUSH(ED)_MEDIA, DELETE(D)_MEDIA, and REMOVE_MEDIA
      */
-    public static class MediaListPayload extends Payload {
+    public static class FetchedMediaListPayload extends Payload {
         public SiteModel site;
         public MediaError error;
         public List<MediaModel> mediaList;
         public MediaFilter filter;
-        public MediaListPayload(SiteModel site, List<MediaModel> mediaList, MediaFilter filter) {
+        public FetchedMediaListPayload(SiteModel site, List<MediaModel> mediaList, MediaFilter filter) {
             this(site, mediaList, null, filter);
         }
-        public MediaListPayload(SiteModel site, List<MediaModel> mediaList, MediaError error, MediaFilter filter) {
+        public FetchedMediaListPayload(SiteModel site, List<MediaModel> mediaList, MediaError error, MediaFilter filter) {
             this.site = site;
             this.mediaList = mediaList;
             this.error = error;
@@ -278,8 +278,8 @@ public class MediaStore extends Store {
             case UPLOADED_MEDIA:
                 handleMediaUploaded((ProgressPayload) action.getPayload());
                 break;
-            case FETCHED_ALL_MEDIA:
-                handleAllMediaFetched((MediaListPayload) action.getPayload());
+            case FETCHED_MEDIA_LIST:
+                handleAllMediaFetched((FetchedMediaListPayload) action.getPayload());
                 break;
             case FETCHED_MEDIA:
                 handleMediaFetched((MediaPayload) action.getPayload());
@@ -587,8 +587,8 @@ public class MediaStore extends Store {
         emitChange(onMediaUploaded);
     }
 
-    private void handleAllMediaFetched(@NonNull MediaListPayload payload) {
-        OnMediaChanged onMediaChanged = new OnMediaChanged(MediaAction.FETCH_ALL_MEDIA, payload.mediaList);
+    private void handleAllMediaFetched(@NonNull FetchedMediaListPayload payload) {
+        OnMediaChanged onMediaChanged = new OnMediaChanged(MediaAction.FETCHED_MEDIA_LIST, payload.mediaList);
 
         if (!payload.isError()) {
             MediaSqlUtils.deleteAllSiteMedia(payload.site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -565,8 +565,14 @@ public class MediaStore extends Store {
     private void handleMediaListFetched(@NonNull FetchMediaListResponsePayload payload) {
         OnMediaChanged onMediaChanged = new OnMediaChanged(MediaAction.FETCHED_MEDIA_LIST, payload.mediaList);
 
-        if (!payload.isError()) {
-            MediaSqlUtils.deleteAllSiteMedia(payload.site);
+        if (payload.isError()) {
+            onMediaChanged.error = payload.error;
+        } else {
+            // Clear existing media if this is a fresh fetch (loadMore = false in the original request)
+            // This is the simplest way of keeping our local media in sync with remote media (in case of deletions)
+            if (!payload.loadedMore) {
+                MediaSqlUtils.deleteAllSiteMedia(payload.site);
+            }
             if (!payload.mediaList.isEmpty()) {
                 for (MediaModel media : payload.mediaList) {
                     updateMedia(media, false);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 @Singleton
 public class MediaStore extends Store {
     public static class MediaFilter {
+        public static final int NUMBER = 20;
         public static final int ALL_NUMBER = -1;
         public static final int MAX_NUMBER = 100;
 
@@ -501,8 +502,9 @@ public class MediaStore extends Store {
     }
 
     private void performFetchAllMedia(MediaListPayload payload) {
+        List<MediaModel> mediaList = getAllSiteMedia(payload.site);
         if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
-            mMediaRestClient.fetchAllMedia(payload.site);
+            mMediaRestClient.fetchAllMedia(payload.site, mediaList.size());
         } else {
             mMediaXmlrpcClient.fetchAllMedia(payload.site);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -76,7 +76,7 @@ public class MediaStore extends Store {
     }
 
     /**
-     * Actions: FETCH_MEDIA_LIST
+     * Actions: FETCHED_MEDIA_LIST
      */
     public static class FetchMediaListResponsePayload extends Payload {
         public SiteModel site;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -152,11 +152,9 @@ public class MediaStore extends Store {
 
     public class OnMediaListFetched extends OnChanged<MediaError> {
         public SiteModel site;
-        public List<MediaModel> mediaList;
         public boolean canLoadMore;
-        public OnMediaListFetched(SiteModel site, @NonNull List<MediaModel> mediaList, boolean canLoadMore) {
+        public OnMediaListFetched(SiteModel site, boolean canLoadMore) {
             this.site = site;
-            this.mediaList = mediaList;
             this.canLoadMore = canLoadMore;
         }
         public OnMediaListFetched(SiteModel site, MediaError error) {
@@ -598,7 +596,7 @@ public class MediaStore extends Store {
                     updateMedia(media, false);
                 }
             }
-            onMediaListFetched = new OnMediaListFetched(payload.site, payload.mediaList, payload.canLoadMore);
+            onMediaListFetched = new OnMediaListFetched(payload.site, payload.canLoadMore);
         }
 
         emitChange(onMediaListFetched);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -573,7 +573,7 @@ public class MediaStore extends Store {
             // Clear existing media if this is a fresh fetch (loadMore = false in the original request)
             // This is the simplest way of keeping our local media in sync with remote media (in case of deletions)
             if (!payload.loadedMore) {
-                MediaSqlUtils.deleteAllSiteMedia(payload.site);
+                MediaSqlUtils.deleteAllUploadedSiteMedia(payload.site);
             }
             if (!payload.mediaList.isEmpty()) {
                 for (MediaModel media : payload.mediaList) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -79,7 +79,7 @@ public class MediaStore extends Store {
         public List<MediaModel> mediaList;
         public boolean loadedMore;
         public boolean canLoadMore;
-        public FetchMediaListResponsePayload(SiteModel site, List<MediaModel> mediaList, boolean loadedMore,
+        public FetchMediaListResponsePayload(SiteModel site, @NonNull List<MediaModel> mediaList, boolean loadedMore,
                                              boolean canLoadMore) {
             this.site = site;
             this.mediaList = mediaList;
@@ -88,6 +88,7 @@ public class MediaStore extends Store {
         }
 
         public FetchMediaListResponsePayload(SiteModel site, MediaError error) {
+            this.mediaList = new ArrayList<>();
             this.site = site;
             this.error = error;
         }
@@ -153,7 +154,7 @@ public class MediaStore extends Store {
         public SiteModel site;
         public List<MediaModel> mediaList;
         public boolean canLoadMore;
-        public OnMediaListFetched(SiteModel site, List<MediaModel> mediaList, boolean canLoadMore) {
+        public OnMediaListFetched(SiteModel site, @NonNull List<MediaModel> mediaList, boolean canLoadMore) {
             this.site = site;
             this.mediaList = mediaList;
             this.canLoadMore = canLoadMore;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -102,15 +102,13 @@ public class MediaStore extends Store {
     /**
      * Actions: FETCH_MEDIA_LIST
      */
-    public static class FetchedMediaListPayload extends Payload {
+    public static class FetchMediaListResponsePayload extends Payload {
         public SiteModel site;
         public MediaError error;
         public List<MediaModel> mediaList;
         public MediaFilter filter;
-        public FetchedMediaListPayload(SiteModel site, List<MediaModel> mediaList, MediaFilter filter) {
-            this(site, mediaList, null, filter);
-        }
-        public FetchedMediaListPayload(SiteModel site, List<MediaModel> mediaList, MediaError error, MediaFilter filter) {
+        public FetchMediaListResponsePayload(SiteModel site, List<MediaModel> mediaList, MediaError error,
+                                             MediaFilter filter) {
             this.site = site;
             this.mediaList = mediaList;
             this.error = error;
@@ -274,7 +272,7 @@ public class MediaStore extends Store {
                 handleMediaUploaded((ProgressPayload) action.getPayload());
                 break;
             case FETCHED_MEDIA_LIST:
-                handleAllMediaFetched((FetchedMediaListPayload) action.getPayload());
+                handleAllMediaFetched((FetchMediaListResponsePayload) action.getPayload());
                 break;
             case FETCHED_MEDIA:
                 handleMediaFetched((MediaPayload) action.getPayload());
@@ -582,7 +580,7 @@ public class MediaStore extends Store {
         emitChange(onMediaUploaded);
     }
 
-    private void handleAllMediaFetched(@NonNull FetchedMediaListPayload payload) {
+    private void handleAllMediaFetched(@NonNull FetchMediaListResponsePayload payload) {
         OnMediaChanged onMediaChanged = new OnMediaChanged(MediaAction.FETCHED_MEDIA_LIST, payload.mediaList);
 
         if (!payload.isError()) {


### PR DESCRIPTION
Fixes #314. This PR changes how the pagination works in MediaStore. In order to make things clearer, I opted to make some changes to payloads, I also removed `MediaFilter` for now as it was not being used very much and it just made things harder to understand. While on it, I made some naming changes to better reflect how the fetch media list works.

This implementation is pretty much borrowed from PostStore and amazing job @aforcier did. Now the implementations are very close to each other, so things are a little more consistent between stores.

It may be a little more change than we planned at first, but I strongly believe this will help us in the long run. Merging this will be require some changes in wpandroid, which I am hoping to start working as soon as possible.

@aforcier Do you mind checking this one out even if @maxme would be the main reviewer? Since I followed the same patterns as you did. I'd love your feedback!