### PR TITLE
Add rule enforcing space after inline annotations

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -51,6 +51,12 @@
       <property name="severity" value="error"/>
     </module>
 
+    <module name="RegexpSingleline">
+        <property name="format" value="@[\S]*\(\&quot;.*\&quot;\)[^ \t]"/>
+        <property name="message" value="In-line annotations must be followed by one whitespace"/>
+        <property name="severity" value="error"/>
+    </module>
+
     <!-- Specific to FluxC / WordPress -->
     <module name="RegexpSingleline">
       <property name="format" value="dotcom"/>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -52,7 +52,7 @@
     </module>
 
     <module name="RegexpSingleline">
-        <property name="format" value="@[\S]*\(\&quot;.*\&quot;\)[^ \t]"/>
+        <property name="format" value="@[\S]*\(.*\)[^ \t]"/>
         <property name="message" value="In-line annotations must be followed by one whitespace"/>
         <property name="severity" value="error"/>
     </module>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -52,7 +52,7 @@
     </module>
 
     <module name="RegexpSingleline">
-        <property name="format" value="@[\S]*\(.*\)[^ \t]"/>
+        <property name="format" value="@[\S]*(\([{]?\&quot;.*\&quot;[}]?\)|\([^\&quot;]*\))[^ \t]"/>
         <property name="message" value="In-line annotations must be followed by one whitespace"/>
         <property name="severity" value="error"/>
     </module>

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
@@ -48,7 +48,7 @@ public class DebugOkHttpClientModule {
     @Singleton
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(@Named("custom-ssl") OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
@@ -59,7 +59,7 @@ public class DebugOkHttpClientModule {
     @Singleton
     @Provides
     @Named("regular")
-    public OkHttpClient provideMediaOkHttpClientInstance(@Named("regular")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstance(@Named("regular") OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -45,7 +45,7 @@ public class ReleaseOkHttpClientModule {
     @Singleton
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(@Named("custom-ssl")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(@Named("custom-ssl") OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
@@ -56,7 +56,7 @@ public class ReleaseOkHttpClientModule {
     @Singleton
     @Provides
     @Named("regular")
-    public OkHttpClient provideMediaOkHttpClientInstance(@Named("regular")OkHttpClient.Builder builder) {
+    public OkHttpClient provideMediaOkHttpClientInstance(@Named("regular") OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Generates a checkstyle error when there's no whitespace after an in-line annotation followed by text.

For example,

```java
public void exampleMethod(@Named("something")Thingy thingy) {
```

will be flagged, as the correct form is:

```java
public void exampleMethod(@Named("something") Thingy thingy) {
```

cc @maxme