### PR TITLE
Small consistency fixes to upload media

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -294,9 +294,11 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         MediaStore.MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
                         notifyMediaUploaded(media, error);
                     }
+                    mCurrentUploadCall = null;
                 } else {
                     AppLog.w(T.MEDIA, "error uploading media: " + response);
                     notifyMediaUploaded(media, parseUploadError(response));
+                    mCurrentUploadCall = null;
                 }
             }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -124,7 +124,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
         if (!MediaUtils.canReadFile(media.getFilePath())) {
             MediaStore.MediaError error = new MediaError(MediaErrorType.FS_READ_PERMISSION_DENIED);
-            notifyMediaProgress(media, 0.f, error);
+            notifyMediaUploaded(media, error);
             return;
         }
 
@@ -177,12 +177,12 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                     } catch (XMLRPCException fault) {
                         MediaError mediaError = getMediaErrorFromXMLRPCException(fault);
                         AppLog.w(T.MEDIA, "media upload failed with error: " + mediaError.message);
-                        notifyMediaProgress(media, 0.f, mediaError);
+                        notifyMediaUploaded(media, mediaError);
                     }
                 } else {
                     AppLog.w(T.MEDIA, "error uploading media: " + response.message());
                     MediaError error = new MediaError(MediaErrorType.fromHttpStatusCode(response.code()));
-                    notifyMediaProgress(media, 0.f, error);
+                    notifyMediaUploaded(media, error);
                 }
                 mCurrentUploadCall = null;
             }
@@ -192,7 +192,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 AppLog.w(T.MEDIA, "media upload failed: " + e);
                 MediaStore.MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
                 error.message = e.getLocalizedMessage();
-                notifyMediaProgress(media, 0.f, error);
+                notifyMediaUploaded(media, error);
                 mCurrentUploadCall = null;
             }
         });


### PR DESCRIPTION
In `MediaRestClient` we use `notifyMediaUploaded` to report an error and in `MediaXMLRPCClient` we use `notifyMediaProgress`. I think these should be consistent, so I changed the `MediaXMLRPCClient` because I think `notifyMediaUploaded` makes more sense since it's final.

I also found that we nullify the current upload call in `MediaXMLRPCClient` and not in `MediaRestClient`, so I made that change as well in the same branch (sorry for the naming).