### PR TITLE
Fix compiler warning in XMLRPCRequest

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
@@ -13,7 +13,8 @@ import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
  * {@link AuthenticationAction#AUTHENTICATE_ERROR} events.
  */
 public class DiscoveryXMLRPCRequest extends XMLRPCRequest {
-    DiscoveryXMLRPCRequest(String url, XMLRPC method, Listener listener, BaseErrorListener errorListener) {
+    DiscoveryXMLRPCRequest(String url, XMLRPC method, Listener<? super Object[]> listener,
+                           BaseErrorListener errorListener) {
         super(url, method, null, listener, errorListener);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -193,7 +193,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         final XMLRPC method = post.isLocalDraft() ? XMLRPC.NEW_POST : XMLRPC.EDIT_POST;
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), method, params,
-                new Listener() {
+                new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
                         if (method.equals(XMLRPC.NEW_POST) && response instanceof String) {
@@ -242,7 +242,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         params.add(post.getRemotePostId());
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.DELETE_POST, params,
-                new Listener() {
+                new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
                         RemotePostPayload payload = new RemotePostPayload(post, site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -156,7 +156,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         params.add(contentStruct);
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.NEW_TERM, params,
-                new Listener() {
+                new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
                         term.setRemoteTermId(Long.valueOf((String) response));


### PR DESCRIPTION
Fixes our last compiler warning (the rest are in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/441).

I tried out a few approaches for this one, and settled on this. It forces the XML-RPC clients to set a parameter for the `Listener`, and restricts that to only `Object` or `Object[]`. A perfect solution would've been to refactor the `XMLRPCSerializer` to be parameterizable, but I'm unwilling to mess with code we've had for so long just for this.