### PR TITLE
WordPress.com fetch + signout collision fix

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -151,6 +151,19 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertEquals(newValue, String.valueOf(mAccountStore.getAccount().getPrimarySiteId()));
     }
 
+    public void testWPComSignOut() throws InterruptedException {
+        mNextEvent = TestEvents.AUTHENTICATE;
+        authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+
+        mCountDownLatch = new CountDownLatch(2); // Wait for OnAuthenticationChanged and OnAccountChanged
+        mNextEvent = TestEvents.AUTHENTICATE;
+        mDispatcher.dispatch(AccountActionBuilder.newSignOutAction());
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        assertFalse(mAccountStore.hasAccessToken());
+        assertEquals(0, mAccountStore.getAccount().getUserId());
+    }
+
     public void testSendAuthEmail() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(BuildConfig.TEST_WPCOM_EMAIL_TEST1));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
@@ -3,11 +3,13 @@ package org.wordpress.android.fluxc.release;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
@@ -304,6 +306,16 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
+    public void onAccountChanged(OnAccountChanged event) {
+        AppLog.d(T.TESTS, "Received OnAccountChanged event");
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
     public void onSiteChanged(OnSiteChanged event) {
         AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
         if (event.isError()) {
@@ -340,12 +352,18 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         // Wait for a network response / onChanged event
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
+        // Fetch account from REST API, and wait for OnAccountChanged event
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
         // Fetch sites from REST API, and wait for onSiteChanged event
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mSiteStore.getSitesCount() > 0);
     }
 
     private void signOutWPCom() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -175,11 +175,17 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         // Wait for a network response / onChanged event
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        // Fetch sites from REST API, and wait for onSiteChanged event
+        // Fetch account from REST API, and wait for OnAccountChanged event
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Fetch sites from REST API, and wait for OnSiteChanged event
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mSiteStore.getSitesCount() > 0);
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -3,12 +3,14 @@ package org.wordpress.android.fluxc.release;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
@@ -82,9 +84,43 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertNotSame(0, postFormats.size());
     }
 
