### PR TITLE
Site store getters renaming

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -540,7 +540,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type " + event.error.type);
         }
         assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasSelfHostedSite());
+        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
         assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
@@ -553,7 +553,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type " + event.error.type);
         }
         assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasSelfHostedSite());
+        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
         assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
@@ -54,15 +54,15 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         assertEquals(1, mSiteStore.getSitesCount());
         assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getJetpackSitesCount());
-        assertEquals(0, mSiteStore.getSelfHostedSitesCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
+        assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         signOutWPCom();
 
         assertFalse(mSiteStore.hasSite());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasJetpackSite());
-        assertFalse(mSiteStore.hasSelfHostedSite());
+        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
+        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
     }
 
     public void testWPComSingleJetpackSiteFetch() throws InterruptedException {
@@ -71,14 +71,14 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         assertEquals(2, mSiteStore.getSitesCount());
         assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getJetpackSitesCount());
-        assertEquals(0, mSiteStore.getSelfHostedSitesCount());
+        assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
+        assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         signOutWPCom();
 
         assertFalse(mSiteStore.hasSite());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasJetpackSite());
+        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testWPComMultipleJetpackSiteFetch() throws InterruptedException {
@@ -87,14 +87,14 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         assertEquals(3, mSiteStore.getSitesCount());
         assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(2, mSiteStore.getJetpackSitesCount());
-        assertEquals(0, mSiteStore.getSelfHostedSitesCount());
+        assertEquals(3, mSiteStore.getSitesAccessedViaWPComRestCount());
+        assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         signOutWPCom();
 
         assertFalse(mSiteStore.hasSite());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasJetpackSite());
+        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testWPComJetpackMultisiteSiteFetch() throws InterruptedException {
@@ -105,14 +105,14 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         // Only one non-Jetpack site exists, all the other fetched sites should be Jetpack sites
         assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(sitesCount - 1, mSiteStore.getJetpackSitesCount());
-        assertEquals(0, mSiteStore.getSelfHostedSitesCount());
+        assertEquals(sitesCount, mSiteStore.getSitesAccessedViaWPComRestCount());
+        assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         signOutWPCom();
 
         assertFalse(mSiteStore.hasSite());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasJetpackSite());
+        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testXMLRPCNonJetpackSiteFetch() throws InterruptedException {
@@ -126,8 +126,8 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         assertEquals(1, mSiteStore.getSitesCount());
         assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
-        assertEquals(0, mSiteStore.getJetpackSitesCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         SiteModel site = mSiteStore.getSites().get(0);
 
@@ -147,8 +147,8 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         assertEquals(1, mSiteStore.getSitesCount());
         assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
-        assertEquals(1, mSiteStore.getJetpackSitesCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         SiteModel site = mSiteStore.getSites().get(0);
 
@@ -167,8 +167,8 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         assertEquals(1, mSiteStore.getSitesCount());
         assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
-        assertEquals(0, mSiteStore.getJetpackSitesCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         SiteModel site = mSiteStore.getSites().get(0);
 
@@ -183,9 +183,9 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
 
         assertEquals(1, mSiteStore.getSitesCount());
-        assertTrue(mSiteStore.hasJetpackSite());
+        assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSelfHostedSite());
+        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         // Attempt to add the same Jetpack site as a self-hosted site
         RefreshSitesXMLRPCPayload xmlrpcPayload = new RefreshSitesXMLRPCPayload();
@@ -203,15 +203,15 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         // Expect no DB changes
         assertEquals(1, mSiteStore.getSitesCount());
-        assertTrue(mSiteStore.hasJetpackSite());
+        assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSelfHostedSite());
+        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         signOutWPCom();
 
         assertFalse(mSiteStore.hasSite());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasJetpackSite());
+        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testXMLRPCJetpackToWPComDuplicateSiteFetch() throws InterruptedException {
@@ -226,11 +226,11 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertEquals(1, mSiteStore.getSitesCount());
         // We added the site from an XMLRPC call, but it's a Jetpack site accessible via the .com REST API but accessed
         // via XMLRPC (ie. not pull from the REST call).
-        assertTrue(mSiteStore.hasJetpackSite());
+        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
         // not considered a .com site
         assertFalse(mSiteStore.hasWPComSite());
         // accessed via XMLRPC, that's why we consider it a "self hosted site"
-        assertTrue(mSiteStore.hasSelfHostedSite());
+        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         // Authenticate as WP.com user with a single site, which is the Jetpack site we already added as self-hosted
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
@@ -238,15 +238,15 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         // We expect the XML-RPC Jetpack site to be 'upgraded' to a WPcom Jetpack site
         assertEquals(1, mSiteStore.getSitesCount());
-        assertTrue(mSiteStore.hasJetpackSite());
+        assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSelfHostedSite());
+        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         signOutWPCom();
 
         assertFalse(mSiteStore.hasSite());
         assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasJetpackSite());
