### PR TITLE
Add getMediaWithLocalId()

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -92,6 +92,18 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
+    public static MediaModel getMediaWithLocalId(int localMediaId) {
+        List<MediaModel> result = WellSql.select(MediaModel.class).where()
+                .equals(MediaModelTable.ID, localMediaId)
+                .endWhere()
+                .getAsModel();
+        if (result.isEmpty()) {
+            return null;
+        } else {
+            return result.get(0);
+        }
+    }
+
     public static List<MediaModel> searchSiteMedia(SiteModel siteModel, String column, String searchTerm) {
         return searchSiteMediaQuery(siteModel, column, searchTerm).getAsModel();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -346,6 +346,10 @@ public class MediaStore extends Store {
         return media.size() > 0 ? media.get(0) : null;
     }
 
+    public MediaModel getMediaWithLocalId(int localMediaId) {
+        return MediaSqlUtils.getMediaWithLocalId(localMediaId);
+    }
+
     public List<MediaModel> getSiteMediaWithIds(SiteModel siteModel, List<Long> mediaIds) {
         return MediaSqlUtils.getSiteMediaWithIds(siteModel, mediaIds);
     }


### PR DESCRIPTION
Adds a `getMediaWIthLocalId()` method to `MediaStore` so we can look up media by local ID rather than relying on `getSiteMediaWithId()`, which doesn't help us for local media.