### PR TITLE
Fix Jetpack media test class

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -11,13 +11,18 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -113,7 +118,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onAuthenticationChanged(AccountStore.OnAuthenticationChanged event) {
+    public void onAuthenticationChanged(OnAuthenticationChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -122,8 +127,8 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onAccountChanged(AccountStore.OnAccountChanged event) {
-        AppLog.d(AppLog.T.TESTS, "Received OnAccountChanged event");
+    public void onAccountChanged(OnAccountChanged event) {
+        AppLog.d(T.TESTS, "Received OnAccountChanged event");
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -132,8 +137,8 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onSiteChanged(SiteStore.OnSiteChanged event) {
-        AppLog.i(AppLog.T.TESTS, "site count " + mSiteStore.getSitesCount());
+    public void onSiteChanged(OnSiteChanged event) {
+        AppLog.d(T.TESTS, "site count " + mSiteStore.getSitesCount());
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -144,8 +149,8 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onSiteRemoved(SiteStore.OnSiteRemoved event) {
-        AppLog.e(AppLog.T.TESTS, "site count " + mSiteStore.getSitesCount());
+    public void onSiteRemoved(OnSiteRemoved event) {
+        AppLog.d(T.TESTS, "site count " + mSiteStore.getSitesCount());
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }


### PR DESCRIPTION
Adds missing `FETCH_ACCOUNT` step to authorization for `ReleaseStack_MediaTestJetpack` (the single test in this class fails without it).

Background: This test was added after https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/438 (since which an `AccountModel` is required before WP.com REST sites can be stored in the database), but before the feature branch that PR was targeting was merged into `develop`, and we missed that this test was broken.