+        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testWPComToXMLRPCJetpackDifferentAccountsSiteFetch() throws InterruptedException {
@@ -256,11 +256,11 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         int wpComSiteCount = mSiteStore.getWPComSitesCount();
         int totalSiteCount = mSiteStore.getSitesCount();
-        int jetpackSiteCount = mSiteStore.getJetpackSitesCount();
-        int selfhostedSiteCount = mSiteStore.getSelfHostedSitesCount();
+        int accessedViaWPComRestSiteCount = mSiteStore.getSitesAccessedViaWPComRestCount();
+        int selfhostedSiteCount = mSiteStore.getSitesAccessedViaXMLRPCCount();
 
         assertEquals(0, selfhostedSiteCount);
-        assertEquals(totalSiteCount, wpComSiteCount + jetpackSiteCount);
+        assertEquals(totalSiteCount, accessedViaWPComRestSiteCount);
 
         // Add a Jetpack-connected site as self-hosted (connected to a different WP.com account than the one above)
         fetchSitesXMLRPC(BuildConfig.TEST_WPORG_USERNAME_SINGLE_JETPACK_ONLY,
@@ -268,15 +268,16 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
                 BuildConfig.TEST_WPORG_URL_SINGLE_JETPACK_ONLY_ENDPOINT);
 
         // Fetch site details (including Jetpack status)
-        SiteModel selfHostedSite = mSiteStore.getSelfHostedSites().get(0);
+        SiteModel selfHostedSite = mSiteStore.getSitesAccessedViaXMLRPC().get(0);
         fetchSite(selfHostedSite);
 
         assertEquals(totalSiteCount + 1, mSiteStore.getSitesCount());
-        // The site is connected to a different wpcom account but we count it as a Jetpack site anyway.
-        assertEquals(jetpackSiteCount + 1, mSiteStore.getJetpackSitesCount());
-        assertEquals(selfhostedSiteCount + 1, mSiteStore.getSelfHostedSitesCount());
+        // The site is accessible via WPCom (Jetpack connected) but accessed via XMLRPC, so previous
+        // accessedViaWPComRestSiteCount must be the same
+        assertEquals(accessedViaWPComRestSiteCount, mSiteStore.getSitesAccessedViaWPComRestCount());
+        assertEquals(selfhostedSiteCount + 1, mSiteStore.getSitesAccessedViaXMLRPCCount());
         assertEquals(wpComSiteCount, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         assertTrue(selfHostedSite.isJetpackConnected());
         assertFalse(selfHostedSite.isWPCom());
@@ -285,11 +286,11 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         // Expect all WP.com sites to be removed
         assertEquals(0, mSiteStore.getWPComSitesCount());
+        assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         // Site accessed via XMLRPC should not be removed
-        assertEquals(1, mSiteStore.getJetpackSitesCount());
         assertEquals(1, mSiteStore.getSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
     }
 
     @SuppressWarnings("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -160,7 +160,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
 
         mNextEvent = TestEvents.SITE_REMOVED;
         mCountDownLatch = new CountDownLatch(1);
-        SiteModel selfHostedSite = mSiteStore.getSelfHostedSites().get(0);
+        SiteModel selfHostedSite = mSiteStore.getSitesAccessedViaXMLRPC().get(0);
         mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(selfHostedSite));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -225,7 +225,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
             return;
         }
         assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasSelfHostedSite());
+        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
         assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
