### PR TITLE
Change getPostByLocalPostId's parameter to int

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -319,7 +319,7 @@ public class PostStore extends Store {
     /**
      * Given a local ID for a post, returns that post as a {@link PostModel}.
      */
-    public PostModel getPostByLocalPostId(long localId) {
+    public PostModel getPostByLocalPostId(int localId) {
         List<PostModel> result = WellSql.select(PostModel.class)
                 .where().equals(PostModelTable.ID, localId).endWhere()
                 .getAsModel();


### PR DESCRIPTION
Since the `PostModel`'s `id` is `int` we should be using `int` inside `getPostByLocalPostId` instead of `long`.

I ran every test that this change touches and haven't found any issues. I'll check the wpandroid side as well once this is merged.

/cc @aforcier 