### PR TITLE
Fix loading images from HTTP Auth sites

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedToolsModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedToolsModule.java
@@ -1,0 +1,35 @@
+package org.wordpress.android.fluxc.module;
+
+import android.graphics.Bitmap;
+import android.support.v4.util.LruCache;
+
+import com.android.volley.toolbox.ImageLoader.ImageCache;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class MockedToolsModule {
+    @Provides
+    public ImageCache getBitmapCache() {
+        int maxMemory = (int) (Runtime.getRuntime().maxMemory() / 1024);
+        int cacheSize = maxMemory / 16;
+        return new PrettyUselessCache(cacheSize);
+    }
+
+    private class PrettyUselessCache extends LruCache<String, Bitmap> implements ImageCache {
+        PrettyUselessCache(int maxSize) {
+            super(maxSize);
+        }
+
+        @Override
+        public Bitmap getBitmap(String key) {
+            return null;
+        }
+
+        @Override
+        public void putBitmap(String key, Bitmap bitmap) {
+            // no op
+        }
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -2,10 +2,12 @@ package org.wordpress.android.fluxc.release;
 
 import org.wordpress.android.fluxc.example.AppSecretsModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
+import org.wordpress.android.fluxc.module.MockedToolsModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseStoreModule;
+import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 
 import javax.inject.Singleton;
 
@@ -19,7 +21,9 @@ import dagger.Component;
         ReleaseOkHttpClientModule.class,
         ReleaseBaseModule.class,
         ReleaseNetworkModule.class,
-        ReleaseStoreModule.class
+        ReleaseStoreModule.class,
+        ReleaseToolsModule.class,
+        MockedToolsModule.class
 })
 public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_AccountTest test);
@@ -27,6 +31,7 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_CommentTestWPCom test);
     void inject(ReleaseStack_CommentTestXMLRPC test);
     void inject(ReleaseStack_DiscoveryTest test);
+    void inject(ReleaseStack_FluxCImageLoaderTest test);
     void inject(ReleaseStack_MediaTestWPCom test);
     void inject(ReleaseStack_MediaTestXMLRPC test);
     void inject(ReleaseStack_PostTestWPCom test);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
