### PR TITLE
Add email_verified field to Account fetch response

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -20,6 +20,7 @@ public class AccountModel extends Payload implements Identifiable {
     @Column private String mProfileUrl; // profile_URL
     @Column private String mAvatarUrl; // avatar_URL
     @Column private long mPrimarySiteId;
+    @Column private boolean mEmailVerified;
     @Column private int mSiteCount;
     @Column private int mVisibleSiteCount;
     @Column private String mEmail;
@@ -63,6 +64,7 @@ public class AccountModel extends Payload implements Identifiable {
                && StringUtils.equals(getAvatarUrl(), otherAccount.getAvatarUrl())
                && getPrimarySiteId() == otherAccount.getPrimarySiteId()
                && getSiteCount() == otherAccount.getSiteCount()
+               && getEmailVerified() == otherAccount.getEmailVerified()
                && getVisibleSiteCount() == otherAccount.getVisibleSiteCount()
                && StringUtils.equals(getFirstName(), otherAccount.getFirstName())
                && StringUtils.equals(getLastName(), otherAccount.getLastName())
@@ -82,6 +84,7 @@ public class AccountModel extends Payload implements Identifiable {
         mAvatarUrl = "";
         mPrimarySiteId = 0;
         mSiteCount = 0;
+        mEmailVerified = false;
         mVisibleSiteCount = 0;
         mEmail = "";
         mFirstName = "";
@@ -108,6 +111,7 @@ public class AccountModel extends Payload implements Identifiable {
         setVisibleSiteCount(other.getVisibleSiteCount());
         setEmail(other.getEmail());
         setHasUnseenNotes(other.getHasUnseenNotes());
+        setEmailVerified(other.getEmailVerified());
     }
 
     /**
@@ -173,6 +177,14 @@ public class AccountModel extends Payload implements Identifiable {
 
     public void setAvatarUrl(String avatarUrl) {
         mAvatarUrl = avatarUrl;
+    }
+
+    public boolean getEmailVerified() {
+        return mEmailVerified;
+    }
+
+    public void setEmailVerified(boolean emailVerified) {
+        mEmailVerified = emailVerified;
     }
 
     public int getSiteCount() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -84,7 +84,7 @@ public class AccountModel extends Payload implements Identifiable {
         mAvatarUrl = "";
         mPrimarySiteId = 0;
         mSiteCount = 0;
-        mEmailVerified = false;
+        mEmailVerified = true;
         mVisibleSiteCount = 0;
         mEmail = "";
         mFirstName = "";

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountResponse.java
@@ -16,6 +16,7 @@ public class AccountResponse implements Response {
     public long primary_blog;
     public String avatar_URL;
     public String profile_URL;
+    public boolean email_verified;
     public String date;
     public int site_count;
     public int visible_site_count;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -299,6 +299,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         account.setPrimarySiteId(from.primary_blog);
         account.setAvatarUrl(from.avatar_URL);
         account.setProfileUrl(from.profile_URL);
+        account.setEmailVerified(from.email_verified);
         account.setDate(from.date);
         account.setSiteCount(from.site_count);
         account.setVisibleSiteCount(from.visible_site_count);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -42,7 +42,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 3;
+        return 4;
     }
 
     @Override
@@ -71,6 +71,10 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 2:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add FRAME_NONCE text;");
+                oldVersion++;
+            case 3:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table AccountModel add EMAIL_VERIFIED boolean;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
See wordpress-mobile/WordPress-Android#4600 for details.

This PR updates the Account response handling to store the `email_verified` field, required for referenced issue in WP-Android.

cc @maxme 