### PR TITLE
okHttpClient shared instance

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -122,18 +122,18 @@ public class MockedNetworkModule {
     @Provides
     public MediaRestClient provideMediaRestClient(Dispatcher dispatcher, Context appContext,
                                                   @Named("regular") RequestQueue requestQueue,
-                                                  @Named("regular") OkHttpClient.Builder okHttpClientBuilder,
+                                                  @Named("regular") OkHttpClient okHttpClient,
                                                   AccessToken token, UserAgent userAgent) {
-        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClientBuilder, token, userAgent);
+        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClient, token, userAgent);
     }
 
     @Singleton
     @Provides
-    public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher, OkHttpClient.Builder okHttpClientBuilder,
+    public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher, OkHttpClient okHttpClient,
                                                       @Named("regular") RequestQueue requestQueue,
                                                       AccessToken token, UserAgent userAgent,
                                                       HTTPAuthManager httpAuthManager) {
-        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClientBuilder, token, userAgent, httpAuthManager);
+        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClient, token, userAgent, httpAuthManager);
     }
 
     @Singleton

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -35,9 +35,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         FETCHED_KNOWN_IMAGES,
         PUSHED_MEDIA,
         UPLOADED_MEDIA,
-        UPLOADED_MUTIPLE_MEDIA, // these don't exist in FluxC, but are an artifact to wait for all
+        UPLOADED_MULTIPLE_MEDIA, // these don't exist in FluxC, but are an artifact to wait for all
                                 // uploads to finish
-        UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, // same as above
+        UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, // same as above
         PUSH_ERROR,
         REMOVED_MEDIA,
     }
@@ -182,7 +182,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     public void testUploadMultipleImages() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MUTIPLE_MEDIA;
+        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA;
 
         mUploadedMediaModels = new HashMap<>();
         // here we use the newMediaModel() with id builder, as we need it to identify uploads
@@ -218,7 +218,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     public void testUploadMultipleImagesAndCancel() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL;
+        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL;
 
         mUploadedMediaModels = new HashMap<>();
         // here we use the newMediaModel() with id builder, as we need it to identify uploads
@@ -280,13 +280,13 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         if (event.canceled) {
-            if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
+            if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
                 mCountDownLatch.countDown();
             }
         } else if (event.completed) {
-            if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
+            if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
                 mUploadedIds.add(event.media.getMediaId());
                 // now update our own map object with the new media id
                 MediaModel media = mUploadedMediaModels.get(event.media.getId());
@@ -296,8 +296,8 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
                     AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
                 }
                 assertNotNull(media);
-            } else if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA, mNextEvent);
+            } else if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA, mNextEvent);
                 mUploadedIds.add(event.media.getMediaId());
                 // now update our own map object with the new media id
                 MediaModel media = mUploadedMediaModels.get(event.media.getId());

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
@@ -2,14 +2,17 @@ package org.wordpress.android.fluxc.example;
 
 import com.facebook.stetho.okhttp3.StethoInterceptor;
 
+import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -40,5 +43,27 @@ public class DebugOkHttpClientModule {
         }
         builder.addNetworkInterceptor(new StethoInterceptor());
         return builder;
+    }
+
+    @Singleton
+    @Provides
+    @Named("custom-ssl")
+    public OkHttpClient provideOkHttpClientSharedInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+        return builder
+                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
+    }
+
+    @Singleton
+    @Provides
+    @Named("regular")
+    public OkHttpClient provideOkHttpClientSharedInstance(@Named("regular")OkHttpClient.Builder builder) {
+        return builder
+                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.java
@@ -84,7 +84,7 @@ public class AccountFragment extends Fragment {
             prependToLog("Signed Out");
         } else {
             if (event.causeOfChange == AccountAction.SEND_VERIFICATION_EMAIL) {
-                if (event.accountInfosChanged) {
+                if (!event.isError()) {
                     prependToLog("Verification email sent, check your inbox.");
                 } else {
                     prependToLog("Error sending verification email. Are you already verified?");

--- a/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.java
@@ -13,6 +13,7 @@ import android.widget.EditText;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
@@ -53,6 +54,14 @@ public class AccountFragment extends Fragment {
                 mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
             }
         });
+
+        view.findViewById(R.id.account_email_verification).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mDispatcher.dispatch(AccountActionBuilder.newSendVerificationEmailAction());
+            }
+        });
+
         return view;
     }
 
