### PR TITLE
Issue/368 handle cancel upload event take 2

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -231,7 +231,7 @@ public class MediaFragment extends Fragment {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaUploaded(OnMediaUploaded event) {
         if (!event.isError()) {
-            if (event.progress < 0.f) {
+            if (event.canceled) {
                 prependToLog("Upload canceled: " + event.media.getFileName());
                 mCancelButton.setEnabled(false);
                 mCurrentUpload = null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -248,7 +248,6 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
             AppLog.d(T.MEDIA, "Canceled in-progress upload: " + media.getFileName());
             mCurrentUploadCall.cancel();
-            // always report without error
             notifyMediaUploadCanceled(media);
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -302,7 +302,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
             @Override
             public void onFailure(Call call, IOException e) {
                 if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
-                    // Do not report errors since the upload was canceled
+                    // Do not report errors since the upload was canceled and notified separately
                     mCurrentUploadCall = null;
                     return;
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -248,10 +248,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
             AppLog.d(T.MEDIA, "Canceled in-progress upload: " + media.getFileName());
             mCurrentUploadCall.cancel();
-            mCurrentUploadCall = null;
+            // always report without error
+            notifyMediaUploadCanceled(media);
         }
-        // always report without error
-        notifyMediaUploadCanceled(media);
     }
 
     private void performUpload(final MediaModel media, final SiteModel siteModel) {
@@ -294,19 +293,24 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         MediaStore.MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
                         notifyMediaUploaded(media, error);
                     }
-                    mCurrentUploadCall = null;
                 } else {
                     AppLog.w(T.MEDIA, "error uploading media: " + response);
                     notifyMediaUploaded(media, parseUploadError(response));
-                    mCurrentUploadCall = null;
                 }
+                mCurrentUploadCall = null;
             }
 
             @Override
             public void onFailure(Call call, IOException e) {
+                if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
+                    // Do not report errors since the upload was canceled
+                    mCurrentUploadCall = null;
+                    return;
+                }
                 AppLog.w(T.MEDIA, "media upload failed: " + e);
                 MediaStore.MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
                 notifyMediaUploaded(media, error);
+                mCurrentUploadCall = null;
             }
         });
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -194,7 +194,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             @Override
             public void onFailure(Call call, IOException e) {
                 if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
-                    // Do not report errors since the upload was canceled
+                    // Do not report errors since the upload was canceled and notified separately
                     mCurrentUploadCall = null;
                     return;
                 }
@@ -334,7 +334,6 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         // cancel in-progress upload if necessary
         if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
             mCurrentUploadCall.cancel();
-            // always report without error
             notifyMediaUploadCanceled(media);
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -193,6 +193,11 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
             @Override
             public void onFailure(Call call, IOException e) {
+                if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
+                    // Do not report errors since the upload was canceled
+                    mCurrentUploadCall = null;
+                    return;
+                }
                 AppLog.w(T.MEDIA, "media upload failed: " + e);
                 MediaStore.MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
                 error.message = e.getLocalizedMessage();
@@ -329,10 +334,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         // cancel in-progress upload if necessary
         if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
             mCurrentUploadCall.cancel();
-            mCurrentUploadCall = null;
+            // always report without error
+            notifyMediaUploadCanceled(media);
         }
-        // always report without error
-        notifyMediaUploadCanceled(media);
     }
 
     //


### PR DESCRIPTION
Fix #368 by checking if the connection was cancelled in the onFailure callback.

Opened this new PR since the original one w(https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/385) was messed up by me :/ 

cc @oguzkocer - Feel free to close both PRs once merged.