### PR TITLE
Generics cleanup

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/XMLRPCUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/XMLRPCUtilsTest.java
@@ -5,9 +5,11 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCUtils;
 
+import java.sql.Time;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -93,6 +95,23 @@ public class XMLRPCUtilsTest {
     public void testGetValueDate() {
         Date theDate = new Date();
         assertThat(XMLRPCUtils.safeGetMapValue(getTestMapForValue(theDate), new Date(4244)), equalTo(theDate));
+    }
+
+    @Test(expected = Exception.class)
+    public void testGetValueInvalidType() {
+        // Something bad should happen if we try this - Random isn't a possible type the XML-RPC deserializer would
+        // parse into, so it's guaranteed to always return the default value, without us ever knowing that we're
+        // asking safeGetMapValue() for an impossible type
+        Random thing = new Random();
+        assertThat(XMLRPCUtils.safeGetMapValue(getTestMapForValue("text"), thing), equalTo(thing));
+    }
+
+    @Test
+    public void testGetValueInvalidTypeSubclass() {
+        // If we pass a Date subclass as the default value, we might expect it to work as a match for a Date entry
+        // But it doesn't - we'll always receive the default value
+        Date theDate = new Date();
+        assertThat(XMLRPCUtils.safeGetMapValue(getTestMapForValue(theDate), new Time(4244)), equalTo(theDate));
     }
 
     private static Map<String, String> getTestMapForValue(String value) {

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/XMLRPCUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/XMLRPCUtilsTest.java
@@ -97,7 +97,7 @@ public class XMLRPCUtilsTest {
         assertThat(XMLRPCUtils.safeGetMapValue(getTestMapForValue(theDate), new Date(4244)), equalTo(theDate));
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = RuntimeException.class)
     public void testGetValueInvalidType() {
         // Something bad should happen if we try this - Random isn't a possible type the XML-RPC deserializer would
         // parse into, so it's guaranteed to always return the default value, without us ever knowing that we're
@@ -106,10 +106,12 @@ public class XMLRPCUtilsTest {
         assertThat(XMLRPCUtils.safeGetMapValue(getTestMapForValue("text"), thing), equalTo(thing));
     }
 
-    @Test
+    @Test(expected = RuntimeException.class)
     public void testGetValueInvalidTypeSubclass() {
         // If we pass a Date subclass as the default value, we might expect it to work as a match for a Date entry
         // But it doesn't - we'll always receive the default value
+        // Something bad should happen if we try this too - we should be warned that we're giving safeGetMapValue()
+        // an impossible type
         Date theDate = new Date();
         assertThat(XMLRPCUtils.safeGetMapValue(getTestMapForValue(theDate), new Time(4244)), equalTo(theDate));
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/XMLRPCUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/XMLRPCUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCUtils;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -88,8 +89,22 @@ public class XMLRPCUtilsTest {
         assertThat(XMLRPCUtils.safeGetMapValue(getTestMapForValue("false"), 42.42), equalTo(42.42));
     }
 
+    @Test
+    public void testGetValueDate() {
+        Date theDate = new Date();
+        assertThat(XMLRPCUtils.safeGetMapValue(getTestMapForValue(theDate), new Date(4244)), equalTo(theDate));
+    }
+
     private static Map<String, String> getTestMapForValue(String value) {
         Map<String, String> map = new HashMap<>();
+        map.put("key", "test-key");
+        map.put("id", "42");
+        map.put("value", value);
+        return map;
+    }
+
+    private static Map<String, Object> getTestMapForValue(Object value) {
+        Map<String, Object> map = new HashMap<>();
         map.put("key", "test-key");
         map.put("id", "42");
         map.put("value", value);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -167,12 +167,12 @@ public class AccountRestClient extends BaseWPComRestClient {
     public void pushAccountSettings(Map<String, Object> body) {
         if (body == null || body.isEmpty()) return;
         String url = WPCOMREST.me.settings.getUrlV1_1();
-        // Note: we have to use a HashMap as a response here because the API response format is different depending
+        // Note: we have to use a Map as a response here because the API response format is different depending
         // of the request we do.
-        add(WPComGsonRequest.buildPostRequest(url, body, HashMap.class,
-                new Listener<HashMap>() {
+        add(WPComGsonRequest.buildPostRequest(url, body, Map.class,
+                new Listener<Map<String, Object>>() {
                     @Override
-                    public void onResponse(HashMap response) {
+                    public void onResponse(Map<String, Object> response) {
                         AccountPushSettingsResponsePayload payload = new AccountPushSettingsResponsePayload(null);
                         payload.settings = response;
                         mDispatcher.dispatch(AccountActionBuilder.newPushedSettingsAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
@@ -20,23 +20,30 @@ public class XMLRPCUtils {
         if (!map.containsKey(key)) {
             return defaultValue;
         }
+        Class<T> clazz = (Class<T>) defaultValue.getClass();
+
         Object value = map.get(key);
-        if (defaultValue.getClass().isInstance(value)) {
-            return (T) value;
+        if (clazz.isInstance(value)) {
+            return clazz.cast(value);
         }
 
+        Object result;
         if (defaultValue instanceof String) {
-            return (T) MapUtils.getMapStr(map, key);
+            result = MapUtils.getMapStr(map, key);
         } else if (defaultValue instanceof Boolean) {
-            return (T) Boolean.valueOf(MapUtils.getMapBool(map, key));
+            result = MapUtils.getMapBool(map, key);
         } else if (defaultValue instanceof Integer) {
-            return (T) Integer.valueOf(MapUtils.getMapInt(map, key, (Integer) defaultValue));
+            result = MapUtils.getMapInt(map, key, (Integer) defaultValue);
         } else if (defaultValue instanceof Long) {
-            return (T) Long.valueOf(MapUtils.getMapLong(map, key, (Long) defaultValue));
+            result = MapUtils.getMapLong(map, key, (Long) defaultValue);
         } else if (defaultValue instanceof Float) {
-            return (T) Float.valueOf(MapUtils.getMapFloat(map, key, (Float) defaultValue));
+            result = MapUtils.getMapFloat(map, key, (Float) defaultValue);
         } else if (defaultValue instanceof Double) {
-            return (T) Double.valueOf(MapUtils.getMapDouble(map, key, (Double) defaultValue));
+            result = MapUtils.getMapDouble(map, key, (Double) defaultValue);
+        }
+
+        if (result != null) {
+            return clazz.cast(result);
         }
 
         return defaultValue;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
@@ -17,29 +17,28 @@ public class XMLRPCUtils {
 
     @NonNull
     public static <T> T safeGetMapValue(@NonNull Map<?, ?> map, String key, T defaultValue) {
-        if (map != null) {
-            if (!map.containsKey(key)) {
-                return defaultValue;
-            }
-            Object value = map.get(key);
-            if (defaultValue.getClass().isInstance(value)) {
-                return (T) value;
-            }
-
-            if (defaultValue instanceof String) {
-                return (T) MapUtils.getMapStr(map, key);
-            } else if (defaultValue instanceof Boolean) {
-                return (T) Boolean.valueOf(MapUtils.getMapBool(map, key));
-            } else if (defaultValue instanceof Integer) {
-                return (T) Integer.valueOf(MapUtils.getMapInt(map, key, (Integer) defaultValue));
-            } else if (defaultValue instanceof Long) {
-                return (T) Long.valueOf(MapUtils.getMapLong(map, key, (Long) defaultValue));
-            } else if (defaultValue instanceof Float) {
-                return (T) Float.valueOf(MapUtils.getMapFloat(map, key, (Float) defaultValue));
-            } else if (defaultValue instanceof Double) {
-                return (T) Double.valueOf(MapUtils.getMapDouble(map, key, (Double) defaultValue));
-            }
+        if (!map.containsKey(key)) {
+            return defaultValue;
         }
+        Object value = map.get(key);
+        if (defaultValue.getClass().isInstance(value)) {
+            return (T) value;
+        }
+
+        if (defaultValue instanceof String) {
+            return (T) MapUtils.getMapStr(map, key);
+        } else if (defaultValue instanceof Boolean) {
+            return (T) Boolean.valueOf(MapUtils.getMapBool(map, key));
+        } else if (defaultValue instanceof Integer) {
+            return (T) Integer.valueOf(MapUtils.getMapInt(map, key, (Integer) defaultValue));
+        } else if (defaultValue instanceof Long) {
+            return (T) Long.valueOf(MapUtils.getMapLong(map, key, (Long) defaultValue));
+        } else if (defaultValue instanceof Float) {
+            return (T) Float.valueOf(MapUtils.getMapFloat(map, key, (Float) defaultValue));
+        } else if (defaultValue instanceof Double) {
+            return (T) Double.valueOf(MapUtils.getMapDouble(map, key, (Double) defaultValue));
+        }
+
         return defaultValue;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
@@ -23,10 +23,6 @@ public class XMLRPCUtils {
         }
         Class<T> clazz = (Class<T>) defaultValue.getClass();
 
-        Object value = map.get(key);
-        if (clazz.isInstance(value)) {
-            return clazz.cast(value);
-        }
 
         Object result;
         if (defaultValue instanceof String) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
@@ -47,6 +47,13 @@ public class XMLRPCUtils {
             // clazz will have the exact value of the runtime class of defaultValue, and if we allow subclasses (by
             // using instanceof), we will end up trying to cast, e.g., a Date object from the map to a Time
             result = map.get(key);
+        } else {
+            // The XML-RPC deserializer only returns the above types. Any other type passed for the default value
+            // will cause the default value to be returned 100% of the time, regardless of whether the value is set
+            // in the map or not
+            // Instead, make it obvious that an impossible type was given as the default value
+            throw new RuntimeException("Invalid type: " + clazz.getName() + ". Expected "
+                    + "String, boolean, int, long, float, double, or Date.");
         }
 
         if (result != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import org.wordpress.android.util.MapUtils;
 
+import java.util.Date;
 import java.util.Map;
 
 public class XMLRPCUtils {
@@ -40,6 +41,12 @@ public class XMLRPCUtils {
             result = MapUtils.getMapFloat(map, key, (Float) defaultValue);
         } else if (defaultValue instanceof Double) {
             result = MapUtils.getMapDouble(map, key, (Double) defaultValue);
+        } else if (clazz == Date.class) {
+            // Matching clazz specifically here to exclude subclasses of Date from being passed as default value
+            // (Date is the only non-final type the XML-RPC deserializer returns - instanceof is safe for the rest)
+            // clazz will have the exact value of the runtime class of defaultValue, and if we allow subclasses (by
+            // using instanceof), we will end up trying to cast, e.g., a Date object from the map to a Time
+            result = map.get(key);
         }
 
         if (result != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCUtils.java
@@ -21,8 +21,12 @@ public class XMLRPCUtils {
         if (!map.containsKey(key)) {
             return defaultValue;
         }
-        Class<T> clazz = (Class<T>) defaultValue.getClass();
 
+        // The XML deserializer returns a narrow set of values, and they're all matched exactly below.
+        // None of them are parameterizable, and we'll throw an exception below if any unexpected type is given
+        // Given those constraints, it's safe to ignore this warning
+        @SuppressWarnings("unchecked")
+        Class<T> clazz = (Class<T>) defaultValue.getClass();
 
         Object result;
         if (defaultValue instanceof String) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLSerializerUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLSerializerUtils.java
@@ -78,9 +78,9 @@ public class XMLSerializerUtils {
             pullParser.nextTag(); // TAG_VALUE (<value>)
             // no parser.require() here since its called in XMLRPCSerializer.deserialize() below
             // deserialize fault result
-            Map<String, Object> map = (Map<String, Object>) XMLRPCSerializer.deserialize(pullParser);
-            String faultString = (String) map.get(TAG_FAULT_STRING);
-            int faultCode = (Integer) map.get(TAG_FAULT_CODE);
+            Map<?, ?> map = (Map<?, ?>) XMLRPCSerializer.deserialize(pullParser);
+            String faultString = XMLRPCUtils.safeGetMapValue(map, TAG_FAULT_STRING, "");
+            int faultCode = XMLRPCUtils.safeGetMapValue(map, TAG_FAULT_CODE, 0);
             throw new XMLRPCFault(faultString, faultCode);
         } else {
             throw new XMLRPCException("Bad tag <" + tag + "> in XMLRPC response - neither <params> nor <fault>");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/AccountSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/AccountSqlUtils.java
@@ -31,7 +31,7 @@ public class AccountSqlUtils {
             WellSql.insert(account).execute();
             return 0;
         } else {
-            ContentValues cv = new UpdateAllExceptId<AccountModel>().toCv(account);
+            ContentValues cv = new UpdateAllExceptId<>(AccountModel.class).toCv(account);
             return updateAccount(accountResults.get(0).getId(), cv);
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -45,7 +45,7 @@ public class CommentSqlUtils {
             // update
             int oldId = commentResult.get(0).getId();
             return WellSql.update(CommentModel.class).whereId(oldId)
-                    .put(comment, new UpdateAllExceptId<CommentModel>()).execute();
+                    .put(comment, new UpdateAllExceptId<>(CommentModel.class)).execute();
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -238,7 +238,7 @@ public class MediaSqlUtils {
             // update, media item already exists
             int oldId = existingMedia.get(0).getId();
             return WellSql.update(MediaModel.class).whereId(oldId)
-                    .put(media, new UpdateAllExceptId<MediaModel>()).execute();
+                    .put(media, new UpdateAllExceptId<>(MediaModel.class)).execute();
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -50,7 +50,7 @@ public class PostSqlUtils {
             if (overwriteLocalChanges || !postResult.get(0).isLocallyChanged()) {
                 int oldId = postResult.get(0).getId();
                 return WellSql.update(PostModel.class).whereId(oldId)
-                        .put(post, new UpdateAllExceptId<PostModel>()).execute();
+                        .put(post, new UpdateAllExceptId<>(PostModel.class)).execute();
             }
         }
         return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -135,7 +135,7 @@ public class SiteSqlUtils {
             int oldId = siteResult.get(0).getId();
             try {
                 return WellSql.update(SiteModel.class).whereId(oldId)
-                        .put(site, new UpdateAllExceptId<SiteModel>()).execute();
+                        .put(site, new UpdateAllExceptId<>(SiteModel.class)).execute();
             } catch (SQLiteConstraintException e) {
                 AppLog.e(T.DB, "Error while updating site: siteId=" + site.getSiteId() + " url=" + site.getUrl()
                         + " xmlrpc=" + site.getXmlRpcUrl(), e);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -32,7 +32,7 @@ public class TaxonomySqlUtils {
             return 1;
         } else {
             return WellSql.update(TermModel.class).whereId(termResult.get(0).getId())
-                    .put(term, new UpdateAllExceptId<TermModel>()).execute();
+                    .put(term, new UpdateAllExceptId<>(TermModel.class)).execute();
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/UpdateAllExceptId.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/UpdateAllExceptId.java
@@ -6,11 +6,16 @@ import com.yarolegovich.wellsql.WellSql;
 import com.yarolegovich.wellsql.mapper.InsertMapper;
 import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 
-public class UpdateAllExceptId<T> implements InsertMapper<T> {
+class UpdateAllExceptId<T> implements InsertMapper<T> {
+    private final SQLiteMapper<T> mMapper;
+
+    UpdateAllExceptId(Class<T> clazz) {
+        mMapper = WellSql.mapperFor(clazz);
+    }
+
     @Override
     public ContentValues toCv(T item) {
-        SQLiteMapper<T> mapper = WellSql.mapperFor((Class<T>) item.getClass());
-        ContentValues cv = mapper.toCv(item);
+        ContentValues cv = mMapper.toCv(item);
         cv.remove("_id");
         return cv;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -6,6 +6,7 @@ import android.database.sqlite.SQLiteDatabase;
 import com.yarolegovich.wellsql.DefaultWellConfig;
 import com.yarolegovich.wellsql.WellSql;
 import com.yarolegovich.wellsql.WellTableManager;
+import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.TableClass;
 import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 
@@ -21,6 +22,8 @@ import org.wordpress.android.fluxc.network.HTTPAuthModel;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class WellSqlConfig extends DefaultWellConfig {
@@ -28,17 +31,17 @@ public class WellSqlConfig extends DefaultWellConfig {
         super(context);
     }
 
-    private static final Class[] TABLES = {
-            AccountModel.class,
-            SiteModel.class,
-            MediaModel.class,
-            PostFormatModel.class,
-            PostModel.class,
-            CommentModel.class,
-            TaxonomyModel.class,
-            TermModel.class,
-            HTTPAuthModel.class
-    };
+    private static final List<Class<? extends Identifiable>> TABLES = new ArrayList<Class<? extends Identifiable>>() {{
+        add(AccountModel.class);
+        add(CommentModel.class);
+        add(HTTPAuthModel.class);
+        add(MediaModel.class);
+        add(PostFormatModel.class);
+        add(PostModel.class);
+        add(SiteModel.class);
+        add(TaxonomyModel.class);
+        add(TermModel.class);
+    }};
 
     @Override
     public int getDbVersion() {
@@ -52,7 +55,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public void onCreate(SQLiteDatabase db, WellTableManager helper) {
-        for (Class table : TABLES) {
+        for (Class<? extends Identifiable> table : TABLES) {
             helper.createTable(table);
         }
     }
@@ -117,7 +120,7 @@ public class WellSqlConfig extends DefaultWellConfig {
      */
     public void reset() {
         SQLiteDatabase db = WellSql.giveMeWritableDb();
-        for (Class clazz : TABLES) {
+        for (Class<? extends Identifiable> clazz : TABLES) {
             TableClass table = getTable(clazz);
             db.execSQL("DROP TABLE IF EXISTS " + table.getTableName());
             db.execSQL(table.createStatement());


### PR DESCRIPTION
Refactors some of our generic code, reducing our compiler warnings from `13` to `1`. The final warning is address in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/442.

No major issues fixed - I mostly learned a few things, fixed a few potential traps, and added some documentation.

I had to use `SuppressWarnings` in [one spot](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/441/files#diff-3c2b3bb0a2654c0ed1fab89a38c2dfe5R28), but there's an explanation of why it's safe to do so in that case.