@@ -74,7 +83,13 @@ public class AccountFragment extends Fragment {
         if (!mAccountStore.hasAccessToken()) {
             prependToLog("Signed Out");
         } else {
-            if (event.accountInfosChanged) {
+            if (event.causeOfChange == AccountAction.SEND_VERIFICATION_EMAIL) {
+                if (event.accountInfosChanged) {
+                    prependToLog("Verification email sent, check your inbox.");
+                } else {
+                    prependToLog("Error sending verification email. Are you already verified?");
+                }
+            } else if (event.accountInfosChanged) {
                 prependToLog("Display Name: " + mAccountStore.getAccount().getDisplayName());
             }
         }

--- a/example/src/main/res/layout/fragment_account.xml
+++ b/example/src/main/res/layout/fragment_account.xml
@@ -17,4 +17,10 @@
         android:layout_height="wrap_content"
         android:text="Fetch Account" />
 
+    <Button
+        android:id="@+id/account_email_verification"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Send Verification Email" />
+
 </LinearLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -19,6 +19,8 @@ public enum AccountAction implements IAction {
     FETCH_ACCOUNT,          // request fetch of Account information
     @Action
     FETCH_SETTINGS,         // request fetch of Account Settings
+    @Action
+    SEND_VERIFICATION_EMAIL, // request verification email for unverified accounts
     @Action(payloadType = PushAccountSettingsPayload.class)
     PUSH_SETTINGS,          // request saving Account Settings remotely
     @Action(payloadType = NewAccountPayload.class)
@@ -37,6 +39,8 @@ public enum AccountAction implements IAction {
     FETCHED_ACCOUNT,        // response received from Account fetch request
     @Action(payloadType = AccountRestPayload.class)
     FETCHED_SETTINGS,       // response received from Account Settings fetch
+    @Action(payloadType = NewAccountResponsePayload.class)
+    SENT_VERIFICATION_EMAIL,
     @Action(payloadType = AccountPushSettingsResponsePayload.class)
     PUSHED_SETTINGS,        // response received from Account Settings post
     @Action(payloadType = NewAccountResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 @Table
 public class PostModel extends Payload implements Cloneable, Identifiable, Serializable {
-    private static final long FEATURED_IMAGE_INIT_VALUE = -2;
     private static final long LATITUDE_REMOVED_VALUE = 8888;
     private static final long LONGITUDE_REMOVED_VALUE = 8888;
 
@@ -43,7 +42,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     @Column private String mTagNames;
     @Column private String mStatus;
     @Column private String mPassword;
-    @Column private long mFeaturedImageId = FEATURED_IMAGE_INIT_VALUE;
+    @Column private long mFeaturedImageId;
     @Column private String mPostFormat;
     @Column private String mSlug;
     @Column private double mLatitude = PostLocation.INVALID_LATITUDE;
@@ -62,7 +61,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     // XML-RPC only, needed to work around a bug with the API:
     // https://github.com/wordpress-mobile/WordPress-Android/pull/3425
     // We may be able to drop this if we switch to wp.editPost (and it doesn't have the same bug as metaWeblog.editPost)
-    @Column private long mLastKnownRemoteFeaturedImageId = FEATURED_IMAGE_INIT_VALUE;
+    @Column private long mLastKnownRemoteFeaturedImageId;
 
     // WPCom capabilities
     @Column private boolean mHasCapabilityPublishPost;
@@ -206,18 +205,10 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     }
 
     public long getFeaturedImageId() {
-        if (mFeaturedImageId == FEATURED_IMAGE_INIT_VALUE) {
-            return 0;
-        }
-
         return mFeaturedImageId;
     }
 
     public void setFeaturedImageId(long featuredImageId) {
-        if (mFeaturedImageId == FEATURED_IMAGE_INIT_VALUE) {
-            mLastKnownRemoteFeaturedImageId = mFeaturedImageId;
-        }
-
         mFeaturedImageId = featuredImageId;
     }
 
@@ -307,10 +298,12 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         mIsLocallyChanged = isLocallyChanged;
     }
 
+    @Deprecated
     public long getLastKnownRemoteFeaturedImageId() {
         return mLastKnownRemoteFeaturedImageId;
     }
 
+    @Deprecated
     public void setLastKnownRemoteFeaturedImageId(long lastKnownRemoteFeaturedImageId) {
         mLastKnownRemoteFeaturedImageId = lastKnownRemoteFeaturedImageId;
     }
@@ -361,7 +354,6 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
                 && Double.compare(otherPost.getLongitude(), getLongitude()) == 0
                 && isPage() == otherPost.isPage()
                 && isLocalDraft() == otherPost.isLocalDraft() && isLocallyChanged() == otherPost.isLocallyChanged()
-                && getLastKnownRemoteFeaturedImageId() == otherPost.getLastKnownRemoteFeaturedImageId()
                 && getHasCapabilityPublishPost() == otherPost.getHasCapabilityPublishPost()
                 && getHasCapabilityEditPost() == otherPost.getHasCapabilityEditPost()
                 && getHasCapabilityDeletePost() == otherPost.getHasCapabilityDeletePost()
@@ -438,11 +430,7 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
     }
 
     public void clearFeaturedImage() {
-        setFeaturedImageId(-1);
-    }
-
-    public boolean featuredImageHasChanged() {
-        return (mLastKnownRemoteFeaturedImageId != mFeaturedImageId);
+        setFeaturedImageId(0);
     }
 
     private static List<Long> termIdStringToList(String ids) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -120,19 +120,19 @@ public class ReleaseNetworkModule {
     @Provides
     public MediaRestClient provideMediaRestClient(Context appContext, Dispatcher dispatcher,
                                                   @Named("regular") RequestQueue requestQueue,
-                                                  @Named("regular") OkHttpClient.Builder okHttpClientBuilder,
+                                                  @Named("regular") OkHttpClient okHttpClient,
                                                   AccessToken token, UserAgent userAgent) {
-        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClientBuilder, token, userAgent);
+        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClient, token, userAgent);
     }
 
     @Singleton
     @Provides
     public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher,
                                                       @Named("custom-ssl") RequestQueue requestQueue,
-                                                      @Named("custom-ssl") OkHttpClient.Builder okHttpClientBuilder,
+                                                      @Named("custom-ssl") OkHttpClient okHttpClient,
                                                       AccessToken token, UserAgent userAgent,
                                                       HTTPAuthManager httpAuthManager) {
-        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClientBuilder, token, userAgent, httpAuthManager);
+        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClient, token, userAgent, httpAuthManager);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -1,13 +1,16 @@
 package org.wordpress.android.fluxc.module;
 
