### PR TITLE
Drop INSTANTIATE actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Action naming guide:
     UPDATE_X - local change
     REMOVE_X - local remove
     DELETE_X - request deletion on the server
-    INSTANTIATE_X - request a new instance of X
 
 Each action enum should be annotated with `@ActionEnum`, with individual actions receiving an `@Action` annotation with an optional `payloadType` setting (see [SiteAction][5] for an example).
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -10,9 +10,7 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.store.CommentStore;
 import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType;
 import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsPayload;
-import org.wordpress.android.fluxc.store.CommentStore.InstantiateCommentPayload;
 import org.wordpress.android.fluxc.store.CommentStore.OnCommentChanged;
-import org.wordpress.android.fluxc.store.CommentStore.OnCommentInstantiated;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentPayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload;
 import org.wordpress.android.fluxc.store.PostStore;
@@ -35,7 +33,6 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private enum TestEvents {
         NONE,
         POSTS_FETCHED,
-        COMMENT_INSTANTIATED,
         COMMENT_CHANGED,
         COMMENT_CHANGED_ERROR,
         COMMENT_CHANGED_UNKNOWN_COMMENT,
@@ -80,20 +77,16 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     public void testInstantiateAndCreateNewComment() throws InterruptedException {
         // New Comment
-        InstantiateCommentPayload payload1 = new InstantiateCommentPayload(sSite);
-        mNextEvent = TestEvents.COMMENT_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newInstantiateCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        createNewComment();
 
         // Edit comment instance
         mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
 
         // Create new Comment
         mNextEvent = TestEvents.COMMENT_CHANGED;
-        RemoteCreateCommentPayload payload2 = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
+        RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload2));
+        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
@@ -103,26 +96,22 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     public void testInstantiateAndCreateNewCommentDuplicate() throws InterruptedException {
         // New Comment
-        InstantiateCommentPayload payload1 = new InstantiateCommentPayload(sSite);
-        mNextEvent = TestEvents.COMMENT_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newInstantiateCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        createNewComment();
 
         // Edit comment instance
         mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
 
         // Create new Comment
         mNextEvent = TestEvents.COMMENT_CHANGED;
-        RemoteCreateCommentPayload payload2 = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
+        RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload2));
+        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Same comment again
         mNextEvent = TestEvents.COMMENT_CHANGED_ERROR;
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload2));
+        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -144,11 +133,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     public void testInstantiateAndCreateReplyComment() throws InterruptedException {
         // New Comment
-        InstantiateCommentPayload payload1 = new InstantiateCommentPayload(sSite);
-        mNextEvent = TestEvents.COMMENT_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newInstantiateCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        createNewComment();
 
         // Edit comment instance
         mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
@@ -159,9 +144,9 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Create new Reply to that first comment
         mNextEvent = TestEvents.COMMENT_CHANGED;
-        RemoteCreateCommentPayload payload2 = new RemoteCreateCommentPayload(sSite, firstComment, mNewComment);
+        RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, firstComment, mNewComment);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload2));
+        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
@@ -211,20 +196,16 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     public void testDeleteCommentOnce() throws InterruptedException {
         // New Comment
-        InstantiateCommentPayload payload1 = new InstantiateCommentPayload(sSite);
-        mNextEvent = TestEvents.COMMENT_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newInstantiateCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        createNewComment();
 
         // Edit comment instance
         mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
 
         // Create new Comment
         mNextEvent = TestEvents.COMMENT_CHANGED;
-        RemoteCreateCommentPayload payload2 = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
+        RemoteCreateCommentPayload payload1 = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload2));
+        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload1));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
@@ -233,9 +214,9 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Delete
         mNextEvent = TestEvents.COMMENT_CHANGED;
-        RemoteCommentPayload payload3 = new RemoteCommentPayload(sSite, comment);
+        RemoteCommentPayload payload2 = new RemoteCommentPayload(sSite, comment);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload3));
+        mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Make sure the comment is still here but state changed
@@ -245,20 +226,16 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     public void testDeleteCommentTwice() throws InterruptedException {
         // New Comment
-        InstantiateCommentPayload payload1 = new InstantiateCommentPayload(sSite);
-        mNextEvent = TestEvents.COMMENT_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newInstantiateCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        createNewComment();
 
         // Edit comment instance
         mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
 
         // Create new Comment
         mNextEvent = TestEvents.COMMENT_CHANGED;
-        RemoteCreateCommentPayload payload2 = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
+        RemoteCreateCommentPayload payload1 = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload2));
+        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload1));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
@@ -267,14 +244,14 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Delete once (ie. move to trash)
         mNextEvent = TestEvents.COMMENT_CHANGED;
