### PR TITLE
made OkHttpClient a shared instance in MediaRestClient and MediaXMLRPCClient

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -122,18 +122,18 @@ public class MockedNetworkModule {
     @Provides
     public MediaRestClient provideMediaRestClient(Dispatcher dispatcher, Context appContext,
                                                   @Named("regular") RequestQueue requestQueue,
-                                                  @Named("regular") OkHttpClient.Builder okHttpClientBuilder,
+                                                  @Named("regular") OkHttpClient okHttpClient,
                                                   AccessToken token, UserAgent userAgent) {
-        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClientBuilder, token, userAgent);
+        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClient, token, userAgent);
     }
 
     @Singleton
     @Provides
-    public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher, OkHttpClient.Builder okHttpClientBuilder,
+    public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher, OkHttpClient okHttpClient,
                                                       @Named("regular") RequestQueue requestQueue,
                                                       AccessToken token, UserAgent userAgent,
                                                       HTTPAuthManager httpAuthManager) {
-        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClientBuilder, token, userAgent, httpAuthManager);
+        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClient, token, userAgent, httpAuthManager);
     }
 
     @Singleton

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -35,9 +35,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         FETCHED_KNOWN_IMAGES,
         PUSHED_MEDIA,
         UPLOADED_MEDIA,
-        UPLOADED_MUTIPLE_MEDIA, // these don't exist in FluxC, but are an artifact to wait for all
+        UPLOADED_MULTIPLE_MEDIA, // these don't exist in FluxC, but are an artifact to wait for all
                                 // uploads to finish
-        UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, // same as above
+        UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, // same as above
         PUSH_ERROR,
         REMOVED_MEDIA,
     }
@@ -182,7 +182,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     public void testUploadMultipleImages() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MUTIPLE_MEDIA;
+        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA;
 
         mUploadedMediaModels = new HashMap<>();
         // here we use the newMediaModel() with id builder, as we need it to identify uploads
@@ -218,7 +218,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     public void testUploadMultipleImagesAndCancel() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL;
+        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL;
 
         mUploadedMediaModels = new HashMap<>();
         // here we use the newMediaModel() with id builder, as we need it to identify uploads
@@ -280,13 +280,13 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         if (event.canceled) {
-            if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
+            if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
                 mCountDownLatch.countDown();
             }
         } else if (event.completed) {
-            if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
+            if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, mNextEvent);
                 mUploadedIds.add(event.media.getMediaId());
                 // now update our own map object with the new media id
                 MediaModel media = mUploadedMediaModels.get(event.media.getId());
@@ -296,8 +296,8 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
                     AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
                 }
                 assertNotNull(media);