+import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -37,5 +40,27 @@ public class ReleaseOkHttpClientModule {
             AppLog.e(T.API, e);
         }
         return builder;
+    }
+
+    @Singleton
+    @Provides
+    @Named("custom-ssl")
+    public OkHttpClient provideOkHttpClientSharedInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+        return builder
+                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
+    }
+
+    @Singleton
+    @Provides
+    @Named("regular")
+    public OkHttpClient provideOkHttpClientSharedInstance(@Named("regular")OkHttpClient.Builder builder) {
+        return builder
+                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountBoolResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountBoolResponse.java
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.account;
 
 import org.wordpress.android.fluxc.network.Response;
 
-public class NewAccountResponse implements Response {
+public class AccountBoolResponse implements Response {
     public boolean success;
     public String error;
     public String message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -143,14 +143,14 @@ public class AccountRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(NewAccountResponse response) {
                         NewAccountResponsePayload payload = new NewAccountResponsePayload();
-                        mDispatcher.dispatch(AccountActionBuilder.newSentEmailVerificationAction(payload));
+                        mDispatcher.dispatch(AccountActionBuilder.newSentVerificationEmailAction(payload));
                     }
                 },
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         NewAccountResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
-                        mDispatcher.dispatch(AccountActionBuilder.newSentEmailVerificationAction(payload));
+                        mDispatcher.dispatch(AccountActionBuilder.newSentVerificationEmailAction(payload));
                     }
                 }
         ));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -136,7 +136,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         ));
     }
 
