### PR TITLE
Remove unneeded Payload subclassing in WPComRestResponses

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media;
 
-import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.network.Response;
 
 import java.util.List;
@@ -10,7 +9,7 @@ import java.util.List;
  *
  * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/media/%24media_ID/
  */
-public class MediaWPComRestResponse extends Payload implements Response {
+public class MediaWPComRestResponse implements Response {
     public static final String DELETED_STATUS = "deleted";
 
     public class MultipleMediaResponse {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.java
@@ -1,13 +1,12 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.post;
 
-import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.network.Response;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse;
 
 import java.util.List;
 import java.util.Map;
 
-public class PostWPComRestResponse extends Payload implements Response {
+public class PostWPComRestResponse implements Response {
     public class PostsResponse {
         public List<PostWPComRestResponse> posts;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -1,11 +1,10 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site;
 
-import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.network.Response;
 
 import java.util.List;
 
-public class SiteWPComRestResponse extends Payload implements Response {
+public class SiteWPComRestResponse implements Response {
     public class SitesResponse {
         public List<SiteWPComRestResponse> sites;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
@@ -1,11 +1,10 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.taxonomy;
 
-import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.network.Response;
 
 import java.util.List;
 
-public class TermWPComRestResponse extends Payload implements Response {
+public class TermWPComRestResponse implements Response {
     public class TermsResponse {
         public List<TermWPComRestResponse> terms;
     }


### PR DESCRIPTION
These don't need to extend `Payload` and it's kind of misleading.