### PR TITLE
Parse and store the "default sizes" for each media item

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -61,10 +61,10 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
     // Local only
     @Column private String mUploadState;
 
-    // Other Sizes. Image files only
-    @Column private String mFileNameMediumSize;
-    @Column private String mFileNameMediumLargeSize;
-    @Column private String mFileNameLargeSize;
+    // Other Sizes. Only available for images on self-hosted (xmlrpc layer) sites
+    @Column private String mFileUrlMediumSize;
+    @Column private String mFileUrlMediumLargeSize;
+    @Column private String mFileUrlLargeSize;
 
     //
     // Legacy
@@ -112,9 +112,9 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
                 && StringUtils.equals(getAlt(), otherMedia.getAlt())
                 && StringUtils.equals(getVideoPressGuid(), otherMedia.getVideoPressGuid())
                 && StringUtils.equals(getUploadState(), otherMedia.getUploadState())
-                && StringUtils.equals(getFileNameMediumSize(), otherMedia.getFileNameMediumSize())
-                && StringUtils.equals(getFileNameMediumLargeSize(), otherMedia.getFileNameMediumLargeSize())
-                && StringUtils.equals(getFileNameLargeSize(), otherMedia.getFileNameLargeSize());
+                && StringUtils.equals(getFileUrlMediumSize(), otherMedia.getFileUrlMediumSize())
+                && StringUtils.equals(getFileUrlMediumLargeSize(), otherMedia.getFileUrlMediumLargeSize())
+                && StringUtils.equals(getFileUrlLargeSize(), otherMedia.getFileUrlLargeSize());
     }
 
     @Override
@@ -367,27 +367,27 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
         mUploadCancelled = uploadCancelled;
     }
 
