### PR TITLE
The port of the url should be added to media upload request

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -132,6 +132,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         HttpUrl url = new HttpUrl.Builder()
                 .scheme(xmlrpcUrl.getProtocol())
                 .host(xmlrpcUrl.getHost())
+                .port(xmlrpcUrl.getPort())
                 .encodedPath(xmlrpcUrl.getPath())
                 .username(site.getUsername())
                 .password(site.getPassword())


### PR DESCRIPTION
While I was debugging an upload to my locally-hosted wordpress, I realized that the port from the site's url was ignored during upload media. It's unlikely that this will be an issue, but just in case, I think we should have it in the url.