### PR TITLE
Manage media upload state in FluxC

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
@@ -249,7 +249,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
         assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
         MediaModel canceledMedia = mMediaStore.getMediaWithLocalId(testMedia.getId());
-        assertEquals(UploadState.FAILED.toString(), canceledMedia.getUploadState());
+        assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
     }
 
     public void testUploadMultipleImages() throws InterruptedException {
@@ -271,7 +271,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         // verify all have been uploaded
         assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
         assertEquals(mUploadedMediaModels.size(),
-                mMediaStore.getSiteMediaWithState(sSite, UploadState.UPLOADED).size());
+                mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
 
         // verify they exist in the MediaStore
         Iterator<MediaModel> iterator = mUploadedMediaModels.values().iterator();
@@ -320,7 +320,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         // Only completed uploads should exist in the store
         assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaCount(sSite));
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, UploadState.UPLOADED).size());
+        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
 
         // delete test images (bear in mind this is done sequentially)
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -363,9 +363,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         // All the original uploads should exist in the store, whether cancelled or not
         assertEquals(mUploadedMediaModels.size(), mMediaStore.getSiteMediaCount(sSite));
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, UploadState.UPLOADED).size());
+        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
         // All cancelled media should have a FAILED state
-        assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, UploadState.FAILED).size());
+        assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.FAILED).size());
 
         // delete test images (bear in mind this is done sequentially)
         mNextEvent = TestEvents.DELETED_MEDIA;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
@@ -271,7 +271,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
         MediaModel canceledMedia = mMediaStore.getMediaWithLocalId(testMedia.getId());
-        assertEquals(UploadState.FAILED.toString(), canceledMedia.getUploadState());
+        assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
     }
 
     public void testUploadMultipleImages() throws InterruptedException {
@@ -293,7 +293,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // verify all have been uploaded
         assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
         assertEquals(mUploadedMediaModels.size(),
-                mMediaStore.getSiteMediaWithState(sSite, UploadState.UPLOADED).size());
+                mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
 
         // verify they exist in the MediaStore
         Iterator<MediaModel> iterator = mUploadedMediaModels.values().iterator();
@@ -342,7 +342,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Only completed uploads should exist in the store
         assertEquals(mUploadedIds.size(), mMediaStore.getSiteImageCount(sSite));
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, UploadState.UPLOADED).size());
+        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
 
         // delete test images (bear in mind this is done sequentially)
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -385,9 +385,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // All the original uploads should exist in the store, whether cancelled or not
         assertEquals(mUploadedMediaModels.size(), mMediaStore.getSiteMediaCount(sSite));
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, UploadState.UPLOADED).size());
+        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
         // All cancelled media should have a FAILED state