-    public void resendVerificationEmail() {
+    public void sendVerificationEmail() {
         String url = WPCOMREST.me.send_verification_email.getUrlV1_1();
         add(WPComGsonRequest.buildPostRequest(url, null, NewAccountResponse.class,
                 new Listener<NewAccountResponse>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -136,6 +136,26 @@ public class AccountRestClient extends BaseWPComRestClient {
         ));
     }
 
+    public void resendVerificationEmail() {
+        String url = WPCOMREST.me.send_verification_email.getUrlV1_1();
+        add(WPComGsonRequest.buildPostRequest(url, null, NewAccountResponse.class,
+                new Listener<NewAccountResponse>() {
+                    @Override
+                    public void onResponse(NewAccountResponse response) {
+                        NewAccountResponsePayload payload = new NewAccountResponsePayload();
+                        mDispatcher.dispatch(AccountActionBuilder.newSentEmailVerificationAction(payload));
+                    }
+                },
+                new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        NewAccountResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
+                        mDispatcher.dispatch(AccountActionBuilder.newSentEmailVerificationAction(payload));
+                    }
+                }
+        ));
+    }
+
     /**
      * Performs an HTTP POST call to the v1.1 /me/settings/ endpoint. Upon receiving
      * a response (success or error) a {@link AccountAction#PUSHED_SETTINGS} action is dispatched

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -138,10 +138,10 @@ public class AccountRestClient extends BaseWPComRestClient {
 
     public void sendVerificationEmail() {
         String url = WPCOMREST.me.send_verification_email.getUrlV1_1();
-        add(WPComGsonRequest.buildPostRequest(url, null, NewAccountResponse.class,
-                new Listener<NewAccountResponse>() {
+        add(WPComGsonRequest.buildPostRequest(url, null, AccountBoolResponse.class,
+                new Listener<AccountBoolResponse>() {
                     @Override
-                    public void onResponse(NewAccountResponse response) {
+                    public void onResponse(AccountBoolResponse response) {
                         NewAccountResponsePayload payload = new NewAccountResponsePayload();
                         mDispatcher.dispatch(AccountActionBuilder.newSentVerificationEmailAction(payload));
                     }
@@ -199,11 +199,11 @@ public class AccountRestClient extends BaseWPComRestClient {
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());
 
-        WPComGsonRequest<NewAccountResponse> request = WPComGsonRequest.buildPostRequest(url, body,
-                NewAccountResponse.class,
-                new Listener<NewAccountResponse>() {
+        WPComGsonRequest<AccountBoolResponse> request = WPComGsonRequest.buildPostRequest(url, body,
+                AccountBoolResponse.class,
+                new Listener<AccountBoolResponse>() {
                     @Override
-                    public void onResponse(NewAccountResponse response) {
+                    public void onResponse(AccountBoolResponse response) {
                         NewAccountResponsePayload payload = new NewAccountResponsePayload();
                         payload.dryRun = dryRun;
                         mDispatcher.dispatch(AccountActionBuilder.newCreatedNewAccountAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -69,13 +68,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
     public MediaRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
-                           OkHttpClient.Builder okClientBuilder, AccessToken accessToken, UserAgent userAgent) {
+                           OkHttpClient okHttpClient, AccessToken accessToken, UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
-        mOkHttpClient = okClientBuilder
-                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
-                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .build();
+        mOkHttpClient = okHttpClient;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -456,7 +456,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         media.setCaption(from.caption);
         media.setDescription(from.description);
         media.setAlt(from.alt);
-        media.setThumbnailUrl(from.thumbnails.thumbnail);
+        if (from.thumbnails != null) {
+            media.setThumbnailUrl(from.thumbnails.thumbnail);
+        }
         media.setHeight(from.height);
         media.setWidth(from.width);
         media.setLength(from.length);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -293,15 +293,7 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("categories", TextUtils.join(",", post.getCategoryIdList()));
         params.put("tags", TextUtils.join(",", post.getTagNameList()));
 
-        // Will remove any existing featured image if the empty string is sent
-        if (post.featuredImageHasChanged()) {
-            if (post.getFeaturedImageId() < 1 && !post.isLocalDraft()) {
-                // The featured image was removed from a live post
-                params.put("featured_image", "");
-            } else {
-                params.put("featured_image", String.valueOf(post.getFeaturedImageId()));
-            }
-        }
+        params.put("featured_image", post.getFeaturedImageId());
 
         if (post.hasLocation()) {
             // Location data was added to the post

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -42,17 +42,6 @@ import javax.inject.Singleton;
 
 @Singleton
 public class SiteRestClient extends BaseWPComRestClient {
-    //
-    // New site request keys
-    //
-    public static final String SITE_NAME_KEY = "blog_name";
-    public static final String SITE_TITLE_KEY = "blog_title";
-    public static final String LANGUAGE_ID_KEY = "lang_id";
-    public static final String PUBLIC_KEY = "public";
-    public static final String VALIDATE_KEY = "validate";
-    public static final String CLIENT_ID_KEY = "client_id";
-    public static final String CLIENT_SECRET_KEY = "client_secret";
-
     public static final int NEW_SITE_TIMEOUT_MS = 90000;
 
     private final AppSecrets mAppSecrets;
@@ -179,13 +168,13 @@ public class SiteRestClient extends BaseWPComRestClient {
                         @NonNull SiteVisibility visibility, final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1();
         Map<String, Object> body = new HashMap<>();
-        body.put(SITE_NAME_KEY, siteName);
-        body.put(SITE_TITLE_KEY, siteTitle);
-        body.put(LANGUAGE_ID_KEY, language);
-        body.put(PUBLIC_KEY, visibility.toString());
-        body.put(VALIDATE_KEY, dryRun ? "1" : "0");
-        body.put(CLIENT_ID_KEY, mAppSecrets.getAppId());
-        body.put(CLIENT_SECRET_KEY, mAppSecrets.getAppSecret());
+        body.put("blog_name", siteName);
+        body.put("blog_title", siteTitle);
+        body.put("lang_id", language);
+        body.put("public", visibility.toString());
+        body.put("validate", dryRun ? "1" : "0");
+        body.put("client_id", mAppSecrets.getAppId());
+        body.put("client_secret", mAppSecrets.getAppSecret());
 
         WPComGsonRequest<NewSiteResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 NewSiteResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
@@ -43,7 +43,7 @@ public class XMLRPCUtils {
         return defaultValue;
     }
 
-    public static <T> T safeGetMap(@NonNull Map<?, ?> map, String key, T defaultValue) {
+    public static <T> T safeGetNestedMapValue(@NonNull Map<?, ?> map, String key, T defaultValue) {
         if (!map.containsKey(key)) {
             return defaultValue;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -48,7 +48,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -61,15 +60,11 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     // track the network call to support cancelling
     private Call mCurrentUploadCall;
 
-    public MediaXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, OkHttpClient.Builder okClientBuilder,
+    public MediaXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, OkHttpClient okHttpClient,
                              AccessToken accessToken, UserAgent userAgent,
                              HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
-        mOkHttpClient = okClientBuilder
-                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
-                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .build();
+        mOkHttpClient = okHttpClient;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -519,15 +519,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             }
         }
 
-        // Featured images
-        if (post.featuredImageHasChanged()) {
-            if (post.getFeaturedImageId() < 1 && !post.isLocalDraft()) {
-                // The featured image was removed from a live post
-                contentStruct.put("post_thumbnail", "");
-            } else {
-                contentStruct.put("post_thumbnail", post.getFeaturedImageId());
-            }
-        }
+        contentStruct.put("post_thumbnail", post.getFeaturedImageId());
 
         contentStruct.put("post_password", post.getPassword());
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -29,29 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 public class SiteXMLRPCClient extends BaseXMLRPCClient {
-    //
-    // Site fetch request keys
-    //
-    public static final String SOFTWARE_VERSION_KEY = "software_version";
-    public static final String POST_THUMBNAIL_KEY = "post_thumbnail";
-    public static final String DEFAULT_COMMENT_STATUS_KEY = "default_comment_status";
-    public static final String JETPACK_CLIENT_ID_KEY = "jetpack_client_id";
-    public static final String SITE_PUBLIC_KEY = "blog_public";
-    public static final String HOME_URL_KEY = "home_url";
-    public static final String ADMIN_URL_KEY = "admin_url";
-    public static final String LOGIN_URL_KEY = "login_url";
-    public static final String SITE_TITLE_KEY = "blog_title";
-    public static final String TIME_ZONE_KEY = "time_zone";
-
-    //
-    // Sites response keys
-    //
-    public static final String SITE_ID_KEY = "blogid";
-    public static final String SITE_NAME_KEY = "blogName";
-    public static final String SITE_URL_KEY = "url";
-    public static final String SITE_XMLRPC_URL_KEY = "xmlrpc";
-    public static final String SITE_ADMIN_KEY = "isAdmin";
-
     public SiteXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,
                             UserAgent userAgent, HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
@@ -94,8 +71,8 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         params.add(site.getUsername());
         params.add(site.getPassword());
         params.add(new String[] {
-                SOFTWARE_VERSION_KEY, POST_THUMBNAIL_KEY, DEFAULT_COMMENT_STATUS_KEY, JETPACK_CLIENT_ID_KEY,
-                SITE_PUBLIC_KEY, HOME_URL_KEY, ADMIN_URL_KEY, LOGIN_URL_KEY, SITE_TITLE_KEY, TIME_ZONE_KEY });
+                "software_version", "post_thumbnail", "default_comment_status", "jetpack_client_id",
+                "blog_public", "home_url", "admin_url", "login_url", "blog_title", "time_zone" });
         final XMLRPCRequest request = new XMLRPCRequest(
                 site.getXmlRpcUrl(), XMLRPC.GET_OPTIONS, params,
                 new Listener<Object>() {
@@ -157,11 +134,11 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             }
             HashMap<?, ?> siteMap = (HashMap<?, ?>) siteObject;
             SiteModel site = new SiteModel();
-            site.setSelfHostedSiteId(MapUtils.getMapInt(siteMap, SITE_ID_KEY, 1));
-            site.setName(MapUtils.getMapStr(siteMap, SITE_NAME_KEY));
-            site.setUrl(MapUtils.getMapStr(siteMap, SITE_URL_KEY));
-            site.setXmlRpcUrl(MapUtils.getMapStr(siteMap, SITE_XMLRPC_URL_KEY));
-            site.setIsSelfHostedAdmin(MapUtils.getMapBool(siteMap, SITE_ADMIN_KEY));
+            site.setSelfHostedSiteId(MapUtils.getMapInt(siteMap, "blogid", 1));
+            site.setName(MapUtils.getMapStr(siteMap, "blogName"));
+            site.setUrl(MapUtils.getMapStr(siteMap, "url"));
+            site.setXmlRpcUrl(MapUtils.getMapStr(siteMap, "xmlrpc"));
+            site.setIsSelfHostedAdmin(MapUtils.getMapBool(siteMap, "isAdmin"));
             // From what we know about the host
             site.setIsWPCom(false);
             site.setUsername(username);
@@ -192,7 +169,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         // * Jetpack installed, activated and connected: field "jetpack_client_id" included and is correctly
         //   set to wpcom unique id eg. "1234"
 
-        String jetpackClientIdStr = getOption(siteOptions, JETPACK_CLIENT_ID_KEY, String.class);
+        String jetpackClientIdStr = getOption(siteOptions, "jetpack_client_id", String.class);
         long jetpackClientId = 0;
         // jetpackClientIdStr can be a boolean "0" (false), in that case we keep the default value "0".
         if (!"false".equals(jetpackClientIdStr)) {
@@ -223,29 +200,29 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
 
     private SiteModel updateSiteFromOptions(Object response, SiteModel oldModel) {
         Map<?, ?> siteOptions = (Map<?, ?>) response;
-        String siteTitle = getOption(siteOptions, SITE_TITLE_KEY, String.class);
+        String siteTitle = getOption(siteOptions, "blog_title", String.class);
         if (!TextUtils.isEmpty(siteTitle)) {
             oldModel.setName(siteTitle);
         }
 
         // TODO: set a canonical URL here
-        String homeUrl = getOption(siteOptions, HOME_URL_KEY, String.class);
+        String homeUrl = getOption(siteOptions, "home_url", String.class);
         if (!TextUtils.isEmpty(homeUrl)) {
             oldModel.setUrl(homeUrl);
         }
-        oldModel.setSoftwareVersion(getOption(siteOptions, SOFTWARE_VERSION_KEY, String.class));
-        Boolean postThumbnail = getOption(siteOptions, POST_THUMBNAIL_KEY, Boolean.class);
+        oldModel.setSoftwareVersion(getOption(siteOptions, "software_version", String.class));
+        Boolean postThumbnail = getOption(siteOptions, "post_thumbnail", Boolean.class);
         oldModel.setIsFeaturedImageSupported((postThumbnail != null) && postThumbnail);
-        oldModel.setDefaultCommentStatus(getOption(siteOptions, DEFAULT_COMMENT_STATUS_KEY, String.class));
-        oldModel.setTimezone(getOption(siteOptions, TIME_ZONE_KEY, String.class));
-        oldModel.setLoginUrl(getOption(siteOptions, LOGIN_URL_KEY, String.class));
-        oldModel.setAdminUrl(getOption(siteOptions, ADMIN_URL_KEY, String.class));
+        oldModel.setDefaultCommentStatus(getOption(siteOptions, "default_comment_status", String.class));
+        oldModel.setTimezone(getOption(siteOptions, "time_zone", String.class));
+        oldModel.setLoginUrl(getOption(siteOptions, "login_url", String.class));
+        oldModel.setAdminUrl(getOption(siteOptions, "admin_url", String.class));
 
         setJetpackStatus(siteOptions, oldModel);
         // If the site is not public, it's private. Note: this field doesn't always exist.
         oldModel.setIsPrivate(false);
-        if (siteOptions.containsKey(SITE_PUBLIC_KEY)) {
-            Boolean isPublic = getOption(siteOptions, SITE_PUBLIC_KEY, Boolean.class);
+        if (siteOptions.containsKey("blog_public")) {
+            Boolean isPublic = getOption(siteOptions, "blog_public", Boolean.class);
             if (isPublic != null) {
                 oldModel.setIsPrivate(!isPublic);
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -186,6 +186,7 @@ public class AccountStore extends Store {
         ACCOUNT_FETCH_ERROR,
         SETTINGS_FETCH_ERROR,
         SETTINGS_POST_ERROR,
+        SEND_VERIFICATION_EMAIL_ERROR,
         GENERIC_ERROR
     }
 
@@ -451,7 +452,9 @@ public class AccountStore extends Store {
     private void handleSentVerificationEmail(NewAccountResponsePayload payload) {
         OnAccountChanged accountChanged = new OnAccountChanged();
         accountChanged.causeOfChange = AccountAction.SEND_VERIFICATION_EMAIL;
-        accountChanged.accountInfosChanged = !payload.isError();
+        if (payload.isError()) {
+            accountChanged.error = new AccountError(AccountErrorType.SEND_VERIFICATION_EMAIL_ERROR, "");
+        }
         emitChange(accountChanged);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -331,6 +331,9 @@ public class AccountStore extends Store {
             case FETCH_SETTINGS:
                 mAccountRestClient.fetchAccountSettings();
                 break;
+            case SEND_VERIFICATION_EMAIL:
+                mAccountRestClient.resendVerificationEmail();
+                break;
             case PUSH_SETTINGS:
                 mAccountRestClient.pushAccountSettings(((PushAccountSettingsPayload) payload).params);
                 break;
@@ -357,6 +360,9 @@ public class AccountStore extends Store {
                 break;
             case FETCHED_ACCOUNT:
                 handleFetchAccountCompleted((AccountRestPayload) payload);
+                break;
+            case SENT_VERIFICATION_EMAIL:
+                handleSentVerificationEmail((NewAccountResponsePayload) payload);
                 break;
             case IS_AVAILABLE_BLOG:
                 mAccountRestClient.isAvailable((String) payload, IsAvailable.BLOG);
@@ -440,6 +446,13 @@ public class AccountStore extends Store {
         } else {
             emitAccountChangeError(AccountErrorType.SETTINGS_FETCH_ERROR);
         }
+    }
+
+    private void handleSentVerificationEmail(NewAccountResponsePayload payload) {
+        OnAccountChanged accountChanged = new OnAccountChanged();
+        accountChanged.causeOfChange = AccountAction.SEND_VERIFICATION_EMAIL;
+        accountChanged.accountInfosChanged = !payload.isError();
+        emitChange(accountChanged);
     }
 
     private void handlePushSettingsCompleted(AccountPushSettingsResponsePayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -332,7 +332,7 @@ public class AccountStore extends Store {
                 mAccountRestClient.fetchAccountSettings();
                 break;
             case SEND_VERIFICATION_EMAIL:
-                mAccountRestClient.resendVerificationEmail();
+                mAccountRestClient.sendVerificationEmail();
                 break;
             case PUSH_SETTINGS:
                 mAccountRestClient.pushAccountSettings(((PushAccountSettingsPayload) payload).params);

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -1,6 +1,7 @@
 /me/
 /me/settings/
 /me/sites/
+/me/send-verification-email/
 
 /sites/
 /sites/new/


### PR DESCRIPTION
Supersedes #399 (bad commit history)

This PR makes the OkHttpClient being used for media uploads a singleton, as recommended in OkHttpClient specs here https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html

> OkHttpClients should be shared
> 
> OkHttp performs best when you create a single OkHttpClient instance and reuse it for all of your HTTP calls. This is because each client holds its own connection pool and thread pools. Reusing connections and threads reduces latency and saves memory. Conversely, creating a client for each request wastes resources on idle pools.
> 

cc @aforcier 
