### PR TITLE
Feature/multi uploads xmlrpc

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/TestUtils.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/TestUtils.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public class TestUtils {
     public static final int DEFAULT_TIMEOUT_MS = 30000;
-    public static final int MUTIPLE_UPLOADS_TIMEOUT_MS = 60000;
+    public static final int MULTIPLE_UPLOADS_TIMEOUT_MS = 60000;
 
     public static void waitFor(long milliseconds) {
         try {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -202,7 +202,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     public void testUploadMultipleImages() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
-        mNextEvent = ReleaseStack_MediaTestXMLRPC.TestEvents.UPLOADED_MUTIPLE_MEDIA;
+        mNextEvent = TestEvents.UPLOADED_MUTIPLE_MEDIA;
 
         mUploadedMediaModels = new HashMap<>();
         // here we use the newMediaModel() with id builder, as we need it to identify uploads
@@ -227,7 +227,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
 
         // delete test images (bear in mind this is done sequentially)
-        mNextEvent = ReleaseStack_MediaTestXMLRPC.TestEvents.DELETED_MEDIA;
+        mNextEvent = TestEvents.DELETED_MEDIA;
         iterator = mUploadedMediaModels.values().iterator();
         while (iterator.hasNext()) {
             MediaModel media = iterator.next();
@@ -238,7 +238,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     public void testUploadMultipleImagesAndCancel() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
-        mNextEvent = ReleaseStack_MediaTestXMLRPC.TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL;
+        mNextEvent = TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL;
 
         mUploadedMediaModels = new HashMap<>();
         // here we use the newMediaModel() with id builder, as we need it to identify uploads
@@ -266,7 +266,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
 
         // delete test images (bear in mind this is done sequentially)
-        mNextEvent = ReleaseStack_MediaTestXMLRPC.TestEvents.DELETED_MEDIA;
+        mNextEvent = TestEvents.DELETED_MEDIA;
         iterator = mUploadedMediaModels.values().iterator();
         while (iterator.hasNext()) {
             MediaModel media = iterator.next();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -44,9 +44,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         FETCHED_MEDIA,
         DELETED_MEDIA,
         UPLOADED_MEDIA,
-        UPLOADED_MUTIPLE_MEDIA, // these don't exist in FluxC, but are an artifact to wait for all
+        UPLOADED_MULTIPLE_MEDIA, // these don't exist in FluxC, but are an artifact to wait for all
         // uploads to finish
-        UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, // same as above
+        UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, // same as above
         NULL_ERROR,
         MALFORMED_ERROR,
         NOT_FOUND_ERROR,
@@ -202,7 +202,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     public void testUploadMultipleImages() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MUTIPLE_MEDIA;
+        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA;
 
         mUploadedMediaModels = new HashMap<>();
         // here we use the newMediaModel() with id builder, as we need it to identify uploads
@@ -238,7 +238,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     public void testUploadMultipleImagesAndCancel() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL;
+        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL;
 
         mUploadedMediaModels = new HashMap<>();
         // here we use the newMediaModel() with id builder, as we need it to identify uploads
@@ -300,13 +300,13 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         if (event.canceled) {
-            if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
+            if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
                 mCountDownLatch.countDown();
             }
         } else if (event.completed) {
-            if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
+            if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
                 mUploadedIds.add(event.media.getMediaId());
                 // now update our own map object with the new media id
                 MediaModel media = mUploadedMediaModels.get(event.media.getId());
@@ -316,8 +316,8 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                     AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
                 }
                 assertNotNull(media);
-            } else if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA, mNextEvent);
+            } else if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA, mNextEvent);
                 mUploadedIds.add(event.media.getMediaId());
                 // now update our own map object with the new media id
                 MediaModel media = mUploadedMediaModels.get(event.media.getId());
@@ -448,7 +448,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
             }
         }
 
