### PR TITLE
Clean up featured image handling

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 @Table
 public class PostModel extends Payload implements Cloneable, Identifiable, Serializable {
-    private static final long FEATURED_IMAGE_INIT_VALUE = -2;
     private static final long LATITUDE_REMOVED_VALUE = 8888;
     private static final long LONGITUDE_REMOVED_VALUE = 8888;
 
@@ -43,7 +42,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     @Column private String mTagNames;
     @Column private String mStatus;
     @Column private String mPassword;
-    @Column private long mFeaturedImageId = FEATURED_IMAGE_INIT_VALUE;
+    @Column private long mFeaturedImageId;
     @Column private String mPostFormat;
     @Column private String mSlug;
     @Column private double mLatitude = PostLocation.INVALID_LATITUDE;
@@ -62,7 +61,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     // XML-RPC only, needed to work around a bug with the API:
     // https://github.com/wordpress-mobile/WordPress-Android/pull/3425
     // We may be able to drop this if we switch to wp.editPost (and it doesn't have the same bug as metaWeblog.editPost)
-    @Column private long mLastKnownRemoteFeaturedImageId = FEATURED_IMAGE_INIT_VALUE;
+    @Column private long mLastKnownRemoteFeaturedImageId;
 
     // WPCom capabilities
     @Column private boolean mHasCapabilityPublishPost;
@@ -206,18 +205,10 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     }
 
     public long getFeaturedImageId() {
-        if (mFeaturedImageId == FEATURED_IMAGE_INIT_VALUE) {
-            return 0;
-        }
-
         return mFeaturedImageId;
     }
 
     public void setFeaturedImageId(long featuredImageId) {
-        if (mFeaturedImageId == FEATURED_IMAGE_INIT_VALUE) {
-            mLastKnownRemoteFeaturedImageId = mFeaturedImageId;
-        }
-
         mFeaturedImageId = featuredImageId;
     }
 
@@ -307,10 +298,12 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         mIsLocallyChanged = isLocallyChanged;
     }
 
+    @Deprecated
     public long getLastKnownRemoteFeaturedImageId() {
         return mLastKnownRemoteFeaturedImageId;
     }
 
+    @Deprecated
     public void setLastKnownRemoteFeaturedImageId(long lastKnownRemoteFeaturedImageId) {
         mLastKnownRemoteFeaturedImageId = lastKnownRemoteFeaturedImageId;
     }
@@ -361,7 +354,6 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
                 && Double.compare(otherPost.getLongitude(), getLongitude()) == 0
                 && isPage() == otherPost.isPage()
                 && isLocalDraft() == otherPost.isLocalDraft() && isLocallyChanged() == otherPost.isLocallyChanged()
-                && getLastKnownRemoteFeaturedImageId() == otherPost.getLastKnownRemoteFeaturedImageId()
                 && getHasCapabilityPublishPost() == otherPost.getHasCapabilityPublishPost()
                 && getHasCapabilityEditPost() == otherPost.getHasCapabilityEditPost()
                 && getHasCapabilityDeletePost() == otherPost.getHasCapabilityDeletePost()
@@ -438,11 +430,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     }
 
     public void clearFeaturedImage() {
-        setFeaturedImageId(-1);
-    }
-
-    public boolean featuredImageHasChanged() {
-        return (mLastKnownRemoteFeaturedImageId != mFeaturedImageId);
+        setFeaturedImageId(0);
     }
 
     private static List<Long> termIdStringToList(String ids) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -293,15 +293,7 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("categories", TextUtils.join(",", post.getCategoryIdList()));
         params.put("tags", TextUtils.join(",", post.getTagNameList()));
 
-        // Will remove any existing featured image if the empty string is sent
-        if (post.featuredImageHasChanged()) {
-            if (post.getFeaturedImageId() < 1 && !post.isLocalDraft()) {
-                // The featured image was removed from a live post
-                params.put("featured_image", "");
-            } else {
-                params.put("featured_image", String.valueOf(post.getFeaturedImageId()));
-            }
-        }
+        params.put("featured_image", post.getFeaturedImageId());
 
         if (post.hasLocation()) {
             // Location data was added to the post

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -519,15 +519,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             }
         }
 
-        // Featured images
-        if (post.featuredImageHasChanged()) {
-            if (post.getFeaturedImageId() < 1 && !post.isLocalDraft()) {
-                // The featured image was removed from a live post
-                contentStruct.put("post_thumbnail", "");
-            } else {
-                contentStruct.put("post_thumbnail", post.getFeaturedImageId());
-            }
-        }
+        contentStruct.put("post_thumbnail", post.getFeaturedImageId());
 
         contentStruct.put("post_password", post.getPassword());
 


### PR DESCRIPTION
Simplifies the upload logic for featured images. The reason `mLastKnownRemoteFeaturedImageId` and `featuredImageHasChanged()` existed was `metaWeblog.editPost`, which threw an error when attempting to set the featured image id to the already existing value.

We switched to `wp.editPost` since I added that to the `PostModel` (it existed in the old `Post` class too). `wp.editPost` doesn't have this issue (and the REST API never has), and so we no longer have to track featured image changes, only the latest value of the featured image id.

#### Note on migration/deprecation
I went back and forth for a while on what to do with the unused `mLastKnownRemoteFeaturedImageId` field. In the old `WordPressDB`, we didn't do migrations for removed fields. They'd stay there inactive in older installations, and would never be created in new installations.

@maxme suggested either doing a migration for our peace of mind, or keeping the field and deprecating the getters/setters. Migrations for removals/renames/type changes are ugly in SQLite, as you have to create a new table (and hardcode a String with its fields and types) and migrate the data into it. So I went with deprecation, and perhaps a future change to `PostModel` that does require a migration can drop `LAST_KNOWN_REMOTE_FEATURED_IMAGE_ID` at the same time.