### PR TITLE
Add utility method for retrieving a post from the database by a given ID

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -79,6 +79,20 @@ public class PostSqlUtils {
                 .getAsModel();
     }
 
+    public static PostModel getPostWithRemoteId(SiteModel site, long remoteId, boolean getPages) {
+        if (site == null) {
+            return null;
+        }
+
+        List<PostModel> posts = WellSql.select(PostModel.class)
+                .where().beginGroup()
+                .equals(PostModelTable.LOCAL_SITE_ID, site.getId())
+                .equals(PostModelTable.REMOTE_POST_ID, remoteId)
+                .equals(PostModelTable.IS_PAGE, getPages)
+                .endGroup().endWhere().getAsModel();
+        return posts != null && !posts.isEmpty() ? posts.get(0) : null;
+    }
+
     public static List<PostModel> getPostsForSiteWithFormat(SiteModel site, List<String> postFormat, boolean getPages) {
         if (site == null) {
             return Collections.emptyList();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -79,7 +79,7 @@ public class PostSqlUtils {
                 .getAsModel();
     }
 
-    public static PostModel getPostWithRemoteId(SiteModel site, long remoteId, boolean getPages) {
+    public static PostModel getPostForSiteWithRemoteId(SiteModel site, long remoteId, boolean getPages) {
         if (site == null) {
             return null;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -260,6 +260,14 @@ public class PostStore extends Store {
         return PostSqlUtils.getPostsForSite(site, false);
     }
 
+    public PostModel getPostForSiteWithRemoteId(SiteModel site, long remotePostId) {
+        return PostSqlUtils.getPostForSiteWithRemoteId(site, remotePostId, false);
+    }
+
+    public PostModel getPageForSiteWithRemoteId(SiteModel site, long remotePageId) {
+        return PostSqlUtils.getPostForSiteWithRemoteId(site, remotePageId, true);
+    }
+
     /**
      * Returns posts with given format in the store for the given site as a {@link PostModel} list.
      */


### PR DESCRIPTION
Reference:

Moving a helper method added in wordpress-mobile/WordPress-Android#6030 since it's more appropriate in FluxC.

cc @oguzkocer 