### PR TITLE
Update post featured image when removed

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -344,7 +344,11 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("categories", TextUtils.join(",", post.getCategoryIdList()));
         params.put("tags", TextUtils.join(",", post.getTagNameList()));
 
-        params.put("featured_image", post.getFeaturedImageId());
+        if (post.hasFeaturedImage()) {
+            params.put("featured_image", post.getFeaturedImageId());
+        } else {
+            params.put("featured_image", "");
+        }
 
         if (post.hasLocation()) {
             // Location data was added to the post


### PR DESCRIPTION
Fix #460 by passing an empty string as the `featured_image` parameter to remove any previous featured image.

Relevant ticket: wordpress-mobile/WordPress-Android#5930

@aforcier would you mind taking a look at this one?