### PR TITLE
Add remote id to on new site created events

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/NewSiteResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/NewSiteResponse.java
@@ -1,0 +1,15 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import org.wordpress.android.fluxc.network.Response;
+
+public class NewSiteResponse implements Response {
+    public boolean success;
+    public BlogDetails blog_details;
+    public String error;
+    public String message;
+
+    public class BlogDetails {
+        public String url;
+        public String blogid;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -143,6 +143,7 @@ public class SiteStore extends Store {
 
     public class OnNewSiteCreated extends OnChanged<NewSiteError> {
         public boolean dryRun;
+        public long newSiteRemoteId;
     }
 
     public class OnSiteDeleted extends OnChanged<DeleteSiteError> {
@@ -684,6 +685,7 @@ public class SiteStore extends Store {
         OnNewSiteCreated onNewSiteCreated = new OnNewSiteCreated();
         onNewSiteCreated.error = payload.error;
         onNewSiteCreated.dryRun = payload.dryRun;
+        onNewSiteCreated.newSiteRemoteId = payload.newSiteRemoteId;
         emitChange(onNewSiteCreated);
     }
 


### PR DESCRIPTION
Note: I wanted to use the local id instead of the remote site id, but we don't get the full new created site in the new site response, so we don't add it to the local db. We only get the new site after FETCH_SITES or eventually a FETCH_SITE.