### PR TITLE
Fix #455: Filter out empty tags

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
@@ -112,7 +112,7 @@ public class PostModelTest {
     }
 
     @Test
-    public void testFilterEmtpyTagsOnGetTagNameList() {
+    public void testFilterEmptyTagsOnGetTagNameList() {
         PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
 
         testPost.setTagNames("pony,             ,ponies");

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
@@ -110,4 +110,28 @@ public class PostModelTest {
         assertTrue(testPost.shouldDeleteLatitude());
         assertTrue(testPost.shouldDeleteLongitude());
     }
+
+    @Test
+    public void testFilterEmtpyTagsOnGetTagNameList() {
+        PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
+
+        testPost.setTagNames("pony,             ,ponies");
+        List<String> tags = testPost.getTagNameList();
+        assertTrue(tags.contains("pony"));
+        assertTrue(tags.contains("ponies"));
+        assertEquals(2, tags.size());
+    }
+
+    @Test
+    public void testStripTagsOnGetTagNameList() {
+        PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
+
+        testPost.setTagNames("    pony   , ponies    , #popopopopopony");
+        List<String> tags = testPost.getTagNameList();
+
+        assertTrue(tags.contains("pony"));
+        assertTrue(tags.contains("ponies"));
+        assertTrue(tags.contains("#popopopopopony"));
+        assertEquals(3, tags.size());
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -458,7 +458,11 @@ public class PostModel extends Payload implements Cloneable, Identifiable, Seria
         }
         String[] stringArray = terms.split(",");
         List<String> stringList = new ArrayList<>();
-        Collections.addAll(stringList, stringArray);
+        for (String s : stringArray) {
+            if (s != null && !s.trim().isEmpty()) {
+                stringList.add(s.trim());
+            }
+        }
         return stringList;
     }
 


### PR DESCRIPTION
Fixes #455 by removing whitespaces-only tags from the list of tags attached to post upload.

Note: tags are trimmed by the server when we push them, so it's safe to trim them in the client.