+    public void testWPComSiteFetchAndLogoutCollision() throws InterruptedException {
+        authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
+                BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+
+        // Fetch sites again and immediately logout and clear WP.com sites
+        mCountDownLatch = new CountDownLatch(3); // Wait for OnAuthenticationChanged, OnAccountChanged and OnSiteRemoved
+        mNextEvent = TestEvents.SITE_REMOVED;
+        mExpectedRowsAffected = mSiteStore.getSitesCount();
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+        mDispatcher.dispatch(AccountActionBuilder.newSignOutAction());
+        mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
+
+        // Wait for OnAuthenticationChanged, OnAccountChanged and OnSiteRemoved from logout/site removal
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Wait for OnSiteChanged event from fetch
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.SITE_CHANGED;
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        assertEquals(0, mSiteStore.getSitesCount());
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
+        AppLog.d(T.TESTS, "Received OnAuthenticationChanged event");
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onAccountChanged(OnAccountChanged event) {
+        AppLog.d(T.TESTS, "Received OnAccountChanged event");
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -98,8 +134,9 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasWPComSite());
+        if (mSiteStore.getSitesCount() > 0) {
+            assertTrue(mSiteStore.hasWPComSite());
+        }
         assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -41,6 +41,11 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
         super.init();
         mNextEvent = TestEvents.NONE;
 
+        if (!mAccountStore.getAccessToken().isEmpty() && sSite != null) {
+            // We have all we need, move on (the AccountStore is probably empty, but we don't need it)
+            return;
+        }
+
         if (mAccountStore.getAccessToken().isEmpty() || mAccountStore.getAccount().getUserId() == 0) {
             authenticate();
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
@@ -14,6 +14,7 @@ import android.view.ViewGroup;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.example.ThreeEditTextDialog.Listener;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
@@ -181,7 +182,6 @@ public class MainFragment extends Fragment {
 
     private void signIn2fa(String twoStepCode) {
         mAuthenticatePayload.twoStepCode = twoStepCode;
-        mAuthenticatePayload.nextAction = SiteActionBuilder.newFetchSitesAction();
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(mAuthenticatePayload));
     }
 
@@ -229,8 +229,6 @@ public class MainFragment extends Fragment {
 
     private void wpcomFetchSites(String username, String password) {
         mAuthenticatePayload = new AuthenticatePayload(username, password);
-        // Next action will be dispatched if authentication is successful
-        mAuthenticatePayload.nextAction = SiteActionBuilder.newFetchSitesAction();
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(mAuthenticatePayload));
     }
 
@@ -251,6 +249,16 @@ public class MainFragment extends Fragment {
     public void onAccountChanged(OnAccountChanged event) {
         if (!mAccountStore.hasAccessToken()) {
             prependToLog("Signed Out");
+            return;
+        }
+
+        if (event.isError()) {
+            prependToLog("Account error: " + event.error.type);
+        } else {
+            if (!mSiteStore.hasSite() && event.causeOfChange == AccountAction.FETCH_ACCOUNT) {
+                AppLog.d(T.API, "Account data fetched - fetching sites");
+                mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+            }
         }
     }
 
@@ -294,6 +302,12 @@ public class MainFragment extends Fragment {
                 case GENERIC_ERROR:
                     // Show Toast "Network Error"?
                     break;
+            }
+        } else {
+            if (mAccountStore.hasAccessToken()) {
+                AppLog.d(T.API, "Signed in to WordPress.com successfully, fetching account");
+                mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+                mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
             }
         }
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/WellSqlTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WellSqlTestUtils.java
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc;
+
+import com.yarolegovich.wellsql.WellSql;
+
+import org.wordpress.android.fluxc.model.AccountModel;
+
+public class WellSqlTestUtils {
+    public static void setupWordPressComAccount() {
+        AccountModel account = new AccountModel();
+        account.setUserId(20151021);
+        account.setUserName("fluxc");
+        account.setEmail("flux@capacitorsrus.co");
+
+        WellSql.insert(account).execute();
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -36,13 +36,13 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSiteOverRestOnly;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateJetpackSiteOverXMLRPC;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generatePostFormats;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateSelfHostedNonJPSite;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateSelfHostedSiteFutureJetpack;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateTestSite;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateWPComSite;
+import static org.wordpress.android.fluxc.site.SiteUtils.generateJetpackSiteOverRestOnly;
+import static org.wordpress.android.fluxc.site.SiteUtils.generateJetpackSiteOverXMLRPC;
+import static org.wordpress.android.fluxc.site.SiteUtils.generatePostFormats;
+import static org.wordpress.android.fluxc.site.SiteUtils.generateSelfHostedNonJPSite;
+import static org.wordpress.android.fluxc.site.SiteUtils.generateSelfHostedSiteFutureJetpack;
+import static org.wordpress.android.fluxc.site.SiteUtils.generateTestSite;
+import static org.wordpress.android.fluxc.site.SiteUtils.generateWPComSite;
 
 @RunWith(RobolectricTestRunner.class)
 public class SiteStoreUnitTest {

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.WellSqlTestUtils;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
@@ -70,6 +71,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testInsertOrUpdateSite() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel site = generateWPComSite();
         SiteSqlUtils.insertOrUpdateSite(site);
 
@@ -79,6 +82,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testHasSiteAndgetCountMethods() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         assertFalse(mSiteStore.hasSite());
         assertTrue(mSiteStore.getSites().isEmpty());
 
@@ -122,6 +127,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testSelfHostedAndJetpackSites() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         // Note: not using the helper methods to make sure of the SiteModel definition
         SiteModel ponySite = new SiteModel();
         ponySite.setXmlRpcUrl("http://pony.com/xmlrpc.php");
@@ -169,6 +176,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testWPComSiteVisibility() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         // Should not cause any errors
         mSiteStore.isWPComSiteVisibleByLocalId(45);
         SiteSqlUtils.setSiteVisibility(null, true);
@@ -193,6 +202,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testSetAllWPComSitesVisibility() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel selfHostedNonJPSite = generateSelfHostedNonJPSite();
         SiteSqlUtils.insertOrUpdateSite(selfHostedNonJPSite);
 
@@ -222,6 +233,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testGetIdForIdMethods() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         assertEquals(0, mSiteStore.getLocalIdForRemoteSiteId(555));
         assertEquals(0, mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(2626, ""));
         assertEquals(0, mSiteStore.getSiteIdForLocalId(5577));
@@ -253,6 +266,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testGetSiteBySiteId() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         assertNull(mSiteStore.getSiteBySiteId(555));
 
         SiteModel selfHostedSite = generateSelfHostedNonJPSite();
@@ -270,6 +285,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testDeleteSite() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel wpComSite = generateWPComSite();
 
         // Should not cause any errors
@@ -284,6 +301,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testGetWPComSites() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel wpComSite = generateWPComSite();
         SiteModel jetpackSiteOverXMLRPC = generateJetpackSiteOverXMLRPC();
         SiteModel jetpackSiteOverRestOnly = generateJetpackSiteOverRestOnly();
@@ -303,6 +322,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testInsertDuplicateSites() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel futureJetpack = generateSelfHostedSiteFutureJetpack();
         SiteModel jetpack = generateJetpackSiteOverRestOnly();
 
@@ -328,6 +349,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testInsertDuplicateSitesError() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel futureJetpack = generateSelfHostedSiteFutureJetpack();
         SiteModel jetpack = generateJetpackSiteOverRestOnly();
 
@@ -348,6 +371,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testInsertDuplicateSitesDifferentSchemesError1() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel futureJetpack = generateSelfHostedSiteFutureJetpack();
         SiteModel jetpack = generateJetpackSiteOverRestOnly();
 
@@ -371,6 +396,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testInsertDuplicateSitesDifferentSchemesError2() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel futureJetpack = generateSelfHostedSiteFutureJetpack();
         SiteModel jetpack = generateJetpackSiteOverRestOnly();
 
@@ -411,6 +438,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testSearchSitesByNameMatching() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel wpComSite1 = generateWPComSite();
         wpComSite1.setName("Doctor Emmet Brown Homepage");
         SiteModel wpComSite2 = generateWPComSite();
@@ -433,6 +462,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testSearchSitesByNameOrUrlMatching() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel wpComSite1 = generateWPComSite();
         wpComSite1.setName("Doctor Emmet Brown Homepage");
         SiteModel wpComSite2 = generateWPComSite();
@@ -453,6 +484,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testSearchWPComSitesByNameOrUrlMatching() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel wpComSite1 = generateWPComSite();
         wpComSite1.setName("Doctor Emmet Brown Homepage");
         SiteModel wpComSite2 = generateWPComSite();
@@ -473,6 +506,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testRemoveAllSites() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel wpComSite = generateWPComSite();
         SiteModel jetpackXMLRPCSite = generateJetpackSiteOverXMLRPC();
         SiteModel jetpackRestSite = generateJetpackSiteOverRestOnly();
@@ -493,6 +528,8 @@ public class SiteStoreUnitTest {
 
     @Test
     public void testWPComAutomatedTransfer() throws DuplicateSiteException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         SiteModel wpComSite = generateWPComSite();
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
 
@@ -512,6 +549,8 @@ public class SiteStoreUnitTest {
     @Test
     public void testBatchInsertSiteDuplicateWPCom()
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         List<SiteModel> siteList = new ArrayList<>();
         siteList.add(generateTestSite(1, "https://pony1.com", "https://pony1.com/xmlrpc.php", true, true));
         siteList.add(generateTestSite(2, "https://pony2.com", "https://pony2.com/xmlrpc.php", true, true));
@@ -536,6 +575,8 @@ public class SiteStoreUnitTest {
     @Test
     public void testBatchInsertSiteNoDuplicateWPCom()
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         List<SiteModel> siteList = new ArrayList<>();
         siteList.add(generateTestSite(1, "https://pony1.com", "https://pony1.com/xmlrpc.php", true, true));
         siteList.add(generateTestSite(2, "https://pony2.com", "https://pony2.com/xmlrpc.php", true, true));
@@ -558,6 +599,8 @@ public class SiteStoreUnitTest {
     @Test
     public void testSingleInsertSiteDuplicateWPCom()
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        WellSqlTestUtils.setupWordPressComAccount();
+
         List<SiteModel> siteList = new ArrayList<>();
         siteList.add(generateTestSite(1, "https://pony1.com", "https://pony1.com/xmlrpc.php", true, true));
         SitesModel sites = new SitesModel(siteList);

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteUtils.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.utils;
+package org.wordpress.android.fluxc.site;
 
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.wordpress.android.fluxc.utils.SiteUtils.generateWPComSite;
+import static org.wordpress.android.fluxc.site.SiteUtils.generateWPComSite;
 
 @RunWith(RobolectricTestRunner.class)
 public class SiteXMLRPCClientTest {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -432,6 +432,10 @@ public class AccountStore extends Store {
     }
 
     private void handleFetchAccountCompleted(AccountRestPayload payload) {
+        if (!hasAccessToken()) {
+            emitAccountChangeError(AccountErrorType.ACCOUNT_FETCH_ERROR);
+            return;
+        }
         if (!checkError(payload, "Error fetching Account via REST API (/me)")) {
             mAccount.copyAccountAttributes(payload.account);
             updateDefaultAccount(mAccount, AccountAction.FETCH_ACCOUNT);
@@ -441,6 +445,10 @@ public class AccountStore extends Store {
     }
 
     private void handleFetchSettingsCompleted(AccountRestPayload payload) {
+        if (!hasAccessToken()) {
+            emitAccountChangeError(AccountErrorType.SETTINGS_FETCH_ERROR);
+            return;
+        }
         if (!checkError(payload, "Error fetching Account Settings via REST API (/me/settings)")) {
             mAccount.copyAccountSettingsAttributes(payload.account);
             updateDefaultAccount(mAccount, AccountAction.FETCH_SETTINGS);
@@ -459,6 +467,10 @@ public class AccountStore extends Store {
     }
 
     private void handlePushSettingsCompleted(AccountPushSettingsResponsePayload payload) {
+        if (!hasAccessToken()) {
+            emitAccountChangeError(AccountErrorType.SETTINGS_POST_ERROR);
+            return;
+        }
         if (!payload.isError()) {
             boolean updated = AccountRestClient.updateAccountModelFromPushSettingsResponse(mAccount, payload.settings);
             if (updated) {

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
@@ -14,12 +14,15 @@ import android.widget.TextView;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.AccountAction;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnDiscoveryResponse;
@@ -140,9 +143,7 @@ public class MainInstafluxActivity extends AppCompatActivity {
     }
 
     private void wpcomFetchSites(String username, String password) {
-        AccountStore.AuthenticatePayload payload = new AccountStore.AuthenticatePayload(username, password);
-        // Next action will be dispatched if authentication is successful
-        payload.nextAction = SiteActionBuilder.newFetchSitesAction();
+        AuthenticatePayload payload = new AuthenticatePayload(username, password);
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
     }
 
@@ -168,6 +169,16 @@ public class MainInstafluxActivity extends AppCompatActivity {
     public void onAccountChanged(OnAccountChanged event) {
         if (!mAccountStore.hasAccessToken()) {
             // Signed out!
+            return;
+        }
+
+        if (event.isError()) {
+            AppLog.e(AppLog.T.API, "Account error: " + event.error.type);
+        } else {
+            if (!mSiteStore.hasSite() && event.causeOfChange == AccountAction.FETCH_ACCOUNT) {
+                AppLog.d(AppLog.T.API, "Account data fetched - fetching sites");
+                mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+            }
         }
     }
 
@@ -190,6 +201,12 @@ public class MainInstafluxActivity extends AppCompatActivity {
                 default:
                     // Show Toast "Network Error"?
                     break;
+            }
+        } else {
+            if (mAccountStore.hasAccessToken()) {
+                AppLog.d(AppLog.T.API, "Signed in to WordPress.com successfully, fetching account");
+                mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+                mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
             }
         }
     }


### PR DESCRIPTION
Fixes #433 (though I'll be opening another issue or two to track longer-term refactors mentioned in that issue).

~~Marked as 'not ready for review' until I have a companion PR with 'nextable' actions up (see below).~~ Companion PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/439

The gist here is that before WordPress.com sites are added/updated in the database, we now check whether there is a 'valid' WordPress.com account present. 'Valid' just means a non-zero `USER_ID`. (We'll need to change this behavior if/when we add support for multiple accounts.)

A similar problem can happen if we `FETCH_ACCOUNT` and then logout - we can add an `AccountModel` after it was removed, while we have no token. This PR also prevents accounts from being added if there's no auth token.

A side effect of all this fix is that we can't call `FETCH_ACCOUNT` and `FETCH_SITES` concurrently on login anymore - if `FETCH_SITES` completes first, the insertion of sites in the database will fail because there's no account yet. This ends up making for even more fragmented login code as we have to trigger the next action in the `OnChanged` method the last one called. A second PR adding 'nextable' actions (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/439) will allow us to run all the login actions in one place, in sequence.

I'm targeting a feature branch on this one because I'd like https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/439 to also be reviewed/merged before this hits `develop` and we have to update the WordPress app.

To test:
1. Check out 0d97656 and run the new site and account connected tests --> 💥
2. Check out 46fcaa6, run account test --> 🎉
3. Check out the branch, run all tests --> 🎉
4. Test signing in to the demo apps