-            } else if (mNextEvent == TestEvents.UPLOADED_MUTIPLE_MEDIA) {
-                assertEquals(TestEvents.UPLOADED_MUTIPLE_MEDIA, mNextEvent);
+            } else if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA) {
+                assertEquals(TestEvents.UPLOADED_MULTIPLE_MEDIA, mNextEvent);
                 mUploadedIds.add(event.media.getMediaId());
                 // now update our own map object with the new media id
                 MediaModel media = mUploadedMediaModels.get(event.media.getId());

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
@@ -2,14 +2,17 @@ package org.wordpress.android.fluxc.example;
 
 import com.facebook.stetho.okhttp3.StethoInterceptor;
 
+import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -40,5 +43,27 @@ public class DebugOkHttpClientModule {
         }
         builder.addNetworkInterceptor(new StethoInterceptor());
         return builder;
+    }
+
+    @Singleton
+    @Provides
+    @Named("custom-ssl")
+    public OkHttpClient provideOkHttpClientSharedInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+        return builder
+                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
+    }
+
+    @Singleton
+    @Provides
+    @Named("regular")
+    public OkHttpClient provideOkHttpClientSharedInstance(@Named("regular")OkHttpClient.Builder builder) {
+        return builder
+                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
     }
 }

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
@@ -48,7 +48,7 @@ public class DebugOkHttpClientModule {
     @Singleton
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient provideOkHttpClientSharedInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
@@ -59,7 +59,7 @@ public class DebugOkHttpClientModule {
     @Singleton
     @Provides
     @Named("regular")
-    public OkHttpClient provideOkHttpClientSharedInstance(@Named("regular")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstance(@Named("regular")OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -120,19 +120,19 @@ public class ReleaseNetworkModule {
     @Provides
     public MediaRestClient provideMediaRestClient(Context appContext, Dispatcher dispatcher,
                                                   @Named("regular") RequestQueue requestQueue,
-                                                  @Named("regular") OkHttpClient.Builder okHttpClientBuilder,
+                                                  @Named("regular") OkHttpClient okHttpClient,
                                                   AccessToken token, UserAgent userAgent) {
-        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClientBuilder, token, userAgent);
+        return new MediaRestClient(appContext, dispatcher, requestQueue, okHttpClient, token, userAgent);
     }
 
     @Singleton
     @Provides
     public MediaXMLRPCClient provideMediaXMLRPCClient(Dispatcher dispatcher,
                                                       @Named("custom-ssl") RequestQueue requestQueue,
-                                                      @Named("custom-ssl") OkHttpClient.Builder okHttpClientBuilder,
+                                                      @Named("custom-ssl") OkHttpClient okHttpClient,
                                                       AccessToken token, UserAgent userAgent,
                                                       HTTPAuthManager httpAuthManager) {
-        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClientBuilder, token, userAgent, httpAuthManager);
+        return new MediaXMLRPCClient(dispatcher, requestQueue, okHttpClient, token, userAgent, httpAuthManager);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -45,7 +45,7 @@ public class ReleaseOkHttpClientModule {
     @Singleton
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient provideOkHttpClientSharedInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
@@ -56,7 +56,7 @@ public class ReleaseOkHttpClientModule {
     @Singleton
     @Provides
     @Named("regular")
-    public OkHttpClient provideOkHttpClientSharedInstance(@Named("regular")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstance(@Named("regular")OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -29,7 +29,7 @@ public class ReleaseOkHttpClientModule {
 
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient.Builder provideMediaOkHttpClientInstanceCustomSSL(MemorizingTrustManager memorizingTrustManager) {
+    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(MemorizingTrustManager memorizingTrustManager) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -45,7 +45,7 @@ public class ReleaseOkHttpClientModule {
     @Singleton
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient provideMediaOkHttpClientInstance(@Named("custom-ssl")OkHttpClient.Builder builder) {
+    public OkHttpClient provideOkHttpClientSharedInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -29,7 +29,7 @@ public class ReleaseOkHttpClientModule {
 
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(MemorizingTrustManager memorizingTrustManager) {
+    public OkHttpClient.Builder provideMediaOkHttpClientInstanceCustomSSL(MemorizingTrustManager memorizingTrustManager) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -45,7 +45,7 @@ public class ReleaseOkHttpClientModule {
     @Singleton
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient provideOkHttpClientSharedInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstance(@Named("custom-ssl")OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -1,13 +1,16 @@
 package org.wordpress.android.fluxc.module;
 
+import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -37,5 +40,27 @@ public class ReleaseOkHttpClientModule {
             AppLog.e(T.API, e);
         }
         return builder;
+    }
+
+    @Singleton
+    @Provides
+    @Named("custom-ssl")
+    public OkHttpClient provideOkHttpClientSharedInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+        return builder
+                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
+    }
+
+    @Singleton
+    @Provides
+    @Named("regular")
+    public OkHttpClient provideOkHttpClientSharedInstance(@Named("regular")OkHttpClient.Builder builder) {
+        return builder
+                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -69,13 +68,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
     public MediaRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
-                           OkHttpClient.Builder okClientBuilder, AccessToken accessToken, UserAgent userAgent) {
+                           OkHttpClient okHttpClient, AccessToken accessToken, UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
-        mOkHttpClient = okClientBuilder
-                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
-                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .build();
+        mOkHttpClient = okHttpClient;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -48,7 +48,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -61,15 +60,11 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     // track the network call to support cancelling
     private Call mCurrentUploadCall;
 
-    public MediaXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, OkHttpClient.Builder okClientBuilder,
+    public MediaXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, OkHttpClient okHttpClient,
                              AccessToken accessToken, UserAgent userAgent,
                              HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
-        mOkHttpClient = okClientBuilder
-                .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
-                .writeTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
-                .build();
+        mOkHttpClient = okHttpClient;
     }
 
     @Override


### PR DESCRIPTION
Supersedes #399 and #400 (bad commit history)

This PR makes the OkHttpClient being used for media uploads a singleton, as recommended in OkHttpClient specs here https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html

> OkHttpClients should be shared
> 
> OkHttp performs best when you create a single OkHttpClient instance and reuse it for all of your HTTP calls. This is because each client holds its own connection pool and thread pools. Reusing connections and threads reduces latency and saves memory. Conversely, creating a client for each request wastes resources on idle pools.
> 

cc @aforcier 
