### PR TITLE
Update local post ID on given post when updating a post in the database

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -48,8 +48,9 @@ public class PostSqlUtils {
             }
             // Update only if local changes for this post don't exist
             if (overwriteLocalChanges || !postResult.get(0).isLocallyChanged()) {
-                int oldId = postResult.get(0).getId();
-                return WellSql.update(PostModel.class).whereId(oldId)
+                // we should update the given post's local ID to match what's in the DB
+                post.setId(postResult.get(0).getId());
+                return WellSql.update(PostModel.class).whereId(post.getId())
                         .put(post, new UpdateAllExceptId<>(PostModel.class)).execute();
             }
         }


### PR DESCRIPTION
This change came about from wordpress-mobile/WordPress-Android#6030 after noticing the search results don't have valid local ID's.

Now the local ID will be set to the existing DB row's ID after updating it. This will ensure that post change events pass posts with valid local ID's.

cc @oguzkocer 