### PR TITLE
Example app: Add the ability to upload Video

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -126,16 +126,17 @@ public class MediaFragment extends Fragment {
             }
         });
 
-        view.findViewById(R.id.upload_media).setOnClickListener(new View.OnClickListener() {
+        view.findViewById(R.id.upload_image).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (mSite == null) {
-                    prependToLog("Site is null, cannot request upload media.");
-                    return;
-                }
-                Intent intent = new Intent(Intent.ACTION_PICK);
-                intent.setType("image/*");
-                startActivityForResult(intent, RESULT_PICK_MEDIA);
+                uploadMedia(false);
+            }
+        });
+
+        view.findViewById(R.id.upload_video).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                uploadMedia(true);
             }
         });
 
@@ -247,6 +248,16 @@ public class MediaFragment extends Fragment {
             prependToLog("Upload error: " + event.error.type + ", message: " + event.error.message);
             mCurrentUpload = null;
         }
+    }
+
+    private void uploadMedia(boolean isVideo) {
+        if (mSite == null) {
+            prependToLog("Site is null, cannot request upload media.");
+            return;
+        }
+        Intent intent = new Intent(Intent.ACTION_PICK);
+        intent.setType(isVideo ? "video/*" : "image/*");
+        startActivityForResult(intent, RESULT_PICK_MEDIA);
     }
 
     private void prependToLog(final String s) {

--- a/example/src/main/res/layout/fragment_media.xml
+++ b/example/src/main/res/layout/fragment_media.xml
@@ -19,10 +19,16 @@
         android:text="Fetch" />
 
     <Button
-        android:id="@+id/upload_media"
+        android:id="@+id/upload_image"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Upload" />
+        android:text="Upload Image" />
+
+    <Button
+        android:id="@+id/upload_video"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Upload Video" />
 
     <Button
         android:id="@+id/cancel_upload"


### PR DESCRIPTION
This PR adds the ability to upload Videos from the example app.

I thought it was easy as changing the `type` of the picker intent, setting it to ` intent.setType("image/*, video/*");`, instead it seems that the default picker does ignore everything after the first type. 
No matter how you wrote the allowable types. I then added a 2nd button to upload video.