### PR TITLE
Whitelist "3gpp", and "3gpp2" video subformats

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -19,7 +19,7 @@ public class MediaUtils {
             "jpg", "jpeg", "png", "gif"
     };
     public static final String[] SUPPORTED_VIDEO_SUBTYPES = {
-            "mp4", "m4v", "mov", "wmv", "avi", "mpg", "ogv", "3gp", "3g2", "mpeg", "quicktime", "webm"
+            "mp4", "m4v", "mov", "wmv", "avi", "mpg", "ogv", "3gp", "3gpp", "3gpp2", "3g2", "mpeg", "quicktime", "webm"
     };
     public static final String[] SUPPORTED_AUDIO_SUBTYPES = {
             "mp3", "m4a", "ogg", "wav"


### PR DESCRIPTION
Fix #487 by adding the missing video sub-formats.