### PR TITLE
Bump support lib versions

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -66,8 +66,8 @@ dependencies {
     compile project(':fluxc');
 
     compile 'com.google.dagger:dagger:2.0.2'
-    compile 'com.android.support:appcompat-v7:25.1.1'
-    compile 'com.android.support:support-v4:25.1.1'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:support-v4:25.3.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.robolectric:robolectric:3.0'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -58,7 +58,7 @@ android.buildTypes.all { buildType ->
 
 dependencies {
     // WordPress libs
-    compile ('org.wordpress:utils:1.+') {
+    compile ('org.wordpress:utils:1.16.0') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley";
     }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     compile 'com.google.dagger:dagger:2.0.2'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
-    compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 }
 
 version = android.defaultConfig.versionName

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -49,9 +49,9 @@ dependencies {
     compile project(':fluxc');
 
     compile 'com.google.dagger:dagger:2.0.2'
-    compile 'com.android.support:appcompat-v7:25.1.1'
-    compile 'com.android.support:support-v4:25.1.1'
-    compile 'com.android.support:recyclerview-v7:25.1.1'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:support-v4:25.3.1'
+    compile 'com.android.support:recyclerview-v7:25.3.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'


### PR DESCRIPTION
Updates our support libraries to `25.3.1`. Also switches to static versioning for the WP utils lib so that a)we have build predictability and b)Travis doesn't break due to external changes to the utils lib.