### PR TITLE
Retain local post ID after media upload

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -179,6 +179,37 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         deleteMedia(testMedia);
     }
 
+    public void testUploadImageAttachedToPost() throws InterruptedException {
+        // Upload media attached to remotely saved post
+        MediaModel testMedia = newMediaModel(BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
+        testMedia.setLocalPostId(5);
+        testMedia.setPostId(1);
+        mNextEvent = TestEvents.UPLOADED_MEDIA;
+        uploadMedia(testMedia);
+
+        testMedia.setMediaId(mLastUploadedId);
+        MediaModel uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
+        assertNotNull(uploadedMedia);
+        assertEquals(1, uploadedMedia.getPostId());
+
+        mNextEvent = TestEvents.DELETED_MEDIA;
+        deleteMedia(testMedia);
+
+        // Upload media attached to a local draft
+        testMedia = newMediaModel(BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
+        testMedia.setLocalPostId(5);
+        mNextEvent = TestEvents.UPLOADED_MEDIA;
+        uploadMedia(testMedia);
+
+        testMedia.setMediaId(mLastUploadedId);
+        uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
+        assertNotNull(uploadedMedia);
+        assertEquals(0, uploadedMedia.getPostId());
+
+        mNextEvent = TestEvents.DELETED_MEDIA;
+        deleteMedia(testMedia);
+    }
+
     public void testUploadMultipleImages() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -191,6 +191,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         MediaModel uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
         assertNotNull(uploadedMedia);
         assertEquals(1, uploadedMedia.getPostId());
+        assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;
         deleteMedia(testMedia);
@@ -205,6 +206,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
         assertNotNull(uploadedMedia);
         assertEquals(0, uploadedMedia.getPostId());
+        assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;
         deleteMedia(testMedia);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -201,6 +201,37 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    public void testUploadImageAttachedToPost() throws InterruptedException {
+        // Upload media attached to remotely saved post
+        MediaModel testMedia = newMediaModel(BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
+        testMedia.setLocalPostId(5);
+        testMedia.setPostId(1);
+        mNextEvent = TestEvents.UPLOADED_MEDIA;
+        uploadMedia(testMedia);
+
+        testMedia.setMediaId(mLastUploadedId);
+        MediaModel uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
+        assertNotNull(uploadedMedia);
+        assertEquals(1, uploadedMedia.getPostId());
+
+        mNextEvent = TestEvents.DELETED_MEDIA;
+        deleteMedia(testMedia);
+
+        // Upload media attached to a local draft
+        testMedia = newMediaModel(BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
+        testMedia.setLocalPostId(5);
+        mNextEvent = TestEvents.UPLOADED_MEDIA;
+        uploadMedia(testMedia);
+
+        testMedia.setMediaId(mLastUploadedId);
+        uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
+        assertNotNull(uploadedMedia);
+        assertEquals(0, uploadedMedia.getPostId());
+
+        mNextEvent = TestEvents.DELETED_MEDIA;
+        deleteMedia(testMedia);
+    }
+
     public void testUploadMultipleImages() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -213,6 +213,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         MediaModel uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
         assertNotNull(uploadedMedia);
         assertEquals(1, uploadedMedia.getPostId());
+        assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;
         deleteMedia(testMedia);
@@ -227,6 +228,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
         assertNotNull(uploadedMedia);
         assertEquals(0, uploadedMedia.getPostId());
+        assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;
         deleteMedia(testMedia);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -22,6 +22,7 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
 
     // Associated IDs
     @Column private int mLocalSiteId;
+    @Column private int mLocalPostId;
     @Column private long mMediaId;
     @Column private long mPostId;
     @Column private long mAuthorId;
@@ -82,7 +83,8 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
 
         MediaModel otherMedia = (MediaModel) other;
 
-        return getId() == otherMedia.getId() && getLocalSiteId() == otherMedia.getLocalSiteId()
+        return getId() == otherMedia.getId()
+                && getLocalSiteId() == otherMedia.getLocalSiteId() && getLocalPostId() == otherMedia.getLocalPostId()
                 && getMediaId() == otherMedia.getMediaId() && getPostId() == otherMedia.getPostId()
                 && getAuthorId() == otherMedia.getAuthorId() && getWidth() == otherMedia.getWidth()
                 && getHeight() == otherMedia.getHeight() && getLength() == otherMedia.getLength()
@@ -123,6 +125,14 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
 
     public int getLocalSiteId() {
         return mLocalSiteId;
+    }
+
+    public void setLocalPostId(int localPostId) {
+        mLocalPostId = localPostId;
+    }
+
+    public int getLocalPostId() {
+        return mLocalPostId;
     }
 
     public void setMediaId(long mediaId) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -22,9 +22,9 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
 
     // Associated IDs
     @Column private int mLocalSiteId;
-    @Column private int mLocalPostId;
-    @Column private long mMediaId;
-    @Column private long mPostId;
+    @Column private int mLocalPostId; // The local post the media was uploaded from, for lookup after media uploads
+    @Column private long mMediaId; // The remote ID of the media
+    @Column private long mPostId; // The remote post ID ('parent') of the media
     @Column private long mAuthorId;
     @Column private String mGuid;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -304,6 +304,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                     if (responseMedia != null && !responseMedia.isEmpty()) {
                         MediaModel uploadedMedia = responseMedia.get(0);
                         uploadedMedia.setId(media.getId());
+                        uploadedMedia.setLocalPostId(media.getLocalPostId());
+
                         notifyMediaUploaded(uploadedMedia, null);
                     } else {
                         MediaStore.MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -185,6 +185,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                                 // Retain local IDs
                                 responseMedia.setId(media.getId());
                                 responseMedia.setLocalSiteId(site.getId());
+                                responseMedia.setLocalPostId(media.getLocalPostId());
 
                                 notifyMediaUploaded(responseMedia, null);
                             }
@@ -295,6 +296,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                     // Retain local IDs
                     responseMedia.setId(media.getId());
                     responseMedia.setLocalSiteId(site.getId());
+                    responseMedia.setLocalPostId(media.getLocalPostId());
 
                     if (isFreshUpload) {
                         notifyMediaUploaded(responseMedia, null);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
@@ -33,6 +33,7 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
             + "<member><name>name</name><value><string>%s</string></value></member>" // name
             + "<member><name>type</name><value><string>%s</string></value></member>" // type
             + "<member><name>overwrite</name><value><boolean>1</boolean></value></member>"
+            + "<member><name>post_id</name><value><int>%d</int></value></member>" // remote post ID
             + "<member><name>bits</name><value><base64>"; // bits
     private static final String APPEND_XML =
             "</base64></value></member></struct></value></param></params></methodCall>";
@@ -40,8 +41,6 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
     private final String mPrependString;
     private long mMediaSize;
     private long mContentSize = -1;
-
-
     private long mMediaBytesWritten = 0;
 
     public XmlrpcUploadRequestBody(MediaModel media, ProgressListener listener, SiteModel site) {
@@ -53,7 +52,8 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
                 StringEscapeUtils.escapeXml(site.getUsername()),
                 StringEscapeUtils.escapeXml(site.getPassword()),
                 StringEscapeUtils.escapeXml(media.getFileName()),
-                StringEscapeUtils.escapeXml(media.getMimeType()));
+                StringEscapeUtils.escapeXml(media.getMimeType()),
+                media.getPostId());
 
         try {
             mMediaSize = contentLength();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -42,7 +42,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 7;
+        return 8;
     }
 
     @Override
@@ -87,6 +87,10 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 6:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add UNMAPPED_URL text;");
+                oldVersion++;
+            case 7:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table MediaModel add LOCAL_POST_ID integer;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
Fixes #422.

* Adds a `LOCAL_POST_ID` field to `MediaModel`, leaving `POST_ID` to refer only to the remote post ID (`parent`) of the media item
* Preserves the local post ID after upload, so media can be matched to the (possibly local-only) post they were uploaded in
* Modifies the XML-RPC media upload call to set the remote post ID (`POST_ID`) when set

~~#424 should be merged first, and the base branch updated to `develop`.~~

A small WPAndroid-side PR is needed to fix a usage of `setPostId()` that should be `setLocalPostId()` with this changeset. (see it at https://github.com/wordpress-mobile/WordPress-Android/pull/5745)