### PR TITLE
Media upload log should show there was an error instead of saying successful

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -175,9 +175,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         }
                         fetchMedia(site, media, true);
                     } catch (XMLRPCException fault) {
-                        AppLog.w(T.MEDIA, "media upload successful, local id=" + media.getId()
-                                          + " - " + response.message());
                         MediaError mediaError = getMediaErrorFromXMLRPCException(fault);
+                        AppLog.w(T.MEDIA, "media upload failed with error: " + mediaError.message);
                         notifyMediaProgress(media, 0.f, mediaError);
                     }
                 } else {


### PR DESCRIPTION
When an `XMLRPCException` occurs while parsing the media upload error, we say the upload was successful in the logs. It's misleading and I've verified in multiple instances that this exception occurs when the upload actually fails. So, this PR fixes the error log, so it doesn't confuse people.