### PR TITLE
Some lint pickup

### DIFF
--- a/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/DebugOkHttpClientModule.java
@@ -9,6 +9,7 @@ import org.wordpress.android.util.AppLog.T;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
@@ -35,7 +36,7 @@ public class DebugOkHttpClientModule {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new java.security.SecureRandom());
+            sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new SecureRandom());
             final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
             builder.sslSocketFactory(sslSocketFactory);
         } catch (NoSuchAlgorithmException | KeyManagementException e) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
@@ -138,7 +138,7 @@ public class MainFragment extends Fragment {
     private void showSSLWarningDialog(String certifString) {
         FragmentTransaction ft = getFragmentManager().beginTransaction();
         SSLWarningDialog newFragment = SSLWarningDialog.newInstance(
-                new android.content.DialogInterface.OnClickListener() {
+                new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         // Add the certificate to our list

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/Action.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/Action.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.annotations;
 
+import org.wordpress.android.fluxc.annotations.action.NoPayload;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
@@ -9,5 +11,5 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.FIELD)
 public @interface Action {
-    Class payloadType() default org.wordpress.android.fluxc.annotations.action.NoPayload.class;
+    Class payloadType() default NoPayload.class;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/Dispatcher.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/Dispatcher.java
@@ -1,12 +1,12 @@
 package org.wordpress.android.fluxc;
 
 import org.greenrobot.eventbus.EventBus;
+import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.store.Store;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import javax.inject.Singleton;
-
 
 @Singleton
 public class Dispatcher {
@@ -31,7 +31,7 @@ public class Dispatcher {
         mBus.unregister(object);
     }
 
-    public void dispatch(org.wordpress.android.fluxc.annotations.action.Action action) {
+    public void dispatch(Action action) {
         AppLog.d(T.API, "Dispatching action: " + action.getType().getClass().getSimpleName()
                 + "-" + action.getType().name());
         post(action);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
@@ -63,12 +63,12 @@ public enum PostStatus {
     public static synchronized PostStatus fromPost(PostModel post) {
         String value = post.getStatus();
         long dateCreatedGMT = 0;
-        if (post.getDateCreated() != null) {
-            Date dateCreated = DateTimeUtils.dateUTCFromIso8601(post.getDateCreated());
-            if (dateCreated != null) {
-                dateCreatedGMT = dateCreated.getTime();
-            }
+
+        Date dateCreated = DateTimeUtils.dateUTCFromIso8601(post.getDateCreated());
+        if (dateCreated != null) {
+            dateCreatedGMT = dateCreated.getTime();
         }
+
         return fromStringAndDateGMT(value, dateCreatedGMT);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -7,6 +7,7 @@ import org.wordpress.android.util.AppLog.T;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
@@ -33,7 +34,7 @@ public class ReleaseOkHttpClientModule {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new java.security.SecureRandom());
+            sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new SecureRandom());
             final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
             builder.sslSocketFactory(sslSocketFactory);
         } catch (NoSuchAlgorithmException | KeyManagementException e) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequestFuture.java
@@ -21,7 +21,7 @@ package org.wordpress.android.fluxc.network;
 import android.support.annotation.NonNull;
 
 import com.android.volley.Request;
-import com.android.volley.Response;
+import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
 
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
@@ -58,14 +58,14 @@ import java.util.concurrent.TimeoutException;
  *
  * @param <T> The type of parsed response this future expects.
  */
-public class BaseRequestFuture<T> implements Future<T>, Response.Listener<T>, BaseErrorListener {
+public class BaseRequestFuture<T> implements Future<T>, Listener<T>, BaseErrorListener {
     private Request<?> mRequest;
     private boolean mResultReceived = false;
     private T mResult;
     private VolleyError mException;
 
     public static <E> BaseRequestFuture<E> newFuture() {
-        return new BaseRequestFuture<E>();
+        return new BaseRequestFuture<>();
     }
 
     private BaseRequestFuture() {}
@@ -98,7 +98,7 @@ public class BaseRequestFuture<T> implements Future<T>, Response.Listener<T>, Ba
     }
 
     @Override
-    public T get(long timeout, TimeUnit unit)
+    public T get(long timeout, @NonNull TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
         return doGet(TimeUnit.MILLISECONDS.convert(timeout, unit));
     }
@@ -132,10 +132,7 @@ public class BaseRequestFuture<T> implements Future<T>, Response.Listener<T>, Ba
 
     @Override
     public boolean isCancelled() {
-        if (mRequest == null) {
-            return false;
-        }
-        return mRequest.isCanceled();
+        return mRequest != null && mRequest.isCanceled();
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
@@ -29,7 +29,7 @@ import okhttp3.ResponseBody;
 /**
  * Modified version of https://gist.github.com/alashow/c96c09320899e4caa06b
  *
- * OkHttp backed {@link com.android.volley.toolbox.HttpStack HttpStack} that does not
+ * OkHttp backed {@link HttpStack HttpStack} that does not
  * use okhttp-urlconnection
  */
 public class OkHttpStack implements HttpStack {
@@ -40,7 +40,7 @@ public class OkHttpStack implements HttpStack {
     }
 
     @Override
-    public HttpResponse performRequest(com.android.volley.Request<?> request, Map<String, String> additionalHeaders)
+    public HttpResponse performRequest(Request<?> request, Map<String, String> additionalHeaders)
             throws IOException, AuthFailureError {
         int timeoutMs = request.getTimeoutMs();
         mClientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -408,15 +408,13 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         contentStruct.put("post_type", post.isPage() ? "page" : "post");
         contentStruct.put("post_title", post.getTitle());
 
-        if (post.getDateCreated() != null) {
-            String dateCreated = post.getDateCreated();
-            Date date = DateTimeUtils.dateUTCFromIso8601(dateCreated);
-            if (date != null) {
-                contentStruct.put("post_date", date);
-                // Redundant, but left in just in case
-                // Note: XML-RPC sends the same value for dateCreated and date_created_gmt in the first place
-                contentStruct.put("post_date_gmt", date);
-            }
+        String dateCreated = post.getDateCreated();
+        Date date = DateTimeUtils.dateUTCFromIso8601(dateCreated);
+        if (date != null) {
+            contentStruct.put("post_date", date);
+            // Redundant, but left in just in case
+            // Note: XML-RPC sends the same value for dateCreated and date_created_gmt in the first place
+            contentStruct.put("post_date_gmt", date);
         }
 
         String content = post.getContent();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -186,7 +186,6 @@ public class CommentStore extends Store {
      * @param orderByDateAscending If true order the results by ascending published date.
      *                             If false, order the results by descending published date.
      * @param statuses Array of status or CommentStatus.ALL to get all of them.
-     * @return
      */
     public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending,
                                                  CommentStatus... statuses) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
@@ -22,7 +22,7 @@ public abstract class Store {
     }
 
     /**
-     * onAction should {@link Subscribe} with ASYNC {@link ThreadMode}.
+     * onAction should {@link org.greenrobot.eventbus.Subscribe} with ASYNC {@link org.greenrobot.eventbus.ThreadMode}.
      */
     public abstract void onAction(Action action);
     public abstract void onRegister();

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
@@ -111,7 +111,7 @@ public class MainInstafluxActivity extends AppCompatActivity {
     private void showSSLWarningDialog(String certifString) {
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         SSLWarningDialog newFragment = SSLWarningDialog.newInstance(
-                new android.content.DialogInterface.OnClickListener() {
+                new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         // Add the certificate to our list


### PR DESCRIPTION
Fixes all 'unnecessary fully qualified imports' lint warnings (when paired with #429), drops some redundant null checking, and other small tweaks.