-        assertTrue(mCountDownLatch.await(TestUtils.MUTIPLE_UPLOADS_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void deleteMedia(MediaModel media) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -21,6 +21,7 @@ import org.wordpress.android.util.AppLog;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -198,6 +199,84 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    public void testUploadMultipleImages() throws InterruptedException {
+        // upload media to guarantee media exists
+        mUploadedIds = new ArrayList<>();
+        mNextEvent = ReleaseStack_MediaTestXMLRPC.TestEvents.UPLOADED_MUTIPLE_MEDIA;
+
+        mUploadedMediaModels = new HashMap<>();
+        // here we use the newMediaModel() with id builder, as we need it to identify uploads
+        addMediaModelToUploadArray("Test media 1");
+        addMediaModelToUploadArray("Test media 2");
+        addMediaModelToUploadArray("Test media 3");
+        addMediaModelToUploadArray("Test media 4");
+        addMediaModelToUploadArray("Test media 5");
+
+        // upload media, dispatching all at a time (not waiting for each to finish)
+        // also don't cancel any upload (0)
+        uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()), 0);
+
+        // verify all have been uploaded
+        assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
+
+        // verify they exist in the MediaStore
+        Iterator<MediaModel> iterator = mUploadedMediaModels.values().iterator();
+        while (iterator.hasNext()) {
+            MediaModel media = iterator.next();
+            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, media.getMediaId()));
+        }
+
+        // delete test images (bear in mind this is done sequentially)
+        mNextEvent = ReleaseStack_MediaTestXMLRPC.TestEvents.DELETED_MEDIA;
+        iterator = mUploadedMediaModels.values().iterator();
+        while (iterator.hasNext()) {
+            MediaModel media = iterator.next();
+            deleteMedia(media);
+        }
+    }
+
+    public void testUploadMultipleImagesAndCancel() throws InterruptedException {
+        // upload media to guarantee media exists
+        mUploadedIds = new ArrayList<>();
+        mNextEvent = ReleaseStack_MediaTestXMLRPC.TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL;
+
+        mUploadedMediaModels = new HashMap<>();
+        // here we use the newMediaModel() with id builder, as we need it to identify uploads
+        addMediaModelToUploadArray("Test media 1");
+        addMediaModelToUploadArray("Test media 2");
+        addMediaModelToUploadArray("Test media 3");
+        addMediaModelToUploadArray("Test media 4");
+        addMediaModelToUploadArray("Test media 5");
+
+        // use this variable to test cancelling 1, 2, 3, 4 or all 5 uploads
+        int amountToCancel = 4;
+
+        // upload media, dispatching all at a time (not waiting for each to finish)
+        // also cancel the first n=`amountToCancel` media uploads
+        uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()), amountToCancel);
+
+        // verify how many have been uploaded
+        assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
+
+        // verify each one of the remaining, non-cancelled uploads exist in the MediaStore
+        Iterator<MediaModel> iterator = mUploadedMediaModels.values().iterator();
+        while (iterator.hasNext()) {
+            MediaModel media = iterator.next();
+            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, media.getMediaId()));
+        }
+
+        // delete test images (bear in mind this is done sequentially)
+        mNextEvent = ReleaseStack_MediaTestXMLRPC.TestEvents.DELETED_MEDIA;
+        iterator = mUploadedMediaModels.values().iterator();
+        while (iterator.hasNext()) {
+            MediaModel media = iterator.next();
+            // delete only successfully uploaded test images
+            if (mUploadedIds.contains(media.getMediaId())) {
+                deleteMedia(media);
+            }
+        }
+    }
+
     public void testUploadVideo() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(BuildConfig.TEST_LOCAL_VIDEO, MediaUtils.MIME_TYPE_VIDEO);
@@ -218,10 +297,41 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Subscribe
     public void onMediaUploaded(OnMediaUploaded event) throws InterruptedException {
         if (event.isError()) {
-            mCountDownLatch.countDown();
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        if (event.canceled) {
+            if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL) {
+                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
+                mCountDownLatch.countDown();
+            }
         } else if (event.completed) {
-            mLastUploadedId = event.media.getMediaId();
-            assertEquals(TestEvents.UPLOADED_MEDIA, mNextEvent);
+            if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL) {
+                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
+                mUploadedIds.add(event.media.getMediaId());
+                // now update our own map object with the new media id
+                MediaModel media = mUploadedMediaModels.get(event.media.getId());
+                if (media != null) {
+                    media.setMediaId(event.media.getMediaId());
+                } else {
+                    AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
+                }
+                assertNotNull(media);
+            } else if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA) {
+                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA, mNextEvent);
+                mUploadedIds.add(event.media.getMediaId());
+                // now update our own map object with the new media id
+                MediaModel media = mUploadedMediaModels.get(event.media.getId());
+                if (media != null) {
+                    media.setMediaId(event.media.getMediaId());
+                } else {
+                    AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
+                }
+                assertNotNull(media);
+            } else
+            if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
+                assertEquals(TestEvents.UPLOADED_MEDIA, mNextEvent);
+                mLastUploadedId = event.media.getMediaId();
+            }
             mCountDownLatch.countDown();
         }
     }
