### PR TITLE
Correctly set mediaId after upload for self-hosted sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -129,14 +129,16 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         }
 
         XmlrpcUploadRequestBody requestBody = new XmlrpcUploadRequestBody(media, this, site);
-        HttpUrl url = new HttpUrl.Builder()
+        HttpUrl.Builder builder = new HttpUrl.Builder()
                 .scheme(xmlrpcUrl.getProtocol())
                 .host(xmlrpcUrl.getHost())
-                .port(xmlrpcUrl.getPort())
                 .encodedPath(xmlrpcUrl.getPath())
                 .username(site.getUsername())
-                .password(site.getPassword())
-                .build();
+                .password(site.getPassword());
+        if (xmlrpcUrl.getPort() > 0) {
+            builder.port(xmlrpcUrl.getPort());
+        }
+        HttpUrl url = builder.build();
 
         // Use the HTTP Auth Manager to check if we need HTTP Auth for this url
         HTTPAuthModel httpAuthModel = mHTTPAuthManager.getHTTPAuthModel(xmlrpcUrl.toString());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -129,16 +129,16 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         }
 
         XmlrpcUploadRequestBody requestBody = new XmlrpcUploadRequestBody(media, this, site);
-        HttpUrl.Builder builder = new HttpUrl.Builder()
+        HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
                 .scheme(xmlrpcUrl.getProtocol())
                 .host(xmlrpcUrl.getHost())
                 .encodedPath(xmlrpcUrl.getPath())
                 .username(site.getUsername())
                 .password(site.getPassword());
         if (xmlrpcUrl.getPort() > 0) {
-            builder.port(xmlrpcUrl.getPort());
+            urlBuilder.port(xmlrpcUrl.getPort());
         }
-        HttpUrl url = builder.build();
+        HttpUrl url = urlBuilder.build();
 
         // Use the HTTP Auth Manager to check if we need HTTP Auth for this url
         HTTPAuthModel httpAuthModel = mHTTPAuthManager.getHTTPAuthModel(xmlrpcUrl.toString());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -452,7 +452,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             InputStream is = new ByteArrayInputStream(data.getBytes(Charset.forName("UTF-8")));
             Object obj = XMLSerializerUtils.deserialize(XMLSerializerUtils.scrubXmlResponse(is));
             if (obj instanceof Map) {
-                media.setMediaId(MapUtils.getMapLong((Map) obj, "attachment_id"));
+                media.setMediaId(MapUtils.getMapLong((Map) obj, "id"));
             }
         } catch (IOException | XmlPullParserException e) {
             AppLog.w(AppLog.T.MEDIA, "Failed to parse XMLRPC.wpUploadFile response: " + response);


### PR DESCRIPTION
Fixes #348. I found the root cause of why the `mediaId` was not properly being set after uploading to self-hosted sites. We were parsing for `attachment_id` for some reason where we should use the `id` as documented [here](https://codex.wordpress.org/XML-RPC_WordPress_API/Media).

I also found that the port PR I previously authored was faulty as the port would be set to `-1` if there is no port value. This PR fixes that as well.