### PR TITLE
Add NextableActions

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -34,6 +34,7 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_FluxCImageLoaderTest test);
     void inject(ReleaseStack_MediaTestWPCom test);
     void inject(ReleaseStack_MediaTestXMLRPC test);
+    void inject(ReleaseStack_NextableActionTest test);
     void inject(ReleaseStack_PostTestWPCom test);
     void inject(ReleaseStack_PostTestXMLRPC test);
     void inject(ReleaseStack_SiteTestJetpack test);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NextableActionTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NextableActionTest.java
@@ -1,0 +1,128 @@
+package org.wordpress.android.fluxc.release;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.annotations.action.NextableAction;
+import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+public class ReleaseStack_NextableActionTest extends ReleaseStack_Base {
+    @Inject SiteStore mSiteStore;
+    @Inject AccountStore mAccountStore;
+
+    enum TestEvents {
+        NONE,
+        AUTHENTICATED,
+        ACCOUNT_FETCHED,
+        SETTINGS_FETCHED,
+        SITES_FETCHED
+    }
+
+    private TestEvents mNextEvent;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mReleaseStackAppComponent.inject(this);
+        // Register
+        init();
+        // Reset expected test event
+        mNextEvent = TestEvents.NONE;
+    }
+
+    public void testWPComSiteChainedFetch() throws InterruptedException {
+        // Authenticate a test user (actual credentials declared in gradle.properties)
+        // Fetch account and sites, and wait for OnSiteChanged event
+        AuthenticatePayload payload = new AuthenticatePayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
+                BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        NextableAction authAction = AuthenticationActionBuilder.newAuthenticateAction(payload);
+        authAction.doNextOnSuccess(AccountActionBuilder.newFetchAccountAction())
+                .doNextOnSuccess(AccountActionBuilder.newFetchSettingsAction())
+                .doNextOnSuccess(SiteActionBuilder.newFetchSitesAction());
+
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.AUTHENTICATED;
+        mDispatcher.dispatch(authAction);
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.ACCOUNT_FETCHED;
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.SETTINGS_FETCHED;
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.SITES_FETCHED;
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mSiteStore.getSitesCount() > 0);
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onAuthenticationChanged(OnAuthenticationChanged event) {
+        AppLog.i(T.API, "Received OnAuthenticationChanged");
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        } else {
+            if (mAccountStore.hasAccessToken()) {
+                assertEquals(mNextEvent, TestEvents.AUTHENTICATED);
+            }
+        }
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onAccountChanged(OnAccountChanged event) {
+        AppLog.i(T.API, "Received OnAccountChanged");
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        } else {
+            if (event.causeOfChange != null) {
+                switch (event.causeOfChange) {
+                    case FETCH_ACCOUNT:
+                        assertEquals(mNextEvent, TestEvents.ACCOUNT_FETCHED);
+                        assertEquals(BuildConfig.TEST_WPCOM_USERNAME_TEST1, mAccountStore.getAccount().getUserName());
+                        break;
+                    case FETCH_SETTINGS:
+                        assertEquals(mNextEvent, TestEvents.SETTINGS_FETCHED);
+                        assertEquals(BuildConfig.TEST_WPCOM_USERNAME_TEST1, mAccountStore.getAccount().getUserName());
+                        break;
+                }
+            }
+        }
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onSiteChanged(OnSiteChanged event) {
+        AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        if (mSiteStore.getSitesCount() > 0) {
+            assertTrue(mSiteStore.hasWPComSite());
+        }
+        assertEquals(TestEvents.SITES_FETCHED, mNextEvent);
+        mCountDownLatch.countDown();
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.annotations.action.NextableAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
@@ -344,23 +345,15 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
     private void authenticateWPComAndFetchSites(String username, String password) throws InterruptedException {
         // Authenticate a test user (actual credentials declared in gradle.properties)
+        // Fetch account and sites, and wait for OnSiteChanged event
         AuthenticatePayload payload = new AuthenticatePayload(username, password);
-        mCountDownLatch = new CountDownLatch(1);
+        NextableAction authAction = AuthenticationActionBuilder.newAuthenticateAction(payload);
+        authAction.doNextOnSuccess(AccountActionBuilder.newFetchAccountAction())
+                .doNextOnSuccess(SiteActionBuilder.newFetchSitesAction());
 
-        // Correct user we should get an OnAuthenticationChanged message
-        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
-        // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        // Fetch account from REST API, and wait for OnAccountChanged event
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        // Fetch sites from REST API, and wait for onSiteChanged event
-        mCountDownLatch = new CountDownLatch(1);
+        mCountDownLatch = new CountDownLatch(3);
         mNextEvent = TestEvents.SITE_CHANGED;
-        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+        mDispatcher.dispatch(authAction);
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertTrue(mSiteStore.getSitesCount() > 0);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.annotations.action.NextableAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
@@ -10,7 +11,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
-import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.util.AppLog;
@@ -29,9 +29,8 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
 
     private enum TestEvents {
         NONE,
-        AUTHENTICATED,
         ACCOUNT_FETCHED,
-        SITE_CHANGED,
+        SITES_FETCHED
     }
 
     private TestEvents mNextEvent;
@@ -58,39 +57,26 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
 
     private void authenticate() throws InterruptedException {
         // Authenticate a test user (actual credentials declared in gradle.properties)
+        // Fetch account and sites, and wait for OnSiteChanged event
         AuthenticatePayload payload = new AuthenticatePayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
                 BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        NextableAction authAction = AuthenticationActionBuilder.newAuthenticateAction(payload);
+        authAction.doNextOnSuccess(AccountActionBuilder.newFetchAccountAction());
 
-        // Correct user we should get an OnAuthenticationChanged message
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.AUTHENTICATED;
-        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
-        // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        // Also fetch the account - it's required before WP.com sites can be stored in the database
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACCOUNT_FETCHED;
-        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-        // Wait for a network response / onChanged event
+        mDispatcher.dispatch(authAction);
+
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchSites() throws InterruptedException {
         // Fetch sites from REST API, and wait for onSiteChanged event
         mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.SITE_CHANGED;
+        mNextEvent = TestEvents.SITES_FETCHED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe
-    public void onAuthenticationChanged(OnAuthenticationChanged event) {
-        assertFalse(event.isError());
-        assertEquals(TestEvents.AUTHENTICATED, mNextEvent);
-        mCountDownLatch.countDown();
     }
 
     @SuppressWarnings("unused")
@@ -106,11 +92,11 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
     public void onSiteChanged(OnSiteChanged event) {
         AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
         if (event.isError()) {
-            throw new AssertionError("event error type: " + event.error.type);
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertTrue(mSiteStore.hasSite());
         assertTrue(mSiteStore.hasWPComSite());
-        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        assertEquals(TestEvents.SITES_FETCHED, mNextEvent);
         mCountDownLatch.countDown();
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.java
@@ -184,9 +184,9 @@ public class MainFragment extends Fragment {
         mAuthenticatePayload.twoStepCode = twoStepCode;
 
         NextableAction authAction = AuthenticationActionBuilder.newAuthenticateAction(mAuthenticatePayload);
-        authAction.doNext(AccountActionBuilder.newFetchAccountAction())
-                .doNext(AccountActionBuilder.newFetchSettingsAction())
-                .doNext(SiteActionBuilder.newFetchSitesAction());
+        authAction.doNextOnSuccess(AccountActionBuilder.newFetchAccountAction())
+                .doNextOnSuccess(AccountActionBuilder.newFetchSettingsAction())
+                .doNextOnSuccess(SiteActionBuilder.newFetchSitesAction());
         mDispatcher.dispatch(authAction);
     }
 
@@ -236,9 +236,9 @@ public class MainFragment extends Fragment {
         mAuthenticatePayload = new AuthenticatePayload(username, password);
 
         NextableAction authAction = AuthenticationActionBuilder.newAuthenticateAction(mAuthenticatePayload);
-        authAction.doNext(AccountActionBuilder.newFetchAccountAction())
-                .doNext(AccountActionBuilder.newFetchSettingsAction())
-                .doNext(SiteActionBuilder.newFetchSitesAction());
+        authAction.doNextOnSuccess(AccountActionBuilder.newFetchAccountAction())
+                .doNextOnSuccess(AccountActionBuilder.newFetchSettingsAction())
+                .doNextOnSuccess(SiteActionBuilder.newFetchSitesAction());
         mDispatcher.dispatch(authAction);
     }
 

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/Action.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/Action.java
@@ -12,4 +12,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface Action {
     Class payloadType() default NoPayload.class;
+    boolean nextable() default false;
 }

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/action/ActionBuilder.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/action/ActionBuilder.java
@@ -4,4 +4,8 @@ public abstract class ActionBuilder {
     public static Action<Void> generateNoPayloadAction(IAction actionType) {
         return new Action<>(actionType, null);
     }
+
+    public static NextableAction<Void> generateNoPayloadNextableAction(IAction actionType) {
+        return new NextableAction<>(actionType, null);
+    }
 }

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/action/NextableAction.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/action/NextableAction.java
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.annotations.action;
+
+public class NextableAction<T> extends Action<T> {
+    private Action mNextAction;
+
+    public NextableAction(IAction actionType, T payload) {
+        super(actionType, payload);
+    }
+
+    public Action getNextAction() {
+        return mNextAction;
+    }
+
+    public Action doNext(Action action) {
+        mNextAction = action;
+        return mNextAction;
+    }
+
+    public NextableAction doNext(NextableAction action) {
+        mNextAction = action;
+        return (NextableAction) mNextAction;
+    }
+}

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/action/NextableAction.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/action/NextableAction.java
@@ -11,12 +11,12 @@ public class NextableAction<T> extends Action<T> {
         return mNextAction;
     }
 
-    public Action doNext(Action action) {
+    public Action doNextOnSuccess(Action action) {
         mNextAction = action;
         return mNextAction;
     }
 
-    public NextableAction doNext(NextableAction action) {
+    public NextableAction doNextOnSuccess(NextableAction action) {
         mNextAction = action;
         return (NextableAction) mNextAction;
     }

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/AnnotatedAction.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/AnnotatedAction.java
@@ -12,6 +12,7 @@ import javax.lang.model.type.TypeMirror;
 public class AnnotatedAction {
     private String mActionName;
     private TypeMirror mPayloadType;
+    private boolean mIsNextable;
 
     public AnnotatedAction(Element typeElement, Action actionAnnotation) {
         mActionName = typeElement.getSimpleName().toString();
@@ -20,6 +21,7 @@ public class AnnotatedAction {
         } catch (MirroredTypeException e) {
             mPayloadType = e.getTypeMirror();
         }
+        mIsNextable = actionAnnotation.nextable();
     }
 
     public String getActionName() {
@@ -28,5 +30,9 @@ public class AnnotatedAction {
 
     public TypeMirror getPayloadType() {
         return mPayloadType;
+    }
+
+    public boolean isNextable() {
+        return mIsNextable;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -15,9 +15,9 @@ import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload;
 @ActionEnum
 public enum AccountAction implements IAction {
     // Remote actions
-    @Action
+    @Action(nextable = true)
     FETCH_ACCOUNT,          // request fetch of Account information
-    @Action
+    @Action(nextable = true)
     FETCH_SETTINGS,         // request fetch of Account Settings
     @Action
     SEND_VERIFICATION_EMAIL, // request verification email for unverified accounts
@@ -35,9 +35,9 @@ public enum AccountAction implements IAction {
     IS_AVAILABLE_USERNAME,
 
     // Remote responses
-    @Action(payloadType = AccountRestPayload.class)
+    @Action(payloadType = AccountRestPayload.class, nextable = true)
     FETCHED_ACCOUNT,        // response received from Account fetch request
-    @Action(payloadType = AccountRestPayload.class)
+    @Action(payloadType = AccountRestPayload.class, nextable = true)
     FETCHED_SETTINGS,       // response received from Account Settings fetch
     @Action(payloadType = NewAccountResponsePayload.class)
     SENT_VERIFICATION_EMAIL,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AuthenticationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AuthenticationAction.java
@@ -11,7 +11,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 @ActionEnum
 public enum AuthenticationAction implements IAction {
     // Remote actions
-    @Action(payloadType = AuthenticatePayload.class)
+    @Action(payloadType = AuthenticatePayload.class, nextable = true)
     AUTHENTICATE,
     @Action(payloadType = String.class)
     DISCOVER_ENDPOINT,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -99,7 +99,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                         AccountModel account = responseToAccountModel(response);
                         AccountRestPayload payload = new AccountRestPayload(account, null);
                         NextableAction action = AccountActionBuilder.newFetchedAccountAction(payload);
-                        action.doNext(nextAction);
+                        action.doNextOnSuccess(nextAction);
                         mDispatcher.dispatch(action);
                     }
                 },
@@ -128,7 +128,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                         AccountModel settings = responseToAccountSettingsModel(response);
                         AccountRestPayload payload = new AccountRestPayload(settings, null);
                         NextableAction action = AccountActionBuilder.newFetchedSettingsAction(payload);
-                        action.doNext(nextAction);
+                        action.doNextOnSuccess(nextAction);
                         mDispatcher.dispatch(action);
                     }
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -12,6 +12,8 @@ import org.json.JSONObject;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.AccountAction;
+import org.wordpress.android.fluxc.annotations.action.Action;
+import org.wordpress.android.fluxc.annotations.action.NextableAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.AccountModel;
@@ -88,7 +90,7 @@ public class AccountRestClient extends BaseWPComRestClient {
      * with a payload of type {@link AccountRestPayload}. {@link AccountRestPayload#isError()} can
      * be used to determine the result of the request.
      */
-    public void fetchAccount() {
+    public void fetchAccount(final Action nextAction) {
         String url = WPCOMREST.me.getUrlV1_1();
         add(WPComGsonRequest.buildGetRequest(url, null, AccountResponse.class,
                 new Listener<AccountResponse>() {
@@ -96,7 +98,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                     public void onResponse(AccountResponse response) {
                         AccountModel account = responseToAccountModel(response);
                         AccountRestPayload payload = new AccountRestPayload(account, null);
-                        mDispatcher.dispatch(AccountActionBuilder.newFetchedAccountAction(payload));
+                        NextableAction action = AccountActionBuilder.newFetchedAccountAction(payload);
+                        action.doNext(nextAction);
+                        mDispatcher.dispatch(action);
                     }
                 },
                 new BaseErrorListener() {
@@ -115,7 +119,7 @@ public class AccountRestClient extends BaseWPComRestClient {
      * with a payload of type {@link AccountRestPayload}. {@link AccountRestPayload#isError()} can
      * be used to determine the result of the request.
      */
-    public void fetchAccountSettings() {
+    public void fetchAccountSettings(final Action nextAction) {
         String url = WPCOMREST.me.settings.getUrlV1_1();
         add(WPComGsonRequest.buildGetRequest(url, null, AccountSettingsResponse.class,
                 new Listener<AccountSettingsResponse>() {
@@ -123,7 +127,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                     public void onResponse(AccountSettingsResponse response) {
                         AccountModel settings = responseToAccountSettingsModel(response);
                         AccountRestPayload payload = new AccountRestPayload(settings, null);
-                        mDispatcher.dispatch(AccountActionBuilder.newFetchedSettingsAction(payload));
+                        NextableAction action = AccountActionBuilder.newFetchedSettingsAction(payload);
+                        action.doNext(nextAction);
+                        mDispatcher.dispatch(action);
                     }
                 },
                 new BaseErrorListener() {

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/MainInstafluxActivity.java
@@ -145,9 +145,9 @@ public class MainInstafluxActivity extends AppCompatActivity {
     private void wpcomFetchSites(String username, String password) {
         AuthenticatePayload payload = new AuthenticatePayload(username, password);
         NextableAction authAction = AuthenticationActionBuilder.newAuthenticateAction(payload);
-        authAction.doNext(AccountActionBuilder.newFetchAccountAction())
-                .doNext(AccountActionBuilder.newFetchSettingsAction())
-                .doNext(SiteActionBuilder.newFetchSitesAction());
+        authAction.doNextOnSuccess(AccountActionBuilder.newFetchAccountAction())
+                .doNextOnSuccess(AccountActionBuilder.newFetchSettingsAction())
+                .doNextOnSuccess(SiteActionBuilder.newFetchSitesAction());
         mDispatcher.dispatch(authAction);
     }
 


### PR DESCRIPTION
Adds NextableActions: Actions that allow you to set another action to be executed if the first action succeeds.

<s>#438 should be merged first, and then this PR can target `wpcom-login-logout-changes`.</s>

For example:
```java
AuthenticatePayload payload = new AuthenticatePayload(username, password);

NextableAction authAction = AuthenticationActionBuilder.newAuthenticateAction(payload);
authAction.doNextOnSuccess(AccountActionBuilder.newFetchAccountAction())
        .doNextOnSuccess(AccountActionBuilder.newFetchSettingsAction())
        .doNextOnSuccess(SiteActionBuilder.newFetchSitesAction());
mDispatcher.dispatch(authAction);
```

For now, only `AUTHENTICATE`, `FETCH_ACCOUNT` and `FETCH_SETTINGS` are 'nextable' (also `FETCHED_ACCOUNT` and `FETCHED_SETTINGS`, as`FETCH_ACCOUNT` and `FETCH_SETTINGS` aren't completed until those internal actions are dispatched and processed).

We could make any action nextable, it's just a matter of handling the queued action through the corresponding store (and possibly through a network client and back through the store again).