### PR TITLE
Fix #341: Make sure the _id we pass to the insert SQL call will be used

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -10,7 +10,7 @@ import org.wordpress.android.util.StringUtils;
 
 @Table
 public class AccountModel extends Payload implements Identifiable {
-    @PrimaryKey
+    @PrimaryKey(autoincrement = false)
     @Column private int mId;
 
     // Account attributes


### PR DESCRIPTION
By default WellSql primary keys are auto incremented. It means WellSql ignores the `_id` field [on insert](https://github.com/wordpress-mobile/wellsql/blob/master/wellsql/src/main/java/com/yarolegovich/wellsql/InsertQuery.java#L58-L60) and can produce weird results in [the way we use this model in the Account store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/AccountSqlUtils.java#L14-L37).

Fix a rare bug where the first AccountModel _id is not 1 on insert.