### PR TITLE
Fix DB duplicates for posts and media

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -79,6 +79,28 @@ public class PostStoreUnitTest {
     }
 
     @Test
+    public void testPushAndFetchCollision() throws InterruptedException {
+        // Test uploading a post, fetching remote posts and updating the db from the fetch first
+
+        PostModel postModel = PostTestUtils.generateSampleLocalDraftPost();
+        PostSqlUtils.insertPostForResult(postModel);
+
+        // The post after uploading, updating with the remote post ID, about to be saved locally
+        PostModel postFromUploadResponse = PostTestUtils.getPosts().get(0);
+        postFromUploadResponse.setIsLocalDraft(false);
+        postFromUploadResponse.setRemotePostId(42);
+
+        // The same post, but fetched from the server from FETCH_POSTS (so no local ID until insertion)
+        final PostModel postFromPostListFetch = postFromUploadResponse.clone();
+        postFromPostListFetch.setId(0);
+
+        PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromPostListFetch);
+        PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromUploadResponse);
+
+        assertEquals(1, PostTestUtils.getPosts().size());
+    }
+
+    @Test
     public void testInsertWithoutLocalChanges() {
         PostModel postModel = PostTestUtils.generateSampleUploadedPost();
         PostSqlUtils.insertPostForResult(postModel);

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -85,7 +85,7 @@ public class PostStoreUnitTest {
         PostModel postModel = PostTestUtils.generateSampleLocalDraftPost();
         PostSqlUtils.insertPostForResult(postModel);
 
-        // The post after uploading, updating with the remote post ID, about to be saved locally
+        // The post after uploading, updated with the remote post ID, about to be saved locally
         PostModel postFromUploadResponse = PostTestUtils.getPosts().get(0);
         postFromUploadResponse.setIsLocalDraft(false);
         postFromUploadResponse.setRemotePostId(42);

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -98,6 +98,10 @@ public class PostStoreUnitTest {
         PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromUploadResponse);
 
         assertEquals(1, PostTestUtils.getPosts().size());
+
+        PostModel finalPost = PostTestUtils.getPosts().get(0);
+        assertEquals(42, finalPost.getRemotePostId());
+        assertEquals(postModel.getLocalSiteId(), finalPost.getLocalSiteId());
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -192,20 +192,15 @@ public class MediaSqlUtils {
     public static int insertOrUpdateMedia(MediaModel media) {
         if (media == null) return 0;
 
-        // If the site already exist and has an id, we want to update it.
         List<MediaModel> existingMedia = WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.ID, media.getId())
+                .or()
+                .beginGroup()
+                .equals(MediaModelTable.LOCAL_SITE_ID, media.getLocalSiteId())
+                .equals(MediaModelTable.MEDIA_ID, media.getMediaId())
+                .endGroup()
                 .endGroup().endWhere().getAsModel();
-
-        // Looks like a new media, make sure we don't already have it by site id / media id.
-        if (existingMedia.isEmpty()) {
-            existingMedia = WellSql.select(MediaModel.class)
-                    .where().beginGroup()
-                    .equals(MediaModelTable.LOCAL_SITE_ID, media.getLocalSiteId())
-                    .equals(MediaModelTable.MEDIA_ID, media.getMediaId())
-                    .endGroup().endWhere().getAsModel();
-        }
 
         if (existingMedia.isEmpty()) {
             // insert, media item does not exist

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -192,15 +192,23 @@ public class MediaSqlUtils {
     public static int insertOrUpdateMedia(MediaModel media) {
         if (media == null) return 0;
 
-        List<MediaModel> existingMedia = WellSql.select(MediaModel.class)
-                .where().beginGroup()
-                .equals(MediaModelTable.ID, media.getId())
-                .or()
-                .beginGroup()
-                .equals(MediaModelTable.LOCAL_SITE_ID, media.getLocalSiteId())
-                .equals(MediaModelTable.MEDIA_ID, media.getMediaId())
-                .endGroup()
-                .endGroup().endWhere().getAsModel();
+        List<MediaModel> existingMedia;
+        if (media.getMediaId() == 0) {
+            existingMedia = WellSql.select(MediaModel.class)
+                    .where()
+                    .equals(MediaModelTable.ID, media.getId())
+                    .endWhere().getAsModel();
+        } else {
+            existingMedia = WellSql.select(MediaModel.class)
+                    .where().beginGroup()
+                    .equals(MediaModelTable.ID, media.getId())
+                    .or()
+                    .beginGroup()
+                    .equals(MediaModelTable.LOCAL_SITE_ID, media.getLocalSiteId())
+                    .equals(MediaModelTable.MEDIA_ID, media.getMediaId())
+                    .endGroup()
+                    .endGroup().endWhere().getAsModel();
+        }
 
         if (existingMedia.isEmpty()) {
             // insert, media item does not exist

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -207,6 +207,13 @@ public class MediaSqlUtils {
             WellSql.insert(media).asSingleTransaction(true).execute();
             return 1;
         } else {
+            if (existingMedia.size() > 1) {
+                // We've ended up with a duplicate entry, probably due to a push/fetch race condition
+                // One matches based on local ID (this is the one we're trying to update with a remote media ID)
+                // The other matches based on local site ID + remote media ID, and we got it from a fetch
+                // Just remove the entry without a remote media ID (the one matching the current media's local ID)
+                return WellSql.delete(MediaModel.class).whereId(media.getId());
+            }
             // update, media item already exists
             int oldId = existingMedia.get(0).getId();
             return WellSql.update(MediaModel.class).whereId(oldId)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/5258 (hopefully). The issue I found is a race condition where a remote fetch reaches the db before the result of an upload does:

1. `PUSH_POST` for a local draft and `FETCH_POSTS` at ~the same time
2. Say the post list fetch completes after the post is uploaded, but before the DB is updated with the remote ID for the post
3. First db call, remote post is added, local ID is `0`, no match with existing post (site ID + remote ID give no match, the uploaded post hasn’t been updated yet with its remote ID) 💥
4. Second db call, already have two entries for the same post, at this point matches by local ID, and updates the remote post ID, leaving the other entry untouched
5. Two entries for the same post, only different by their local ID

Any model that we store 'local-only' versions of will experience this issue - for now that's only posts and media, so I made the fix for media also.

We should make the same change for other models we might store local versions of in the future, but I didn't want to bloat this PR - once merged, I'll open an issue for this. There might be a more generic way to take care of this for things we add in the future too.

To test:
1. Check out ee36d30, `./gradlew testDebug` 💥
2. Check out ae03283, `./gradlew testDebug` 👍
3. Check out f48990d, `./gradlew testDebug` 💥
2. Check out branch, `./gradlew testDebug` 👍