@@ -78,7 +78,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
                             @Override
                             public void onErrorResponse(VolleyError error) {
                                 AppLog.e(T.TESTS, "Failed to download image: " + error.getMessage());
-                                throw new AssertionError("Image request failed!");
+                                fail("Image request failed!");
                             }
                         }
                 );

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
@@ -1,0 +1,144 @@
+package org.wordpress.android.fluxc.release;
+
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.ImageLoader;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.generated.MediaActionBuilder;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.HTTPAuthManager;
+import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
+import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
+    @Inject SiteStore mSiteStore;
+    @Inject MediaStore mMediaStore;
+    @Inject HTTPAuthManager mHTTPAuthManager;
+    @Inject FluxCImageLoader mFluxCImageLoader;
+
+    enum TestEvents {
+        NONE,
+        SITE_CHANGED,
+        FETCHED_MEDIA_LIST
+    }
+
+    private TestEvents mNextEvent;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mReleaseStackAppComponent.inject(this);
+        // Register
+        init();
+        // Reset expected test event
+        mNextEvent = TestEvents.NONE;
+    }
+
+    public void testLoadImageFromHTTPAuthSite() throws Throwable {
+        signInToHTTPAuthSite();
+
+        final SiteModel site = mSiteStore.getSites().get(0);
+
+        // Fetch media list and verify store is not empty
+        fetchSiteMedia(site);
+
+        // Download one of the media items
+        final String imageUrl = mMediaStore.getAllSiteMedia(site).get(0).getUrl();
+        mCountDownLatch = new CountDownLatch(1);
+
+        Runnable loadImageTask = new Runnable() {
+            @Override
+            public void run() {
+                mFluxCImageLoader.get(imageUrl,
+                        new ImageLoader.ImageListener() {
+                            @Override
+                            public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
+                                if (isImmediate) {
+                                    // Network request hasn't happened yet, keep waiting
+                                    return;
+                                }
+                                assertNotNull(response.getBitmap());
+                                mCountDownLatch.countDown();
+                            }
+
+                            @Override
+                            public void onErrorResponse(VolleyError error) {
+                                AppLog.e(T.TESTS, "Failed to download image: " + error.getMessage());
+                                throw new AssertionError("Image request failed!");
+                            }
+                        }
+                );
+            }
+        };
+
+        runTestOnUiThread(loadImageTask);
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onSiteChanged(OnSiteChanged event) {
+        AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertTrue(mSiteStore.hasSite());
+        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onMediaListFetched(MediaStore.OnMediaListFetched event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
+        mCountDownLatch.countDown();
+    }
+
+    private void signInToHTTPAuthSite() throws InterruptedException {
+        RefreshSitesXMLRPCPayload payload = new RefreshSitesXMLRPCPayload();
+        payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_HTTPAUTH;
+        payload.password = BuildConfig.TEST_WPORG_PASSWORD_SH_HTTPAUTH;
+        payload.url = BuildConfig.TEST_WPORG_URL_SH_HTTPAUTH_ENDPOINT;
+        mNextEvent = TestEvents.SITE_CHANGED;
+        // Set known HTTP Auth credentials
+        mHTTPAuthManager.addHTTPAuthCredentials(BuildConfig.TEST_WPORG_HTTPAUTH_USERNAME_SH_HTTPAUTH,
+                BuildConfig.TEST_WPORG_HTTPAUTH_PASSWORD_SH_HTTPAUTH, BuildConfig.TEST_WPORG_URL_SH_HTTPAUTH_ENDPOINT,
+                null);
+
+        mCountDownLatch = new CountDownLatch(1);
+        // Retry to fetch sites,we expect a site refresh
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
+        // Wait for a network response
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void fetchSiteMedia(SiteModel site) throws InterruptedException {
+        mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
+        mCountDownLatch = new CountDownLatch(1);
+
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(site, false);
+        mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertFalse(mMediaStore.getAllSiteMedia(site).isEmpty());
+    }
+}
+

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FluxCImageLoader.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FluxCImageLoader.java
@@ -71,7 +71,7 @@ public class FluxCImageLoader extends ImageLoader {
                     HTTPAuthModel httpAuthModel = mHTTPAuthManager.getHTTPAuthModel(url);
                     if (httpAuthModel != null) {
                         String creds = String.format("%s:%s", httpAuthModel.getUsername(), httpAuthModel.getPassword());
-                        String auth = "Basic " + Base64.encodeToString(creds.getBytes(), Base64.DEFAULT);
+                        String auth = "Basic " + Base64.encodeToString(creds.getBytes(), Base64.NO_WRAP);
                         headers.put("Authorization", auth);
                     }
                 }


### PR DESCRIPTION
Fixes a couple of issues that were preventing images from being downloaded using the `FluxCImageLoader` for HTTP Auth sites.

We should probably eventually take a more refined approach than what I did in e8c1b88. We could probably update the `ROOT_URL` in `HTTPAuthModel` to the site's reported URL once the initial site fetch is done. There isn't an obvious place to do this (it would have to be handled in the clients, probably), and I decided to skip the necessary refactor for now.

The only situation where the current fix won't work is if the user has moved their `xmlrpc.php` file deeper in their site's folder structure (e.g. their site url is http://mysecretsite.site/wp, and they stored their `xmlrpc.php` file in http://mysecretsite.site/cant-find-me/xmlrpc.php). We can't just use the domain, because their site might live in a subfolder, and we have no way of knowing where the true base URL is from the XML-RPC URL alone.

To test:
1. Check out a0850fe, run test 💥
2. Check out the branch, run test 🎉

cc @maxme