### PR TITLE
fixed log message

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -344,7 +344,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
 
     private void removeCallFromCurrentUploadsMap(int id) {
         mCurrentUploadCalls.remove(id);
-        AppLog.d(T.MEDIA, "mediaXMLRPCClient: removed id: " + id + " from current uploads, remaining: "
+        AppLog.d(T.MEDIA, "mediaRestClient: removed id: " + id + " from current uploads, remaining: "
                 + mCurrentUploadCalls.size());
     }
 


### PR DESCRIPTION
We were using `mediaXMLRPCClient` in the log message instead of `mediaRestClient`, sneaked in as part of #477 

cc @aforcier 