### PR TITLE
Increase timeout for new site creation to 90 seconds

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.site;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
@@ -52,6 +53,8 @@ public class SiteRestClient extends BaseWPComRestClient {
     public static final String VALIDATE_KEY = "validate";
     public static final String CLIENT_ID_KEY = "client_id";
     public static final String CLIENT_SECRET_KEY = "client_secret";
+
+    public static final int NEW_SITE_TIMEOUT_MS = 90000;
 
     private final AppSecrets mAppSecrets;
 
@@ -205,6 +208,8 @@ public class SiteRestClient extends BaseWPComRestClient {
         );
 
         request.disableRetries();
+        request.setRetryPolicy(new DefaultRetryPolicy(NEW_SITE_TIMEOUT_MS,
+                DefaultRetryPolicy.DEFAULT_MAX_RETRIES, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
         add(request);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -207,9 +207,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                 }
         );
 
-        request.disableRetries();
-        request.setRetryPolicy(new DefaultRetryPolicy(NEW_SITE_TIMEOUT_MS,
-                DefaultRetryPolicy.DEFAULT_MAX_RETRIES, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
+        // Disable retries and increase timeout for site creation (it can sometimes take a long time to complete)
+        request.setRetryPolicy(new DefaultRetryPolicy(NEW_SITE_TIMEOUT_MS, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
         add(request);
     }
 


### PR DESCRIPTION
In all my attempts, new site creation (when not a dry run) took over 30 seconds (our default timeout), resulting in an empty error being displayed in WPAndroid (meanwhile the site is actually created and another attempt to create the same site will say it already exists).

The completion time was always less than 60 seconds in my tests, but I'm setting the timeout to 90 seconds for new site creation just to be safe.