### PR TITLE
Fix #393: Account for missing home_url in wp.getOptions

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -223,7 +223,11 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
 
     private SiteModel updateSiteFromOptions(Object response, SiteModel oldModel) {
         Map<?, ?> siteOptions = (Map<?, ?>) response;
-        oldModel.setName(getOption(siteOptions, SITE_TITLE_KEY, String.class));
+        String siteTitle = getOption(siteOptions, SITE_TITLE_KEY, String.class);
+        if (!TextUtils.isEmpty(siteTitle)) {
+            oldModel.setName(siteTitle);
+        }
+
         // TODO: set a canonical URL here
         String homeUrl = getOption(siteOptions, HOME_URL_KEY, String.class);
         if (!TextUtils.isEmpty(homeUrl)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.xmlrpc.site;
 
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
@@ -225,7 +226,10 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         Map<?, ?> siteOptions = (Map<?, ?>) response;
         oldModel.setName(getOption(siteOptions, SITE_TITLE_KEY, String.class));
         // TODO: set a canonical URL here
-        oldModel.setUrl(getOption(siteOptions, HOME_URL_KEY, String.class));
+        String homeUrl = getOption(siteOptions, HOME_URL_KEY, String.class);
+        if (!TextUtils.isEmpty(homeUrl)) {
+            oldModel.setUrl(homeUrl);
+        }
         oldModel.setSoftwareVersion(getOption(siteOptions, SOFTWARE_VERSION_KEY, String.class));
         Boolean postThumbnail = getOption(siteOptions, POST_THUMBNAIL_KEY, Boolean.class);
         oldModel.setIsFeaturedImageSupported((postThumbnail != null) && postThumbnail);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -155,14 +155,13 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             if (!(siteObject instanceof HashMap)) {
                 continue;
             }
-            HashMap<String, ?> siteMap = (HashMap<String, ?>) siteObject;
+            HashMap<?, ?> siteMap = (HashMap<?, ?>) siteObject;
             SiteModel site = new SiteModel();
-            // TODO: use MapUtils.getX(map,"", defaultValue) here
-            site.setSelfHostedSiteId(Integer.parseInt((String) siteMap.get(SITE_ID_KEY)));
-            site.setName((String) siteMap.get(SITE_NAME_KEY));
-            site.setUrl((String) siteMap.get(SITE_URL_KEY));
-            site.setXmlRpcUrl((String) siteMap.get(SITE_XMLRPC_URL_KEY));
-            site.setIsSelfHostedAdmin((Boolean) siteMap.get(SITE_ADMIN_KEY));
+            site.setSelfHostedSiteId(MapUtils.getMapInt(siteMap, SITE_ID_KEY, 1));
+            site.setName(MapUtils.getMapStr(siteMap, SITE_NAME_KEY));
+            site.setUrl(MapUtils.getMapStr(siteMap, SITE_URL_KEY));
+            site.setXmlRpcUrl(MapUtils.getMapStr(siteMap, SITE_XMLRPC_URL_KEY));
+            site.setIsSelfHostedAdmin(MapUtils.getMapBool(siteMap, SITE_ADMIN_KEY));
             // From what we know about the host
             site.setIsWPCom(false);
             site.setUsername(username);


### PR DESCRIPTION
Apparently `wp.getOptions` can be missing `home_url`, and we're ignoring the `@NonNull` annotation in `SiteModel.setUrl()`, causing the crash.

Since we already might have the `home_url` from `wp.getUsersBlogs`, I opted to just not update it if it's null or empty. Even if it's missing from both responses, we mostly use it for display purposes and the app can function without it (I'd like to do a sanity check with `SiteModel.getUrl()` returning `null` in WPAndroid to be sure though).

cc @maxme