### PR TITLE
Fix #339: Handle site fetch response for VIP sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -19,6 +19,8 @@ import java.net.URISyntaxException;
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
 public class SiteModel extends Payload implements Identifiable, Serializable {
+    public static final long VIP_PLAN_ID = 31337;
+
     @PrimaryKey
     @Column private int mId;
     // Only given a value for wpcom and Jetpack sites - self-hosted sites use mSelfHostedSiteId

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -323,7 +323,14 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setTimezone(from.options.timezone);
         }
         if (from.plan != null) {
-            site.setPlanId(from.plan.product_id);
+            try {
+                site.setPlanId(Long.valueOf(from.plan.product_id));
+            } catch (NumberFormatException e) {
+                // VIP sites return a String plan ID ('vip') rather than a number
+                if (from.plan.product_id.equals("vip")) {
+                    site.setPlanId(SiteWPComRestResponse.VIP_PLAN_ID);
+                }
+            }
             site.setPlanShortName(from.plan.product_name_short);
         }
         if (from.capabilities != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -328,7 +328,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             } catch (NumberFormatException e) {
                 // VIP sites return a String plan ID ('vip') rather than a number
                 if (from.plan.product_id.equals("vip")) {
-                    site.setPlanId(SiteWPComRestResponse.VIP_PLAN_ID);
+                    site.setPlanId(SiteModel.VIP_PLAN_ID);
                 }
             }
             site.setPlanShortName(from.plan.product_name_short);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -6,8 +6,6 @@ import org.wordpress.android.fluxc.network.Response;
 import java.util.List;
 
 public class SiteWPComRestResponse extends Payload implements Response {
-    public static final long VIP_PLAN_ID = 31337;
-
     public class SitesResponse {
         public List<SiteWPComRestResponse> sites;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -6,6 +6,8 @@ import org.wordpress.android.fluxc.network.Response;
 import java.util.List;
 
 public class SiteWPComRestResponse extends Payload implements Response {
+    public static final long VIP_PLAN_ID = 31337;
+
     public class SitesResponse {
         public List<SiteWPComRestResponse> sites;
     }
@@ -20,7 +22,7 @@ public class SiteWPComRestResponse extends Payload implements Response {
     }
 
     public class Plan {
-        public long product_id;
+        public String product_id;
         public String product_name_short;
     }
 


### PR DESCRIPTION
Fixes #339. VIP sites return a String `product_id` (`'vip'`) rather than a number. This caused a handled `NumberFormatException`, resulting in no WP.com sites being fetched.