@@ -263,13 +373,21 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch.countDown();
     }
 
+    private void addMediaModelToUploadArray(String title) {
+        MediaModel mediaModel = newMediaModel(title, BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
+        mUploadedMediaModels.put(mediaModel.getId(), mediaModel);
+    }
+
     private MediaModel newMediaModel(String mediaPath, String mimeType) {
-        final String testTitle = "Test Title";
+        return newMediaModel("Test Title", mediaPath, mimeType);
+    }
+
+    private MediaModel newMediaModel(String testTitle, String mediaPath, String mimeType) {
         final String testDescription = "Test Description";
         final String testCaption = "Test Caption";
         final String testAlt = "Test Alt";
 
-        MediaModel testMedia = new MediaModel();
+        MediaModel testMedia = mMediaStore.instantiateMediaModel();
         testMedia.setFilePath(mediaPath);
         testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1, mediaPath.length()));
         testMedia.setMimeType(mimeType + testMedia.getFileExtension());
@@ -309,6 +427,28 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void uploadMultipleMedia(List<MediaModel> mediaList, int howManyFirstToCancel) throws InterruptedException {
+        mCountDownLatch = new CountDownLatch(mediaList.size());
+        for (MediaModel media : mediaList) {
+            MediaStore.MediaPayload payload = new MediaStore.MediaPayload(sSite, media);
+            mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
+        }
+
+        if (howManyFirstToCancel > 0 && howManyFirstToCancel <= mediaList.size()) {
+            // wait a bit and issue the cancel command
+            TestUtils.waitFor(1000);
+
+            // we'e only cancelling the first n=howManyFirstToCancel uploads
+            for (int i = 0; i < howManyFirstToCancel; i++) {
+                MediaModel media = mediaList.get(i);
+                MediaStore.MediaPayload payload = new MediaStore.MediaPayload(sSite, media);
+                mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
+            }
+        }
+
+        assertTrue(mCountDownLatch.await(TestUtils.MUTIPLE_UPLOADS_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void deleteMedia(MediaModel media) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +43,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         FETCHED_MEDIA,
         DELETED_MEDIA,
         UPLOADED_MEDIA,
+        UPLOADED_MUTIPLE_MEDIA, // these don't exist in FluxC, but are an artifact to wait for all
+        // uploads to finish
+        UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, // same as above
         NULL_ERROR,
         MALFORMED_ERROR,
         NOT_FOUND_ERROR,
@@ -50,6 +54,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     private TestEvents mNextEvent;
     private long mLastUploadedId = -1L;
+
+    private List<Long> mUploadedIds = new ArrayList<>();
+    private HashMap<Integer, MediaModel> mUploadedMediaModels = new HashMap<>();
 
     @Override
     protected void setUp() throws Exception {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -334,6 +334,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                     // TODO it would be great to raise some more fine grained errors here, for
                     // instance timeouts should be raised instead of GENERIC_ERROR
                     MediaStore.MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
+                    error.message = e.getLocalizedMessage();
                     notifyMediaUploaded(media, error);
                 }
                 // clean from the current uploads map

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -48,6 +48,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
@@ -58,8 +59,9 @@ import okhttp3.Request.Builder;
 
 public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListener {
     private OkHttpClient mOkHttpClient;
-    // track the network call to support cancelling
-    private Call mCurrentUploadCall;
+    // this will hold which media is being uploaded by which call, in order to be able
+    // to monitor multiple uploads
+    private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
     public MediaXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, OkHttpClient.Builder okClientBuilder,
                              AccessToken accessToken, UserAgent userAgent,
@@ -159,8 +161,11 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         }
         okhttp3.Request request = builder.build();
 
-        mCurrentUploadCall = mOkHttpClient.newCall(request);
-        mCurrentUploadCall.enqueue(new Callback() {
+        Call call = mOkHttpClient.newCall(request);
+        mCurrentUploadCalls.put(media.getId(), call);
+
+        AppLog.d(T.MEDIA, "starting upload for: " + media.getId());
+        call.enqueue(new Callback() {
             @Override
             public void onResponse(Call call, okhttp3.Response response) throws IOException {
                 if (response.code() == HttpURLConnection.HTTP_OK) {
@@ -181,30 +186,43 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         MediaError mediaError = getMediaErrorFromXMLRPCException(fault);
                         AppLog.w(T.MEDIA, "media upload failed with error: " + mediaError.message);
                         notifyMediaUploaded(media, mediaError);
+
+                        // clean from the current uploads map
+                        removeCallFromCurrentUploadsMap(media.getId());
                     }
                 } else {
                     AppLog.w(T.MEDIA, "error uploading media: " + response.message());
                     MediaError error = new MediaError(MediaErrorType.fromHttpStatusCode(response.code()));
                     error.message = response.message();
                     notifyMediaUploaded(media, error);
+
+                    // clean from the current uploads map
+                    removeCallFromCurrentUploadsMap(media.getId());
                 }
-                mCurrentUploadCall = null;
             }
 
             @Override
             public void onFailure(Call call, IOException e) {
-                if (mCurrentUploadCall != null && mCurrentUploadCall.isCanceled()) {
-                    // Do not report errors since the upload was canceled and notified separately
-                    mCurrentUploadCall = null;
-                    return;
-                }
                 AppLog.w(T.MEDIA, "media upload failed: " + e);
-                MediaStore.MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
-                error.message = e.getLocalizedMessage();
-                notifyMediaUploaded(media, error);
-                mCurrentUploadCall = null;
+                if (!media.isUploadCancelled()) {
+                    // TODO it would be great to raise some more fine grained errors here, for
+                    // instance timeouts should be raised instead of GENERIC_ERROR
+                    MediaStore.MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
+                    error.message = e.getLocalizedMessage();
+                    notifyMediaUploaded(media, error);
+                }
+                // clean from the current uploads map
+                mCurrentUploadCalls.remove(media.getId());
             }
         });
+    }
+
+    private void removeCallFromCurrentUploadsMap(int id) {
+        // clean from the current uploads map
+        mCurrentUploadCalls.remove(id);
+        AppLog.d(T.MEDIA, "mediaXMLRPCClient: removed id: " +  id + " from current"
+                + " uploads, remaining: "
+                + mCurrentUploadCalls.size());
     }
 
     /**
@@ -280,6 +298,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                     MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
                     notifyMediaFetched(site, media, error);
                 }
+
+                // clean from the current uploads map
+                removeCallFromCurrentUploadsMap(media.getId());
+
             }
         }, new BaseRequest.BaseErrorListener() {
             @Override
@@ -331,9 +353,26 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     public void cancelUpload(final MediaModel media) {
+        if (media == null) {
+            MediaStore.MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
+            notifyMediaUploaded(null, error);
+            return;
+        }
+
         // cancel in-progress upload if necessary
-        if (mCurrentUploadCall != null && mCurrentUploadCall.isExecuted() && !mCurrentUploadCall.isCanceled()) {
-            mCurrentUploadCall.cancel();
+        int mediaModelId = media.getId();
+        // make sure we know which call/media to look for
+        Call correspondingCall = mCurrentUploadCalls.get(mediaModelId);
+        if (correspondingCall != null && correspondingCall.isExecuted() && !correspondingCall.isCanceled()) {
+            AppLog.d(T.MEDIA, "Canceled in-progress upload: " + media.getFileName());
+            // set the upload Cancelled flag on the media model so in case a failure is raised for this upload
+            // after cancellation (or as a product of it) we don't need to notify about the error
+            media.setUploadCancelled(true);
+            correspondingCall.cancel();
+            // clean from the current uploads map
+            mCurrentUploadCalls.remove(mediaModelId);
+
+            // report the upload was successfully cancelled
             notifyMediaUploadCanceled(media);
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -301,7 +301,6 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
                 // clean from the current uploads map
                 removeCallFromCurrentUploadsMap(media.getId());
-
             }
         }, new BaseRequest.BaseErrorListener() {
             @Override


### PR DESCRIPTION
Provides multiupload-multicancel capabilties and tests on FluxC for XMLRPC.

cc @aforcier 