### PR TITLE
Site client cleanup

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -42,17 +42,6 @@ import javax.inject.Singleton;
 
 @Singleton
 public class SiteRestClient extends BaseWPComRestClient {
-    //
-    // New site request keys
-    //
-    public static final String SITE_NAME_KEY = "blog_name";
-    public static final String SITE_TITLE_KEY = "blog_title";
-    public static final String LANGUAGE_ID_KEY = "lang_id";
-    public static final String PUBLIC_KEY = "public";
-    public static final String VALIDATE_KEY = "validate";
-    public static final String CLIENT_ID_KEY = "client_id";
-    public static final String CLIENT_SECRET_KEY = "client_secret";
-
     public static final int NEW_SITE_TIMEOUT_MS = 90000;
 
     private final AppSecrets mAppSecrets;
@@ -179,13 +168,13 @@ public class SiteRestClient extends BaseWPComRestClient {
                         @NonNull SiteVisibility visibility, final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1();
         Map<String, Object> body = new HashMap<>();
-        body.put(SITE_NAME_KEY, siteName);
-        body.put(SITE_TITLE_KEY, siteTitle);
-        body.put(LANGUAGE_ID_KEY, language);
-        body.put(PUBLIC_KEY, visibility.toString());
-        body.put(VALIDATE_KEY, dryRun ? "1" : "0");
-        body.put(CLIENT_ID_KEY, mAppSecrets.getAppId());
-        body.put(CLIENT_SECRET_KEY, mAppSecrets.getAppSecret());
+        body.put("blog_name", siteName);
+        body.put("blog_title", siteTitle);
+        body.put("lang_id", language);
+        body.put("public", visibility.toString());
+        body.put("validate", dryRun ? "1" : "0");
+        body.put("client_id", mAppSecrets.getAppId());
+        body.put("client_secret", mAppSecrets.getAppSecret());
 
         WPComGsonRequest<NewSiteResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 NewSiteResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
@@ -43,7 +43,7 @@ public class XMLRPCUtils {
         return defaultValue;
     }
 
-    public static <T> T safeGetMap(@NonNull Map<?, ?> map, String key, T defaultValue) {
+    public static <T> T safeGetNestedMapValue(@NonNull Map<?, ?> map, String key, T defaultValue) {
         if (!map.containsKey(key)) {
             return defaultValue;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -29,29 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 public class SiteXMLRPCClient extends BaseXMLRPCClient {
-    //
-    // Site fetch request keys
-    //
-    public static final String SOFTWARE_VERSION_KEY = "software_version";
-    public static final String POST_THUMBNAIL_KEY = "post_thumbnail";
-    public static final String DEFAULT_COMMENT_STATUS_KEY = "default_comment_status";
-    public static final String JETPACK_CLIENT_ID_KEY = "jetpack_client_id";
-    public static final String SITE_PUBLIC_KEY = "blog_public";
-    public static final String HOME_URL_KEY = "home_url";
-    public static final String ADMIN_URL_KEY = "admin_url";
-    public static final String LOGIN_URL_KEY = "login_url";
-    public static final String SITE_TITLE_KEY = "blog_title";
-    public static final String TIME_ZONE_KEY = "time_zone";
-
-    //
-    // Sites response keys
-    //
-    public static final String SITE_ID_KEY = "blogid";
-    public static final String SITE_NAME_KEY = "blogName";
-    public static final String SITE_URL_KEY = "url";
-    public static final String SITE_XMLRPC_URL_KEY = "xmlrpc";
-    public static final String SITE_ADMIN_KEY = "isAdmin";
-
     public SiteXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,
                             UserAgent userAgent, HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
@@ -94,8 +71,8 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         params.add(site.getUsername());
         params.add(site.getPassword());
         params.add(new String[] {
-                SOFTWARE_VERSION_KEY, POST_THUMBNAIL_KEY, DEFAULT_COMMENT_STATUS_KEY, JETPACK_CLIENT_ID_KEY,
-                SITE_PUBLIC_KEY, HOME_URL_KEY, ADMIN_URL_KEY, LOGIN_URL_KEY, SITE_TITLE_KEY, TIME_ZONE_KEY });
+                "software_version", "post_thumbnail", "default_comment_status", "jetpack_client_id",
+                "blog_public", "home_url", "admin_url", "login_url", "blog_title", "time_zone" });
         final XMLRPCRequest request = new XMLRPCRequest(
                 site.getXmlRpcUrl(), XMLRPC.GET_OPTIONS, params,
                 new Listener<Object>() {
@@ -157,11 +134,11 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             }
             HashMap<?, ?> siteMap = (HashMap<?, ?>) siteObject;
             SiteModel site = new SiteModel();
-            site.setSelfHostedSiteId(MapUtils.getMapInt(siteMap, SITE_ID_KEY, 1));
-            site.setName(MapUtils.getMapStr(siteMap, SITE_NAME_KEY));
-            site.setUrl(MapUtils.getMapStr(siteMap, SITE_URL_KEY));
-            site.setXmlRpcUrl(MapUtils.getMapStr(siteMap, SITE_XMLRPC_URL_KEY));
-            site.setIsSelfHostedAdmin(MapUtils.getMapBool(siteMap, SITE_ADMIN_KEY));
+            site.setSelfHostedSiteId(MapUtils.getMapInt(siteMap, "blogid", 1));
+            site.setName(MapUtils.getMapStr(siteMap, "blogName"));
+            site.setUrl(MapUtils.getMapStr(siteMap, "url"));
+            site.setXmlRpcUrl(MapUtils.getMapStr(siteMap, "xmlrpc"));
+            site.setIsSelfHostedAdmin(MapUtils.getMapBool(siteMap, "isAdmin"));
             // From what we know about the host
             site.setIsWPCom(false);
             site.setUsername(username);
@@ -192,7 +169,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         // * Jetpack installed, activated and connected: field "jetpack_client_id" included and is correctly
         //   set to wpcom unique id eg. "1234"
 
-        String jetpackClientIdStr = getOption(siteOptions, JETPACK_CLIENT_ID_KEY, String.class);
+        String jetpackClientIdStr = getOption(siteOptions, "jetpack_client_id", String.class);
         long jetpackClientId = 0;
         // jetpackClientIdStr can be a boolean "0" (false), in that case we keep the default value "0".
         if (!"false".equals(jetpackClientIdStr)) {
@@ -223,29 +200,29 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
 
     private SiteModel updateSiteFromOptions(Object response, SiteModel oldModel) {
         Map<?, ?> siteOptions = (Map<?, ?>) response;
-        String siteTitle = getOption(siteOptions, SITE_TITLE_KEY, String.class);
+        String siteTitle = getOption(siteOptions, "blog_title", String.class);
         if (!TextUtils.isEmpty(siteTitle)) {
             oldModel.setName(siteTitle);
         }
 
         // TODO: set a canonical URL here
-        String homeUrl = getOption(siteOptions, HOME_URL_KEY, String.class);
+        String homeUrl = getOption(siteOptions, "home_url", String.class);
         if (!TextUtils.isEmpty(homeUrl)) {
             oldModel.setUrl(homeUrl);
         }
-        oldModel.setSoftwareVersion(getOption(siteOptions, SOFTWARE_VERSION_KEY, String.class));
-        Boolean postThumbnail = getOption(siteOptions, POST_THUMBNAIL_KEY, Boolean.class);
+        oldModel.setSoftwareVersion(getOption(siteOptions, "software_version", String.class));
+        Boolean postThumbnail = getOption(siteOptions, "post_thumbnail", Boolean.class);
         oldModel.setIsFeaturedImageSupported((postThumbnail != null) && postThumbnail);
-        oldModel.setDefaultCommentStatus(getOption(siteOptions, DEFAULT_COMMENT_STATUS_KEY, String.class));
-        oldModel.setTimezone(getOption(siteOptions, TIME_ZONE_KEY, String.class));
-        oldModel.setLoginUrl(getOption(siteOptions, LOGIN_URL_KEY, String.class));
-        oldModel.setAdminUrl(getOption(siteOptions, ADMIN_URL_KEY, String.class));
+        oldModel.setDefaultCommentStatus(getOption(siteOptions, "default_comment_status", String.class));
+        oldModel.setTimezone(getOption(siteOptions, "time_zone", String.class));
+        oldModel.setLoginUrl(getOption(siteOptions, "login_url", String.class));
+        oldModel.setAdminUrl(getOption(siteOptions, "admin_url", String.class));
 
         setJetpackStatus(siteOptions, oldModel);
         // If the site is not public, it's private. Note: this field doesn't always exist.
         oldModel.setIsPrivate(false);
-        if (siteOptions.containsKey(SITE_PUBLIC_KEY)) {
-            Boolean isPublic = getOption(siteOptions, SITE_PUBLIC_KEY, Boolean.class);
+        if (siteOptions.containsKey("blog_public")) {
+            Boolean isPublic = getOption(siteOptions, "blog_public", Boolean.class);
             if (isPublic != null) {
                 oldModel.setIsPrivate(!isPublic);
             }


### PR DESCRIPTION
Cleans up a few things up in the site clients. ~#394 should be merged first.~

1. Fixed some lint warnings
2. Dropped the constant key declarations in favor of using the String literals in the code, for improved readability (as we're doing in most of the rest of FluxC)
3. Refactored `SiteXMLRPCClient` to use an existing utility method for extracting fields from `wp.getOptions`