### PR TITLE
Fix #391: Guard against null media thumnails response from WP.com REST

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -430,7 +430,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         media.setCaption(from.caption);
         media.setDescription(from.description);
         media.setAlt(from.alt);
-        media.setThumbnailUrl(from.thumbnails.thumbnail);
+        if (from.thumbnails != null) {
+            media.setThumbnailUrl(from.thumbnails.thumbnail);
+        }
         media.setHeight(from.height);
         media.setWidth(from.width);
         media.setLength(from.length);


### PR DESCRIPTION
I did a check for other instances where we're parsing a Gson response from WP.com REST responses, this looks to be the only nested case we've missed a null check for.