### PR TITLE
Add unMappedUrl to SiteModel

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -71,7 +71,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private String mPlanShortName;
     @Column private String mIconUrl;
     @Column private boolean mHasFreePlan;
-    @Column private String mUnMappedUrl;
+    @Column private String mUnmappedUrl;
 
     // WPCom capabilities
     @Column private boolean mHasCapabilityEditPages;
@@ -448,12 +448,12 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
         mHasFreePlan = hasFreePlan;
     }
 
-    public String getUnMappedUrl() {
-        return mUnMappedUrl;
+    public String getUnmappedUrl() {
+        return mUnmappedUrl;
     }
 
-    public void setUnMappedUrl(String unMappedUrl) {
-        mUnMappedUrl = unMappedUrl;
+    public void setUnmappedUrl(String unMappedUrl) {
+        mUnmappedUrl = unMappedUrl;
     }
 
     public boolean isJetpackInstalled() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -71,6 +71,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private String mPlanShortName;
     @Column private String mIconUrl;
     @Column private boolean mHasFreePlan;
+    @Column private String mUnMappedUrl;
 
     // WPCom capabilities
     @Column private boolean mHasCapabilityEditPages;
@@ -445,6 +446,14 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
 
     public void setHasFreePlan(boolean hasFreePlan) {
         mHasFreePlan = hasFreePlan;
+    }
+
+    public String getUnMappedUrl() {
+        return mUnMappedUrl;
+    }
+
+    public void setUnMappedUrl(String unMappedUrl) {
+        mUnMappedUrl = unMappedUrl;
     }
 
     public boolean isJetpackInstalled() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -311,6 +311,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setLoginUrl(from.options.login_url);
             site.setTimezone(from.options.gmt_offset);
             site.setFrameNonce(from.options.frame_nonce);
+            site.setUnMappedUrl(from.options.unmapped_url);
         }
         if (from.plan != null) {
             try {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -311,7 +311,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setLoginUrl(from.options.login_url);
             site.setTimezone(from.options.gmt_offset);
             site.setFrameNonce(from.options.frame_nonce);
-            site.setUnMappedUrl(from.options.unmapped_url);
+            site.setUnmappedUrl(from.options.unmapped_url);
         }
         if (from.plan != null) {
             try {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -18,6 +18,7 @@ public class SiteWPComRestResponse extends Payload implements Response {
         public String login_url;
         public String gmt_offset;
         public String frame_nonce;
+        public String unmapped_url;
     }
 
     public class Plan {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -86,7 +86,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 6:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("alter table SiteModel add UN_MAPPED_URL text;");
+                db.execSQL("alter table SiteModel add UNMAPPED_URL text;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -42,7 +42,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 6;
+        return 7;
     }
 
     @Override
@@ -83,6 +83,10 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 5:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add HAS_FREE_PLAN boolean;");
+                oldVersion++;
+            case 6:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SiteModel add UN_MAPPED_URL text;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
I am planning to use the unmapped url to fix the unauthenticated post preview issue on Android: https://github.com/wordpress-mobile/WordPress-Android/issues/5326. That issue still persists for custom domains and changing the custom domain to it's unmapped url should fix it.

P.S: `unMappedUrl` is the correct form, and not the `unmappedUrl`, right? I wasn't really sure about that.