### PR TITLE
Adds frame-nonce property to SiteModel

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -34,6 +34,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private boolean mIsFeaturedImageSupported;
     @Column private String mDefaultCommentStatus = "open";
     @Column private String mTimezone; // Expressed as an offset relative to GMT (e.g. '-8')
+    @Column private String mFrameNonce; // only wpcom and Jetpack sites
 
     // Self hosted specifics
     // The siteId for self hosted sites. Jetpack sites will also have a mSiteId, which is their id on wpcom
@@ -391,6 +392,14 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
 
     public void setTimezone(String timezone) {
         mTimezone = timezone;
+    }
+
+    public String getFrameNonce() {
+        return mFrameNonce;
+    }
+
+    public void setFrameNonce(String frameNonce) {
+        mFrameNonce = frameNonce;
     }
 
     public String getPlanShortName() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -321,6 +321,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setAdminUrl(from.options.admin_url);
             site.setLoginUrl(from.options.login_url);
             site.setTimezone(from.options.gmt_offset);
+            site.setFrameNonce(from.options.frame_nonce);
         }
         if (from.plan != null) {
             try {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -17,6 +17,7 @@ public class SiteWPComRestResponse extends Payload implements Response {
         public String admin_url;
         public String login_url;
         public String gmt_offset;
+        public String frame_nonce;
     }
 
     public class Plan {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -67,9 +67,11 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 1:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add FRAME_NONCE text;");
+                oldVersion++;
             case 2:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add frame_nonce text;");
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -42,7 +42,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 2;
+        return 3;
     }
 
     @Override
@@ -66,7 +66,10 @@ public class WellSqlConfig extends DefaultWellConfig {
         switch (oldVersion) {
             case 1:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("alter table SiteModel add ICON_URL text;");
+                db.execSQL("alter table SiteModel add FRAME_NONCE text;");
+            case 2:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SiteModel add frame_nonce text;");
         }
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -66,11 +66,11 @@ public class WellSqlConfig extends DefaultWellConfig {
         switch (oldVersion) {
             case 1:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("alter table SiteModel add FRAME_NONCE text;");
+                db.execSQL("alter table SiteModel add ICON_URL text;");
                 oldVersion++;
             case 2:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("alter table SiteModel add frame_nonce text;");
+                db.execSQL("alter table SiteModel add FRAME_NONCE text;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
Closes #357. We need the `frame_nonce` property in SiteModel to be able to show the post previews authenticated on Jetpack sites.