### PR TITLE
Set IsAvailableResponsePayload type/value on error

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -261,6 +261,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                         // We don't expect anything but server errors here - the API itself returns errors with a
                         // 200 status code, which will appear under Listener.onResponse instead
                         IsAvailableResponsePayload payload = new IsAvailableResponsePayload();
+                        payload.value = value;
+                        payload.type = type;
+
                         payload.error = new IsAvailableError(((WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newCheckedIsAvailableAction(payload));
                     }


### PR DESCRIPTION
Fixes a NPE if an `is-available` request returns an error.