### PR TITLE
Add SEARCH_POSTS action to PostStore

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
+import org.wordpress.android.fluxc.store.PostStore.OnPostsSearched;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.SearchPostsPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
@@ -121,11 +122,6 @@ public class PostsFragment extends Fragment {
             return;
         }
 
-        if (event.causeOfChange.equals(PostAction.SEARCH_POSTS)) {
-            prependToLog("Found " + event.rowsAffected + " posts from the search.");
-            return;
-        }
-
         SiteModel firstSite = getFirstSite();
         if (!mPostStore.getPostsForSite(firstSite).isEmpty()) {
             if (event.causeOfChange.equals(PostAction.FETCH_POSTS)
@@ -141,6 +137,18 @@ public class PostsFragment extends Fragment {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostUploaded(OnPostUploaded event) {
         prependToLog("Post uploaded! Remote post id: " + event.post.getRemotePostId());
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onPostsSearched(OnPostsSearched event) {
+        if (event.isError()) {
+            prependToLog("Error searching posts: " + event.error.type);
+            return;
+        }
+        List<PostModel> results = event.searchResults != null ? event.searchResults.getPosts() : null;
+        int resultCount = results == null ? 0 : results.size();
+        prependToLog("Found " + resultCount + " posts from the search.");
     }
 
     private void prependToLog(final String s) {

--- a/example/src/main/res/layout/fragment_posts.xml
+++ b/example/src/main/res/layout/fragment_posts.xml
@@ -23,4 +23,16 @@
         android:layout_height="wrap_content"
         android:text="Delete a post from first site" />
 
+    <EditText
+        android:id="@+id/search_posts_query"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Search query" />
+
+    <Button
+        android:id="@+id/search_posts"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Search" />
+
 </LinearLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -22,6 +22,8 @@ public enum PostAction implements IAction {
     PUSH_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETE_POST,
+    @Action(payloadType = RemotePostPayload.class)
+    SEARCH_POSTS,
 
     // Remote responses
     @Action(payloadType = FetchPostsResponsePayload.class)
@@ -32,6 +34,8 @@ public enum PostAction implements IAction {
     PUSHED_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETED_POST,
+    @Action(payloadType = RemotePostPayload.class)
+    SEARCHED_POST,
 
     // Local actions
     @Action(payloadType = PostModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -6,6 +6,8 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
+import org.wordpress.android.fluxc.store.PostStore.SearchPostsPayload;
+import org.wordpress.android.fluxc.store.PostStore.SearchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 
@@ -22,7 +24,7 @@ public enum PostAction implements IAction {
     PUSH_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETE_POST,
-    @Action(payloadType = RemotePostPayload.class)
+    @Action(payloadType = SearchPostsPayload.class)
     SEARCH_POSTS,
 
     // Remote responses
@@ -34,7 +36,7 @@ public enum PostAction implements IAction {
     PUSHED_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETED_POST,
-    @Action(payloadType = RemotePostPayload.class)
+    @Action(payloadType = SearchPostsResponsePayload.class)
     SEARCHED_POST,
 
     // Local actions

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -37,7 +37,7 @@ public enum PostAction implements IAction {
     @Action(payloadType = RemotePostPayload.class)
     DELETED_POST,
     @Action(payloadType = SearchPostsResponsePayload.class)
-    SEARCHED_POST,
+    SEARCHED_POSTS,
 
     // Local actions
     @Action(payloadType = PostModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -26,6 +26,8 @@ public enum PostAction implements IAction {
     DELETE_POST,
     @Action(payloadType = SearchPostsPayload.class)
     SEARCH_POSTS,
+    @Action(payloadType = SearchPostsPayload.class)
+    SEARCH_PAGES,
 
     // Remote responses
     @Action(payloadType = FetchPostsResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -253,9 +253,9 @@ public class PostRestClient extends BaseWPComRestClient {
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        PostError postError = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
                         SearchPostsResponsePayload payload =
-                            new SearchPostsResponsePayload(null, site, searchTerm, false, false);
-                        payload.error = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
+                                new SearchPostsResponsePayload(site, searchTerm, postError);
                         mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -247,7 +247,7 @@ public class PostRestClient extends BaseWPComRestClient {
 
                         SearchPostsResponsePayload payload =
                             new SearchPostsResponsePayload(postsModel, site, searchTerm, loadedMore, canLoadMore);
-                        mDispatcher.dispatch(PostActionBuilder.newSearchedPostAction(payload));
+                        mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
                     }
                 },
                 new BaseErrorListener() {
@@ -256,7 +256,7 @@ public class PostRestClient extends BaseWPComRestClient {
                         SearchPostsResponsePayload payload =
                             new SearchPostsResponsePayload(null, site, searchTerm, false, false);
                         payload.error = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
-                        mDispatcher.dispatch(PostActionBuilder.newSearchedPostAction(payload));
+                        mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -245,8 +245,8 @@ public class PostRestClient extends BaseWPComRestClient {
                         boolean canLoadMore = postArray.size() == PostStore.NUM_POSTS_PER_FETCH;
                         PostsModel postsModel = new PostsModel(postArray);
 
-                        SearchPostsResponsePayload payload =
-                            new SearchPostsResponsePayload(postsModel, site, searchTerm, loadedMore, canLoadMore);
+                        SearchPostsResponsePayload payload = new SearchPostsResponsePayload(
+                                postsModel, site, searchTerm, pages, loadedMore, canLoadMore);
                         mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
                     }
                 },
@@ -255,7 +255,7 @@ public class PostRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         PostError postError = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
                         SearchPostsResponsePayload payload =
-                                new SearchPostsResponsePayload(site, searchTerm, postError);
+                                new SearchPostsResponsePayload(site, searchTerm, pages, postError);
                         mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -215,6 +215,9 @@ public class PostRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void searchPosts(final SiteModel site, final String searchTerm) {
+    }
+
     private PostModel postResponseToPostModel(PostWPComRestResponse from) {
         PostModel post = new PostModel();
         post.setRemotePostId(from.ID);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -32,7 +32,6 @@ import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
-import org.wordpress.android.fluxc.store.PostStore.SearchPostsResponsePayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -273,12 +272,6 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         request.disableRetries();
         add(request);
-    }
-
-    public void searchPosts(final SiteModel site, final String searchTerm) {
-        SearchPostsResponsePayload payload = new SearchPostsResponsePayload(null, site, searchTerm, false, false);
-        payload.error = new PostError(PostErrorType.UNSUPPORTED_ACTION, "Search only supported on .com/Jetpack sites");
-        mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
     }
 
     private PostsModel postsResponseToPostsModel(Object[] response, SiteModel site, boolean isPage) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -276,7 +276,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
     }
 
     public void searchPosts(final SiteModel site, final String searchTerm) {
-        SearchPostsResponsePayload payload = new SearchPostsResponsePayload(null, site, false, false);
+        SearchPostsResponsePayload payload = new SearchPostsResponsePayload(null, site, searchTerm, false, false);
         payload.error = new PostError(PostErrorType.UNSUPPORTED_ACTION, "Search only supported on .com/Jetpack sites");
         mDispatcher.dispatch(PostActionBuilder.newSearchedPostAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
+import org.wordpress.android.fluxc.store.PostStore.SearchPostsResponsePayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -272,6 +273,12 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         request.disableRetries();
         add(request);
+    }
+
+    public void searchPosts(final SiteModel site, final String searchTerm) {
+        SearchPostsResponsePayload payload = new SearchPostsResponsePayload(null, site, false, false);
+        payload.error = new PostError(PostErrorType.UNSUPPORTED_ACTION, "Search only supported on .com/Jetpack sites");
+        mDispatcher.dispatch(PostActionBuilder.newSearchedPostAction(payload));
     }
 
     private PostsModel postsResponseToPostsModel(Object[] response, SiteModel site, boolean isPage) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -278,7 +278,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
     public void searchPosts(final SiteModel site, final String searchTerm) {
         SearchPostsResponsePayload payload = new SearchPostsResponsePayload(null, site, searchTerm, false, false);
         payload.error = new PostError(PostErrorType.UNSUPPORTED_ACTION, "Search only supported on .com/Jetpack sites");
-        mDispatcher.dispatch(PostActionBuilder.newSearchedPostAction(payload));
+        mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
     }
 
     private PostsModel postsResponseToPostsModel(Object[] response, SiteModel site, boolean isPage) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -12,7 +12,6 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.PostAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -76,21 +75,24 @@ public class PostStore extends Store {
         public PostsModel posts;
         public SiteModel site;
         public String searchTerm;
+        public boolean isPages;
         public boolean loadedMore;
         public boolean canLoadMore;
 
-        public SearchPostsResponsePayload(PostsModel posts, SiteModel site, String searchTerm,
+        public SearchPostsResponsePayload(PostsModel posts, SiteModel site, String searchTerm, boolean isPages,
                                           boolean loadedMore, boolean canLoadMore) {
             this.posts = posts;
             this.site = site;
             this.searchTerm = searchTerm;
+            this.isPages = isPages;
             this.loadedMore = loadedMore;
             this.canLoadMore = canLoadMore;
         }
 
-        public SearchPostsResponsePayload(SiteModel site, String searchTerm, PostError error) {
+        public SearchPostsResponsePayload(SiteModel site, String searchTerm, boolean isPages, PostError error) {
             this.site = site;
             this.searchTerm = searchTerm;
+            this.isPages = isPages;
             this.error = error;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -370,7 +370,7 @@ public class PostStore extends Store {
             case SEARCH_POSTS:
                 searchPosts((SearchPostsPayload) action.getPayload(), false);
                 break;
-            case SEARCHED_POST:
+            case SEARCHED_POSTS:
                 handleSearchPostsCompleted((SearchPostsResponsePayload) action.getPayload());
                 break;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -370,6 +370,9 @@ public class PostStore extends Store {
             case SEARCH_POSTS:
                 searchPosts((SearchPostsPayload) action.getPayload(), false);
                 break;
+            case SEARCH_PAGES:
+                searchPosts((SearchPostsPayload) action.getPayload(), true);
+                break;
             case SEARCHED_POSTS:
                 handleSearchPostsCompleted((SearchPostsResponsePayload) action.getPayload());
                 break;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -358,12 +358,6 @@ public class PostStore extends Store {
         }
     }
 
-    private void searchPosts(SearchPostsPayload payload) {
-    }
-
-    private void handleSearchPostsCompleted(SearchPostsResponsePayload payload) {
-    }
-
     private void deletePost(RemotePostPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mPostRestClient.deletePost(payload.post, payload.site);
@@ -393,6 +387,14 @@ public class PostStore extends Store {
         } else {
             // TODO: check for WP-REST-API plugin and use it here
             mPostXMLRPCClient.fetchPosts(payload.site, pages, offset);
+        }
+    }
+
+    private void searchPosts(SearchPostsPayload payload) {
+        if (payload.site.isUsingWpComRestApi()) {
+            mPostRestClient.searchPosts(payload.site, payload.searchTerm);
+        } else {
+            // TODO: emit error, only REST API supported
         }
     }
 
@@ -438,6 +440,10 @@ public class PostStore extends Store {
         }
 
         emitChange(onPostChanged);
+    }
+
+    private void handleSearchPostsCompleted(SearchPostsResponsePayload payload) {
+        // TODO
     }
 
     private void handleFetchSinglePostCompleted(FetchPostResponsePayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -72,12 +72,15 @@ public class PostStore extends Store {
         public PostError error;
         public PostsModel posts;
         public SiteModel site;
+        public String searchTerm;
         public boolean loadedMore;
         public boolean canLoadMore;
 
-        public SearchPostsResponsePayload(PostsModel posts, SiteModel site, boolean loadedMore, boolean canLoadMore) {
+        public SearchPostsResponsePayload(PostsModel posts, SiteModel site, String searchTerm,
+                                          boolean loadedMore, boolean canLoadMore) {
             this.posts = posts;
             this.site = site;
+            this.searchTerm = searchTerm;
             this.loadedMore = loadedMore;
             this.canLoadMore = canLoadMore;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -408,6 +408,7 @@ public class PostStore extends Store {
         if (payload.site.isUsingWpComRestApi()) {
             mPostRestClient.searchPosts(payload.site, payload.searchTerm);
         } else {
+            // TODO: check for WP-REST-API plugin and use it here
             mPostXMLRPCClient.searchPosts(payload.site, payload.searchTerm);
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -86,6 +86,12 @@ public class PostStore extends Store {
             this.loadedMore = loadedMore;
             this.canLoadMore = canLoadMore;
         }
+
+        public SearchPostsResponsePayload(SiteModel site, String searchTerm, PostError error) {
+            this.site = site;
+            this.searchTerm = searchTerm;
+            this.error = error;
+        }
     }
 
     public static class FetchPostsResponsePayload extends Payload {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -170,6 +170,7 @@ public class PostStore extends Store {
     public enum PostErrorType {
         UNKNOWN_POST,
         UNKNOWN_POST_TYPE,
+        UNSUPPORTED_ACTION,
         UNAUTHORIZED,
         INVALID_RESPONSE,
         GENERIC_ERROR;
@@ -394,7 +395,7 @@ public class PostStore extends Store {
         if (payload.site.isUsingWpComRestApi()) {
             mPostRestClient.searchPosts(payload.site, payload.searchTerm);
         } else {
-            // TODO: emit error, only REST API supported
+            mPostXMLRPCClient.searchPosts(payload.site, payload.searchTerm);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -320,7 +320,19 @@ public class PostStore extends Store {
             case REMOVE_ALL_POSTS:
                 removeAllPosts();
                 break;
+            case SEARCH_POSTS:
+                searchPosts((RemotePostPayload) action.getPayload());
+                break;
+            case SEARCHED_POST:
+                handleSearchPostsCompleted((RemotePostPayload) action.getPayload());
+                break;
         }
+    }
+
+    private void searchPosts(RemotePostPayload payload) {
+    }
+
+    private void handleSearchPostsCompleted(RemotePostPayload payload) {
     }
 
     private void deletePost(RemotePostPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -54,18 +54,18 @@ public class PostStore extends Store {
         }
     }
 
-    public static class SearchPostsPayload extends FetchPostsPayload {
+    public static class SearchPostsPayload extends Payload {
+        public SiteModel site;
         public String searchTerm;
         public int offset;
 
         public SearchPostsPayload(SiteModel site, String searchTerm) {
-            super(site);
+            this.site = site;
             this.searchTerm = searchTerm;
         }
 
         public SearchPostsPayload(SiteModel site, String searchTerm, int offset) {
-            super(site);
-            this.searchTerm = searchTerm;
+            this(site, searchTerm);
             this.offset = offset;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -54,6 +54,35 @@ public class PostStore extends Store {
         }
     }
 
+    public static class SearchPostsPayload extends FetchPostsPayload {
+        public String searchTerm;
+
+        public SearchPostsPayload(SiteModel site, String searchTerm) {
+            super(site);
+            this.searchTerm = searchTerm;
+        }
+
+        public SearchPostsPayload(SiteModel site, String searchTerm, boolean loadMore) {
+            super(site, loadMore);
+            this.searchTerm = searchTerm;
+        }
+    }
+
+    public static class SearchPostsResponsePayload extends Payload {
+        public PostError error;
+        public PostsModel posts;
+        public SiteModel site;
+        public boolean loadedMore;
+        public boolean canLoadMore;
+
+        public SearchPostsResponsePayload(PostsModel posts, SiteModel site, boolean loadedMore, boolean canLoadMore) {
+            this.posts = posts;
+            this.site = site;
+            this.loadedMore = loadedMore;
+            this.canLoadMore = canLoadMore;
+        }
+    }
+
     public static class FetchPostsResponsePayload extends Payload {
         public PostError error;
         public PostsModel posts;
@@ -321,18 +350,18 @@ public class PostStore extends Store {
                 removeAllPosts();
                 break;
             case SEARCH_POSTS:
-                searchPosts((RemotePostPayload) action.getPayload());
+                searchPosts((SearchPostsPayload) action.getPayload());
                 break;
             case SEARCHED_POST:
-                handleSearchPostsCompleted((RemotePostPayload) action.getPayload());
+                handleSearchPostsCompleted((SearchPostsResponsePayload) action.getPayload());
                 break;
         }
     }
 
-    private void searchPosts(RemotePostPayload payload) {
+    private void searchPosts(SearchPostsPayload payload) {
     }
 
-    private void handleSearchPostsCompleted(RemotePostPayload payload) {
+    private void handleSearchPostsCompleted(SearchPostsResponsePayload payload) {
     }
 
     private void deletePost(RemotePostPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.PostAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -422,7 +423,11 @@ public class PostStore extends Store {
             mPostRestClient.searchPosts(payload.site, payload.searchTerm, pages, payload.offset);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
-            mPostXMLRPCClient.searchPosts(payload.site, payload.searchTerm);
+            PostError error =
+                    new PostError(PostErrorType.UNSUPPORTED_ACTION, "Search only supported on .com/Jetpack sites");
+            OnPostsSearched onPostsSearched = new OnPostsSearched(payload.searchTerm, null, false);
+            onPostsSearched.error = error;
+            emitChange(onPostsSearched);
         }
     }
 


### PR DESCRIPTION
The new action is only available for the REST client, the XMLRPC client immediately dispatches an error event. There's also a new event `OnPostsSearched` since the other two events didn't make much sense to overload. `PostErrorType.UNSUPPORTED_ACTION` was added to specify error events from XMLRPC calls.

Successful responses to a search will update the local DB. I was debating whether or not to include `rowsEffected` but it didn't seem relevant to the action response. I also thought about overloading the `FETCH_POSTS` action but that would end up complicating a pretty straightforward implementation. Thoughts on this would be appreciated 😄 