### PR TITLE
Save post's slug in remote

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -324,6 +324,7 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("title", StringUtils.notNullStr(post.getTitle()));
         params.put("content", StringUtils.notNullStr(post.getContent()));
         params.put("excerpt", StringUtils.notNullStr(post.getExcerpt()));
+        params.put("slug", StringUtils.notNullStr(post.getSlug()));
 
         if (!TextUtils.isEmpty(post.getDateCreated())) {
             params.put("date", post.getDateCreated());


### PR DESCRIPTION
Fixes #449. You can test this by adding `examplePost.setSlug("sample slug");` to the `create_new_post_first_site`'s callback in `PostsFragment`.