### PR TITLE
Fix offset calculation when fetching more pages

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -344,7 +344,7 @@ public class PostStore extends Store {
     private void fetchPosts(FetchPostsPayload payload, boolean pages) {
         int offset = 0;
         if (payload.loadMore) {
-            offset = getUploadedPostsCountForSite(payload.site);
+            offset = PostSqlUtils.getUploadedPostsForSite(payload.site, pages).size();
         }
 
         if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {


### PR DESCRIPTION
We were using the wrong method when getting the current number of fetched pages, so our offset was never changing as more pages were fetched.