### PR TITLE
Add method to search local posts by title

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.List;
 
 import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -327,5 +328,61 @@ public class PostStoreUnitTest {
         PostSqlUtils.deleteAllPosts();
 
         assertEquals(0, PostTestUtils.getPostsCount());
+    }
+
+    @Test
+    public void testSearchPostTitles() {
+        final int testSiteId = 628;
+        final int testPoolSize = 10;
+        final String[] testTitles = new String[testPoolSize];
+        final SiteModel site = new SiteModel();
+
+        site.setId(testSiteId);
+        String baseString = "Base Title String ";
+        for (int i = 0; i < testPoolSize; ++i) {
+            testTitles[i] = baseString;
+            PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
+            testPost.setIsPage(false);
+            testPost.setId(i + 53);
+            testPost.setTitle(baseString);
+            testPost.setLocalSiteId(site.getId());
+            assertTrue(PostSqlUtils.insertOrUpdatePost(testPost, true) == 1);
+            baseString += String.valueOf(i);
+        }
+
+        for (int i = 0; i < testPoolSize; ++i) {
+            assertTrue(mPostStore.searchPageTitles(site, testTitles[i]).isEmpty());
+            List<PostModel> storePost = mPostStore.searchPostTitles(site, testTitles[i]);
+            assertNotNull(storePost);
+            assertTrue(storePost.size() == testPoolSize - i);
+        }
+    }
+
+    @Test
+    public void testSearchPageTitles() {
+        final int testSiteId = 628;
+        final int testPoolSize = 10;
+        final String[] testTitles = new String[testPoolSize];
+        final SiteModel site = new SiteModel();
+
+        site.setId(testSiteId);
+        String baseString = "Base Title String ";
+        for (int i = 0; i < testPoolSize; ++i) {
+            testTitles[i] = baseString;
+            PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
+            testPost.setIsPage(true);
+            testPost.setId(i + 53);
+            testPost.setTitle(baseString);
+            testPost.setLocalSiteId(site.getId());
+            assertTrue(PostSqlUtils.insertOrUpdatePost(testPost, true) == 1);
+            baseString += String.valueOf(i);
+        }
+
+        for (int i = 0; i < testPoolSize; ++i) {
+            assertTrue(mPostStore.searchPostTitles(site, testTitles[i]).isEmpty());
+            List<PostModel> storePost = mPostStore.searchPageTitles(site, testTitles[i]);
+            assertNotNull(storePost);
+            assertTrue(storePost.size() == testPoolSize - i);
+        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -111,6 +111,22 @@ public class PostSqlUtils {
                 .getAsModel();
     }
 
+    public static List<PostModel> searchPostTitles(SiteModel site, String searchQuery, boolean getPages) {
+        if (site == null) {
+            return Collections.emptyList();
+        }
+
+        return WellSql.select(PostModel.class)
+                .where().beginGroup()
+                .equals(PostModelTable.LOCAL_SITE_ID, site.getId())
+                .contains(PostModelTable.TITLE, searchQuery)
+                .equals(PostModelTable.IS_PAGE, getPages)
+                .endGroup().endWhere()
+                .orderBy(PostModelTable.IS_LOCAL_DRAFT, SelectQuery.ORDER_DESCENDING)
+                .orderBy(PostModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
+                .getAsModel();
+    }
+
     public static PostModel insertPostForResult(PostModel post) {
         WellSql.insert(post).asSingleTransaction(true).execute();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -275,6 +275,14 @@ public class PostStore extends Store {
         }
     }
 
+    public List<PostModel> searchPostTitles(SiteModel site, String searchTerm) {
+        return PostSqlUtils.searchPostTitles(site, searchTerm, false);
+    }
+
+    public List<PostModel> searchPageTitles(SiteModel site, String searchTerm) {
+        return PostSqlUtils.searchPostTitles(site, searchTerm, true);
+    }
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
     public void onAction(Action action) {


### PR DESCRIPTION
This is similar to the [MediaStore's search method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java#L419). wordpress-mobile/WordPress-Android#62 will be using this to search the post list.