### PR TITLE
Fix #281 by using reflection in Payload.isError() implementation

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
@@ -3,11 +3,18 @@ package org.wordpress.android.fluxc;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
+import java.lang.reflect.Field;
+
 public abstract class Payload {
     public BaseNetworkError error;
 
     public boolean isError() {
-        return error != null;
+        try {
+            Field field = getClass().getDeclaredField("error");
+            return field.get(this) != null;
+        } catch (Exception e) {
+            return true;
+        }
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
@@ -10,7 +10,7 @@ public abstract class Payload {
 
     public boolean isError() {
         try {
-            Field field = getClass().getDeclaredField("error");
+            Field field = getClass().getField("error");
             return field.get(this) != null;
         } catch (Exception e) {
             return true;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -45,12 +45,6 @@ public class AccountRestClient extends BaseWPComRestClient {
             this.account = account;
             this.error = error;
         }
-
-        public boolean isError() {
-            return error != null;
-        }
-
-        public BaseNetworkError error;
         public AccountModel account;
     }
 
@@ -58,10 +52,6 @@ public class AccountRestClient extends BaseWPComRestClient {
         public AccountPushSettingsResponsePayload(BaseNetworkError error) {
             this.error = error;
         }
-        public boolean isError() {
-            return error != null;
-        }
-        public BaseNetworkError error;
         public Map<String, Object> settings;
     }
 
@@ -76,11 +66,6 @@ public class AccountRestClient extends BaseWPComRestClient {
         public boolean isAvailable;
         public List<String> suggestions;
         public IsAvailableError error;
-
-        @Override
-        public boolean isError() {
-            return error != null;
-        }
     }
 
     public enum IsAvailable {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -69,11 +69,6 @@ public class Authenticator {
     public static class AuthEmailResponsePayload extends Payload {
         public AuthEmailError error;
         public AuthEmailResponsePayload() {}
-
-        @Override
-        public boolean isError() {
-            return error != null;
-        }
     }
 
     @Inject

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -74,11 +74,6 @@ public class MediaStore extends Store {
             this.media = media;
             this.error = error;
         }
-
-        @Override
-        public boolean isError() {
-            return error != null;
-        }
     }
 
     /**
@@ -97,11 +92,6 @@ public class MediaStore extends Store {
             this.mediaList = mediaList;
             this.error = error;
             this.filter = filter;
-        }
-
-        @Override
-        public boolean isError() {
-            return error != null;
         }
     }
 
@@ -123,11 +113,6 @@ public class MediaStore extends Store {
             this.progress = progress;
             this.completed = completed;
             this.error = error;
-        }
-
-        @Override
-        public boolean isError() {
-            return error != null;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -74,11 +74,6 @@ public class PostStore extends Store {
         public FetchPostsResponsePayload(PostError error) {
             this.error = error;
         }
-
-        @Override
-        public boolean isError() {
-            return error != null;
-        }
     }
 
     public static class RemotePostPayload extends Payload {
@@ -89,11 +84,6 @@ public class PostStore extends Store {
         public RemotePostPayload(PostModel post, SiteModel site) {
             this.post = post;
             this.site = site;
-        }
-
-        @Override
-        public boolean isError() {
-            return error != null;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -53,11 +53,6 @@ public class TaxonomyStore extends Store {
             this.error = error;
             this.taxonomy = taxonomy;
         }
-
-        @Override
-        public boolean isError() {
-            return error != null;
-        }
     }
 
     public static class RemoteTermPayload extends Payload {
@@ -68,11 +63,6 @@ public class TaxonomyStore extends Store {
         public RemoteTermPayload(TermModel term, SiteModel site) {
             this.term = term;
             this.site = site;
-        }
-
-        @Override
-        public boolean isError() {
-            return error != null;
         }
     }
 


### PR DESCRIPTION
Fix #281 by using reflection in Payload.isError() implementation.

It's not super clean, but it's less prone to error than https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/320