@@ -238,7 +238,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasSelfHostedSite());
+        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
         assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -88,8 +88,7 @@ public class SiteStoreUnitTest {
 
         assertTrue(mSiteStore.hasSite());
         assertTrue(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSelfHostedSite());
-        assertFalse(mSiteStore.hasJetpackSite());
+        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         assertEquals(1, mSiteStore.getSitesCount());
         assertEquals(1, mSiteStore.getWPComSitesCount());
@@ -100,13 +99,12 @@ public class SiteStoreUnitTest {
 
         assertTrue(mSiteStore.hasSite());
         assertTrue(mSiteStore.hasWPComSite());
-        assertTrue(mSiteStore.hasSelfHostedSite());
-        assertFalse(mSiteStore.hasJetpackSite());
+        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         assertEquals(2, mSiteStore.getSitesCount());
         assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
-        assertEquals(1, mSiteStore.getWPComAndJetpackSitesCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         // Test counts with one .COM, one self-hosted and one Jetpack site
         SiteModel jetpackSiteOverRest = generateJetpackSiteOverRestOnly();
@@ -114,14 +112,12 @@ public class SiteStoreUnitTest {
 
         assertTrue(mSiteStore.hasSite());
         assertTrue(mSiteStore.hasWPComSite());
-        assertTrue(mSiteStore.hasSelfHostedSite());
-        assertTrue(mSiteStore.hasJetpackSite());
+        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         assertEquals(3, mSiteStore.getSitesCount());
         assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
-        assertEquals(1, mSiteStore.getJetpackSitesCount());
-        assertEquals(2, mSiteStore.getWPComAndJetpackSitesCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
     }
 
     @Test
@@ -154,9 +150,8 @@ public class SiteStoreUnitTest {
 
         assertEquals(3, mSiteStore.getSitesCount());
         assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(2, mSiteStore.getSelfHostedSitesCount());
-        assertEquals(2, mSiteStore.getJetpackSitesCount()); // misleading but we will remove that method
-        assertEquals(1, mSiteStore.getWPComAndJetpackSitesCount());
+        assertEquals(2, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         // User "install and connect" ponySite site to Jetpack via his connected .com account
 
@@ -167,26 +162,9 @@ public class SiteStoreUnitTest {
 
         assertEquals(3, mSiteStore.getSitesCount());
         assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSelfHostedSitesCount());
-        assertEquals(3, mSiteStore.getJetpackSitesCount());
-        assertEquals(2, mSiteStore.getWPComAndJetpackSitesCount());
-    }
-
-    @Test
-    public void testHasSiteWithSiteIdAndXmlRpcUrl() throws DuplicateSiteException {
-        assertFalse(mSiteStore.hasSelfHostedSiteWithSiteIdAndXmlRpcUrl(124, ""));
-
-        SiteModel selfHostedSite = generateSelfHostedNonJPSite();
-        SiteSqlUtils.insertOrUpdateSite(selfHostedSite);
-
-        assertTrue(mSiteStore.hasSelfHostedSiteWithSiteIdAndXmlRpcUrl(selfHostedSite.getSelfHostedSiteId(),
-                selfHostedSite.getXmlRpcUrl()));
-
-        SiteModel jetpackSite = generateJetpackSiteOverXMLRPC();
-        SiteSqlUtils.insertOrUpdateSite(jetpackSite);
-
-        assertTrue(mSiteStore.hasSelfHostedSiteWithSiteIdAndXmlRpcUrl(jetpackSite.getSelfHostedSiteId(),
-                jetpackSite.getXmlRpcUrl()));
+        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        // Now ponySite is accessed via the WPCom REST API
+        assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
     }
 
     @Test
@@ -284,7 +262,7 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
         SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverXMLRPC);
 
-        assertEquals(1, SiteSqlUtils.getWPComAndJetpackSites().getAsCursor().getCount());
+        assertEquals(1, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
         assertNotNull(mSiteStore.getSiteBySiteId(wpComSite.getSiteId()));
         assertNotNull(mSiteStore.getSiteBySiteId(jetpackSiteOverXMLRPC.getSiteId()));
         assertNull(mSiteStore.getSiteBySiteId(selfHostedSite.getSiteId()));
@@ -314,7 +292,7 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverXMLRPC);
         SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverRestOnly);
 
-        assertEquals(2, SiteSqlUtils.getWPComAndJetpackSites().getAsCursor().getCount());
+        assertEquals(2, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
 
         List<SiteModel> wpComSites = SiteSqlUtils.getWPComSites().getAsModel();
         assertEquals(1, wpComSites.size());
@@ -340,7 +318,7 @@ public class SiteStoreUnitTest {
 
         List<SiteModel> wpComSites = SiteSqlUtils.getWPComSites().getAsModel();
         assertEquals(0, wpComSites.size());
-        assertEquals(1, SiteSqlUtils.getWPComAndJetpackSites().getAsCursor().getCount());
+        assertEquals(1, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
         List<SiteModel> jetpackSites =
                 SiteSqlUtils.getSitesWith(SiteModelTable.IS_JETPACK_CONNECTED, true).getAsModel();
         assertEquals(jetpack.getSiteId(), jetpackSites.get(0).getSiteId());
@@ -486,10 +464,10 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(wpComSite2);
         SiteSqlUtils.insertOrUpdateSite(selfHostedSite);
 
-        List<SiteModel> matchingSites = SiteSqlUtils.getWPComAndJetpackSitesByNameOrUrlMatching("eye");
+        List<SiteModel> matchingSites = SiteSqlUtils.getSitesAccessedViaWPComRestByNameOrUrlMatching("eye");
         assertEquals(1, matchingSites.size());
 
-        matchingSites = SiteSqlUtils.getWPComAndJetpackSitesByNameOrUrlMatching("EYE");
+        matchingSites = SiteSqlUtils.getSitesAccessedViaWPComRestByNameOrUrlMatching("EYE");
         assertEquals(1, matchingSites.size());
     }
 
@@ -529,7 +507,6 @@ public class SiteStoreUnitTest {
 
         assertEquals(1, mSiteStore.getSitesCount());
         assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getJetpackSitesCount());
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -32,7 +32,7 @@ public class SiteSqlUtils {
                 .where().equals(field, value).endWhere();
     }
 
-    public static List<SiteModel> getWPComAndJetpackSitesByNameOrUrlMatching(String searchString) {
+    public static List<SiteModel> getSitesAccessedViaWPComRestByNameOrUrlMatching(String searchString) {
         // Note: by default SQLite "LIKE" operator is case insensitive, and that's what we're looking for.
         return WellSql.select(SiteModel.class).where()
                 // ORIGIN = ORIGIN_WPCOM_REST AND (x in url OR x in name)
@@ -184,26 +184,24 @@ public class SiteSqlUtils {
     }
 
     /**
-     * TODO: rename this method
-     *
      * @return A selectQuery to get all the sites accessed via the XMLRPC, this includes: pure self hosted sites,
      * but also Jetpack sites connected via XMLRPC.
      */
-    public static SelectQuery<SiteModel> getSelfHostedSites() {
+    public static SelectQuery<SiteModel> getSitesAccessedViaXMLRPC() {
         return WellSql.select(SiteModel.class)
                 .where().beginGroup()
                 .equals(SiteModelTable.ORIGIN, SiteModel.ORIGIN_XMLRPC)
                 .endGroup().endWhere();
     }
 
-    public static SelectQuery<SiteModel> getWPComAndJetpackSites() {
+    public static SelectQuery<SiteModel> getSitesAccessedViaWPComRest() {
         return WellSql.select(SiteModel.class)
                 .where().beginGroup()
                 .equals(SiteModelTable.ORIGIN, SiteModel.ORIGIN_WPCOM_REST)
                 .endGroup().endWhere();
     }
 
-    public static SelectQuery<SiteModel> getVisibleWPComAndJetpackSites() {
+    public static SelectQuery<SiteModel> getVisibleSitesAccessedViaWPCom() {
         return WellSql.select(SiteModel.class)
                 .where().beginGroup()
                 .equals(SiteModelTable.ORIGIN, SiteModel.ORIGIN_WPCOM_REST)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -401,22 +401,23 @@ public class SiteStore extends Store {
     }
 
     /**
-     * Returns all .COM and Jetpack sites in the store.
+     * Returns sites accessed via WPCom REST API (WPCom sites or Jetpack sites connected via WPCom REST API).
      */
     public List<SiteModel> getSitesAccessedViaWPComRest() {
         return SiteSqlUtils.getSitesAccessedViaWPComRest().getAsModel();
     }
 
     /**
-     * Returns the number of .COM and Jetpack sites in the store.
+     * Returns the number of sites accessed via WPCom REST API (WPCom sites or Jetpack sites connected
+     * via WPCom REST API).
      */
     public int getSitesAccessedViaWPComRestCount() {
         return SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount();
     }
 
     /**
-     * Checks whether the store contains at least one site accessed via XMLRPC (self-hosted sites or
-     * Jetpack sites accessed via XMLRPC).
+     * Checks whether the store contains at least one site accessed via WPCom REST API (WPCom sites or Jetpack
+     * sites connected via WPCom REST API).
      */
     public boolean hasSitesAccessedViaWPComRest() {
         return getSitesAccessedViaWPComRestCount() != 0;
@@ -454,7 +455,7 @@ public class SiteStore extends Store {
     }
 
     /**
-     * Returns all self-hosted sites (can't be Jetpack) in the store.
+     * Returns sites accessed via XMLRPC (self-hosted sites or Jetpack sites accessed via XMLRPC).
      */
     public List<SiteModel> getSitesAccessedViaXMLRPC() {
         return SiteSqlUtils.getSitesAccessedViaXMLRPC().getAsModel();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -403,15 +403,23 @@ public class SiteStore extends Store {
     /**
      * Returns all .COM and Jetpack sites in the store.
      */
-    public List<SiteModel> getWPComAndJetpackSites() {
-        return SiteSqlUtils.getWPComAndJetpackSites().getAsModel();
+    public List<SiteModel> getSitesAccessedViaWPComRest() {
+        return SiteSqlUtils.getSitesAccessedViaWPComRest().getAsModel();
     }
 
     /**
      * Returns the number of .COM and Jetpack sites in the store.
      */
-    public int getWPComAndJetpackSitesCount() {
-        return SiteSqlUtils.getWPComAndJetpackSites().getAsCursor().getCount();
+    public int getSitesAccessedViaWPComRestCount() {
+        return SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount();
+    }
+
+    /**
+     * Checks whether the store contains at least one site accessed via XMLRPC (self-hosted sites or
+     * Jetpack sites accessed via XMLRPC).
+     */
+    public boolean hasSitesAccessedViaWPComRest() {
+        return getSitesAccessedViaWPComRestCount() != 0;
     }
 
     /**
@@ -430,11 +438,12 @@ public class SiteStore extends Store {
     }
 
     /**
-     * Returns .COM and Jetpack sites with a name or url matching the search string.
+     * Returns sites accessed via WPCom REST API (WPCom sites or Jetpack sites connected via WPCom REST API) with a
+     * name or url matching the search string.
      */
     @NonNull
-    public List<SiteModel> getWPComAndJetpackSitesByNameOrUrlMatching(@NonNull String searchString) {
-        return SiteSqlUtils.getWPComAndJetpackSitesByNameOrUrlMatching(searchString);
+    public List<SiteModel> getSitesAccessedViaWPComRestByNameOrUrlMatching(@NonNull String searchString) {
+        return SiteSqlUtils.getSitesAccessedViaWPComRestByNameOrUrlMatching(searchString);
     }
 
     /**
@@ -447,60 +456,23 @@ public class SiteStore extends Store {
     /**
      * Returns all self-hosted sites (can't be Jetpack) in the store.
      */
-    public List<SiteModel> getSelfHostedSites() {
-        return SiteSqlUtils.getSelfHostedSites().getAsModel();
+    public List<SiteModel> getSitesAccessedViaXMLRPC() {
+        return SiteSqlUtils.getSitesAccessedViaXMLRPC().getAsModel();
     }
 
     /**
-     * Returns the number of self-hosted sites (can't be Jetpack) in the store.
-     * TODO: rename this method
+     * Returns the number of sites accessed via XMLRPC (self-hosted sites or Jetpack sites accessed via XMLRPC).
      */
-    public int getSelfHostedSitesCount() {
-        return SiteSqlUtils.getSelfHostedSites().getAsCursor().getCount();
+    public int getSitesAccessedViaXMLRPCCount() {
+        return SiteSqlUtils.getSitesAccessedViaXMLRPC().getAsCursor().getCount();
     }
 
     /**
-     * Checks whether the store contains at least one self-hosted site (can't be Jetpack).
-     * TODO: rename this method
+     * Checks whether the store contains at least one site accessed via XMLRPC (self-hosted sites or
+     * Jetpack sites accessed via XMLRPC).
      */
-    public boolean hasSelfHostedSite() {
-        return getSelfHostedSitesCount() != 0;
-    }
-
-    /**
-     * Returns all Jetpack sites in the store.
-     * TODO: remove this method
-     */
-    public List<SiteModel> getJetpackSites() {
-        return SiteSqlUtils.getSitesWith(SiteModelTable.IS_JETPACK_CONNECTED, true).getAsModel();
-    }
-
-    /**
-     * Returns the number of Jetpack sites in the store.
-     * TODO: remove this method
-     */
-    public int getJetpackSitesCount() {
-        return SiteSqlUtils.getSitesWith(SiteModelTable.IS_JETPACK_CONNECTED, true).getAsCursor().getCount();
-    }
-
-    /**
-     * Checks whether the store contains at least one Jetpack site.
-     * TODO: remove this method
-     */
-    public boolean hasJetpackSite() {
-        return getJetpackSitesCount() != 0;
-    }
-
-    /**
-     * Checks whether the store contains a self-hosted site matching the given (remote) site id and XML-RPC URL.
-     */
-    public boolean hasSelfHostedSiteWithSiteIdAndXmlRpcUrl(long selfHostedSiteId, String xmlRpcUrl) {
-        return WellSql.select(SiteModel.class)
-                .where().beginGroup()
-                .equals(SiteModelTable.SELF_HOSTED_SITE_ID, selfHostedSiteId)
-                .equals(SiteModelTable.XMLRPC_URL, xmlRpcUrl)
-                .endGroup().endWhere()
-                .getAsCursor().getCount() > 0;
+    public boolean hasSiteAccessedViaXMLRPC() {
+        return getSitesAccessedViaXMLRPCCount() != 0;
     }
 
     /**
@@ -520,15 +492,15 @@ public class SiteStore extends Store {
     /**
      * Returns all visible .COM sites as {@link SiteModel}s.
      */
-    public List<SiteModel> getVisibleWPComAndJetpackSites() {
-        return SiteSqlUtils.getVisibleWPComAndJetpackSites().getAsModel();
+    public List<SiteModel> getVisibleSitesAccessedViaWPCom() {
+        return SiteSqlUtils.getVisibleSitesAccessedViaWPCom().getAsModel();
     }
 
     /**
      * Returns the number of visible .COM sites.
      */
-    public int getVisibleWPComAndJetpackSitesCount() {
-        return SiteSqlUtils.getVisibleWPComAndJetpackSites().getAsCursor().getCount();
+    public int getVisibleSitesAccessedViaWPComCount() {
+        return SiteSqlUtils.getVisibleSitesAccessedViaWPCom().getAsCursor().getCount();
     }
 
     /**
@@ -735,7 +707,7 @@ public class SiteStore extends Store {
     private void removeWPComAndJetpackSites() {
         // Logging out of WP.com. Drop all WP.com sites, and all Jetpack sites that were fetched over the WP.com
         // REST API only (they don't have a .org site id)
-        List<SiteModel> wpcomAndJetpackSites = SiteSqlUtils.getWPComAndJetpackSites().getAsModel();
+        List<SiteModel> wpcomAndJetpackSites = SiteSqlUtils.getSitesAccessedViaWPComRest().getAsModel();
         int rowsAffected = removeSites(wpcomAndJetpackSites);
         emitChange(new OnSiteRemoved(rowsAffected));
     }


### PR DESCRIPTION
`getSelfHostedSite` gradually became another kind of method to get sites that are accessed via XMLRPC, These sites could be Jetpack sites (installed or connected) or pure self hosted sites depending how the user addded the site in the app.

To make these getters less confusing, we renamed these them to getSitesAccessedViaXMLRPC / getSitesAccessedViaWPComRest - they now reflects the data model more accurately.

I also removed `getJetpackSites` and his siblings, it's not used in the app and it's misleading: what's a Jetpack site? a self hosted with Jetpack installed? or Connected? What about Jetpack sites accessed via XMLRPC?

Note: I kept `getLocalIdForSelfHostedSiteIdAndXmlRpcUrl` because it's used in a very specific case (migration) in wpandroid, but once we drop migration code, we can drop that getter too.