### PR TITLE
Report parse errors in an OnChanged event

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -15,6 +15,7 @@ import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnParseError;
 import org.wordpress.android.util.AppLog;
 
 import java.util.HashMap;
@@ -32,10 +33,14 @@ public abstract class BaseRequest<T> extends Request<T> {
     public interface BaseErrorListener {
         void onErrorResponse(@NonNull BaseNetworkError error);
     }
+    public interface OnParseErrorListener {
+        void onParseError(OnParseError event);
+    }
 
     private static final String USER_AGENT_HEADER = "User-Agent";
 
     protected OnAuthFailedListener mOnAuthFailedListener;
+    protected OnParseErrorListener mOnParseErrorListener;
     protected final Map<String, String> mHeaders = new HashMap<>(2);
     private BaseErrorListener mErrorListener;
 
@@ -150,6 +155,10 @@ public abstract class BaseRequest<T> extends Request<T> {
         mOnAuthFailedListener = onAuthFailedListener;
     }
 
+    public void setOnParseErrorListener(OnParseErrorListener onParseErrorListener) {
+        mOnParseErrorListener = onParseErrorListener;
+    }
+
     public void setUserAgent(String userAgent) {
         mHeaders.put(USER_AGENT_HEADER, userAgent);
     }
@@ -219,6 +228,9 @@ public abstract class BaseRequest<T> extends Request<T> {
     @Override
     public final void deliverError(VolleyError volleyError) {
         AppLog.e(AppLog.T.API, "Volley error", volleyError);
+        if (volleyError instanceof ParseError) {
+            mOnParseErrorListener.onParseError(new OnParseError((ParseError) volleyError));
+        }
         BaseNetworkError baseNetworkError = getBaseNetworkError(volleyError);
         BaseNetworkError modifiedBaseNetworkError = deliverBaseNetworkError(baseNetworkError);
         mErrorListener.onErrorResponse(modifiedBaseNetworkError);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -15,7 +15,7 @@ import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
-import org.wordpress.android.fluxc.utils.ErrorUtils.OnParseError;
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError;
 import org.wordpress.android.util.AppLog;
 
 import java.util.HashMap;
@@ -34,7 +34,7 @@ public abstract class BaseRequest<T> extends Request<T> {
         void onErrorResponse(@NonNull BaseNetworkError error);
     }
     public interface OnParseErrorListener {
-        void onParseError(OnParseError event);
+        void onParseError(OnUnexpectedError event);
     }
 
     private static final String USER_AGENT_HEADER = "User-Agent";
@@ -229,7 +229,7 @@ public abstract class BaseRequest<T> extends Request<T> {
     public final void deliverError(VolleyError volleyError) {
         AppLog.e(AppLog.T.API, "Volley error", volleyError);
         if (volleyError instanceof ParseError) {
-            mOnParseErrorListener.onParseError(new OnParseError((ParseError) volleyError));
+            mOnParseErrorListener.onParseError(new OnUnexpectedError(volleyError, "API response parse error"));
         }
         BaseNetworkError baseNetworkError = getBaseNetworkError(volleyError);
         BaseNetworkError modifiedBaseNetworkError = deliverBaseNetworkError(baseNetworkError);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.OnParseErrorListener;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
-import org.wordpress.android.fluxc.utils.ErrorUtils.OnParseError;
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError;
 import org.wordpress.android.util.LanguageUtils;
 
 public class BaseWPComRestClient {
@@ -40,7 +40,7 @@ public class BaseWPComRestClient {
         };
         mOnParseErrorListener = new OnParseErrorListener() {
             @Override
-            public void onParseError(OnParseError event) {
+            public void onParseError(OnUnexpectedError event) {
                 mDispatcher.emitChange(event);
             }
         };

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -8,9 +8,11 @@ import com.android.volley.RequestQueue;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.network.BaseRequest.OnAuthFailedListener;
+import org.wordpress.android.fluxc.network.BaseRequest.OnParseErrorListener;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnParseError;
 import org.wordpress.android.util.LanguageUtils;
 
 public class BaseWPComRestClient {
@@ -21,6 +23,7 @@ public class BaseWPComRestClient {
     protected UserAgent mUserAgent;
 
     protected OnAuthFailedListener mOnAuthFailedListener;
+    protected OnParseErrorListener mOnParseErrorListener;
 
     public BaseWPComRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
                                AccessToken accessToken, UserAgent userAgent) {
@@ -33,6 +36,12 @@ public class BaseWPComRestClient {
             @Override
             public void onAuthFailed(AuthenticateErrorPayload authError) {
                 mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateErrorAction(authError));
+            }
+        };
+        mOnParseErrorListener = new OnParseErrorListener() {
+            @Override
+            public void onParseError(OnParseError event) {
+                mDispatcher.emitChange(event);
             }
         };
     }
@@ -56,6 +65,7 @@ public class BaseWPComRestClient {
 
     private WPComGsonRequest setRequestAuthParams(WPComGsonRequest request) {
         request.setOnAuthFailedListener(mOnAuthFailedListener);
+        request.setOnParseErrorListener(mOnParseErrorListener);
         request.setUserAgent(mUserAgent.getUserAgent());
         request.setAccessToken(mAccessToken.get());
         return request;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
@@ -3,17 +3,19 @@ package org.wordpress.android.fluxc.network.xmlrpc;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 
-import org.wordpress.android.fluxc.network.HTTPAuthManager;
-import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.OnAuthFailedListener;
+import org.wordpress.android.fluxc.network.BaseRequest.OnParseErrorListener;
+import org.wordpress.android.fluxc.network.HTTPAuthManager;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.discovery.DiscoveryRequest;
 import org.wordpress.android.fluxc.network.discovery.DiscoveryXMLRPCRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError;
 
 public class BaseXMLRPCClient {
     private AccessToken mAccessToken;
@@ -21,8 +23,10 @@ public class BaseXMLRPCClient {
     private final RequestQueue mRequestQueue;
     protected final Dispatcher mDispatcher;
     protected UserAgent mUserAgent;
-    protected OnAuthFailedListener mOnAuthFailedListener;
     protected HTTPAuthManager mHTTPAuthManager;
+
+    protected OnAuthFailedListener mOnAuthFailedListener;
+    protected OnParseErrorListener mOnParseErrorListener;
 
     public BaseXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,
                             UserAgent userAgent, HTTPAuthManager httpAuthManager) {
@@ -35,6 +39,12 @@ public class BaseXMLRPCClient {
             @Override
             public void onAuthFailed(AuthenticateErrorPayload authError) {
                 mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateErrorAction(authError));
+            }
+        };
+        mOnParseErrorListener = new OnParseErrorListener() {
+            @Override
+            public void onParseError(OnUnexpectedError event) {
+                mDispatcher.emitChange(event);
             }
         };
     }
@@ -53,6 +63,7 @@ public class BaseXMLRPCClient {
 
     private BaseRequest setRequestAuthParams(BaseRequest request) {
         request.setOnAuthFailedListener(mOnAuthFailedListener);
+        request.setOnParseErrorListener(mOnParseErrorListener);
         request.setUserAgent(mUserAgent.getUserAgent());
         request.setHTTPAuthHeaderOnMatchingURL(mHTTPAuthManager);
         return request;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/ErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/ErrorUtils.java
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.utils;
+
+import com.android.volley.ParseError;
+
+public class ErrorUtils {
+    public static class OnParseError {
+        public ParseError parseError;
+        public OnParseError(ParseError parseError) {
+            this.parseError = parseError;
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/ErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/ErrorUtils.java
@@ -1,12 +1,26 @@
 package org.wordpress.android.fluxc.utils;
 
-import com.android.volley.ParseError;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 
 public class ErrorUtils {
-    public static class OnParseError {
-        public ParseError parseError;
-        public OnParseError(ParseError parseError) {
-            this.parseError = parseError;
+    public static class OnUnexpectedError {
+        public Exception exception;
+        public String description;
+        public AppLog.T type;
+
+        public OnUnexpectedError(Exception exception) {
+            this(exception, "");
+        }
+
+        public OnUnexpectedError(Exception exception, String description) {
+            this(exception, description, T.API);
+        }
+
+        public OnUnexpectedError(Exception exception, String description, T type) {
+            this.exception = exception;
+            this.description = description;
+            this.type = type;
         }
     }
 }


### PR DESCRIPTION
As part of https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/100, this helps ensure we get error reports for Gson parse errors, even though they don't actually cause an app crash.