### PR TITLE
Make OnChanged classes static

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -9,9 +9,10 @@ import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
+import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 
@@ -199,7 +200,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onMediaChanged(MediaStore.OnMediaChanged event) {
+    public void onMediaChanged(OnMediaChanged event) {
         if (event.isError()) {
             if (event.cause == MediaAction.PUSH_MEDIA) {
                 assertEquals(TestEvents.PUSH_ERROR, mNextEvent);
@@ -227,7 +228,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onMediaListFetched(MediaStore.OnMediaListFetched event) {
+    public void onMediaListFetched(OnMediaListFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -11,9 +11,11 @@ import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
-import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
 
@@ -207,7 +209,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onMediaUploaded(MediaStore.OnMediaUploaded event) throws InterruptedException {
+    public void onMediaUploaded(OnMediaUploaded event) throws InterruptedException {
         if (event.isError()) {
             mCountDownLatch.countDown();
         } else if (event.completed) {
@@ -246,7 +248,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onMediaListFetched(MediaStore.OnMediaListFetched event) {
+    public void onMediaListFetched(OnMediaListFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.java
@@ -68,6 +68,7 @@ public class AccountFragment extends Fragment {
         mDispatcher.unregister(this);
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAccountChanged(OnAccountChanged event) {
         if (!mAccountStore.hasAccessToken()) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -119,6 +119,7 @@ public class CommentsFragment extends Fragment {
                         !getFirstComment().getILike())));
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onCommentChanged(OnCommentChanged event) {
         if (event.isError()) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
@@ -246,6 +246,7 @@ public class MainFragment extends Fragment {
 
     // Event listeners
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAccountChanged(OnAccountChanged event) {
         if (!mAccountStore.hasAccessToken()) {
@@ -253,6 +254,7 @@ public class MainFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
         if (event.isError()) {
@@ -296,6 +298,7 @@ public class MainFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onDiscoveryResponse(OnDiscoveryResponse event) {
         if (event.isError()) {
@@ -319,6 +322,7 @@ public class MainFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
         if (event.isError()) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.java
@@ -96,6 +96,7 @@ public class PostsFragment extends Fragment {
     }
 
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostChanged(OnPostChanged event) {
         if (event.isError()) {
@@ -114,6 +115,7 @@ public class PostsFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostUploaded(OnPostUploaded event) {
         prependToLog("Post uploaded! Remote post id: " + event.post.getRemotePostId());

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -125,6 +125,7 @@ public class SignedOutActionsFragment extends Fragment {
         alert.show();
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onNewUserValidated(OnNewUserCreated event) {
         String message = event.dryRun ? "validation" : "creation";
@@ -135,6 +136,7 @@ public class SignedOutActionsFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAuthEmailSent(OnAuthEmailSent event) {
         if (event.isError()) {
@@ -144,6 +146,7 @@ public class SignedOutActionsFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onUrlChecked(OnURLChecked event) {
         if (event.isError()) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.NewAccountPayload;
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthEmailSent;
 import org.wordpress.android.fluxc.store.AccountStore.OnNewUserCreated;
 import org.wordpress.android.fluxc.store.SiteStore.OnURLChecked;
 
@@ -135,7 +136,7 @@ public class SignedOutActionsFragment extends Fragment {
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onAuthEmailSent(AccountStore.OnAuthEmailSent event) {
+    public void onAuthEmailSent(OnAuthEmailSent event) {
         if (event.isError()) {
             prependToLog("Error sending magic link: " + event.error.type + " - " + event.error.message);
         } else {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -130,6 +130,7 @@ public class SitesFragment extends Fragment {
         newFragment.show(ft, "dialog");
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
         if (event.isError()) {
@@ -140,6 +141,7 @@ public class SitesFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onNewSiteCreated(OnNewSiteCreated event) {
         String message = event.dryRun ? "validated" : "created";
@@ -150,6 +152,7 @@ public class SitesFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteDeleted(OnSiteDeleted event) {
         if (event.isError()) {
@@ -159,6 +162,7 @@ public class SitesFragment extends Fragment {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteExported(OnSiteExported event) {
         if (event.isError()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -93,25 +93,25 @@ public class AccountStore extends Store {
     }
 
     // OnChanged Events
-    public class OnAccountChanged extends OnChanged<AccountError> {
+    public static class OnAccountChanged extends OnChanged<AccountError> {
         public boolean accountInfosChanged;
         public AccountAction causeOfChange;
     }
 
-    public class OnAuthenticationChanged extends OnChanged<AuthenticationError> {
+    public static class OnAuthenticationChanged extends OnChanged<AuthenticationError> {
     }
 
-    public class OnDiscoveryResponse extends OnChanged<DiscoveryError> {
+    public static class OnDiscoveryResponse extends OnChanged<DiscoveryError> {
         public String xmlRpcEndpoint;
         public String wpRestEndpoint;
         public String failedEndpoint;
     }
 
-    public class OnNewUserCreated extends OnChanged<NewUserError> {
+    public static class OnNewUserCreated extends OnChanged<NewUserError> {
         public boolean dryRun;
     }
 
-    public class OnAvailabilityChecked extends OnChanged<IsAvailableError> {
+    public static class OnAvailabilityChecked extends OnChanged<IsAvailableError> {
         public IsAvailable type;
         public String value;
         public boolean isAvailable;
@@ -124,7 +124,7 @@ public class AccountStore extends Store {
         }
     }
 
-    public class OnAuthEmailSent extends OnChanged<AuthEmailError> {}
+    public static class OnAuthEmailSent extends OnChanged<AuthEmailError> {}
 
     public static class AuthenticationError implements OnChangedError {
         public AuthenticationErrorType type;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -166,7 +166,7 @@ public class CommentStore extends Store {
 
     // Actions
 
-    public class OnCommentChanged extends OnChanged<CommentError> {
+    public static class OnCommentChanged extends OnChanged<CommentError> {
         public int rowsAffected;
         public CommentAction causeOfChange;
         public List<Integer> changedCommentsLocalIds = new ArrayList<>();
@@ -175,7 +175,7 @@ public class CommentStore extends Store {
         }
     }
 
-    public class OnCommentInstantiated extends OnChanged<CommentError> {
+    public static class OnCommentInstantiated extends OnChanged<CommentError> {
         public CommentModel comment;
         public OnCommentInstantiated(CommentModel comment) {
             this.comment = comment;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -131,7 +131,7 @@ public class MediaStore extends Store {
         }
     }
 
-    public class OnMediaChanged extends OnChanged<MediaError> {
+    public static class OnMediaChanged extends OnChanged<MediaError> {
         public MediaAction cause;
         public List<MediaModel> mediaList;
         public OnMediaChanged(MediaAction cause) {
@@ -150,7 +150,7 @@ public class MediaStore extends Store {
         }
     }
 
-    public class OnMediaListFetched extends OnChanged<MediaError> {
+    public static class OnMediaListFetched extends OnChanged<MediaError> {
         public SiteModel site;
         public boolean canLoadMore;
         public OnMediaListFetched(SiteModel site, boolean canLoadMore) {
@@ -163,7 +163,7 @@ public class MediaStore extends Store {
         }
     }
 
-    public class OnMediaUploaded extends OnChanged<MediaError> {
+    public static class OnMediaUploaded extends OnChanged<MediaError> {
         public MediaModel media;
         public float progress;
         public boolean completed;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -115,7 +115,7 @@ public class PostStore extends Store {
     }
 
     // OnChanged events
-    public class OnPostChanged extends OnChanged<PostError> {
+    public static class OnPostChanged extends OnChanged<PostError> {
         public int rowsAffected;
         public boolean canLoadMore;
         public PostAction causeOfChange;
@@ -130,7 +130,7 @@ public class PostStore extends Store {
         }
     }
 
-    public class OnPostUploaded extends OnChanged<PostError> {
+    public static class OnPostUploaded extends OnChanged<PostError> {
         public PostModel post;
 
         public OnPostUploaded(PostModel post) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -120,51 +120,51 @@ public class SiteStore extends Store {
     }
 
     // OnChanged Events
-    public class OnSiteChanged extends OnChanged<SiteError> {
+    public static class OnSiteChanged extends OnChanged<SiteError> {
         public int rowsAffected;
         public OnSiteChanged(int rowsAffected) {
             this.rowsAffected = rowsAffected;
         }
     }
 
-    public class OnSiteRemoved extends OnChanged<SiteError> {
+    public static class OnSiteRemoved extends OnChanged<SiteError> {
         public int mRowsAffected;
         public OnSiteRemoved(int rowsAffected) {
             mRowsAffected = rowsAffected;
         }
     }
 
-    public class OnAllSitesRemoved extends OnChanged<SiteError> {
+    public static class OnAllSitesRemoved extends OnChanged<SiteError> {
         public int mRowsAffected;
         public OnAllSitesRemoved(int rowsAffected) {
             mRowsAffected = rowsAffected;
         }
     }
 
-    public class OnNewSiteCreated extends OnChanged<NewSiteError> {
+    public static class OnNewSiteCreated extends OnChanged<NewSiteError> {
         public boolean dryRun;
         public long newSiteRemoteId;
     }
 
-    public class OnSiteDeleted extends OnChanged<DeleteSiteError> {
+    public static class OnSiteDeleted extends OnChanged<DeleteSiteError> {
         public OnSiteDeleted(DeleteSiteError error) {
             this.error = error;
         }
     }
 
-    public class OnSiteExported extends OnChanged<ExportSiteError> {
+    public static class OnSiteExported extends OnChanged<ExportSiteError> {
         public OnSiteExported() {
         }
     }
 
-    public class OnPostFormatsChanged extends OnChanged<PostFormatsError> {
+    public static class OnPostFormatsChanged extends OnChanged<PostFormatsError> {
         public SiteModel site;
         public OnPostFormatsChanged(SiteModel site) {
             this.site = site;
         }
     }
 
-    public class OnURLChecked extends OnChanged<SiteError> {
+    public static class OnURLChecked extends OnChanged<SiteError> {
         public String url;
         public boolean isWPCom;
         public OnURLChecked(@NonNull String url) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
@@ -13,7 +13,7 @@ public abstract class Store {
 
     public interface OnChangedError {}
 
-    public class OnChanged<T extends OnChangedError> {
+    public static class OnChanged<T extends OnChangedError> {
         public T error = null;
 
         public boolean isError() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -85,7 +85,7 @@ public class TaxonomyStore extends Store {
     }
 
     // OnChanged events
-    public class OnTaxonomyChanged extends OnChanged<TaxonomyError> {
+    public static class OnTaxonomyChanged extends OnChanged<TaxonomyError> {
         public int rowsAffected;
         public String taxonomyName;
         public TaxonomyAction causeOfChange;
@@ -100,7 +100,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    public class OnTermInstantiated extends OnChanged<TaxonomyError> {
+    public static class OnTermInstantiated extends OnChanged<TaxonomyError> {
         public TermModel term;
 
         public OnTermInstantiated(TermModel term) {
@@ -108,7 +108,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    public class OnTermUploaded extends OnChanged<TaxonomyError> {
+    public static class OnTermUploaded extends OnChanged<TaxonomyError> {
         public TermModel term;
 
         public OnTermUploaded(TermModel term) {

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
@@ -194,6 +194,7 @@ public class MainInstafluxActivity extends AppCompatActivity {
         }
     }
 
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onDiscoveryResponse(OnDiscoveryResponse event) {
         if (event.isError()) {

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
@@ -20,8 +20,12 @@ import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnDiscoveryResponse;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
@@ -161,7 +165,7 @@ public class MainInstafluxActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onAccountChanged(AccountStore.OnAccountChanged event) {
+    public void onAccountChanged(OnAccountChanged event) {
         if (!mAccountStore.hasAccessToken()) {
             // Signed out!
         }
@@ -169,7 +173,7 @@ public class MainInstafluxActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onAuthenticationChanged(AccountStore.OnAuthenticationChanged event) {
+    public void onAuthenticationChanged(OnAuthenticationChanged event) {
         if (event.isError()) {
             switch (event.error.type) {
                 case HTTP_AUTH_ERROR:
@@ -191,7 +195,7 @@ public class MainInstafluxActivity extends AppCompatActivity {
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onDiscoveryResponse(AccountStore.OnDiscoveryResponse event) {
+    public void onDiscoveryResponse(OnDiscoveryResponse event) {
         if (event.isError()) {
             if (event.error == SelfHostedEndpointFinder.DiscoveryError.WORDPRESS_COM_SITE) {
                 wpcomFetchSites(mSelfhostedPayload.username, mSelfhostedPayload.password);
@@ -210,7 +214,7 @@ public class MainInstafluxActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSiteChanged(SiteStore.OnSiteChanged event) {
+    public void onSiteChanged(OnSiteChanged event) {
         if (mSiteStore.hasSite()) {
             launchPostActivity();
         }

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
@@ -33,10 +33,15 @@ import org.wordpress.android.fluxc.model.MediaModel.UploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
+import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
@@ -227,7 +232,7 @@ public class PostActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onAccountChanged(AccountStore.OnAccountChanged event) {
+    public void onAccountChanged(OnAccountChanged event) {
         if (!mAccountStore.hasAccessToken()) {
             // Signed Out
             finish();
@@ -236,7 +241,7 @@ public class PostActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSiteRemoved(SiteStore.OnSiteRemoved event) {
+    public void onSiteRemoved(OnSiteRemoved event) {
         if (!mSiteStore.hasSite()) {
             // Signed Out
             finish();
@@ -245,7 +250,7 @@ public class PostActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onPostChanged(PostStore.OnPostChanged event) {
+    public void onPostChanged(OnPostChanged event) {
         if (event.isError()) {
             AppLog.e(AppLog.T.POSTS, "Error from " + event.causeOfChange + " - error: " + event.error.type);
             return;
@@ -262,7 +267,7 @@ public class PostActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onPostUploaded(PostStore.OnPostUploaded event) {
+    public void onPostUploaded(OnPostUploaded event) {
         hideProgress();
         if (event.isError()) {
             AppLog.e(AppLog.T.POSTS, "Post upload failed with error" + event.error);
@@ -274,7 +279,7 @@ public class PostActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onMediaUploaded(MediaStore.OnMediaUploaded event) {
+    public void onMediaUploaded(OnMediaUploaded event) {
         if (event.completed && event.media != null) {
             MediaModel media = mMediaStore.getSiteMediaWithId(mSite, event.media.getMediaId());
             AppLog.i(AppLog.T.API, "Media uploaded: " + media.getTitle());


### PR DESCRIPTION
Makes all `OnChanged` classes `static`.

This also makes it easier to use cleaner imports for `OnChanged` events (AS will offer replacing `MediaStore.OnMediaListFetched` with `OnMediaListFetched` without needing to manually add that import.