### PR TITLE
Handle media upload cancel event

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -231,7 +231,11 @@ public class MediaFragment extends Fragment {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaUploaded(OnMediaUploaded event) {
         if (!event.isError()) {
-            if (event.progress < 0.f) {
+            if (event.canceled) {
+                prependToLog("Upload cancelled");
+                mCancelButton.setEnabled(false);
+                mCurrentUpload = null;
+            } else if (event.progress < 0.f) {
                 prependToLog("Upload canceled: " + event.media.getFileName());
                 mCancelButton.setEnabled(false);
                 mCurrentUpload = null;

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -235,10 +235,6 @@ public class MediaFragment extends Fragment {
                 prependToLog("Upload canceled");
                 mCancelButton.setEnabled(false);
                 mCurrentUpload = null;
-            } else if (event.progress < 0.f) {
-                prependToLog("Upload canceled: " + event.media.getFileName());
-                mCancelButton.setEnabled(false);
-                mCurrentUpload = null;
             } else if (event.completed) {
                 prependToLog("Successfully uploaded localId=" + mCurrentUpload.getId()
                              + " - url=" + event.media.getUrl());

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -232,7 +232,7 @@ public class MediaFragment extends Fragment {
     public void onMediaUploaded(OnMediaUploaded event) {
         if (!event.isError()) {
             if (event.canceled) {
-                prependToLog("Upload cancelled");
+                prependToLog("Upload canceled");
                 mCancelButton.setEnabled(false);
                 mCurrentUpload = null;
             } else if (event.progress < 0.f) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -232,7 +232,7 @@ public class MediaFragment extends Fragment {
     public void onMediaUploaded(OnMediaUploaded event) {
         if (!event.isError()) {
             if (event.canceled) {
-                prependToLog("Upload canceled : " + event.media.getFileName());
+                prependToLog("Upload canceled: " + event.media.getFileName());
                 mCancelButton.setEnabled(false);
                 mCurrentUpload = null;
             } else if (event.completed) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -232,7 +232,7 @@ public class MediaFragment extends Fragment {
     public void onMediaUploaded(OnMediaUploaded event) {
         if (!event.isError()) {
             if (event.canceled) {
-                prependToLog("Upload canceled");
+                prependToLog("Upload canceled : " + event.media.getFileName());
                 mCancelButton.setEnabled(false);
                 mCurrentUpload = null;
             } else if (event.completed) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -228,7 +228,7 @@ public abstract class BaseRequest<T> extends Request<T> {
 
     @Override
     public final void deliverError(VolleyError volleyError) {
-        AppLog.e(AppLog.T.API, "Volley error", volleyError);
+        AppLog.e(AppLog.T.API, "Volley error on " + getUrl(), volleyError);
         if (volleyError instanceof ParseError) {
             OnUnexpectedError error = new OnUnexpectedError(volleyError, "API response parse error");
             error.addExtra("url", getUrl());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -303,7 +303,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
             @Override
             public void onFailure(Call call, IOException e) {
                 if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
-                    // Do not report errors since the upload was cancelled
+                    // Do not report errors since the upload was canceled
                     mCurrentUploadCall = null;
                     return;
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -248,7 +248,6 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
             AppLog.d(T.MEDIA, "Canceled in-progress upload: " + media.getFileName());
             mCurrentUploadCall.cancel();
-            mCurrentUploadCall = null;
         }
         // always report without error
         notifyMediaUploadCanceled(media);
@@ -294,19 +293,24 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         MediaStore.MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
                         notifyMediaUploaded(media, error);
                     }
-                    mCurrentUploadCall = null;
                 } else {
                     AppLog.w(T.MEDIA, "error uploading media: " + response);
                     notifyMediaUploaded(media, parseUploadError(response));
-                    mCurrentUploadCall = null;
                 }
+                mCurrentUploadCall = null;
             }
 
             @Override
             public void onFailure(Call call, IOException e) {
+                if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
+                    // Do not report errors since the upload was cancelled
+                    mCurrentUploadCall = null;
+                    return;
+                }
                 AppLog.w(T.MEDIA, "media upload failed: " + e);
                 MediaStore.MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
                 notifyMediaUploaded(media, error);
+                mCurrentUploadCall = null;
             }
         });
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -248,9 +248,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
             AppLog.d(T.MEDIA, "Canceled in-progress upload: " + media.getFileName());
             mCurrentUploadCall.cancel();
+            // always report without error
+            notifyMediaUploadCanceled(media);
         }
-        // always report without error
-        notifyMediaUploadCanceled(media);
     }
 
     private void performUpload(final MediaModel media, final SiteModel siteModel) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -335,9 +335,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         // cancel in-progress upload if necessary
         if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
             mCurrentUploadCall.cancel();
+            // always report without error
+            notifyMediaUploadCanceled(media);
         }
-        // always report without error
-        notifyMediaUploadCanceled(media);
     }
 
     //

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -194,7 +194,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             @Override
             public void onFailure(Call call, IOException e) {
                 if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
-                    // Do not report errors since the upload was cancelled
+                    // Do not report errors since the upload was canceled
                     mCurrentUploadCall = null;
                     return;
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -193,6 +193,12 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
             @Override
             public void onFailure(Call call, IOException e) {
+                if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
+                    // Do not report errors since the upload was cancelled
+                    mCurrentUploadCall = null;
+                    return;
+                }
+
                 AppLog.w(T.MEDIA, "media upload failed: " + e);
                 MediaStore.MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
                 error.message = e.getLocalizedMessage();
@@ -329,7 +335,6 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         // cancel in-progress upload if necessary
         if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
             mCurrentUploadCall.cancel();
-            mCurrentUploadCall = null;
         }
         // always report without error
         notifyMediaUploadCanceled(media);


### PR DESCRIPTION
Fix #368 by checking if the connection was cancelled in the onFailure callback.

cc @oguzkocer 