-        RemoteCommentPayload payload3 = new RemoteCommentPayload(sSite, comment);
+        RemoteCommentPayload payload2 = new RemoteCommentPayload(sSite, comment);
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload3));
+        mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Delete twice (ie. real delete)
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload3));
+        mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Make sure the comment was deleted (local test only, but should mean it was deleted correctly on the server)
@@ -307,16 +284,6 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onCommentInstantiated(OnCommentInstantiated event) {
-        mNewComment = event.comment;
-        assertNotNull(mNewComment);
-        assertTrue(event.comment.getId() != 0);
-        assertEquals(TestEvents.COMMENT_INSTANTIATED, mNextEvent);
-        mCountDownLatch.countDown();
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe
     public void onPostChanged(OnPostChanged event) {
         mPosts = mPostStore.getPostsForSite(sSite);
         assertEquals(mNextEvent, TestEvents.POSTS_FETCHED);
@@ -324,6 +291,16 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     // Private methods
+
+    private CommentModel createNewComment() {
+        CommentModel comment = mCommentStore.instantiateCommentModel(sSite);
+
+        assertNotNull(comment);
+        assertTrue(comment.getId() != 0);
+
+        mNewComment = comment;
+        return comment;
+    }
 
     private void fetchFirstComments() throws InterruptedException {
         if (mComments != null) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -8,9 +8,7 @@ import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
-import org.wordpress.android.fluxc.store.TaxonomyStore.InstantiateTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
-import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermInstantiated;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
@@ -36,7 +34,6 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         TAGS_FETCHED,
         TERMS_FETCHED,
         TERM_UPDATED,
-        TERM_INSTANTIATED,
         TERM_UPLOADED,
         ERROR_INVALID_TAXONOMY,
         ERROR_DUPLICATE,
@@ -277,54 +274,42 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch.countDown();
     }
 
-    @SuppressWarnings("unused")
-    @Subscribe
-    public void onTermInstantiated(OnTermInstantiated event) {
-        AppLog.i(T.API, "Received OnTermInstantiated");
-        assertEquals(TestEvents.TERM_INSTANTIATED, mNextEvent);
-
-        assertEquals(0, event.term.getRemoteTermId());
-        assertNotSame(0, event.term.getId());
-        assertNotSame(0, event.term.getLocalSiteId());
-
-        mTerm = event.term;
-        mCountDownLatch.countDown();
-    }
-
     private void setupTermAttributes() {
         mTerm.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
         mTerm.setDescription(TERM_DEFAULT_DESCRIPTION);
     }
 
-    private void createNewCategory() throws InterruptedException {
-        // Instantiate new category
-        mNextEvent = TestEvents.TERM_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
+    private TermModel createNewCategory() {
+        TermModel term = mTaxonomyStore.instantiateCategory(sSite);
 
-        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateCategoryAction(sSite));
+        assertEquals(0, term.getRemoteTermId());
+        assertNotSame(0, term.getId());
+        assertNotSame(0, term.getLocalSiteId());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mTerm = term;
+        return term;
     }
 
-    private void createNewTag() throws InterruptedException {
-        // Instantiate new tag
-        mNextEvent = TestEvents.TERM_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
+    private TermModel createNewTag() {
+        TermModel term = mTaxonomyStore.instantiateTag(sSite);
 
-        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTagAction(sSite));
+        assertEquals(0, term.getRemoteTermId());
+        assertNotSame(0, term.getId());
+        assertNotSame(0, term.getLocalSiteId());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mTerm = term;
+        return term;
     }
 
-    private void createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
-        // Instantiate new term
-        mNextEvent = TestEvents.TERM_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
+    private TermModel createNewTerm(TaxonomyModel taxonomy) {
+        TermModel term = mTaxonomyStore.instantiateTerm(sSite, taxonomy);
 
-        InstantiateTermPayload payload = new InstantiateTermPayload(sSite, taxonomy);
-        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTermAction(payload));
+        assertEquals(0, term.getRemoteTermId());
+        assertNotSame(0, term.getId());
+        assertNotSame(0, term.getLocalSiteId());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mTerm = term;
+        return term;
     }
 
     private void uploadTerm(TermModel term) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -8,9 +8,7 @@ import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
-import org.wordpress.android.fluxc.store.TaxonomyStore.InstantiateTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
-import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermInstantiated;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
@@ -37,7 +35,6 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         TAGS_FETCHED,
         TERMS_FETCHED,
         TERM_UPDATED,
-        TERM_INSTANTIATED,
         TERM_UPLOADED,
         ERROR_INVALID_TAXONOMY,
         ERROR_DUPLICATE,
@@ -294,54 +291,42 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch.countDown();
     }
 
