### PR TITLE
Store site icons URLs

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -205,6 +205,7 @@
         <module name="UpperEll"/>
 
         <module name="FileContentsHolder"/> <!-- Required by comment suppression filters -->
+        <module name="SuppressWarningsHolder"/> <!-- Required by suppression via annotation filter -->
 
         <module name="OneStatementPerLine"/>
 
@@ -222,4 +223,6 @@
       <property name="checkFormat" value="$1"/>
       <property name="influenceFormat" value="1"/>
     </module>
+
+    <module name="SuppressWarningsFilter"/>
 </module>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -56,6 +56,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private boolean mIsVideoPressSupported;
     @Column private long mPlanId;
     @Column private String mPlanShortName;
+    @Column private String mIconUrl;
 
     // WPCom capabilities
     @Column private boolean mHasCapabilityEditPages;
@@ -406,6 +407,14 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
 
     public void setPlanId(long planId) {
         mPlanId = planId;
+    }
+
+    public String getIconUrl() {
+        return mIconUrl;
+    }
+
+    public void setIconUrl(String iconUrl) {
+        mIconUrl = iconUrl;
     }
 
     public boolean isJetpackInstalled() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -353,6 +353,9 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setHasCapabilityRemoveUsers(from.capabilities.remove_users);
             site.setHasCapabilityViewStats(from.capabilities.view_stats);
         }
+        if (from.icon != null) {
+            site.setIconUrl(from.icon.img);
+        }
         if (from.meta != null) {
             if (from.meta.links != null) {
                 site.setXmlRpcUrl(from.meta.links.xmlrpc);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -45,6 +45,10 @@ public class SiteWPComRestResponse extends Payload implements Response {
         public boolean view_stats;
     }
 
+    public class Icon {
+        public String img;
+    }
+
 
     public class Meta {
         public class Links {
@@ -64,5 +68,6 @@ public class SiteWPComRestResponse extends Payload implements Response {
     public Options options;
     public Capabilities capabilities;
     public Plan plan;
+    public Icon icon;
     public Meta meta;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -56,8 +56,8 @@ public class WellSqlConfig extends DefaultWellConfig {
     }
 
     @Override
-    public void onUpgrade(SQLiteDatabase db, WellTableManager helper, int newVersion, int oldVersion) {
         // drop+create or migrate
+    public void onUpgrade(SQLiteDatabase db, WellTableManager helper, int oldVersion, int newVersion) {
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -57,6 +57,7 @@ public class WellSqlConfig extends DefaultWellConfig {
         }
     }
 
+    @SuppressWarnings({"FallThrough"})
     @Override
     public void onUpgrade(SQLiteDatabase db, WellTableManager helper, int oldVersion, int newVersion) {
         AppLog.d(T.DB, "Upgrading database from version " + oldVersion + " to " + newVersion);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -18,6 +18,8 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.network.HTTPAuthModel;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 
 import java.util.Map;
 
@@ -40,7 +42,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 1;
+        return 2;
     }
 
     @Override
@@ -56,8 +58,17 @@ public class WellSqlConfig extends DefaultWellConfig {
     }
 
     @Override
-        // drop+create or migrate
     public void onUpgrade(SQLiteDatabase db, WellTableManager helper, int oldVersion, int newVersion) {
+        AppLog.d(T.DB, "Upgrading database from version " + oldVersion + " to " + newVersion);
+
+        db.beginTransaction();
+        switch (oldVersion) {
+            case 1:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SiteModel add ICON_URL text;");
+        }
+        db.setTransactionSuccessful();
+        db.endTransaction();
     }
 
     @Override


### PR DESCRIPTION
Stores the `icon.img` field from the WP.com REST API `sites` response. This is necessary to display site icons for Jetpack sites (though normal WP.com sites with an icon will also have its URL stored this way).

Also features our first DB migration 🎉 😂 😱 (assuming it's merged).

This completes the backend requirement to fix https://github.com/wordpress-mobile/WordPress-Android/issues/2822 - I'll make the rest of the changes in a WPAndroid PR.

Note: The `FallThrough` warning suppression part (09bc9cd) isn't necessary yet, but will be on the next migration if we use the incrementing switch approach we've been using in `WordPressDB`.