-    public void setFileNameMediumSize(String file) {
-        mFileNameMediumSize = file;
+    public void setFileUrlMediumSize(String file) {
+        mFileUrlMediumSize = file;
     }
 
-    public String getFileNameMediumSize() {
-        return mFileNameMediumSize;
+    public String getFileUrlMediumSize() {
+        return mFileUrlMediumSize;
     }
 
-    public void setFileNameMediumLargeSize(String file) {
-        mFileNameMediumLargeSize = file;
+    public void setFileUrlMediumLargeSize(String file) {
+        mFileUrlMediumLargeSize = file;
     }
 
-    public String getFileNameMediumLargeSize() {
-        return mFileNameMediumLargeSize;
+    public String getFileUrlMediumLargeSize() {
+        return mFileUrlMediumLargeSize;
     }
 
-    public void setFileNameLargeSize(String file) {
-        mFileNameLargeSize = file;
+    public void setFileUrlLargeSize(String file) {
+        mFileUrlLargeSize = file;
     }
 
-    public String getFileNameLargeSize() {
-        return mFileNameLargeSize;
+    public String getFileUrlLargeSize() {
+        return mFileUrlLargeSize;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.model;
 
-import android.text.TextUtils;
-
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
@@ -391,14 +389,5 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
 
     public String getFileNameLargeSize() {
         return mFileNameLargeSize;
-    }
-
-    public String getFilePathLargeSize() {
-        String thumbPath = getThumbnailUrl();
-        if (TextUtils.isEmpty(getFileNameLargeSize())
-                || TextUtils.isEmpty(thumbPath) || !thumbPath.contains("/")) return null;
-        if (thumbPath.lastIndexOf("/") + 1 >= thumbPath.length()) return null;
-
-        return thumbPath.substring(0, thumbPath.lastIndexOf("/") + 1) + getFileNameLargeSize();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.model;
 
+import android.text.TextUtils;
+
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
@@ -61,6 +63,11 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
     // Local only
     @Column private String mUploadState;
 
+    // Other Sizes. Image files only
+    @Column private String mFileNameMediumSize;
+    @Column private String mFileNameMediumLargeSize;
+    @Column private String mFileNameLargeSize;
+
     //
     // Legacy
     //
@@ -106,7 +113,10 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
                 && StringUtils.equals(getCaption(), otherMedia.getCaption())
                 && StringUtils.equals(getAlt(), otherMedia.getAlt())
                 && StringUtils.equals(getVideoPressGuid(), otherMedia.getVideoPressGuid())
-                && StringUtils.equals(getUploadState(), otherMedia.getUploadState());
+                && StringUtils.equals(getUploadState(), otherMedia.getUploadState())
+                && StringUtils.equals(getFileNameMediumSize(), otherMedia.getFileNameMediumSize())
+                && StringUtils.equals(getFileNameMediumLargeSize(), otherMedia.getFileNameMediumLargeSize())
+                && StringUtils.equals(getFileNameLargeSize(), otherMedia.getFileNameLargeSize());
     }
 
     @Override
@@ -357,5 +367,38 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
 
     public void setUploadCancelled(boolean uploadCancelled) {
         mUploadCancelled = uploadCancelled;
+    }
+
+    public void setFileNameMediumSize(String file) {
+        mFileNameMediumSize = file;
+    }
+
+    public String getFileNameMediumSize() {
+        return mFileNameMediumSize;
+    }
+
+    public void setFileNameMediumLargeSize(String file) {
+        mFileNameMediumLargeSize = file;
+    }
+
+    public String getFileNameMediumLargeSize() {
+        return mFileNameMediumLargeSize;
+    }
+
+    public void setFileNameLargeSize(String file) {
+        mFileNameLargeSize = file;
+    }
+
+    public String getFileNameLargeSize() {
+        return mFileNameLargeSize;
+    }
+
+    public String getFilePathLargeSize() {
+        String thumbPath = getThumbnailUrl();
+        if (TextUtils.isEmpty(getFileNameLargeSize())
+                || TextUtils.isEmpty(thumbPath) || !thumbPath.contains("/")) return null;
+        if (thumbPath.lastIndexOf("/") + 1 >= thumbPath.length()) return null;
+
+        return thumbPath.substring(0, thumbPath.lastIndexOf("/") + 1) + getFileNameLargeSize();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.xmlrpc.media;
 
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 import android.util.Base64;
 
 import com.android.volley.RequestQueue;
@@ -503,13 +504,30 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             Map metadataMap = (Map) metadataObject;
             media.setWidth(MapUtils.getMapInt(metadataMap, "width"));
             media.setHeight(MapUtils.getMapInt(metadataMap, "height"));
-            media.setFileNameMediumSize(getFileForSize(metadataMap, "medium"));
-            media.setFileNameMediumLargeSize(getFileForSize(metadataMap, "medium_large"));
-            media.setFileNameLargeSize(getFileForSize(metadataMap, "large"));
+            media.setFileUrlMediumSize(getFileUrlForSize(link, metadataMap, "medium"));
+            media.setFileUrlMediumLargeSize(getFileUrlForSize(link, metadataMap, "medium_large"));
+            media.setFileUrlLargeSize(getFileUrlForSize(link, metadataMap, "large"));
         }
 
         media.setUploadState(MediaModel.UploadState.UPLOADED.toString());
         return media;
+    }
+
+    private String getFileUrlForSize(String mediaUrl, Map metadataMap, String size) {
+        if (metadataMap == null || TextUtils.isEmpty(mediaUrl) || !mediaUrl.contains("/")) {
+            return null;
+        }
+
+        String fileName = getFileForSize(metadataMap, size);
+        if (TextUtils.isEmpty(fileName)) {
+            return null;
+        }
+
+        // make sure the path to the original image is a valid path to a file
+        if (mediaUrl.lastIndexOf("/") + 1 >= mediaUrl.length()) return null;
+
+        String baseURL = mediaUrl.substring(0, mediaUrl.lastIndexOf("/") + 1);
+        return baseURL + fileName;
     }
 
     private String getFileForSize(Map metadataMap, String size) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -503,10 +503,29 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             Map metadataMap = (Map) metadataObject;
             media.setWidth(MapUtils.getMapInt(metadataMap, "width"));
             media.setHeight(MapUtils.getMapInt(metadataMap, "height"));
+            media.setFileNameMediumSize(getFileForSize(metadataMap, "medium"));
+            media.setFileNameMediumLargeSize(getFileForSize(metadataMap, "medium_large"));
+            media.setFileNameLargeSize(getFileForSize(metadataMap, "large"));
         }
 
         media.setUploadState(MediaModel.UploadState.UPLOADED.toString());
         return media;
+    }
+
+    private String getFileForSize(Map metadataMap, String size) {
+        if (metadataMap == null) {
+            return null;
+        }
+        Object sizesObject = metadataMap.get("sizes");
+        if (sizesObject instanceof Map) {
+            Map sizesMap = (Map) sizesObject;
+            Object requestedSizeObject = sizesMap.get(size);
+            if (requestedSizeObject instanceof Map) {
+                Map requestedSizeMap = (Map) requestedSizeObject;
+                return MapUtils.getMapStr(requestedSizeMap, "file");
+            }
+        }
+        return null;
     }
 
     private MediaError getMediaErrorFromXMLRPCException(XMLRPCException exception) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -94,9 +94,9 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 8:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("alter table MediaModel add FILE_NAME_MEDIUM_SIZE text;");
-                db.execSQL("alter table MediaModel add FILE_NAME_MEDIUM_LARGE_SIZE text;");
-                db.execSQL("alter table MediaModel add FILE_NAME_LARGE_SIZE text;");
+                db.execSQL("alter table MediaModel add FILE_URL_MEDIUM_SIZE text;");
+                db.execSQL("alter table MediaModel add FILE_URL_MEDIUM_LARGE_SIZE text;");
+                db.execSQL("alter table MediaModel add FILE_URL_LARGE_SIZE text;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -42,7 +42,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 8;
+        return 9;
     }
 
     @Override
@@ -91,6 +91,12 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 7:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table MediaModel add LOCAL_POST_ID integer;");
+                oldVersion++;
+            case 8:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table MediaModel add FILE_NAME_MEDIUM_SIZE text;");
+                db.execSQL("alter table MediaModel add FILE_NAME_MEDIUM_LARGE_SIZE text;");
+                db.execSQL("alter table MediaModel add FILE_NAME_LARGE_SIZE text;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
On media uploading, WordPress (the server) creates few predefined image files, together with the original file, and gives them available for future usage. It depends on the server configuration, but in vast majority of them we have the following sizes: `thumbnail`, `medium`, `large`, `medium_large`.
Those files are available via XML-RPC, see [wp.getMediaLibrary](https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaItem), so we should parse and store them, together with other mediaItem info.

This new info will be used in wp-android to improve the loading time of WP Media Library. There is no need to load the full pictures, instead `large` (when available), or `medium` should be OK.

~~This is not ready to be reviewed/merged, I just want an heads up to check if I'm doing it right in regards adding new fields to a model (DB?).~~


cc @aforcier @mzorz 

