### PR TITLE
Track origin of the site and use XMLRPC if the site is jetpack but was added by XMLRPC 

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -596,4 +596,33 @@ public class SiteStoreUnitTest {
         }
         assertTrue(duplicate);
     }
+
+    @Test
+    public void testJetpackSelfHostedAndForceXMLRPC() {
+        SiteModel jetpackSite = generateJetpackSiteOverXMLRPC();
+        jetpackSite.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        assertTrue(jetpackSite.isUsingWpComRestApi());
+
+        // Force the origin, it should now use XMLRPC instead of REST.
+        jetpackSite.setOrigin(SiteModel.ORIGIN_XMLRPC);
+        assertFalse(jetpackSite.isUsingWpComRestApi());
+    }
+
+    @Test
+    public void testDefaultUsageWpComRestApi() {
+        SiteModel wpComSite = generateWPComSite();
+        assertTrue(wpComSite.isUsingWpComRestApi());
+
+        SiteModel jetpack1 = generateJetpackSiteOverRestOnly();
+        assertTrue(jetpack1.isUsingWpComRestApi());
+
+        SiteModel jetpack2 = generateJetpackSiteOverXMLRPC();
+        assertFalse(jetpack2.isUsingWpComRestApi());
+
+        SiteModel pureSelfHosted1 = generateSelfHostedNonJPSite();
+        assertFalse(pureSelfHosted1.isUsingWpComRestApi());
+
+        SiteModel pureSelfHosted2 = generateSelfHostedSiteFutureJetpack();
+        assertFalse(pureSelfHosted2.isUsingWpComRestApi());
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -19,6 +19,11 @@ public class SiteUtils {
         example.setSiteId(remoteId);
         example.setIsWPCom(isWPCom);
         example.setIsVisible(isVisible);
+        if (isWPCom) {
+            example.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        } else {
+            example.setOrigin(SiteModel.ORIGIN_XMLRPC);
+        }
         return example;
     }
 
@@ -30,6 +35,7 @@ public class SiteUtils {
         example.setIsJetpackConnected(false);
         example.setIsVisible(true);
         example.setXmlRpcUrl("http://some.url/xmlrpc.php");
+        example.setOrigin(SiteModel.ORIGIN_XMLRPC);
         return example;
     }
 
@@ -41,7 +47,10 @@ public class SiteUtils {
         example.setIsJetpackInstalled(true);
         example.setIsJetpackConnected(true);
         example.setIsVisible(true);
+        example.setUsername("ponyuser");
+        example.setPassword("ponypass");
         example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");
+        example.setOrigin(SiteModel.ORIGIN_XMLRPC);
         return example;
     }
 
@@ -53,6 +62,7 @@ public class SiteUtils {
         example.setIsJetpackConnected(true);
         example.setIsVisible(true);
         example.setXmlRpcUrl("http://jetpack2.url/xmlrpc.php");
+        example.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         return example;
     }
 
@@ -64,6 +74,7 @@ public class SiteUtils {
         example.setIsJetpackConnected(false);
         example.setIsVisible(true);
         example.setXmlRpcUrl("http://jetpack2.url/xmlrpc.php");
+        example.setOrigin(SiteModel.ORIGIN_XMLRPC);
         return example;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.model;
 
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 
 import com.yarolegovich.wellsql.core.Identifiable;
@@ -13,12 +14,22 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.io.Serializable;
+import java.lang.annotation.Retention;
 import java.net.URI;
 import java.net.URISyntaxException;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
 public class SiteModel extends Payload implements Identifiable, Serializable {
+    @Retention(SOURCE)
+    @IntDef({ORIGIN_UNKNOWN, ORIGIN_WPCOM_REST, ORIGIN_XMLRPC})
+    public @interface SiteOrigin {}
+    public static final int ORIGIN_UNKNOWN = 0;
+    public static final int ORIGIN_WPCOM_REST = 1;
+    public static final int ORIGIN_XMLRPC = 2;
+
     public static final long VIP_PLAN_ID = 31337;
 
     @PrimaryKey
@@ -35,6 +46,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private String mDefaultCommentStatus = "open";
     @Column private String mTimezone; // Expressed as an offset relative to GMT (e.g. '-8')
     @Column private String mFrameNonce; // only wpcom and Jetpack sites
+    @Column private int mOrigin = ORIGIN_UNKNOWN; // Does this site come from a WPCOM REST or XMLRPC fetch_sites call?
 
     // Self hosted specifics
     // The siteId for self hosted sites. Jetpack sites will also have a mSiteId, which is their id on wpcom
@@ -448,5 +460,18 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
 
     public void setIsAutomatedTransfer(boolean automatedTransfer) {
         mIsAutomatedTransfer = automatedTransfer;
+    }
+
+    @SiteOrigin
+    public int getOrigin() {
+        return mOrigin;
+    }
+
+    public void setOrigin(@SiteOrigin int origin) {
+        mOrigin = origin;
+    }
+
+    public boolean isUsingWpComRestApi() {
+        return isWPCom() || (isJetpackConnected() && getOrigin() == ORIGIN_WPCOM_REST);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -164,6 +164,10 @@ public abstract class BaseRequest<T> extends Request<T> {
         mHeaders.put(USER_AGENT_HEADER, userAgent);
     }
 
+    public void addHeader(String header, String value) {
+        mHeaders.put(header, value);
+    }
+
     /**
      * Convenience method for setting a {@link com.android.volley.RetryPolicy} with no retries.
      */

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -355,6 +355,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         if (!from.jetpack) {
             site.setIsWPCom(true);
         }
+        site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         return site;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -143,6 +143,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
             site.setIsWPCom(false);
             site.setUsername(username);
             site.setPassword(password);
+            site.setOrigin(SiteModel.ORIGIN_XMLRPC);
             siteArray.add(site);
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -42,7 +42,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 4;
+        return 5;
     }
 
     @Override
@@ -75,6 +75,10 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 3:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table AccountModel add EMAIL_VERIFIED boolean;");
+                oldVersion++;
+            case 4:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SiteModel add ORIGIN integer;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -298,14 +298,14 @@ public class CommentStore extends Store {
     private void createNewComment(RemoteCreateCommentPayload payload) {
         if (payload.reply == null) {
             // Create a new comment on a specific Post
-            if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+            if (payload.site.isUsingWpComRestApi()) {
                 mCommentRestClient.createNewComment(payload.site, payload.post, payload.comment);
             } else {
                 mCommentXMLRPCClient.createNewComment(payload.site, payload.post, payload.comment);
             }
         } else {
             // Create a new reply to a specific Comment
-            if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+            if (payload.site.isUsingWpComRestApi()) {
                 mCommentRestClient.createNewReply(payload.site, payload.comment, payload.reply);
             } else {
                 mCommentXMLRPCClient.createNewReply(payload.site, payload.comment, payload.reply);
@@ -369,7 +369,7 @@ public class CommentStore extends Store {
         if (payload.comment == null) {
             getCommentBySiteAndRemoteId(payload.site, payload.remoteCommentId);
         }
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mCommentRestClient.deleteComment(payload.site, payload.remoteCommentId, comment);
         } else {
             mCommentXMLRPCClient.deleteComment(payload.site, payload.remoteCommentId, comment);
@@ -398,7 +398,7 @@ public class CommentStore extends Store {
     }
 
     private void fetchComments(FetchCommentsPayload payload) {
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mCommentRestClient.fetchComments(payload.site, payload.number, payload.offset, payload.status);
         } else {
             mCommentXMLRPCClient.fetchComments(payload.site, payload.number, payload.offset, payload.status);
@@ -433,7 +433,7 @@ public class CommentStore extends Store {
             emitChange(event);
             return;
         }
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mCommentRestClient.pushComment(payload.site, payload.comment);
         } else {
             mCommentXMLRPCClient.pushComment(payload.site, payload.comment);
@@ -455,7 +455,7 @@ public class CommentStore extends Store {
     }
 
     private void fetchComment(RemoteCommentPayload payload) {
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mCommentRestClient.fetchComment(payload.site, payload.remoteCommentId, payload.comment);
         } else {
             mCommentXMLRPCClient.fetchComment(payload.site, payload.remoteCommentId, payload.comment);
@@ -483,7 +483,7 @@ public class CommentStore extends Store {
         if (payload.comment == null) {
             getCommentBySiteAndRemoteId(payload.site, payload.remoteCommentId);
         }
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mCommentRestClient.likeComment(payload.site, payload.remoteCommentId, comment, payload.like);
         } else {
             OnCommentChanged event = new OnCommentChanged(0);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -493,7 +493,7 @@ public class MediaStore extends Store {
             return;
         }
 
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.pushMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.pushMedia(payload.site, payload.media);
@@ -513,7 +513,7 @@ public class MediaStore extends Store {
             return;
         }
 
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.uploadMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.uploadMedia(payload.site, payload.media);
@@ -527,7 +527,7 @@ public class MediaStore extends Store {
             list.add(UploadState.UPLOADED.toString());
             offset = MediaSqlUtils.getMediaWithStates(payload.site, list).size();
         }
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.fetchMediaList(payload.site, offset);
         } else {
             mMediaXmlrpcClient.fetchMediaList(payload.site, offset);
@@ -541,7 +541,7 @@ public class MediaStore extends Store {
             return;
         }
 
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.fetchMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.fetchMedia(payload.site, payload.media);
@@ -554,7 +554,7 @@ public class MediaStore extends Store {
             return;
         }
 
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.deleteMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.deleteMedia(payload.site, payload.media);
@@ -563,7 +563,7 @@ public class MediaStore extends Store {
 
     private void performCancelUpload(@NonNull MediaPayload payload) {
         if (payload.media != null) {
-            if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+            if (payload.site.isUsingWpComRestApi()) {
                 mMediaRestClient.cancelUpload(payload.media);
             } else {
                 mMediaXmlrpcClient.cancelUpload(payload.media);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -324,7 +324,7 @@ public class PostStore extends Store {
     }
 
     private void deletePost(RemotePostPayload payload) {
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mPostRestClient.deletePost(payload.post, payload.site);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
@@ -333,7 +333,7 @@ public class PostStore extends Store {
     }
 
     private void fetchPost(RemotePostPayload payload) {
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mPostRestClient.fetchPost(payload.post, payload.site);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
@@ -347,7 +347,7 @@ public class PostStore extends Store {
             offset = PostSqlUtils.getUploadedPostsForSite(payload.site, pages).size();
         }
 
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mPostRestClient.fetchPosts(payload.site, pages, DEFAULT_POST_STATUS_LIST, offset);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
@@ -427,7 +427,7 @@ public class PostStore extends Store {
             onPostUploaded.error = payload.error;
             emitChange(onPostUploaded);
         } else {
-            if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+            if (payload.site.isUsingWpComRestApi()) {
                 // The WP.COM REST API response contains the modified post, so we're already in sync with the server
                 // All we need to do is store it and emit OnPostChanged
                 updatePost(payload.post, false);
@@ -443,7 +443,7 @@ public class PostStore extends Store {
     }
 
     private void pushPost(RemotePostPayload payload) {
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mPostRestClient.pushPost(payload.post, payload.site);
         } else {
             // TODO: check for WP-REST-API plugin and use it here

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -695,7 +695,7 @@ public class SiteStore extends Store {
     }
 
     private void fetchSite(SiteModel site) {
-        if (site.isWPCom() || site.isJetpackConnected()) {
+        if (site.isUsingWpComRestApi()) {
             mSiteRestClient.fetchSite(site);
         } else {
             mSiteXMLRPCClient.fetchSite(site);
@@ -707,7 +707,7 @@ public class SiteStore extends Store {
     }
 
     private void fetchPostFormats(SiteModel site) {
-        if (site.isWPCom() || site.isJetpackConnected()) {
+        if (site.isUsingWpComRestApi()) {
             mSiteRestClient.fetchPostFormats(site);
         } else {
             mSiteXMLRPCClient.fetchPostFormats(site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -296,7 +296,7 @@ public class TaxonomyStore extends Store {
     }
 
     private void fetchTerm(RemoteTermPayload payload) {
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.fetchTerm(payload.term, payload.site);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
@@ -306,7 +306,7 @@ public class TaxonomyStore extends Store {
 
     private void fetchTerms(SiteModel site, String taxonomyName) {
         // TODO: Support large number of terms (currently pulling 100 from REST, and ? from XML-RPC) - pagination?
-        if (site.isWPCom() || site.isJetpackConnected()) {
+        if (site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.fetchTerms(site, taxonomyName);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
@@ -381,7 +381,7 @@ public class TaxonomyStore extends Store {
             onTermUploaded.error = payload.error;
             emitChange(onTermUploaded);
         } else {
-            if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+            if (payload.site.isUsingWpComRestApi()) {
                 // The WP.COM REST API response contains the modified term, so we're already in sync with the server
                 // All we need to do is store it and emit OnTaxonomyChanged
                 updateTerm(payload.term);
@@ -396,7 +396,7 @@ public class TaxonomyStore extends Store {
     }
 
     private void pushTerm(RemoteTermPayload payload) {
-        if (payload.site.isWPCom() || payload.site.isJetpackConnected()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.pushTerm(payload.term, payload.site);
         } else {
             // TODO: check for WP-REST-API plugin and use it here


### PR DESCRIPTION
Track origin of the site and use XMLRPC if the site is jetpack but was added by XMLRPC.

This allows us to know if a certain site is Jetpack connected but added via XMLRPC, in that case the user might not want to connect to wpcom and continue via XMLRPC.

If the user later connects to his wpcom account, the same site will be fetched by a WPCOM REST and thus will override previous origin.