### PR TITLE
Fetch uploaded media only if mediaId is known

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -172,6 +172,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                             AppLog.d(T.MEDIA, "media upload successful, local id=" + media.getId());
                             // We only get the media Id from the response
                             media.setMediaId(responseMedia.getMediaId());
+                            // Upload media response only has `type, id, file, url` fields whereas we need
+                            // `parent, title, caption, description, videopress_shortcode, thumbnail,
+                            // date_created_gmt, link, width, height` fields, so we need to make a fetch for them
                             fetchMedia(site, media, true);
                         }
                     } catch (XMLRPCException fault) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -172,8 +172,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                             AppLog.d(T.MEDIA, "media upload successful, local id=" + media.getId());
                             // We only get the media Id from the response
                             media.setMediaId(responseMedia.getMediaId());
+                            fetchMedia(site, media, true);
                         }
-                        fetchMedia(site, media, true);
                     } catch (XMLRPCException fault) {
                         MediaError mediaError = getMediaErrorFromXMLRPCException(fault);
                         AppLog.w(T.MEDIA, "media upload failed with error: " + mediaError.message);


### PR DESCRIPTION
There is no point trying to fetch the uploaded media if the `mediaId` is unknown and the only way we actually get that mediaId is if we could parse the response.

I don't exactly remember why we were doing the fetch in the first place, but if I remember correctly it's to get some missing details from the response. So, I am leaving it in there.