-        assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, UploadState.FAILED).size());
+        assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.FAILED).size());
 
         // delete test images (bear in mind this is done sequentially)
         mNextEvent = TestEvents.DELETED_MEDIA;

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -15,7 +15,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.persistence.MediaSqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
@@ -230,7 +230,7 @@ public class MediaSqlUtilsTest {
         int testLength = 60;
         String testVideoPressGuid = "testVideoPressGuid";
         boolean testVideoPressProcessing = false;
-        String testUploadState = MediaModel.UploadState.UPLOADING.toString();
+        String testUploadState = MediaUploadState.UPLOADING.toString();
         int testHorizontalAlign = 500;
         boolean testVerticalAlign = false;
         boolean testFeatured = false;
@@ -343,7 +343,7 @@ public class MediaSqlUtilsTest {
 
         // Insert one deleted media
         MediaModel image = getTestMedia(42);
-        image.setUploadState(UploadState.DELETED);
+        image.setUploadState(MediaUploadState.DELETED);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(image));
 
         Assert.assertEquals(SMALL_TEST_POOL,
@@ -359,12 +359,12 @@ public class MediaSqlUtilsTest {
 
         // Insert one detached but deleted media
         MediaModel media = getTestMedia(42);
-        media.setUploadState(UploadState.DELETED);
+        media.setUploadState(MediaUploadState.DELETED);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(media));
 
         // Insert one attached media
         media = getTestMedia(43);
-        media.setUploadState(UploadState.UPLOADED);
+        media.setUploadState(MediaUploadState.UPLOADED);
         media.setPostId(42);
 
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(media));
@@ -382,7 +382,7 @@ public class MediaSqlUtilsTest {
         // Insert one deleted image
         MediaModel image = getTestMedia(42);
         image.setMimeType(MediaUtils.MIME_TYPE_IMAGE + "jpg");
-        image.setUploadState(UploadState.DELETED);
+        image.setUploadState(MediaUploadState.DELETED);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(image));
 
         Assert.assertEquals(SMALL_TEST_POOL,
@@ -402,12 +402,12 @@ public class MediaSqlUtilsTest {
 
         // The media item after uploading, updated with the remote media ID, about to be saved locally
         MediaModel mediaFromUploadResponse = MediaSqlUtils.getAllSiteMedia(site).get(0);
-        mediaFromUploadResponse.setUploadState(UploadState.UPLOADED);
+        mediaFromUploadResponse.setUploadState(MediaUploadState.UPLOADED);
         mediaFromUploadResponse.setMediaId(42);
 
         // The same media, but fetched from the server from FETCH_MEDIA_LIST (so no local ID until insertion)
         final MediaModel mediaFromMediaListFetch = MediaSqlUtils.getAllSiteMedia(site).get(0);
-        mediaFromMediaListFetch.setUploadState(UploadState.UPLOADED);
+        mediaFromMediaListFetch.setUploadState(MediaUploadState.UPLOADED);
         mediaFromMediaListFetch.setMediaId(42);
         mediaFromMediaListFetch.setId(0);
 
@@ -428,7 +428,7 @@ public class MediaSqlUtilsTest {
         for (int i = 0; i < num; ++i) {
             testItemIds[i] = mRandom.nextLong();
             MediaModel media = getTestMedia(testItemIds[i]);
-            media.setUploadState(UploadState.UPLOADED);
+            media.setUploadState(MediaUploadState.UPLOADED);
             Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(media));
         }
         return testItemIds;
@@ -440,7 +440,7 @@ public class MediaSqlUtilsTest {
             testItemIds[i] = Math.abs(mRandom.nextInt());
             MediaModel image = getTestMedia(testItemIds[i]);
             image.setMimeType(MediaUtils.MIME_TYPE_IMAGE + "jpg");
-            image.setUploadState(UploadState.UPLOADED);
+            image.setUploadState(MediaUploadState.UPLOADED);
             Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(image));
         }
         return testItemIds;

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -343,7 +343,7 @@ public class MediaSqlUtilsTest {
 
         // Insert one deleted media
         MediaModel image = getTestMedia(42);
-        image.setUploadState(UploadState.DELETED.toString());
+        image.setUploadState(UploadState.DELETED);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(image));
 
         Assert.assertEquals(SMALL_TEST_POOL,
@@ -359,12 +359,12 @@ public class MediaSqlUtilsTest {
 
         // Insert one detached but deleted media
         MediaModel media = getTestMedia(42);
-        media.setUploadState(UploadState.DELETED.toString());
+        media.setUploadState(UploadState.DELETED);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(media));
 
         // Insert one attached media
         media = getTestMedia(43);
-        media.setUploadState(UploadState.UPLOADED.toString());
+        media.setUploadState(UploadState.UPLOADED);
         media.setPostId(42);
 
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(media));
@@ -382,7 +382,7 @@ public class MediaSqlUtilsTest {
         // Insert one deleted image
         MediaModel image = getTestMedia(42);
         image.setMimeType(MediaUtils.MIME_TYPE_IMAGE + "jpg");
-        image.setUploadState(UploadState.DELETED.toString());
+        image.setUploadState(UploadState.DELETED);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(image));
 
         Assert.assertEquals(SMALL_TEST_POOL,
@@ -402,12 +402,12 @@ public class MediaSqlUtilsTest {
 
         // The media item after uploading, updated with the remote media ID, about to be saved locally
         MediaModel mediaFromUploadResponse = MediaSqlUtils.getAllSiteMedia(site).get(0);
-        mediaFromUploadResponse.setUploadState(UploadState.UPLOADED.name());
+        mediaFromUploadResponse.setUploadState(UploadState.UPLOADED);
         mediaFromUploadResponse.setMediaId(42);
 
         // The same media, but fetched from the server from FETCH_MEDIA_LIST (so no local ID until insertion)
         final MediaModel mediaFromMediaListFetch = MediaSqlUtils.getAllSiteMedia(site).get(0);
-        mediaFromMediaListFetch.setUploadState(UploadState.UPLOADED.name());
+        mediaFromMediaListFetch.setUploadState(UploadState.UPLOADED);
         mediaFromMediaListFetch.setMediaId(42);
         mediaFromMediaListFetch.setId(0);
 
@@ -428,7 +428,7 @@ public class MediaSqlUtilsTest {
         for (int i = 0; i < num; ++i) {
             testItemIds[i] = mRandom.nextLong();
             MediaModel media = getTestMedia(testItemIds[i]);
-            media.setUploadState(UploadState.UPLOADED.toString());
+            media.setUploadState(UploadState.UPLOADED);
             Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(media));
         }
         return testItemIds;
@@ -440,7 +440,7 @@ public class MediaSqlUtilsTest {
             testItemIds[i] = Math.abs(mRandom.nextInt());
             MediaModel image = getTestMedia(testItemIds[i]);
             image.setMimeType(MediaUtils.MIME_TYPE_IMAGE + "jpg");
-            image.setUploadState(UploadState.UPLOADED.toString());
+            image.setUploadState(UploadState.UPLOADED);
             Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(image));
         }
         return testItemIds;

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -283,7 +283,7 @@ public class MediaStoreTest {
         final MediaModel localMedia = getBasicMedia();
         localMedia.setLocalSiteId(testSiteId);
         localMedia.setMediaId(localMediaId);
-        localMedia.setUploadState(UploadState.UPLOADING.toString());
+        localMedia.setUploadState(UploadState.UPLOADING);
         insertMediaIntoDatabase(localMedia);
 
         // add remote media
@@ -291,7 +291,7 @@ public class MediaStoreTest {
         remoteMedia.setLocalSiteId(testSiteId);
         remoteMedia.setMediaId(remoteMediaId);
         // remote media has a defined upload date, simulated here
-        remoteMedia.setUploadState(UploadState.UPLOADED.toString());
+        remoteMedia.setUploadState(UploadState.UPLOADED);
         insertMediaIntoDatabase(remoteMedia);
 
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
@@ -435,9 +435,9 @@ public class MediaStoreTest {
         final List<MediaModel> pendingDelete = generateRandomizedMediaList(count, testSiteId);
         final List<MediaModel> other = generateRandomizedMediaList(count, testSiteId);
         for (int i = 0; i < count; ++i) {
-            pendingDelete.get(i).setUploadState(UploadState.DELETE.toString());
+            pendingDelete.get(i).setUploadState(UploadState.DELETE);
             pendingDelete.get(i).setMediaId(i + (count * 2));
-            other.get(i).setUploadState(UploadState.UPLOADED.toString());
+            other.get(i).setUploadState(UploadState.UPLOADED);
             other.get(i).setMediaId(i + count);
             insertMediaIntoDatabase(pendingDelete.get(i));
             insertMediaIntoDatabase(other.get(i));
@@ -467,9 +467,9 @@ public class MediaStoreTest {
         final List<MediaModel> pendingDelete = generateRandomizedMediaList(count, testSiteId);
         final List<MediaModel> other = generateRandomizedMediaList(count, testSiteId);
         for (int i = 0; i < count; ++i) {
-            pendingDelete.get(i).setUploadState(UploadState.DELETE.toString());
+            pendingDelete.get(i).setUploadState(UploadState.DELETE);
             pendingDelete.get(i).setMediaId(i + (count * 2));
-            other.get(i).setUploadState(UploadState.DELETED.toString());
+            other.get(i).setUploadState(UploadState.DELETED);
             other.get(i).setMediaId(i + count);
             insertMediaIntoDatabase(pendingDelete.get(i));
             insertMediaIntoDatabase(other.get(i));

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -13,7 +13,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
@@ -283,7 +283,7 @@ public class MediaStoreTest {
         final MediaModel localMedia = getBasicMedia();
         localMedia.setLocalSiteId(testSiteId);
         localMedia.setMediaId(localMediaId);
-        localMedia.setUploadState(UploadState.UPLOADING);
+        localMedia.setUploadState(MediaUploadState.UPLOADING);
         insertMediaIntoDatabase(localMedia);
 
         // add remote media
@@ -291,7 +291,7 @@ public class MediaStoreTest {
         remoteMedia.setLocalSiteId(testSiteId);
         remoteMedia.setMediaId(remoteMediaId);
         // remote media has a defined upload date, simulated here
-        remoteMedia.setUploadState(UploadState.UPLOADED);
+        remoteMedia.setUploadState(MediaUploadState.UPLOADED);
         insertMediaIntoDatabase(remoteMedia);
 
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
@@ -305,7 +305,8 @@ public class MediaStoreTest {
         assertEquals(localMediaId, localSiteMedia.get(0).getMediaId());
 
         // verify uploaded store media
-        final List<MediaModel> uploadedSiteMedia = mMediaStore.getSiteMediaWithState(testSite, UploadState.UPLOADED);
+        final List<MediaModel> uploadedSiteMedia = mMediaStore.getSiteMediaWithState(testSite,
+                MediaUploadState.UPLOADED);
         assertNotNull(uploadedSiteMedia);
         assertEquals(1, uploadedSiteMedia.size());
         assertNotNull(uploadedSiteMedia.get(0));
@@ -435,9 +436,9 @@ public class MediaStoreTest {
         final List<MediaModel> pendingDelete = generateRandomizedMediaList(count, testSiteId);
         final List<MediaModel> other = generateRandomizedMediaList(count, testSiteId);
         for (int i = 0; i < count; ++i) {
-            pendingDelete.get(i).setUploadState(UploadState.DELETING);
+            pendingDelete.get(i).setUploadState(MediaUploadState.DELETING);
             pendingDelete.get(i).setMediaId(i + (count * 2));
-            other.get(i).setUploadState(UploadState.UPLOADED);
+            other.get(i).setUploadState(MediaUploadState.UPLOADED);
             other.get(i).setMediaId(i + count);
             insertMediaIntoDatabase(pendingDelete.get(i));
             insertMediaIntoDatabase(other.get(i));
@@ -450,7 +451,7 @@ public class MediaStoreTest {
         for (int i = 0; i < count; ++i) {
             MediaModel next = mMediaStore.getNextSiteMediaToDelete(testSite);
             assertNotNull(next);
-            assertEquals(UploadState.DELETING, UploadState.fromString(next.getUploadState()));
+            assertEquals(MediaUploadState.DELETING, MediaUploadState.fromString(next.getUploadState()));
             assertTrue(pendingDelete.contains(next));
             MediaSqlUtils.deleteMedia(next);
             assertEquals(count * 2 - i - 1, mMediaStore.getSiteMediaCount(testSite));
@@ -467,9 +468,9 @@ public class MediaStoreTest {
         final List<MediaModel> pendingDelete = generateRandomizedMediaList(count, testSiteId);
         final List<MediaModel> other = generateRandomizedMediaList(count, testSiteId);
         for (int i = 0; i < count; ++i) {
-            pendingDelete.get(i).setUploadState(UploadState.DELETING);
+            pendingDelete.get(i).setUploadState(MediaUploadState.DELETING);
             pendingDelete.get(i).setMediaId(i + (count * 2));
-            other.get(i).setUploadState(UploadState.DELETED);
+            other.get(i).setUploadState(MediaUploadState.DELETED);
             other.get(i).setMediaId(i + count);
             insertMediaIntoDatabase(pendingDelete.get(i));
             insertMediaIntoDatabase(other.get(i));

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -450,7 +450,7 @@ public class MediaStoreTest {
         for (int i = 0; i < count; ++i) {
             MediaModel next = mMediaStore.getNextSiteMediaToDelete(testSite);
             assertNotNull(next);
-            assertEquals(UploadState.DELETING.toString(), next.getUploadState());
+            assertEquals(UploadState.DELETING, UploadState.fromString(next.getUploadState()));
             assertTrue(pendingDelete.contains(next));
             MediaSqlUtils.deleteMedia(next);
             assertEquals(count * 2 - i - 1, mMediaStore.getSiteMediaCount(testSite));

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -435,7 +435,7 @@ public class MediaStoreTest {
         final List<MediaModel> pendingDelete = generateRandomizedMediaList(count, testSiteId);
         final List<MediaModel> other = generateRandomizedMediaList(count, testSiteId);
         for (int i = 0; i < count; ++i) {
-            pendingDelete.get(i).setUploadState(UploadState.DELETE);
+            pendingDelete.get(i).setUploadState(UploadState.DELETING);
             pendingDelete.get(i).setMediaId(i + (count * 2));
             other.get(i).setUploadState(UploadState.UPLOADED);
             other.get(i).setMediaId(i + count);
@@ -450,7 +450,7 @@ public class MediaStoreTest {
         for (int i = 0; i < count; ++i) {
             MediaModel next = mMediaStore.getNextSiteMediaToDelete(testSite);
             assertNotNull(next);
-            assertEquals(UploadState.DELETE.toString(), next.getUploadState());
+            assertEquals(UploadState.DELETING.toString(), next.getUploadState());
             assertTrue(pendingDelete.contains(next));
             MediaSqlUtils.deleteMedia(next);
             assertEquals(count * 2 - i - 1, mMediaStore.getSiteMediaCount(testSite));
@@ -467,7 +467,7 @@ public class MediaStoreTest {
         final List<MediaModel> pendingDelete = generateRandomizedMediaList(count, testSiteId);
         final List<MediaModel> other = generateRandomizedMediaList(count, testSiteId);
         for (int i = 0; i < count; ++i) {
-            pendingDelete.get(i).setUploadState(UploadState.DELETE);
+            pendingDelete.get(i).setUploadState(UploadState.DELETING);
             pendingDelete.get(i).setMediaId(i + (count * 2));
             other.get(i).setUploadState(UploadState.DELETED);
             other.get(i).setMediaId(i + count);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -19,7 +19,7 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
         public static MediaUploadState fromString(String stringState) {
             if (stringState != null) {
                 for (MediaUploadState state: MediaUploadState.values()) {
-                    if (stringState.equalsIgnoreCase(state.name())) {
+                    if (stringState.equalsIgnoreCase(state.toString())) {
                         return state;
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -14,7 +14,18 @@ import java.io.Serializable;
 @Table
 public class MediaModel extends Payload implements Identifiable, Serializable {
     public enum UploadState {
-        QUEUED, UPLOADING, DELETING, DELETED, FAILED, UPLOADED
+        QUEUED, UPLOADING, DELETING, DELETED, FAILED, UPLOADED;
+
+        public static UploadState fromString(String stringState) {
+            if (stringState != null) {
+                for (UploadState state: UploadState.values()) {
+                    if (stringState.equalsIgnoreCase(state.name())) {
+                        return state;
+                    }
+                }
+            }
+            return UPLOADED;
+        }
     }
 
     @PrimaryKey

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -13,12 +13,12 @@ import java.io.Serializable;
 
 @Table
 public class MediaModel extends Payload implements Identifiable, Serializable {
-    public enum UploadState {
+    public enum MediaUploadState {
         QUEUED, UPLOADING, DELETING, DELETED, FAILED, UPLOADED;
 
-        public static UploadState fromString(String stringState) {
+        public static MediaUploadState fromString(String stringState) {
             if (stringState != null) {
-                for (UploadState state: UploadState.values()) {
+                for (MediaUploadState state: MediaUploadState.values()) {
                     if (stringState.equalsIgnoreCase(state.name())) {
                         return state;
                     }
@@ -318,7 +318,7 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
         return mUploadState;
     }
 
-    public void setUploadState(UploadState uploadState) {
+    public void setUploadState(MediaUploadState uploadState) {
         mUploadState = uploadState.toString();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
 @Table
 public class MediaModel extends Payload implements Identifiable, Serializable {
     public enum UploadState {
-        QUEUED, UPLOADING, DELETE, DELETED, FAILED, UPLOADED
+        QUEUED, UPLOADING, DELETING, DELETED, FAILED, UPLOADED
     }
 
     @PrimaryKey

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -307,6 +307,10 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
         return mUploadState;
     }
 
+    public void setUploadState(UploadState uploadState) {
+        mUploadState = uploadState.toString();
+    }
+
     //
     // Legacy methods
     //

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -96,28 +96,29 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
 
         String url = WPCOMREST.sites.site(site.getSiteId()).media.item(media.getMediaId()).getUrlV1_1();
 
-        add(WPComGsonRequest.buildPostRequest(url, getEditRequestParams(media),
-                MediaWPComRestResponse.class, new Listener<MediaWPComRestResponse>() {
-            @Override
-            public void onResponse(MediaWPComRestResponse response) {
-                MediaModel responseMedia = getMediaFromRestResponse(response);
-                if (responseMedia != null) {
-                    AppLog.v(T.MEDIA, "media changes pushed for " + responseMedia.getTitle());
-                    responseMedia.setLocalSiteId(site.getId());
-                    notifyMediaPushed(site, responseMedia, null);
-                } else {
-                    MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
-                    notifyMediaPushed(site, media, error);
+        add(WPComGsonRequest.buildPostRequest(url, getEditRequestParams(media), MediaWPComRestResponse.class,
+                new Listener<MediaWPComRestResponse>() {
+                    @Override
+                    public void onResponse(MediaWPComRestResponse response) {
+                        MediaModel responseMedia = getMediaFromRestResponse(response);
+                        if (responseMedia != null) {
+                            AppLog.v(T.MEDIA, "media changes pushed for " + responseMedia.getTitle());
+                            responseMedia.setLocalSiteId(site.getId());
+                            notifyMediaPushed(site, responseMedia, null);
+                        } else {
+                            MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
+                            notifyMediaPushed(site, media, error);
+                        }
+                    }
+                }, new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AppLog.w(T.MEDIA, "error editing remote media: " + error);
+                        MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
+                        notifyMediaPushed(site, media, mediaError);
+                    }
                 }
-            }
-        }, new BaseErrorListener() {
-            @Override
-            public void onErrorResponse(@NonNull BaseNetworkError error) {
-                AppLog.w(T.MEDIA, "error editing remote media: " + error);
-                MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
-                notifyMediaPushed(site, media, mediaError);
-            }
-        }));
+        ));
     }
 
     /**
@@ -242,7 +243,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         notifyMediaListFetched(site, mediaError);
                     }
-        }));
+                }
+        ));
     }
 
     /**
@@ -279,7 +281,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         notifyMediaFetched(site, media, mediaError);
                     }
-        }));
+                }
+            ));
     }
 
     /**
@@ -318,7 +321,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         }
                         notifyMediaDeleted(site, media, new MediaError(mediaError));
                     }
-        }));
+                }
+            ));
     }
 
     public void cancelUpload(final MediaModel media) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.MediaModel.UploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
@@ -493,9 +494,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         media.setVideoPressProcessingDone(from.videopress_processing_done);
         media.setDeleted(MediaWPComRestResponse.DELETED_STATUS.equals(from.status));
         if (!media.getDeleted()) {
-            media.setUploadState(MediaModel.UploadState.UPLOADED.toString());
+            media.setUploadState(UploadState.UPLOADED);
         } else {
-            media.setUploadState(MediaModel.UploadState.DELETED.toString());
+            media.setUploadState(UploadState.DELETED);
         }
         return media;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -84,8 +84,6 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         }
     }
 
-    /**
-     */
     public void pushMedia(final SiteModel site, final MediaModel media) {
         if (media == null) {
             // caller may be expecting a notification
@@ -333,9 +331,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         }
 
         // cancel in-progress upload if necessary
-        int mediaModelId = media.getId();
-        // make sure we know which call/media to look for
-        Call correspondingCall = mCurrentUploadCalls.get(mediaModelId);
+        Call correspondingCall = mCurrentUploadCalls.get(media.getId());
         if (correspondingCall != null && correspondingCall.isExecuted() && !correspondingCall.isCanceled()) {
             AppLog.d(T.MEDIA, "Canceled in-progress upload: " + media.getFileName());
             removeCallFromCurrentUploadsMap(media.getId());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
@@ -415,7 +415,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
 
     private void notifyMediaUploaded(MediaModel media, MediaError error) {
         if (media != null) {
-            media.setUploadState(error == null ? UploadState.UPLOADED : UploadState.FAILED);
+            media.setUploadState(error == null ? MediaUploadState.UPLOADED : MediaUploadState.FAILED);
         }
         ProgressPayload payload = new ProgressPayload(media, 1.f, error == null, error);
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
@@ -497,9 +497,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         media.setVideoPressProcessingDone(from.videopress_processing_done);
         media.setDeleted(MediaWPComRestResponse.DELETED_STATUS.equals(from.status));
         if (!media.getDeleted()) {
-            media.setUploadState(UploadState.UPLOADED);
+            media.setUploadState(MediaUploadState.UPLOADED);
         } else {
-            media.setUploadState(UploadState.DELETED);
+            media.setUploadState(MediaUploadState.DELETED);
         }
         return media;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -414,6 +414,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     }
 
     private void notifyMediaUploaded(MediaModel media, MediaError error) {
+        if (media != null) {
+            media.setUploadState(error == null ? UploadState.UPLOADED : UploadState.FAILED);
+        }
         ProgressPayload payload = new ProgressPayload(media, 1.f, error == null, error);
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -113,7 +113,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                 }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.w(T.MEDIA, "error editing remote media: " + error);
+                        AppLog.e(T.MEDIA, "error editing remote media: " + error);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         notifyMediaPushed(site, media, mediaError);
                     }
@@ -186,7 +186,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         notifyMediaUploaded(media, error);
                     }
                 } else {
-                    AppLog.w(T.MEDIA, "error uploading media: " + response);
+                    AppLog.e(T.MEDIA, "error uploading media: " + response.message());
                     notifyMediaUploaded(media, parseUploadError(response, site));
                 }
             }
@@ -239,7 +239,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                 }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.v(T.MEDIA, "VolleyError Fetching media: " + error);
+                        AppLog.e(T.MEDIA, "VolleyError Fetching media: " + error);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         notifyMediaListFetched(site, mediaError);
                     }
@@ -277,7 +277,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                 }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.v(T.MEDIA, "VolleyError Fetching media: " + error);
+                        AppLog.e(T.MEDIA, "VolleyError Fetching media: " + error);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         notifyMediaFetched(site, media, mediaError);
                     }
@@ -314,7 +314,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                 }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.v(T.MEDIA, "VolleyError deleting media (ID=" + media.getMediaId() + "): " + error);
+                        AppLog.e(T.MEDIA, "VolleyError deleting media (ID=" + media.getMediaId() + "): " + error);
                         MediaErrorType mediaError = MediaErrorType.fromBaseNetworkError(error);
                         if (mediaError == MediaErrorType.NOT_FOUND) {
                             AppLog.i(T.MEDIA, "Attempted to delete media that does not exist remotely.");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -422,6 +422,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
     private void notifyMediaUploaded(MediaModel media, MediaError error) {
         if (media != null) {
+            media.setUploadState(error == null ? UploadState.UPLOADED : UploadState.FAILED);
             removeCallFromCurrentUploadsMap(media.getId());
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -388,9 +388,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         }
 
         // cancel in-progress upload if necessary
-        int mediaModelId = media.getId();
-        // make sure we know which call/media to look for
-        Call correspondingCall = mCurrentUploadCalls.get(mediaModelId);
+        Call correspondingCall = mCurrentUploadCalls.get(media.getId());
         if (correspondingCall != null && correspondingCall.isExecuted() && !correspondingCall.isCanceled()) {
             AppLog.d(T.MEDIA, "Canceled in-progress upload: " + media.getFileName());
             removeCallFromCurrentUploadsMap(media.getId());
@@ -417,7 +415,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     private void notifyMediaProgress(MediaModel media, float progress, MediaError error) {
-        ProgressPayload payload = new ProgressPayload(media, progress, progress == 1.f, error);
+        ProgressPayload payload = new ProgressPayload(media, progress, false, error);
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }
 
@@ -431,7 +429,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, List<MediaModel> media,
+    private void notifyMediaListFetched(SiteModel site, @NonNull List<MediaModel> media,
                                         boolean loadedMore, boolean canLoadMore) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
                 loadedMore, canLoadMore);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -218,7 +218,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         notifyMediaUploaded(media, mediaError);
                     }
                 } else {
-                    AppLog.w(T.MEDIA, "error uploading media: " + response.message());
+                    AppLog.e(T.MEDIA, "error uploading media: " + response.message());
                     MediaError error = new MediaError(MediaErrorType.fromHttpStatusCode(response.code()));
                     error.message = response.message();
                     notifyMediaUploaded(media, error);
@@ -331,7 +331,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.v(T.MEDIA, "XMLRPC.GET_MEDIA_ITEM error response: " + error);
+                        AppLog.e(T.MEDIA, "XMLRPC.GET_MEDIA_ITEM error response: " + error);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         if (isFreshUpload) {
                             // we tried to fetch a media that's just uploaded but failed, so we should return
@@ -372,7 +372,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.v(T.MEDIA, "Error response from XMLRPC.DELETE_MEDIA:" + error);
+                        AppLog.e(T.MEDIA, "Error response from XMLRPC.DELETE_MEDIA:" + error);
                         MediaErrorType mediaError = MediaErrorType.fromBaseNetworkError(error);
                         notifyMediaDeleted(site, media, new MediaError(mediaError));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.XMLRPC;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
@@ -422,7 +422,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
     private void notifyMediaUploaded(MediaModel media, MediaError error) {
         if (media != null) {
-            media.setUploadState(error == null ? UploadState.UPLOADED : UploadState.FAILED);
+            media.setUploadState(error == null ? MediaUploadState.UPLOADED : MediaUploadState.FAILED);
             removeCallFromCurrentUploadsMap(media.getId());
         }
 
@@ -508,7 +508,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             media.setFileUrlLargeSize(getFileUrlForSize(link, metadataMap, "large"));
         }
 
-        media.setUploadState(UploadState.UPLOADED);
+        media.setUploadState(MediaUploadState.UPLOADED);
         return media;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -134,6 +134,13 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             return;
         }
 
+        if (media == null || media.getId() == 0) {
+            // we can't have a MediaModel without an ID - otherwise we can't keep track of them.
+            MediaError error = new MediaError(MediaErrorType.INVALID_ID);
+            notifyMediaUploaded(media, error);
+            return;
+        }
+
         if (!MediaUtils.canReadFile(media.getFilePath())) {
             MediaError error = new MediaError(MediaErrorType.FS_READ_PERMISSION_DENIED);
             notifyMediaUploaded(media, error);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -105,8 +105,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         AppLog.i(T.MEDIA, "Media updated on remote: " + media.getTitle());
                         notifyMediaPushed(site, media, null);
                     }
-                },
-                new BaseErrorListener() {
+                }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(T.MEDIA, "error response to XMLRPC.EDIT_MEDIA request: " + error);
@@ -119,7 +118,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         }
                     }
                 }
-            ));
+        ));
     }
 
     /**
@@ -241,14 +240,6 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         });
     }
 
-    private void removeCallFromCurrentUploadsMap(int id) {
-        // clean from the current uploads map
-        mCurrentUploadCalls.remove(id);
-        AppLog.d(T.MEDIA, "mediaXMLRPCClient: removed id: " + id + " from current"
-                + " uploads, remaining: "
-                + mCurrentUploadCalls.size());
-    }
-
     /**
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
@@ -277,8 +268,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                             notifyMediaListFetched(site, error);
                         }
                     }
-                },
-                new BaseErrorListener() {
+                }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(T.MEDIA, "XMLRPC.GET_MEDIA_LIBRARY error response:", error.volleyError);
@@ -286,7 +276,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         notifyMediaListFetched(site, mediaError);
                     }
                 }
-            ));
+        ));
     }
 
     public void fetchMedia(final SiteModel site, final MediaModel media) {
@@ -338,8 +328,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                             }
                         }
                     }
-                },
-                new BaseErrorListener() {
+                }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.v(T.MEDIA, "XMLRPC.GET_MEDIA_ITEM error response: " + error);
@@ -380,8 +369,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         AppLog.v(T.MEDIA, "Successful response from XMLRPC.DELETE_MEDIA");
                         notifyMediaDeleted(site, media, null);
                     }
-                },
-                new BaseErrorListener() {
+                }, new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.v(T.MEDIA, "Error response from XMLRPC.DELETE_MEDIA:" + error);
@@ -411,6 +399,12 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             // report the upload was successfully cancelled
             notifyMediaUploadCanceled(media);
         }
+    }
+
+    private void removeCallFromCurrentUploadsMap(int id) {
+        mCurrentUploadCalls.remove(id);
+        AppLog.d(T.MEDIA, "mediaXMLRPCClient: removed id: " + id + " from current uploads, remaining: "
+                + mCurrentUploadCalls.size());
     }
 
     //

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.XMLRPC;
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.MediaModel.UploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
@@ -506,7 +507,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             media.setFileUrlLargeSize(getFileUrlForSize(link, metadataMap, "large"));
         }
 
-        media.setUploadState(MediaModel.UploadState.UPLOADED.toString());
+        media.setUploadState(UploadState.UPLOADED);
         return media;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -6,7 +6,7 @@ import com.yarolegovich.wellsql.WellCursor;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 
@@ -296,7 +296,7 @@ public class MediaSqlUtils {
         return WellSql.delete(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
-                .equals(MediaModelTable.UPLOAD_STATE, UploadState.UPLOADED.toString())
+                .equals(MediaModelTable.UPLOAD_STATE, MediaUploadState.UPLOADED.toString())
                 .endGroup().endWhere().execute();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -571,7 +571,7 @@ public class MediaStore extends Store {
     }
 
     private void notifyMediaUploadError(MediaErrorType errorType, String errorMessage, MediaModel media) {
-        OnMediaUploaded onMediaUploaded = new OnMediaUploaded(media, 1, true, false);
+        OnMediaUploaded onMediaUploaded = new OnMediaUploaded(media, 1, false, false);
         onMediaUploaded.error = new MediaError(errorType, errorMessage);
         emitChange(onMediaUploaded);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -640,7 +640,7 @@ public class MediaStore extends Store {
         if (payload.delete) {
             MediaSqlUtils.deleteMedia(media);
         } else {
-            media.setUploadState(UploadState.FAILED.toString());
+            media.setUploadState(UploadState.FAILED);
             MediaSqlUtils.insertOrUpdateMedia(media);
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -381,7 +381,7 @@ public class MediaStore extends Store {
 
     public static final List<String> NOT_DELETED_STATES = new ArrayList<>();
     static {
-        NOT_DELETED_STATES.add(UploadState.DELETE.toString());
+        NOT_DELETED_STATES.add(UploadState.DELETING.toString());
         NOT_DELETED_STATES.add(UploadState.FAILED.toString());
         NOT_DELETED_STATES.add(UploadState.QUEUED.toString());
         NOT_DELETED_STATES.add(UploadState.UPLOADED.toString());
@@ -501,7 +501,7 @@ public class MediaStore extends Store {
 
     public MediaModel getNextSiteMediaToDelete(SiteModel siteModel) {
         List<MediaModel> media = MediaSqlUtils.matchSiteMedia(siteModel,
-                MediaModelTable.UPLOAD_STATE, UploadState.DELETE.toString());
+                MediaModelTable.UPLOAD_STATE, UploadState.DELETING.toString());
         return media.size() > 0 ? media.get(0) : null;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest;
@@ -381,11 +381,11 @@ public class MediaStore extends Store {
 
     public static final List<String> NOT_DELETED_STATES = new ArrayList<>();
     static {
-        NOT_DELETED_STATES.add(UploadState.DELETING.toString());
-        NOT_DELETED_STATES.add(UploadState.FAILED.toString());
-        NOT_DELETED_STATES.add(UploadState.QUEUED.toString());
-        NOT_DELETED_STATES.add(UploadState.UPLOADED.toString());
-        NOT_DELETED_STATES.add(UploadState.UPLOADING.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.DELETING.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.FAILED.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.QUEUED.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.UPLOADED.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.UPLOADING.toString());
     }
 
     public WellCursor<MediaModel> getNotDeletedSiteMediaAsCursor(SiteModel site) {
@@ -458,11 +458,11 @@ public class MediaStore extends Store {
     }
 
     public List<MediaModel> getLocalSiteMedia(SiteModel siteModel) {
-        UploadState expectedState = UploadState.UPLOADED;
+        MediaUploadState expectedState = MediaUploadState.UPLOADED;
         return MediaSqlUtils.getSiteMediaExcluding(siteModel, MediaModelTable.UPLOAD_STATE, expectedState);
     }
 
-    public List<MediaModel> getSiteMediaWithState(SiteModel siteModel, UploadState expectedState) {
+    public List<MediaModel> getSiteMediaWithState(SiteModel siteModel, MediaUploadState expectedState) {
         return MediaSqlUtils.matchSiteMedia(siteModel, MediaModelTable.UPLOAD_STATE, expectedState);
     }
 
@@ -494,14 +494,14 @@ public class MediaStore extends Store {
         return MediaSqlUtils.matchPostMedia(postModel.getId());
     }
 
-    public List<MediaModel> getMediaForPostWithState(PostModel postModel, UploadState expectedState) {
+    public List<MediaModel> getMediaForPostWithState(PostModel postModel, MediaUploadState expectedState) {
         return MediaSqlUtils.matchPostMedia(postModel.getId(), MediaModelTable.UPLOAD_STATE,
                 expectedState);
     }
 
     public MediaModel getNextSiteMediaToDelete(SiteModel siteModel) {
         List<MediaModel> media = MediaSqlUtils.matchSiteMedia(siteModel,
-                MediaModelTable.UPLOAD_STATE, UploadState.DELETING.toString());
+                MediaModelTable.UPLOAD_STATE, MediaUploadState.DELETING.toString());
         return media.size() > 0 ? media.get(0) : null;
     }
 
@@ -579,13 +579,13 @@ public class MediaStore extends Store {
     private void performUploadMedia(MediaPayload payload) {
         String errorMessage = isWellFormedForUpload(payload.media);
         if (errorMessage != null) {
-            payload.media.setUploadState(UploadState.FAILED);
+            payload.media.setUploadState(MediaUploadState.FAILED);
             MediaSqlUtils.insertOrUpdateMedia(payload.media);
             notifyMediaUploadError(MediaErrorType.MALFORMED_MEDIA_ARG, errorMessage, payload.media);
             return;
         }
 
-        payload.media.setUploadState(UploadState.UPLOADING);
+        payload.media.setUploadState(MediaUploadState.UPLOADING);
         MediaSqlUtils.insertOrUpdateMedia(payload.media);
 
         if (payload.site.isUsingWpComRestApi()) {
@@ -599,7 +599,7 @@ public class MediaStore extends Store {
         int offset = 0;
         if (payload.loadMore) {
             List<String> list = new ArrayList<>();
-            list.add(UploadState.UPLOADED.toString());
+            list.add(MediaUploadState.UPLOADED.toString());
             offset = MediaSqlUtils.getMediaWithStates(payload.site, list).size();
         }
         if (payload.site.isUsingWpComRestApi()) {
@@ -645,7 +645,7 @@ public class MediaStore extends Store {
         if (payload.delete) {
             MediaSqlUtils.deleteMedia(media);
         } else {
-            media.setUploadState(UploadState.FAILED);
+            media.setUploadState(MediaUploadState.FAILED);
             MediaSqlUtils.insertOrUpdateMedia(media);
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -583,6 +583,9 @@ public class MediaStore extends Store {
             return;
         }
 
+        payload.media.setUploadState(UploadState.UPLOADING);
+        MediaSqlUtils.insertOrUpdateMedia(payload.media);
+
         if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.uploadMedia(payload.site, payload.media);
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -579,6 +579,8 @@ public class MediaStore extends Store {
     private void performUploadMedia(MediaPayload payload) {
         String errorMessage = isWellFormedForUpload(payload.media);
         if (errorMessage != null) {
+            payload.media.setUploadState(UploadState.FAILED);
+            MediaSqlUtils.insertOrUpdateMedia(payload.media);
             notifyMediaUploadError(MediaErrorType.MALFORMED_MEDIA_ARG, errorMessage, payload.media);
             return;
         }

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
@@ -29,7 +29,6 @@ import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -222,7 +221,6 @@ public class PostActivity extends AppCompatActivity {
         mediaModel.setMimeType(mimeType);
         mediaModel.setFileName(MediaUtils.getFileName(imagePath));
         mediaModel.setLocalSiteId(mSite.getId());
-        mediaModel.setUploadState(MediaUploadState.UPLOADING);
         mediaModel.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
 

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
@@ -29,7 +29,7 @@ import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.UploadState;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -222,7 +222,7 @@ public class PostActivity extends AppCompatActivity {
         mediaModel.setMimeType(mimeType);
         mediaModel.setFileName(MediaUtils.getFileName(imagePath));
         mediaModel.setLocalSiteId(mSite.getId());
-        mediaModel.setUploadState(UploadState.UPLOADING);
+        mediaModel.setUploadState(MediaUploadState.UPLOADING);
         mediaModel.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
 

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
@@ -222,7 +222,7 @@ public class PostActivity extends AppCompatActivity {
         mediaModel.setMimeType(mimeType);
         mediaModel.setFileName(MediaUtils.getFileName(imagePath));
         mediaModel.setLocalSiteId(mSite.getId());
-        mediaModel.setUploadState(UploadState.UPLOADING.toString());
+        mediaModel.setUploadState(UploadState.UPLOADING);
         mediaModel.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
 


### PR DESCRIPTION
Fixes #415, moving the responsibility for updating media states (`QUEUED` --> `UPLOADING`, and `UPLOADING` --> `UPLOADED`/`FAILED`) to FluxC.

I also did some smaller cleanup:
* Renamed `UploadState` to `MediaUploadState`
* Renamed `UploadState.DELETE` to `UploadState.DELETING`
* Overloaded `MediaModel.setUploadState()` to accept `MediaUploadState` enums directly as well as strings
* Refactored the `MediaRestClient` and `MediaXMLRPCClient` to make them more consistent and easier to read/compare (thanks @mzorz for [suggesting it](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/457#issuecomment-308172811))

I'll be opening a WPAndroid PR to address the renaming and to drop the now-redundant setting of the media upload state - please wait to merge this until that one is also ready to merge.

cc @mzorz