### PR TITLE
SiteStore: New domain suggestions action

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     }
 
     checkstyle {
-        toolVersion = '7.3'
+        toolVersion = '7.6.1'
         configFile file("${project.rootDir}/config/checkstyle.xml")
     }
 }

--- a/example/src/main/res/layout/fragment_signed_out_actions.xml
+++ b/example/src/main/res/layout/fragment_signed_out_actions.xml
@@ -23,4 +23,10 @@
         android:layout_height="wrap_content"
         android:text="Check if URL is WPCom site (or Jetpack)" />
 
+    <Button
+        android:id="@+id/domain_suggestions"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Domain suggestions" />
+
 </LinearLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -6,12 +6,14 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.DeleteSiteResponsePayload;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.ExportSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPComResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
-import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.ExportSiteResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
+import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
+import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
 
 @ActionEnum
 public enum SiteAction implements IAction {
@@ -32,6 +34,8 @@ public enum SiteAction implements IAction {
     EXPORT_SITE,
     @Action(payloadType = String.class)
     IS_WPCOM_URL,
+    @Action(payloadType = SuggestDomainsPayload.class)
+    SUGGEST_DOMAINS,
 
     // Remote responses
     @Action(payloadType = NewSiteResponsePayload.class)
@@ -59,5 +63,7 @@ public enum SiteAction implements IAction {
     @Action(payloadType = SitesModel.class)
     HIDE_SITES,
     @Action(payloadType = IsWPComResponsePayload.class)
-    CHECKED_IS_WPCOM_URL
+    CHECKED_IS_WPCOM_URL,
+    @Action(payloadType = SuggestDomainsResponsePayload.class)
+    SUGGESTED_DOMAINS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class WPAPIGsonRequest<T> extends GsonRequest<T> {
     public WPAPIGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
                              Class<T> clazz, Listener<T> listener, BaseErrorListener errorListener) {
-        super(method, params, body, url, clazz, listener, errorListener);
+        super(method, params, body, url, clazz, null, listener, errorListener);
         // If it's a GET request, add the parameters to the URL
         if (method == Method.GET) {
             addQueryParameters(params);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError;
 
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 public class WPComGsonRequest<T> extends GsonRequest<T> {
@@ -30,8 +30,8 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
     }
 
     private WPComGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
-                            Class<T> clazz, Listener<T> listener, BaseErrorListener errorListener) {
-        super(method, params, body, url, clazz, listener, errorListener);
+                             Class<T> clazz, Type type, Listener<T> listener, BaseErrorListener errorListener) {
+        super(method, params, body, url, clazz, type, listener, errorListener);
         // If it's a GET request, add the parameters to the URL
         if (method == Method.GET) {
             addQueryParameters(params);
@@ -48,7 +48,12 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
      */
     public static <T> WPComGsonRequest<T> buildGetRequest(String url, Map<String, String> params, Class<T> clazz,
                                                           Listener<T> listener, BaseErrorListener errorListener) {
-        return new WPComGsonRequest<>(Method.GET, url, params, null, clazz, listener, errorListener);
+        return new WPComGsonRequest<>(Method.GET, url, params, null, clazz, null, listener, errorListener);
+    }
+
+    public static <T> WPComGsonRequest<T> buildGetRequest(String url, Map<String, String> params, Type type,
+                                                          Listener<T> listener, BaseErrorListener errorListener) {
+        return new WPComGsonRequest<>(Method.GET, url, params, null, null, type, listener, errorListener);
     }
 
     /**
@@ -61,11 +66,12 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
      */
     public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, Object> body, Class<T> clazz,
                                                            Listener<T> listener, BaseErrorListener errorListener) {
-        // HTTP RFC requires a body (even empty) for all POST requests.
-        if (body == null) {
-            body = new HashMap<>();
-        }
-        return new WPComGsonRequest<>(Method.POST, url, null, body, clazz, listener, errorListener);
+        return new WPComGsonRequest<>(Method.POST, url, null, body, clazz, null, listener, errorListener);
+    }
+
+    public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, Object> body, Type type,
+                                                           Listener<T> listener, BaseErrorListener errorListener) {
+        return new WPComGsonRequest<>(Method.POST, url, null, body, null, type, listener, errorListener);
     }
 
     private String addDefaultParameters(String url) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainSuggestionResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainSuggestionResponse.java
@@ -1,0 +1,13 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import org.wordpress.android.fluxc.network.Response;
+
+public class DomainSuggestionResponse implements Response {
+    public String cost;
+    public String domain_name;
+    public boolean is_free;
+
+    public int product_id;
+    public String product_slug;
+    public float relevance;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainSuggestionResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainSuggestionResponse.java
@@ -7,7 +7,7 @@ public class DomainSuggestionResponse implements Response {
     public String domain_name;
     public boolean is_free;
 
-    public int product_id;
+    public String product_id;
     public String product_slug;
     public float relevance;
 }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -12,6 +12,8 @@
 
 /read/feed/$feed_url_or_id#long,String
 
+/domains/suggestions
+
 /sites/
 /sites/$site/delete
 /sites/$site/exports/start


### PR DESCRIPTION
Note: I had to change the GsonRequest a bit in 5dbea5f to allow "generic element" (aka json array) as root response. it's not a huge change since it's only affects the new request used here in this PR - cAT tests are fine.

I didn't want to add connected tests because it's not a fundamental endpoint. No unit tests either because it's a pure network round trip.

To test: open the example app, go to "Signed Out Actions", click "Domain suggestions", have fun.