### PR TITLE
Default sites to visible in SiteModel

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -49,7 +49,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private boolean mIsAutomatedTransfer;
 
     // WPCom specifics
-    @Column private boolean mIsVisible;
+    @Column private boolean mIsVisible = true;
     @Column private boolean mIsPrivate;
     @Column private boolean mIsVideoPressSupported;
     @Column private long mPlanId;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -162,8 +162,6 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             site.setUrl((String) siteMap.get(SITE_URL_KEY));
             site.setXmlRpcUrl((String) siteMap.get(SITE_XMLRPC_URL_KEY));
             site.setIsSelfHostedAdmin((Boolean) siteMap.get(SITE_ADMIN_KEY));
-            // Self Hosted won't be hidden
-            site.setIsVisible(true);
             // From what we know about the host
             site.setIsWPCom(false);
             site.setUsername(username);


### PR DESCRIPTION
The default setting for site visibility in `SiteModel` should be `true` - self-hosted sites shouldn't have to worry about handling this, and WP.com sites already handle it on site fetch.