### PR TITLE
Use REST client when cancelling media uploads to Jetpack sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -563,7 +563,7 @@ public class MediaStore extends Store {
 
     private void performCancelUpload(@NonNull MediaPayload payload) {
         if (payload.media != null) {
-            if (payload.site.isWPCom()) {
+            if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
                 mMediaRestClient.cancelUpload(payload.media);
             } else {
                 mMediaXmlrpcClient.cancelUpload(payload.media);


### PR DESCRIPTION
Noticed a case where we weren't using the WP.com REST client for Jetpack sites.