### PR TITLE
Support fetching from /sites/$site/ using a URL

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -13,9 +13,12 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
+import org.wordpress.android.fluxc.store.SiteStore.OnWPComSiteFetched;
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -38,6 +41,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         POST_FORMATS_CHANGED,
         SITE_REMOVED,
         FETCHED_CONNECT_SITE_INFO,
+        FETCHED_WPCOM_SITE_BY_URL,
+        SITE_FETCH_ERROR
     }
 
     private TestEvents mNextEvent;
@@ -89,6 +94,20 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         String site = "http://www.example.com";
         mDispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(site));
         mNextEvent = TestEvents.FETCHED_CONNECT_SITE_INFO;
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    public void testFetchWPComSiteByUrl() throws InterruptedException {
+        String site = "http://en.blog.wordpress.com";
+        mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
+        mNextEvent = TestEvents.FETCHED_WPCOM_SITE_BY_URL;
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        site = "http://example.com";
+        mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
+        mNextEvent = TestEvents.SITE_FETCH_ERROR;
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -176,11 +195,26 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onFetchedConnectSiteInfo(SiteStore.OnConnectSiteInfoChecked event) {
+    public void onFetchedConnectSiteInfo(OnConnectSiteInfoChecked event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occured with type: " + event.error.type);
         }
         assertEquals(TestEvents.FETCHED_CONNECT_SITE_INFO, mNextEvent);
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onWPComSiteFetched(OnWPComSiteFetched event) {
+        if (event.isError()) {
+            if (mNextEvent.equals(TestEvents.SITE_FETCH_ERROR)) {
+                assertEquals(SiteErrorType.INVALID_SITE, event.error.type);
+                mCountDownLatch.countDown();
+                return;
+            }
+            throw new AssertionError("Unexpected error occured with type: " + event.error.type);
+        }
+        assertEquals(TestEvents.FETCHED_WPCOM_SITE_BY_URL, mNextEvent);
         mCountDownLatch.countDown();
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -105,7 +105,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        site = "http://example.com";
+        site = "http://definitelynotawpcomsite.impossible";
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
         mNextEvent = TestEvents.SITE_FETCH_ERROR;
         mCountDownLatch = new CountDownLatch(1);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -42,7 +42,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         SITE_REMOVED,
         FETCHED_CONNECT_SITE_INFO,
         FETCHED_WPCOM_SITE_BY_URL,
-        ERROR_INVALID_SITE
+        ERROR_INVALID_SITE,
+        ERROR_UNKNOWN_SITE
     }
 
     private TestEvents mNextEvent;
@@ -113,7 +114,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
         site = "http://definitelynotawpcomsite.impossible";
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
-        mNextEvent = TestEvents.ERROR_INVALID_SITE;
+        mNextEvent = TestEvents.ERROR_UNKNOWN_SITE;
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -226,6 +227,10 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         if (event.isError()) {
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_SITE)) {
                 assertEquals(SiteErrorType.INVALID_SITE, event.error.type);
+                mCountDownLatch.countDown();
+                return;
+            } else if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_SITE)) {
+                assertEquals(SiteErrorType.UNKNOWN_SITE, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -24,9 +24,10 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.NewAccountPayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthEmailSent;
 import org.wordpress.android.fluxc.store.AccountStore.OnNewUserCreated;
-import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains;
 import org.wordpress.android.fluxc.store.SiteStore.OnURLChecked;
+import org.wordpress.android.fluxc.store.SiteStore.OnWPComSiteFetched;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
 
 import javax.inject.Inject;
@@ -65,6 +66,12 @@ public class SignedOutActionsFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 showCheckWPComUrlDialog();
+            }
+        });
+        view.findViewById(R.id.fetch_wpcom_site).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showFetchWPComSiteDialog();
             }
         });
         view.findViewById(R.id.domain_suggestions).setOnClickListener(new OnClickListener() {
@@ -173,6 +180,21 @@ public class SignedOutActionsFragment extends Fragment {
         alert.show();
     }
 
+    private void showFetchWPComSiteDialog() {
+        AlertDialog.Builder alert = new AlertDialog.Builder(getActivity());
+        final EditText editText = new EditText(getActivity());
+        editText.setSingleLine();
+        alert.setMessage("Fetch the WordPress.com site with URL:");
+        alert.setView(editText);
+        alert.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                String url = editText.getText().toString();
+                mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(url));
+            }
+        });
+        alert.show();
+    }
+
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onNewUserValidated(OnNewUserCreated event) {
@@ -219,11 +241,21 @@ public class SignedOutActionsFragment extends Fragment {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onFetchedConnectSiteInfo(SiteStore.OnConnectSiteInfoChecked event) {
+    public void onFetchedConnectSiteInfo(OnConnectSiteInfoChecked event) {
         if (event.isError()) {
             prependToLog("Connect Site Info: error: " + event.error.type);
         } else {
             prependToLog("Connect Site Info: success! " + event.info.description());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onFetchedConnectSiteInfo(OnWPComSiteFetched event) {
+        if (event.isError()) {
+            prependToLog("Fetch WP.com site: error: " + event.error.type);
+        } else {
+            prependToLog("Fetch WP.com site: success! Site url: " + event.site.getUrl());
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -253,9 +253,10 @@ public class SignedOutActionsFragment extends Fragment {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onFetchedConnectSiteInfo(OnWPComSiteFetched event) {
         if (event.isError()) {
-            prependToLog("Fetch WP.com site: error: " + event.error.type);
+            prependToLog("Fetch WP.com site for URL " + event.checkedUrl + ": error: " + event.error.type);
         } else {
-            prependToLog("Fetch WP.com site: success! Site url: " + event.site.getUrl());
+            prependToLog("Fetch WP.com site for URL " + event.checkedUrl + ": success! Site name: "
+                    + event.site.getName());
         }
     }
 

--- a/example/src/main/res/layout/fragment_signed_out_actions.xml
+++ b/example/src/main/res/layout/fragment_signed_out_actions.xml
@@ -24,6 +24,12 @@
         android:text="Check if URL is WPCom site (or Jetpack)" />
 
     <Button
+        android:id="@+id/fetch_wpcom_site"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch WP.com (or Jetpack) Site" />
+
+    <Button
         android:id="@+id/domain_suggestions"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -17,6 +17,8 @@ public class WPComEndpointTest {
         assertEquals("/sites/56/", WPCOMREST.sites.site(56).getEndpoint());
         assertEquals("/sites/56/post-formats/", WPCOMREST.sites.site(56).post_formats.getEndpoint());
 
+        assertEquals("/sites/mysite.wordpress.com/", WPCOMREST.sites.siteUrl("mysite.wordpress.com").getEndpoint());
+
         // Sites - Posts
         assertEquals("/sites/56/posts/", WPCOMREST.sites.site(56).posts.getEndpoint());
         assertEquals("/sites/56/posts/78/", WPCOMREST.sites.site(56).posts.post(78).getEndpoint());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -39,6 +39,8 @@ public enum SiteAction implements IAction {
     SUGGEST_DOMAINS,
     @Action(payloadType = String.class)
     FETCH_CONNECT_SITE_INFO,
+    @Action(payloadType = String.class)
+    FETCH_WPCOM_SITE_BY_URL,
 
     // Remote responses
     @Action(payloadType = NewSiteResponsePayload.class)
@@ -51,6 +53,8 @@ public enum SiteAction implements IAction {
     EXPORTED_SITE,
     @Action(payloadType = ConnectSiteInfoPayload.class)
     FETCHED_CONNECT_SITE_INFO,
+    @Action(payloadType = SiteModel.class)
+    FETCHED_WPCOM_SITE_BY_URL,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.DeleteSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.ExportSiteResponsePayload;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.FetchWPComSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPComResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
@@ -53,7 +54,7 @@ public enum SiteAction implements IAction {
     EXPORTED_SITE,
     @Action(payloadType = ConnectSiteInfoPayload.class)
     FETCHED_CONNECT_SITE_INFO,
-    @Action(payloadType = SiteModel.class)
+    @Action(payloadType = FetchWPComSiteResponsePayload.class)
     FETCHED_WPCOM_SITE_BY_URL,
 
     // Local actions

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -191,12 +191,20 @@ public class SiteRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         FetchWPComSiteResponsePayload payload = new FetchWPComSiteResponsePayload();
                         payload.checkedUrl = siteUrl;
-                        if (error instanceof WPComGsonNetworkError
-                                && ("unauthorized".equals(((WPComGsonNetworkError) error).apiError))) {
-                            payload.error = new SiteError(SiteErrorType.UNAUTHORIZED);
-                        } else {
-                            payload.error = new SiteError(SiteErrorType.INVALID_SITE);
+
+                        SiteErrorType siteErrorType = SiteErrorType.GENERIC_ERROR;
+                        if (error instanceof WPComGsonNetworkError) {
+                            switch (((WPComGsonNetworkError) error).apiError) {
+                                case "unauthorized":
+                                    siteErrorType = SiteErrorType.UNAUTHORIZED;
+                                    break;
+                                case "unknown_blog":
+                                    siteErrorType = SiteErrorType.UNKNOWN_SITE;
+                                    break;
+                            }
                         }
+                        payload.error = new SiteError(siteErrorType);
+
                         mDispatcher.dispatch(SiteActionBuilder.newFetchedWpcomSiteByUrlAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -143,6 +143,31 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void fetchWPComSiteByUrl(@NonNull final String siteUrl) {
+        URI uri = URI.create(UrlUtils.addUrlSchemeIfNeeded(siteUrl, false));
+        String url = WPCOMREST.sites.siteUrl(uri.getHost()).getUrlV1_1();
+
+        final WPComGsonRequest<SiteWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,
+                SiteWPComRestResponse.class,
+                new Listener<SiteWPComRestResponse>() {
+                    @Override
+                    public void onResponse(SiteWPComRestResponse response) {
+                        SiteModel site = siteResponseToSiteModel(response);
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchedWpcomSiteByUrlAction(site));
+                    }
+                },
+                new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        SiteModel payload = new SiteModel();
+                        payload.error = error;
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchedWpcomSiteByUrlAction(payload));
+                    }
+                }
+        );
+        add(request);
+    }
+
     public void checkUrlIsWPCom(@NonNull final String testedUrl) {
         String url = WPCOMREST.sites.getUrlV1_1() + testedUrl;
         final WPComGsonRequest<SiteWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -153,7 +153,17 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void fetchWPComSiteByUrl(@NonNull final String siteUrl) {
-        URI uri = URI.create(UrlUtils.addUrlSchemeIfNeeded(siteUrl, false));
+        URI uri;
+        try {
+            uri = URI.create(UrlUtils.addUrlSchemeIfNeeded(siteUrl, false));
+        } catch (IllegalArgumentException e) {
+            FetchWPComSiteResponsePayload payload = new FetchWPComSiteResponsePayload();
+            payload.checkedUrl = siteUrl;
+            payload.error = new SiteError(SiteErrorType.INVALID_SITE);
+            mDispatcher.dispatch(SiteActionBuilder.newFetchedWpcomSiteByUrlAction(payload));
+            return;
+        }
+
         String url = WPCOMREST.sites.siteUrl(uri.getHost()).getUrlV1_1();
 
         final WPComGsonRequest<SiteWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -78,6 +78,13 @@ public class SiteRestClient extends BaseWPComRestClient {
         public boolean isWPCom;
     }
 
+    public static class FetchWPComSiteResponsePayload extends Payload {
+        public FetchWPComSiteResponsePayload() {
+        }
+        public String checkedUrl;
+        public SiteModel site;
+    }
+
     @Inject
     public SiteRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue, AppSecrets appSecrets,
                           AccessToken accessToken, UserAgent userAgent) {
@@ -152,14 +159,17 @@ public class SiteRestClient extends BaseWPComRestClient {
                 new Listener<SiteWPComRestResponse>() {
                     @Override
                     public void onResponse(SiteWPComRestResponse response) {
-                        SiteModel site = siteResponseToSiteModel(response);
-                        mDispatcher.dispatch(SiteActionBuilder.newFetchedWpcomSiteByUrlAction(site));
+                        FetchWPComSiteResponsePayload payload = new FetchWPComSiteResponsePayload();
+                        payload.checkedUrl = siteUrl;
+                        payload.site = siteResponseToSiteModel(response);
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchedWpcomSiteByUrlAction(payload));
                     }
                 },
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        SiteModel payload = new SiteModel();
+                        FetchWPComSiteResponsePayload payload = new FetchWPComSiteResponsePayload();
+                        payload.checkedUrl = siteUrl;
                         payload.error = error;
                         mDispatcher.dispatch(SiteActionBuilder.newFetchedWpcomSiteByUrlAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -269,6 +269,7 @@ public class SiteStore extends Store {
     public enum SiteErrorType {
         INVALID_SITE,
         DUPLICATE_SITE,
+        UNAUTHORIZED,
         GENERIC_ERROR
     }
 
@@ -892,9 +893,7 @@ public class SiteStore extends Store {
 
     private void handleFetchedWPComSiteByUrl(FetchWPComSiteResponsePayload payload) {
         OnWPComSiteFetched event = new OnWPComSiteFetched(payload.checkedUrl, payload.site);
-        if (payload.isError()) {
-            event.error = new SiteError(SiteErrorType.INVALID_SITE);
-        }
+        event.error = payload.error;
         emitChange(event);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -233,6 +233,13 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class OnWPComSiteFetched extends OnChanged<SiteError> {
+        public SiteModel site;
+        public OnWPComSiteFetched(@NonNull SiteModel site) {
+            this.site = site;
+        }
+    }
+
     public static class SuggestDomainError implements OnChangedError {
         public SuggestDomainErrorType type;
         public String message;
@@ -694,6 +701,9 @@ public class SiteStore extends Store {
             case FETCH_CONNECT_SITE_INFO:
                 fetchConnectSiteInfo((String) action.getPayload());
                 break;
+            case FETCH_WPCOM_SITE_BY_URL:
+                fetchWPComSiteByUrl((String) action.getPayload());
+                break;
             case IS_WPCOM_URL:
                 checkUrlIsWPCom((String) action.getPayload());
                 break;
@@ -717,6 +727,9 @@ public class SiteStore extends Store {
                 break;
             case FETCHED_CONNECT_SITE_INFO:
                 handleFetchedConnectSiteInfo((ConnectSiteInfoPayload) action.getPayload());
+                break;
+            case FETCHED_WPCOM_SITE_BY_URL:
+                handleFetchedWPComSiteByUrl((SiteModel) action.getPayload());
                 break;
             case CHECKED_IS_WPCOM_URL:
                 handleCheckedIsWPComUrl((IsWPComResponsePayload) action.getPayload());
@@ -864,6 +877,18 @@ public class SiteStore extends Store {
 
     private void handleFetchedConnectSiteInfo(ConnectSiteInfoPayload payload) {
         OnConnectSiteInfoChecked event = new OnConnectSiteInfoChecked(payload);
+        if (payload.isError()) {
+            event.error = new SiteError(SiteErrorType.INVALID_SITE);
+        }
+        emitChange(event);
+    }
+
+    private void fetchWPComSiteByUrl(String payload) {
+        mSiteRestClient.fetchWPComSiteByUrl(payload);
+    }
+
+    private void handleFetchedWPComSiteByUrl(SiteModel payload) {
+        OnWPComSiteFetched event = new OnWPComSiteFetched(payload);
         if (payload.isError()) {
             event.error = new SiteError(SiteErrorType.INVALID_SITE);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -116,8 +116,9 @@ public class SiteStore extends Store {
         public boolean isJetpackActive;
         public boolean isJetpackConnected;
         public boolean isWPCom;
+        public SiteError error;
 
-        public ConnectSiteInfoPayload(@NonNull String url, BaseNetworkError error) {
+        public ConnectSiteInfoPayload(@NonNull String url, SiteError error) {
             this.url = url;
             this.error = error;
         }
@@ -881,9 +882,7 @@ public class SiteStore extends Store {
 
     private void handleFetchedConnectSiteInfo(ConnectSiteInfoPayload payload) {
         OnConnectSiteInfoChecked event = new OnConnectSiteInfoChecked(payload);
-        if (payload.isError()) {
-            event.error = new SiteError(SiteErrorType.INVALID_SITE);
-        }
+        event.error = payload.error;
         emitChange(event);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionRespo
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.DeleteSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.ExportSiteResponsePayload;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.FetchWPComSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPComResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
@@ -234,8 +235,10 @@ public class SiteStore extends Store {
     }
 
     public static class OnWPComSiteFetched extends OnChanged<SiteError> {
+        public String checkedUrl;
         public SiteModel site;
-        public OnWPComSiteFetched(@NonNull SiteModel site) {
+        public OnWPComSiteFetched(String checkedUrl, @NonNull SiteModel site) {
+            this.checkedUrl = checkedUrl;
             this.site = site;
         }
     }
@@ -729,7 +732,7 @@ public class SiteStore extends Store {
                 handleFetchedConnectSiteInfo((ConnectSiteInfoPayload) action.getPayload());
                 break;
             case FETCHED_WPCOM_SITE_BY_URL:
-                handleFetchedWPComSiteByUrl((SiteModel) action.getPayload());
+                handleFetchedWPComSiteByUrl((FetchWPComSiteResponsePayload) action.getPayload());
                 break;
             case CHECKED_IS_WPCOM_URL:
                 handleCheckedIsWPComUrl((IsWPComResponsePayload) action.getPayload());
@@ -887,8 +890,8 @@ public class SiteStore extends Store {
         mSiteRestClient.fetchWPComSiteByUrl(payload);
     }
 
-    private void handleFetchedWPComSiteByUrl(SiteModel payload) {
-        OnWPComSiteFetched event = new OnWPComSiteFetched(payload);
+    private void handleFetchedWPComSiteByUrl(FetchWPComSiteResponsePayload payload) {
+        OnWPComSiteFetched event = new OnWPComSiteFetched(payload.checkedUrl, payload.site);
         if (payload.isError()) {
             event.error = new SiteError(SiteErrorType.INVALID_SITE);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -269,6 +269,7 @@ public class SiteStore extends Store {
 
     public enum SiteErrorType {
         INVALID_SITE,
+        UNKNOWN_SITE,
         DUPLICATE_SITE,
         UNAUTHORIZED,
         GENERIC_ERROR

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -45,4 +45,6 @@
 /sites/$site/taxonomies/$taxonomy#String/terms/new/
 /sites/$site/taxonomies/$taxonomy#String/terms/slug:$slug#String/
 
+/sites/$siteUrl#String
+
 /users/new/


### PR DESCRIPTION
Adds support for calling the `/sites/$site/` endpoint using a URL instead of a WP.com site ID. This call can be made through a new action, `FETCH_WPCOM_SITE_BY_URL`.

This action is intended to be used during login/discovery only, and does not require authentication - it also does not store the resulting `SiteModel` in the database.

There's a pre-existing action, `IS_WPCOM_URL`, which does something very similar (but returns a boolean instead of a `SiteModel`, and has different criteria for returning an error). Once the use of `FETCH_WPCOM_SITE_BY_URL` is finalized and this is merged, I'll revisit that one as we can probably fold it into `FETCH_WPCOM_SITE_BY_URL` and drop some code.

cc @hypest 