-    @SuppressWarnings("unused")
-    @Subscribe
-    public void onTermInstantiated(OnTermInstantiated event) {
-        AppLog.i(T.API, "Received OnTermInstantiated");
-        assertEquals(TestEvents.TERM_INSTANTIATED, mNextEvent);
-
-        assertEquals(0, event.term.getRemoteTermId());
-        assertNotSame(0, event.term.getId());
-        assertNotSame(0, event.term.getLocalSiteId());
-
-        mTerm = event.term;
-        mCountDownLatch.countDown();
-    }
-
     private void setupTermAttributes() {
         mTerm.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
         mTerm.setDescription(TERM_DEFAULT_DESCRIPTION);
     }
 
-    private void createNewCategory() throws InterruptedException {
-        // Instantiate new category
-        mNextEvent = TestEvents.TERM_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
+    private TermModel createNewCategory() throws InterruptedException {
+        TermModel term = mTaxonomyStore.instantiateCategory(sSite);
 
-        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateCategoryAction(sSite));
+        assertEquals(0, term.getRemoteTermId());
+        assertNotSame(0, term.getId());
+        assertNotSame(0, term.getLocalSiteId());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mTerm = term;
+        return term;
     }
 
-    private void createNewTag() throws InterruptedException {
-        // Instantiate new tag
-        mNextEvent = TestEvents.TERM_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
+    private TermModel createNewTag() throws InterruptedException {
+        TermModel term = mTaxonomyStore.instantiateTag(sSite);
 
-        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTagAction(sSite));
+        assertEquals(0, term.getRemoteTermId());
+        assertNotSame(0, term.getId());
+        assertNotSame(0, term.getLocalSiteId());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mTerm = term;
+        return term;
     }
 
-    private void createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
-        // Instantiate new term
-        mNextEvent = TestEvents.TERM_INSTANTIATED;
-        mCountDownLatch = new CountDownLatch(1);
+    private TermModel createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
+        TermModel term = mTaxonomyStore.instantiateTerm(sSite, taxonomy);
 
-        InstantiateTermPayload payload = new InstantiateTermPayload(sSite, taxonomy);
-        mDispatcher.dispatch(TaxonomyActionBuilder.newInstantiateTermAction(payload));
+        assertEquals(0, term.getRemoteTermId());
+        assertNotSame(0, term.getId());
+        assertNotSame(0, term.getLocalSiteId());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mTerm = term;
+        return term;
     }
 
     private void uploadTerm(TermModel term) throws InterruptedException {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/CommentAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/CommentAction.java
@@ -7,7 +7,6 @@ import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsPayload;
 import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsResponsePayload;
-import org.wordpress.android.fluxc.store.CommentStore.InstantiateCommentPayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentPayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentResponsePayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload;
@@ -43,8 +42,6 @@ public enum CommentAction implements IAction {
     LIKED_COMMENT,
 
     // Local actions
-    @Action(payloadType = InstantiateCommentPayload.class)
-    INSTANTIATE_COMMENT,
     @Action(payloadType = CommentModel.class)
     UPDATE_COMMENT,
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -8,7 +8,6 @@ import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
-import org.wordpress.android.fluxc.store.TaxonomyStore.InstantiateTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 
 @ActionEnum
@@ -34,12 +33,6 @@ public enum TaxonomyAction implements IAction {
     PUSHED_TERM,
 
     // Local actions
-    @Action(payloadType = SiteModel.class)
-    INSTANTIATE_CATEGORY,
-    @Action(payloadType = SiteModel.class)
-    INSTANTIATE_TAG,
-    @Action(payloadType = InstantiateTermPayload.class)
-    INSTANTIATE_TERM,
     @Action(payloadType = TermModel.class)
     UPDATE_TERM,
     @Action

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -49,6 +49,12 @@ public class CommentSqlUtils {
         }
     }
 
+    public static CommentModel insertCommentForResult(CommentModel comment) {
+        WellSql.insert(comment).asSingleTransaction(true).execute();
+
+        return comment;
+    }
+
     public static int removeComment(CommentModel comment) {
         if (comment == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -301,7 +301,14 @@ public class MediaStore extends Store {
 
     public MediaModel instantiateMediaModel() {
         MediaModel media = new MediaModel();
-        return MediaSqlUtils.insertMediaForResult(media);
+
+        media = MediaSqlUtils.insertMediaForResult(media);
+
+        if (media.getId() == -1) {
+            media = null;
+        }
+
+        return media;
     }
 
     public List<MediaModel> getAllSiteMedia(SiteModel siteModel) {


### PR DESCRIPTION
Replaces remaining `INSTANTIATE` actions (comments and terms) by synchronous `instantiateX()` methods.