### PR TITLE
Match by local post ID in getPostMediaWithPath()

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -13,6 +13,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
@@ -368,7 +369,7 @@ public class MediaStoreTest {
     @Test
     public void testGetPostMedia() {
         final int testSiteId = 11235813;
-        final long testPostId = 213253;
+        final int testLocalPostId = 213253;
         final long postMediaId = 13;
         final long unattachedMediaId = 57;
         final long otherMediaId = 911;
@@ -377,7 +378,7 @@ public class MediaStoreTest {
         // add post media with test path
         final MediaModel postMedia = getBasicMedia();
         postMedia.setLocalSiteId(testSiteId);
-        postMedia.setPostId(testPostId);
+        postMedia.setLocalPostId(testLocalPostId);
         postMedia.setMediaId(postMediaId);
         postMedia.setFilePath(testPath);
         insertMediaIntoDatabase(postMedia);
@@ -385,7 +386,7 @@ public class MediaStoreTest {
         // add unattached media with test path
         final MediaModel unattachedMedia = getBasicMedia();
         unattachedMedia.setLocalSiteId(testSiteId);
-        unattachedMedia.setPostId(testPostId);
+        unattachedMedia.setLocalPostId(testLocalPostId);
         unattachedMedia.setFilePath(testPath);
         unattachedMedia.setMediaId(unattachedMediaId);
         insertMediaIntoDatabase(unattachedMedia);
@@ -393,13 +394,15 @@ public class MediaStoreTest {
         // add post media with different file path
         final MediaModel otherPathMedia = getBasicMedia();
         otherPathMedia.setLocalSiteId(testSiteId);
-        otherPathMedia.setPostId(testPostId);
+        otherPathMedia.setLocalPostId(testLocalPostId);
         otherPathMedia.setMediaId(otherMediaId);
         otherPathMedia.setFilePath("appended/" + testPath);
         insertMediaIntoDatabase(otherPathMedia);
 
         // verify the correct media is in the store
-        final MediaModel storeMedia = mMediaStore.getPostMediaWithPath(testPostId, testPath);
+        PostModel post = new PostModel();
+        post.setId(testLocalPostId);
+        final MediaModel storeMedia = mMediaStore.getPostMediaWithPath(post, testPath);
         assertNotNull(storeMedia);
         assertEquals(testPath, storeMedia.getFilePath());
         assertEquals(postMediaId, storeMedia.getMediaId());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -179,10 +179,10 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
-    public static List<MediaModel> matchPostMedia(long postId, String column, Object value) {
+    public static List<MediaModel> matchPostMedia(int localPostId, String column, Object value) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
-                .equals(MediaModelTable.POST_ID, postId)
+                .equals(MediaModelTable.LOCAL_POST_ID, localPostId)
                 .equals(column, value)
                 .endGroup().endWhere()
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseUploadRequestBody;
@@ -427,8 +428,8 @@ public class MediaStore extends Store {
         return MediaSqlUtils.searchSiteMediaAsCursor(siteModel, MediaModelTable.TITLE, titleSearch);
     }
 
-    public MediaModel getPostMediaWithPath(long postId, String filePath) {
-        List<MediaModel> media = MediaSqlUtils.matchPostMedia(postId, MediaModelTable.FILE_PATH, filePath);
+    public MediaModel getPostMediaWithPath(PostModel postModel, String filePath) {
+        List<MediaModel> media = MediaSqlUtils.matchPostMedia(postModel.getId(), MediaModelTable.FILE_PATH, filePath);
         return media.size() > 0 ? media.get(0) : null;
     }
 


### PR DESCRIPTION
Our actual use case for `MediaStore.getPostMediaWithPath()` is to retrieve local media that have been attached to a post. We were doing this lookup by the remote post ID, but we should actually use the local ID of the post (this used to work because local and remote post IDs were conflated in the `MediaModel`, until https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/426).