### PR TITLE
Media upload -  Handle 413 HTTP error

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -322,6 +322,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         } else if (response.code() == 413) {
             mediaError.type = MediaErrorType.REQUEST_TOO_LARGE;
             mediaError.message = response.message();
+            return mediaError;
         }
         try {
             JSONObject body = new JSONObject(response.body().string());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -319,6 +319,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         MediaError mediaError = new MediaError(MediaErrorType.GENERIC_ERROR);
         if (response.code() == 403) {
             mediaError.type = MediaErrorType.AUTHORIZATION_REQUIRED;
+        } else if (response.code() == 413) {
+            mediaError.type = MediaErrorType.REQUEST_TOO_LARGE;
+            mediaError.message = response.message();
         }
         try {
             JSONObject body = new JSONObject(response.body().string());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -185,6 +185,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 } else {
                     AppLog.w(T.MEDIA, "error uploading media: " + response.message());
                     MediaError error = new MediaError(MediaErrorType.fromHttpStatusCode(response.code()));
+                    error.message = response.message();
                     notifyMediaUploaded(media, error);
                 }
                 mCurrentUploadCall = null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -192,6 +192,7 @@ public class MediaStore extends Store {
         AUTHORIZATION_REQUIRED,
         PARSE_ERROR,
         NOT_AUTHENTICATED,
+        REQUEST_TOO_LARGE,
 
         // unknown/unspecified
         GENERIC_ERROR;
@@ -217,6 +218,8 @@ public class MediaStore extends Store {
                     return MediaErrorType.NOT_FOUND;
                 case 403:
                     return MediaErrorType.NOT_AUTHENTICATED;
+                case 413:
+                    return MediaErrorType.REQUEST_TOO_LARGE;
                 default:
                     return MediaErrorType.GENERIC_ERROR;
             }


### PR DESCRIPTION
This PR adds the ability to correctly reporting the HTTP 413 error up to the client. 

HTTP 413 is thrown by web servers when the uploaded media is too large. Usually when the `max_post_size` is reached.

To test this fix try to upload a media file to a web server configured to accept small files only. 
I've a self-hosted installation already configured for that on altervista.org. Ping me if you want the credentials.

cc @oguzkocer 