### PR TITLE
Tweak usage of DUPLICATE_SITE

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -686,6 +686,35 @@ public class SiteStoreUnitTest {
     }
 
     @Test
+    public void testInsertSiteDuplicateXmlRpcDifferentUrl() throws DuplicateSiteException {
+        // It's possible for the URL in `wp.getOptions` to be different from the URL in `wp.getUsersBlogs`
+        // This test checks that we can still identify two sites as being identical in this case, and that we quietly
+        // update the existing site rather than throw a duplicate site exception
+        SiteModel selfhostedSite = generateSelfHostedNonJPSite();
+        selfhostedSite.setUrl("http://some.url");
+        selfhostedSite.setXmlRpcUrl("http://some.url/xmlrpc.php");
+
+        SiteSqlUtils.insertOrUpdateSite(selfhostedSite);
+
+        SiteModel selfhostedSite2 = generateSelfHostedNonJPSite();
+        selfhostedSite2.setUrl("http://user5242.stagingsite.url");
+        selfhostedSite2.setXmlRpcUrl("http://some.url/xmlrpc.php");
+
+        boolean duplicate = false;
+        try {
+            // Insert the same site with a different URL, but the same XML-RPC URL
+            // (this should succeed, replacing the existing site)
+            SiteSqlUtils.insertOrUpdateSite(selfhostedSite2);
+        } catch (DuplicateSiteException e) {
+            // Caught !
+            duplicate = true;
+        }
+        assertFalse(duplicate);
+        int sitesCount = WellSql.select(SiteModel.class).getAsCursor().getCount();
+        assertEquals(1, sitesCount);
+    }
+
+    @Test
     public void testUpdateSiteUniqueConstraintFail() throws DuplicateSiteException {
         // Create 2 test sites
         SiteModel site1 = generateTestSite(0, "https://pony1.com", "https://pony1.com/xmlrpc.php", false, true);

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteUtils.java
@@ -34,6 +34,7 @@ public class SiteUtils {
         example.setIsJetpackInstalled(false);
         example.setIsJetpackConnected(false);
         example.setIsVisible(true);
+        example.setUrl("http://some.url");
         example.setXmlRpcUrl("http://some.url/xmlrpc.php");
         example.setOrigin(SiteModel.ORIGIN_XMLRPC);
         return example;
@@ -49,6 +50,7 @@ public class SiteUtils {
         example.setIsVisible(true);
         example.setUsername("ponyuser");
         example.setPassword("ponypass");
+        example.setUrl("http://jetpack.url");
         example.setXmlRpcUrl("http://jetpack.url/xmlrpc.php");
         example.setOrigin(SiteModel.ORIGIN_XMLRPC);
         return example;
@@ -61,6 +63,7 @@ public class SiteUtils {
         example.setIsJetpackInstalled(true);
         example.setIsJetpackConnected(true);
         example.setIsVisible(true);
+        example.setUrl("http://jetpack2.url");
         example.setXmlRpcUrl("http://jetpack2.url/xmlrpc.php");
         example.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         return example;
@@ -73,6 +76,7 @@ public class SiteUtils {
         example.setIsJetpackInstalled(false);
         example.setIsJetpackConnected(false);
         example.setIsVisible(true);
+        example.setUrl("http://jetpack2.url");
         example.setXmlRpcUrl("http://jetpack2.url/xmlrpc.php");
         example.setOrigin(SiteModel.ORIGIN_XMLRPC);
         return example;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -59,8 +59,8 @@ public class SiteSqlUtils {
      * 1. Exists in the DB already and matches by local id (simple update) -> UPDATE
      * 2. Exists in the DB, is a Jetpack or WordPress site and matches by remote id (SITE_ID) -> UPDATE
      * 3. Exists in the DB, is a pure self hosted and matches by remote id (SITE_ID) + URL -> UPDATE
-     * 4. Exists in the DB, was not a Jetpack site but is now a Jetpack site, and matches by XMLRPC_URL -> UPDATE
-     * 5. Exists in the DB, and matches by XMLRPC_URL -> THROW a DuplicateSiteException
+     * 4. Exists in the DB, originally a WP.com REST site, and matches by XMLRPC_URL -> THROW a DuplicateSiteException
+     * 5. Exists in the DB, originally an XML-RPC site, and matches by XMLRPC_URL -> UPDATE
      * 6. Not matching any previous cases -> INSERT
      */
     public static int insertOrUpdateSite(SiteModel site) throws DuplicateSiteException {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -135,12 +135,19 @@ public class SiteSqlUtils {
                     .endWhere().getAsModel();
             if (!siteResult.isEmpty()) {
                 AppLog.d(T.DB, "Site found using XML-RPC url: " + site.getXmlRpcUrl());
-                // If the site already in the DB is a self hosted and the new one is a Jetpack connected site, it means
-                // we upgraded from self hosted to jetpack, we want to update the site with the new informations.
-                if (siteResult.get(0).isJetpackConnected() || !site.isJetpackConnected()) {
+                // Four possibilities here:
+                // 1. DB site is WP.com, new site is WP.com:
+                // Something really weird is happening, this should have been caught earlier --> DuplicateSiteException
+                // 2. DB site is WP.com, new site is XML-RPC:
+                // It looks like an existing Jetpack-connected site over the REST API was added again as an XML-RPC
+                // Wed don't allow this --> DuplicateSiteException
+                // 3. DB site is XML-RPC, new site is WP.com:
+                // Upgrading a self-hosted site to Jetpack --> proceed
+                // 4. DB site is XML-RPC, new site is XML-RPC:
+                // An existing self-hosted site was logged-into again, and we couldn't identify it by URL or
+                // by WP.com site ID + URL --> proceed
+                if (siteResult.get(0).getOrigin() == SiteModel.ORIGIN_WPCOM_REST) {
                     AppLog.d(T.DB, "Site is a duplicate");
-                    // In other cases (examples: adding the same self hosted twice or adding self hosted on top of an
-                    // existing jetpack site), we consider it as an error.
                     throw new DuplicateSiteException();
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.persistence;
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteConstraintException;
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
 
 import com.wellsql.generated.AccountModelTable;
 import com.wellsql.generated.PostFormatModelTable;
@@ -108,11 +107,7 @@ public class SiteSqlUtils {
                 siteResult = WellSql.select(SiteModel.class)
                         .where().beginGroup()
                         .equals(SiteModelTable.SITE_ID, site.getSiteId())
-                        .beginGroup()
-                        .equals(SiteModelTable.URL, stripTrailingSlashes(site.getUrl()))
-                        .or()
-                        .equals(SiteModelTable.URL, addTrailingSlash(site.getUrl()))
-                        .endGroup()
+                        .equals(SiteModelTable.URL, site.getUrl())
                         .endGroup().endWhere().getAsModel();
                 if (!siteResult.isEmpty()) {
                     AppLog.d(T.DB, "Site found by SITE_ID: " + site.getSiteId() + " and URL: " + site.getUrl());
@@ -256,23 +251,5 @@ public class SiteSqlUtils {
             postFormat.setSiteId(site.getId());
         }
         WellSql.insert(postFormats).execute();
-    }
-
-    private static String stripTrailingSlashes(String url) {
-        if (TextUtils.isEmpty(url)) return url;
-
-        while (url.endsWith("/")) {
-            url = url.substring(0, url.length() - 1);
-        }
-        return url;
-    }
-
-    private static String addTrailingSlash(String url) {
-        if (TextUtils.isEmpty(url)) return url;
-
-        if (!url.endsWith("/")) {
-            url = url + "/";
-        }
-        return url;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence;
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteConstraintException;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.wellsql.generated.AccountModelTable;
 import com.wellsql.generated.PostFormatModelTable;
@@ -107,7 +108,11 @@ public class SiteSqlUtils {
                 siteResult = WellSql.select(SiteModel.class)
                         .where().beginGroup()
                         .equals(SiteModelTable.SITE_ID, site.getSiteId())
-                        .equals(SiteModelTable.URL, site.getUrl())
+                        .beginGroup()
+                        .equals(SiteModelTable.URL, stripTrailingSlashes(site.getUrl()))
+                        .or()
+                        .equals(SiteModelTable.URL, addTrailingSlash(site.getUrl()))
+                        .endGroup()
                         .endGroup().endWhere().getAsModel();
                 if (!siteResult.isEmpty()) {
                     AppLog.d(T.DB, "Site found by SITE_ID: " + site.getSiteId() + " and URL: " + site.getUrl());
@@ -244,5 +249,23 @@ public class SiteSqlUtils {
             postFormat.setSiteId(site.getId());
         }
         WellSql.insert(postFormats).execute();
+    }
+
+    private static String stripTrailingSlashes(String url) {
+        if (TextUtils.isEmpty(url)) return url;
+
+        while (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        return url;
+    }
+
+    private static String addTrailingSlash(String url) {
+        if (TextUtils.isEmpty(url)) return url;
+
+        if (!url.endsWith("/")) {
+            url = url + "/";
+        }
+        return url;
     }
 }


### PR DESCRIPTION
Fixes #479, quietly updating existing self-hosted sites when logging into them again, instead of throwing an error.

This is mainly accounting for the differences between `wp.getUsersBlogs` and `wp.getOptions`. If a self-hosted site already exists in the app, we've called `wp.getOptions` on it (using `FETCH_SITE`). If we attempt to sign in to that same site again, we'll be working with the results of `wp.getUsersBlogs` (`FETCH_SITES`), which are different (the site's URL can be different, and `wp.getUsersBlogs` lacks  info about the site's Jetpack status).

Previously, if a self-hosted site was not recognized as already existing in the `SiteStore` based on its URL or its URL + its WP.com site ID, we would do an XML-RPC URL match. This used to throw an error for all but the case where a Jetpack-connected site is replacing a non-Jetpack connected site. This is now less strict, and will permit any self-hosted site to be overwritten.

cc @maxme