### PR TITLE
Search posts of any status (draft, published, scheduled, etc…)

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -227,6 +227,7 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("number", String.valueOf(PostStore.NUM_POSTS_PER_FETCH));
         params.put("offset", String.valueOf(offset));
         params.put("search", searchTerm);
+        params.put("status", "any");
 
         final WPComGsonRequest<PostsResponse> request = WPComGsonRequest.buildGetRequest(url, params,
                 PostsResponse.class,


### PR DESCRIPTION
Fix #451.

Adds `status` parameter to post search REST call so that searches include all remote posts, not just published posts.

cc @oguzkocer 