### PR TITLE
Do not report "broken pipe" errors to end users

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -221,7 +222,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             return mediaError;
         }
 
-        errorMessage =  errorMessage.toLowerCase();
+        errorMessage =  errorMessage.toLowerCase(Locale.US);
         if (errorMessage.contains("broken pipe") || errorMessage.contains("epipe")) {
             // do not use the real error message.
             mediaError.message = "";

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -214,9 +214,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
     private MediaError parseUploadError(IOException e) {
         MediaError mediaError = new MediaError(MediaErrorType.GENERIC_ERROR);
+        mediaError.message = e.getLocalizedMessage();
+
         String errorMessage = e.getMessage();
         if (TextUtils.isEmpty(errorMessage)) {
-            mediaError.message = e.getLocalizedMessage();
             return mediaError;
         }
 


### PR DESCRIPTION
![device-2017-04-19-203218](https://cloud.githubusercontent.com/assets/518232/25225859/3b305e3c-25c3-11e7-91e0-9e92d6f19da5.png)

This PR does check the IOException error message, and hides `broken pipe` detailed message to end users. The error is logged in the app log, and wp-android does use the dafault error message in this case. 

We can provide a more useful error message, `An error happened, please contact the support if persist`, if we think it's a better solution. 