### PR TITLE
Store correct timezone data from site options

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -33,7 +33,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private boolean mIsWPCom;
     @Column private boolean mIsFeaturedImageSupported;
     @Column private String mDefaultCommentStatus = "open";
-    @Column private String mTimezone;
+    @Column private String mTimezone; // Expressed as an offset relative to GMT (e.g. '-8')
 
     // Self hosted specifics
     // The siteId for self hosted sites. Jetpack sites will also have a mSiteId, which is their id on wpcom

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -320,7 +320,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setIsAutomatedTransfer(from.options.is_automated_transfer);
             site.setAdminUrl(from.options.admin_url);
             site.setLoginUrl(from.options.login_url);
-            site.setTimezone(from.options.timezone);
+            site.setTimezone(from.options.gmt_offset);
         }
         if (from.plan != null) {
             try {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -16,7 +16,7 @@ public class SiteWPComRestResponse extends Payload implements Response {
         public boolean is_automated_transfer;
         public String admin_url;
         public String login_url;
-        public String timezone;
+        public String gmt_offset;
     }
 
     public class Plan {


### PR DESCRIPTION
The `timezone` field we were previously using from site options always seems to be blank - we actually want the `gmt_offset` field, which contains the GMT offset as a number (defaults to `0`).

This is the same format as the `time_zone` field from XML-RPC, and is what current WPAndroid code is expecting from `SiteModel.getTimezone()`.