### PR TITLE
Handle /read/feed/$feed_url_or_id endpoint processing

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -59,6 +59,8 @@ public class WPComEndpointTest {
 
         // Magic link email sender
         assertEquals("/auth/send-login-email/", WPCOMREST.auth.send_login_email.getEndpoint());
+
+        assertEquals("/read/feed/56/", WPCOMREST.read.feed.feed_url_or_id(56).getEndpoint());
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -61,6 +61,7 @@ public class WPComEndpointTest {
         assertEquals("/auth/send-login-email/", WPCOMREST.auth.send_login_email.getEndpoint());
 
         assertEquals("/read/feed/56/", WPCOMREST.read.feed.feed_url_or_id(56).getEndpoint());
+        assertEquals("/read/feed/somewhere.site/", WPCOMREST.read.feed.feed_url_or_id("somewhere.site").getEndpoint());
     }
 
     @Test

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
@@ -72,7 +72,7 @@ public class EndpointNode {
             // For 'mixed' endpoints, e.g. item:$theItem, return the label part ('item')
             return getLocalEndpoint().substring(0, getLocalEndpoint().indexOf(":")).replaceAll("-", "_");
         } else {
-            return getLocalEndpoint().replaceAll("/|\\$|#.*|_ID|_id|<|>", "").replaceAll("-", "_");
+            return getLocalEndpoint().replaceAll("/|\\$|#.*|(?<!_or)(_ID|_id)|<|>", "").replaceAll("-", "_");
         }
     }
 

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/RESTPoet.java
@@ -151,7 +151,7 @@ public class RESTPoet {
             // Add a constructor for each type this endpoint accepts (usually long)
             for (Class endpointType : getVariableEndpointTypes(endpointNode)) {
                 String variableName = endpointName;
-                if (endpointType.equals(long.class) && !endpointName.equals("id")) {
+                if (endpointType.equals(long.class) && !endpointName.toLowerCase(Locale.US).endsWith("id")) {
                     variableName = endpointName + "Id";
                 }
 
@@ -200,7 +200,7 @@ public class RESTPoet {
             }
 
             String variableName = endpointName;
-            if (endpointType.equals(long.class) && !endpointName.equals("id")) {
+            if (endpointType.equals(long.class) && !endpointName.toLowerCase(Locale.US).endsWith("id")) {
                 variableName = endpointName + "Id";
             }
 

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -1,3 +1,10 @@
+/auth/send-login-email/
+
+/is-available/blog/
+/is-available/domain/
+/is-available/email/
+/is-available/username/
+
 /me/
 /me/settings/
 /me/sites/
@@ -5,10 +12,22 @@
 /read/feed/$feed_url_or_id#long,String
 
 /sites/
-/sites/new/
-/sites/$site/post-formats/
 /sites/$site/delete
 /sites/$site/exports/start
+/sites/$site/post-formats/
+/sites/new/
+
+/sites/$site/comments/
+/sites/$site/comments/$comment_ID
+/sites/$site/comments/$comment_ID/delete
+/sites/$site/comments/$comment_ID/likes/new
+/sites/$site/comments/$comment_ID/likes/mine/delete
+/sites/$site/comments/$comment_ID/replies/new
+
+/sites/$site/media/
+/sites/$site/media/$media_ID/
+/sites/$site/media/$media_ID/delete/
+/sites/$site/media/new/
 
 /sites/$site/posts/
 /sites/$site/posts/$post_ID/
@@ -17,27 +36,8 @@
 /sites/$site/posts/new/
 /sites/$site/posts/slug:$post_slug#String/
 
-/sites/$site/media/
-/sites/$site/media/$media_ID/
-/sites/$site/media/$media_ID/delete/
-/sites/$site/media/new/
-
-/sites/$site/comments/
-/sites/$site/comments/$comment_ID
-/sites/$site/comments/$comment_ID/delete
-/sites/$site/comments/$comment_ID/replies/new
-/sites/$site/comments/$comment_ID/likes/new
-/sites/$site/comments/$comment_ID/likes/mine/delete
-
 /sites/$site/taxonomies/$taxonomy#String/terms/
 /sites/$site/taxonomies/$taxonomy#String/terms/new/
 /sites/$site/taxonomies/$taxonomy#String/terms/slug:$slug#String/
 
 /users/new/
-
-/is-available/email/
-/is-available/username/
-/is-available/blog/
-/is-available/domain/
-
-/auth/send-login-email/

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -2,7 +2,7 @@
 /me/settings/
 /me/sites/
 
-/read/feed/$feed_url_or_id
+/read/feed/$feed_url_or_id#long,String
 
 /sites/
 /sites/new/

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -2,6 +2,8 @@
 /me/settings/
 /me/sites/
 
+/read/feed/$feed_url_or_id
+
 /sites/
 /sites/new/
 /sites/$site/post-formats/


### PR DESCRIPTION
Addresses item 2 in #128:

> Fix stripping of _id from /read/feed/$feed_url_or_id (or create a new rule that catches this case) ref: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/126#issuecomment-240675471

I ended up just adding the endpoint itself - we'll eventually need it for `ReaderStore` anyway. In the meantime it's useful for testing this PR and as an example of using mixed-type endpoints, which were added in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/181.