### PR TITLE
Fix #404 and Fix #403: XML encode strings and add back Content-Length header

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.AccountAction;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
@@ -39,6 +39,8 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
 
     private final String mPrependString;
     private long mMediaSize;
+    private long mContentSize = -1;
+
 
     private long mMediaBytesWritten = 0;
 
@@ -73,7 +75,10 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
 
     @Override
     public long contentLength() throws IOException {
-        return getMediaBase64EncodedSize() + mPrependString.length() + APPEND_XML.length();
+        if (mContentSize == -1) {
+            mContentSize = getMediaBase64EncodedSize() + mPrependString.length() + APPEND_XML.length();
+        }
+        return mContentSize;
     }
 
     private long getMediaBase64EncodedSize() throws IOException {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.xmlrpc.media;
 
 import android.util.Base64;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseUploadRequestBody;
@@ -48,9 +49,13 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
         File mediaFile = new File(media.getFilePath());
         mMediaSize = mediaFile.length();
 
+        // TODO: we should use the XMLRPCSerializer instead of doing this
         mPrependString = String.format(Locale.ENGLISH, PREPEND_XML_FORMAT,
-                site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(),
-                media.getFileName(), media.getMimeType());
+                site.getSelfHostedSiteId(),
+                StringEscapeUtils.escapeXml(site.getUsername()),
+                StringEscapeUtils.escapeXml(site.getPassword()),
+                StringEscapeUtils.escapeXml(media.getFileName()),
+                StringEscapeUtils.escapeXml(media.getMimeType()));
     }
 
     @Override


### PR DESCRIPTION
Fix #404 and Fix #403: XML encode strings and add back Content-Length header.

This also fix the `getProgress()` method (was returning invalid number since bytes counted were different from bytes wrote on the socket).

cc @daniloercoli 