### PR TITLE
Use lenient mode when parsing with Gson

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
     compile 'com.squareup.okhttp3:okhttp-urlconnection:3.4.1'
     compile 'com.android.volley:volley:1.0.0'
-    compile 'com.google.code.gson:gson:2.4'
+    compile 'com.google.code.gson:gson:2.7'
     compile 'com.google.dagger:dagger:2.0.2'
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -74,6 +74,7 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
 
     private GsonBuilder setupGsonBuilder() {
         GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.setLenient();
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrFalse.class, new JsonObjectOrFalseDeserializer());
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrEmptyArray.class,
                 new JsonObjectOrEmptyArrayDeserializer());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -24,9 +25,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaWPComRestResponse.MultipleMediaResponse;
 import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
-import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
 import org.wordpress.android.fluxc.utils.MediaUtils;
@@ -34,6 +35,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -277,8 +279,12 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                 if (response.isSuccessful()) {
                     AppLog.d(T.MEDIA, "media upload successful: " + response);
                     String jsonBody = response.body().string();
-                    MultipleMediaResponse mediaResponse =
-                            new Gson().fromJson(jsonBody, MultipleMediaResponse.class);
+
+                    Gson gson = new Gson();
+                    JsonReader reader = new JsonReader(new StringReader(jsonBody));
+                    reader.setLenient(true);
+                    MultipleMediaResponse mediaResponse = gson.fromJson(reader, MultipleMediaResponse.class);
+
                     List<MediaModel> responseMedia = getMediaListFromRestResponse(mediaResponse, siteModel.getId());
                     if (responseMedia != null && !responseMedia.isEmpty()) {
                         MediaModel uploadedMedia = responseMedia.get(0);


### PR DESCRIPTION
I was not confident doing so, but the doc specifies "ignored" syntax errors, and it seems fair:

http://static.javadoc.io/com.google.code.gson/gson/2.8.0/com/google/gson/stream/JsonReader.html#setLenient-boolean-

We can still get syntax errors if the response is totally broken.