### PR TITLE
Media uploading first fix

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -25,6 +25,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 public abstract class BaseRequest<T> extends Request<T> {
     public static final int DEFAULT_REQUEST_TIMEOUT = 30000;
+    public static final int DEFAULT_READ_REQUEST_TIMEOUT = 60000;
     public Uri mUri;
 
     public interface OnAuthFailedListener {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -25,7 +25,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 public abstract class BaseRequest<T> extends Request<T> {
     public static final int DEFAULT_REQUEST_TIMEOUT = 30000;
-    public static final int DEFAULT_REQUEST_READ_TIMEOUT = 60000;
+    public static final int UPLOAD_REQUEST_READ_TIMEOUT = 60000;
     public Uri mUri;
 
     public interface OnAuthFailedListener {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -25,7 +25,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 public abstract class BaseRequest<T> extends Request<T> {
     public static final int DEFAULT_REQUEST_TIMEOUT = 30000;
-    public static final int DEFAULT_READ_REQUEST_TIMEOUT = 60000;
+    public static final int DEFAULT_REQUEST_READ_TIMEOUT = 60000;
     public Uri mUri;
 
     public interface OnAuthFailedListener {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -70,7 +70,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
         mOkHttpClient = okClientBuilder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .readTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.DEFAULT_READ_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .build();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -70,7 +70,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
         mOkHttpClient = okClientBuilder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .readTimeout(BaseRequest.DEFAULT_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .build();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -70,7 +70,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
         mOkHttpClient = okClientBuilder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .readTimeout(BaseRequest.DEFAULT_READ_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.DEFAULT_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .build();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -67,7 +67,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
         mOkHttpClient = okClientBuilder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .readTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .build();
     }


### PR DESCRIPTION
Fix #370 by setting the read_timeout to 60secs.

Not sure how you can reproduce the issue, but you could try by uploading big pictures or videos to your dotcom blog. All the details in the ticket.