### PR TITLE
Handle ClassCastExceptions during XML-RPC site fetch

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -240,7 +240,7 @@ public class SiteXMLRPCClientTest {
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect UPDATE_SITES to be dispatched with an INVALID_RESPONSE error
                 Action action = invocation.getArgumentAt(0, Action.class);
-                assertEquals(SiteAction.UPDATE_SITES, action.getType());
+                assertEquals(SiteAction.FETCHED_SITES, action.getType());
 
                 SitesModel result = (SitesModel) action.getPayload();
                 assertTrue(result.isError());

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -160,8 +160,8 @@ public class SiteXMLRPCClientTest {
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect an OnUnexpectedError to be emitted with a parse error
                 OnUnexpectedError event = invocation.getArgumentAt(0, OnUnexpectedError.class);
-                assertEquals(site.getXmlRpcUrl(), event.extras.get("url"));
-                assertEquals("whoops", event.extras.get("response"));
+                assertEquals(site.getXmlRpcUrl(), event.extras.get(OnUnexpectedError.KEY_URL));
+                assertEquals("whoops", event.extras.get(OnUnexpectedError.KEY_RESPONSE));
                 assertEquals(ClassCastException.class, event.exception.getClass());
 
                 mCountDownLatch.countDown();

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.wordpress.android.fluxc.site.SiteUtils.generateWPComSite;
+import static org.wordpress.android.fluxc.site.SiteUtils.generateSelfHostedNonJPSite;
 
 @RunWith(RobolectricTestRunner.class)
 public class SiteXMLRPCClientTest {
@@ -86,7 +86,7 @@ public class SiteXMLRPCClientTest {
 
     @Test
     public void testFetchSite() throws Exception {
-        SiteModel site = generateWPComSite();
+        SiteModel site = generateSelfHostedNonJPSite();
         mCountDownLatch = new CountDownLatch(1);
         mMockedResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                           + "<methodResponse><params><param><value>\n"

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -189,4 +189,26 @@ public class SiteXMLRPCClientTest {
         mSiteXMLRPCClient.fetchSite(site);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
+
+    @Test
+    public void testFetchSites() throws Exception {
+        mMockedResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<methodResponse><params><param><value>\n"
+                + "<array><data><value><struct>\n"
+                + "<member><name>isAdmin</name><value><boolean>1</boolean></value></member>\n"
+                + "<member><name>url</name><value>\n"
+                + "<string>http://docbrown.url/</string>\n"
+                + "</value></member>\n"
+                + "<member><name>blogid</name><value><string>1</string></value></member>\n"
+                + "<member><name>blogName</name><value><string>Doc Brown Testing</string></value></member>\n"
+                + "<member><name>xmlrpc</name><value>\n"
+                + "<string>http://docbrown.url/xmlrpc.php</string>\n"
+                + "</value></member></struct></value></data></array>\n"
+                + "</value></param></params></methodResponse>";
+        final String xmlrpcUrl = "http://docbrown.url/xmlrpc.php";
+
+        mCountDownLatch = new CountDownLatch(1);
+        mSiteXMLRPCClient.fetchSites(xmlrpcUrl, "thedoc", "gr3@tsc0tt");
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -18,20 +18,26 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowLog;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.action.SiteAction;
+import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.wordpress.android.fluxc.site.SiteUtils.generateSelfHostedNonJPSite;
@@ -39,6 +45,7 @@ import static org.wordpress.android.fluxc.site.SiteUtils.generateSelfHostedNonJP
 @RunWith(RobolectricTestRunner.class)
 public class SiteXMLRPCClientTest {
     private SiteXMLRPCClient mSiteXMLRPCClient;
+    private Dispatcher mDispatcher;
     private RequestQueue mMockedQueue;
     private String mMockedResponse = "";
     private CountDownLatch mCountDownLatch;
@@ -48,6 +55,7 @@ public class SiteXMLRPCClientTest {
         ShadowLog.stream = System.out;
 
         mMockedQueue = mock(RequestQueue.class);
+        mDispatcher = mock(Dispatcher.class);
         when(mMockedQueue.add(any(Request.class))).thenAnswer(new Answer<Void>() {
             public Void answer(InvocationOnMock invocation) {
                 XMLRPCRequest request = (XMLRPCRequest) invocation.getArguments()[0];
@@ -73,7 +81,7 @@ public class SiteXMLRPCClientTest {
                 return null;
             }
         });
-        mSiteXMLRPCClient = new SiteXMLRPCClient(new Dispatcher(), mMockedQueue,
+        mSiteXMLRPCClient = new SiteXMLRPCClient(mDispatcher, mMockedQueue,
                 mock(AccessToken.class), mock(UserAgent.class),
                 mock(HTTPAuthManager.class));
 
@@ -131,6 +139,53 @@ public class SiteXMLRPCClientTest {
                           + "  </value></member></struct></value></member>\n"
                           + "  </struct>\n"
                           + "</value></param></params></methodResponse>";
+        mSiteXMLRPCClient.fetchSite(site);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testFetchSiteBadResponseFormat() throws Exception {
+        // If wp.getOptions returns a String instead of a Map, make sure we:
+        // 1. Don't crash
+        // 2. Emit an UPDATE_SITE action with an INVALID_RESPONSE error
+        // 3. Report the parse error and its details in an OnUnexpectedError
+        final SiteModel site = generateSelfHostedNonJPSite();
+        mMockedResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<methodResponse><params><param><value>\n"
+                + "  <string>whoops</string>\n"
+                + "</value></param></params></methodResponse>";
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                // Expect an OnUnexpectedError to be emitted with a parse error
+                OnUnexpectedError event = invocation.getArgumentAt(0, OnUnexpectedError.class);
+                assertEquals(site.getXmlRpcUrl(), event.extras.get("url"));
+                assertEquals("whoops", event.extras.get("response"));
+                assertEquals(ClassCastException.class, event.exception.getClass());
+
+                mCountDownLatch.countDown();
+                return null;
+            }
+        }).when(mDispatcher).emitChange(any(Object.class));
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                // Expect UPDATE_SITE to be dispatched with an INVALID_RESPONSE error
+                Action action = invocation.getArgumentAt(0, Action.class);
+                assertEquals(SiteAction.UPDATE_SITE, action.getType());
+
+                SiteModel result = (SiteModel) action.getPayload();
+                assertTrue(result.isError());
+                assertEquals(GenericErrorType.INVALID_RESPONSE, result.error.type);
+
+                mCountDownLatch.countDown();
+                return null;
+            }
+        }).when(mDispatcher).dispatch(any(Action.class));
+
+        mCountDownLatch = new CountDownLatch(3);
         mSiteXMLRPCClient.fetchSite(site);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -235,7 +235,7 @@ public abstract class BaseRequest<T> extends Request<T> {
         AppLog.e(AppLog.T.API, "Volley error on " + getUrl(), volleyError);
         if (volleyError instanceof ParseError) {
             OnUnexpectedError error = new OnUnexpectedError(volleyError, "API response parse error");
-            error.addExtra("url", getUrl());
+            error.addExtra(OnUnexpectedError.KEY_URL, getUrl());
             mOnParseErrorListener.onParseError(error);
         }
         BaseNetworkError baseNetworkError = getBaseNetworkError(volleyError);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -32,12 +32,15 @@ import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
+import org.wordpress.android.fluxc.store.SiteStore.PostFormatsError;
+import org.wordpress.android.fluxc.store.SiteStore.PostFormatsErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
 import org.wordpress.android.util.UrlUtils;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -270,8 +273,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         FetchedPostFormatsPayload payload = new FetchedPostFormatsPayload(site,
-                                new ArrayList<PostFormatModel>());
-                        payload.error = error;
+                                Collections.<PostFormatModel>emptyList());
+                        // TODO: what other kind of error could we get here?
+                        payload.error = new PostFormatsError(PostFormatsErrorType.GENERIC_ERROR);
                         mDispatcher.dispatch(SiteActionBuilder.newFetchedPostFormatsAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
@@ -75,12 +75,12 @@ public class BaseXMLRPCClient {
         try {
             clazz.cast(response);
         } catch (ClassCastException e) {
-            OnUnexpectedError onUnexpectedError = new OnUnexpectedError(e, "XML-RPC response parse error: "
-                    + e.getMessage());
+            OnUnexpectedError onUnexpectedError = new OnUnexpectedError(e,
+                    "XML-RPC response parse error: " + e.getMessage());
             if (xmlrpcUrl != null) {
-                onUnexpectedError.addExtra("url", xmlrpcUrl);
+                onUnexpectedError.addExtra(OnUnexpectedError.KEY_URL, xmlrpcUrl);
             }
-            onUnexpectedError.addExtra("response", response.toString());
+            onUnexpectedError.addExtra(OnUnexpectedError.KEY_RESPONSE, response.toString());
             mOnParseErrorListener.onParseError(onUnexpectedError);
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
@@ -68,4 +68,20 @@ public class BaseXMLRPCClient {
         request.setHTTPAuthHeaderOnMatchingURL(mHTTPAuthManager);
         return request;
     }
+
+    protected void reportParseError(Object response, String xmlrpcUrl, Class clazz) {
+        if (response == null) return;
+
+        try {
+            clazz.cast(response);
+        } catch (ClassCastException e) {
+            OnUnexpectedError onUnexpectedError = new OnUnexpectedError(e, "XML-RPC response parse error: "
+                    + e.getMessage());
+            if (xmlrpcUrl != null) {
+                onUnexpectedError.addExtra("url", xmlrpcUrl);
+            }
+            onUnexpectedError.addExtra("response", response.toString());
+            mOnParseErrorListener.onParseError(onUnexpectedError);
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -136,14 +136,14 @@ public class XMLRPCRequest extends BaseRequest<Object> {
      * Helper method to capture the Listener's wildcard parameter type and use it to cast the response before
      * calling {@code onResponse()}.
      */
-    private <T> void deliverResponse(final Listener<T> listener, Object rawResponse) {
+    private <K> void deliverResponse(final Listener<K> listener, Object rawResponse) {
         // The XMLRPCSerializer always returns an Object - it's up to the client making the request to know whether
         // it's really an Object[] (i.e., when requesting a list of values from the API).
         // We've already restricted the Listener parameterization to Object and Object[], so we know this is returning
         // a 'safe' type - but it's still up to the client to know if an Object or an Object[] is the expected response.
         // So, we're matching the parsed response to the Listener parameter we were given, trusting that the network
         // client knows what it's doing
-        @SuppressWarnings("unchecked") T response = (T) rawResponse;
+        @SuppressWarnings("unchecked") K response = (K) rawResponse;
         try {
             listener.onResponse(response);
         } catch (ClassCastException e) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -148,10 +148,10 @@ public class XMLRPCRequest extends BaseRequest<Object> {
             listener.onResponse(response);
         } catch (ClassCastException e) {
             // If we aren't returning the type the client was expecting, treat this as an API response parse error
-            OnUnexpectedError onUnexpectedError = new OnUnexpectedError(e, "API response parse error: "
-                    + e.getMessage());
-            onUnexpectedError.addExtra("url", getUrl());
-            onUnexpectedError.addExtra("response", response.toString());
+            OnUnexpectedError onUnexpectedError = new OnUnexpectedError(e,
+                    "API response parse error: " + e.getMessage());
+            onUnexpectedError.addExtra(OnUnexpectedError.KEY_URL, getUrl());
+            onUnexpectedError.addExtra(OnUnexpectedError.KEY_RESPONSE, response.toString());
             mOnParseErrorListener.onParseError(onUnexpectedError);
             listener.onResponse(null);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -110,7 +110,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                 new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
-                        List<PostFormatModel> postFormats = responseToPostFormats(response);
+                        List<PostFormatModel> postFormats = responseToPostFormats(response, site);
                         if (postFormats != null) {
                             FetchedPostFormatsPayload payload = new FetchedPostFormatsPayload(site, postFormats);
                             mDispatcher.dispatch(SiteActionBuilder.newFetchedPostFormatsAction(payload));
@@ -212,6 +212,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
 
     private SiteModel updateSiteFromOptions(Object response, SiteModel oldModel) {
         if (!(response instanceof Map)) {
+            reportParseError(response, oldModel.getXmlRpcUrl(), Map.class);
             return null;
         }
 
@@ -242,8 +243,9 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         return oldModel;
     }
 
-    private List<PostFormatModel> responseToPostFormats(Object response) {
+    private List<PostFormatModel> responseToPostFormats(Object response, SiteModel site) {
         if (!(response instanceof Map)) {
+            reportParseError(response, site.getXmlRpcUrl(), Map.class);
             return null;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -25,7 +25,6 @@ import org.wordpress.android.util.MapUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,9 +40,9 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         params.add(password);
         final XMLRPCRequest request = new XMLRPCRequest(
                 xmlrpcUrl, XMLRPC.GET_USERS_SITES, params,
-                new Listener<Object>() {
+                new Listener<Object[]>() {
                     @Override
-                    public void onResponse(Object response) {
+                    public void onResponse(Object[] response) {
                         SitesModel sites = sitesResponseToSitesModel(response, username, password);
                         if (sites != null) {
                             mDispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sites));
@@ -136,17 +135,15 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    private SitesModel sitesResponseToSitesModel(Object response, String username, String password) {
-        if (!(response instanceof Object[])) {
-            return null;
-        }
-        Object[] responseArray = (Object[]) response;
+    private SitesModel sitesResponseToSitesModel(Object[] response, String username, String password) {
+        if (response == null) return null;
+
         List<SiteModel> siteArray = new ArrayList<>();
-        for (Object siteObject: responseArray) {
-            if (!(siteObject instanceof HashMap)) {
+        for (Object siteObject: response) {
+            if (!(siteObject instanceof Map)) {
                 continue;
             }
-            HashMap<?, ?> siteMap = (HashMap<?, ?>) siteObject;
+            Map<?, ?> siteMap = (Map<?, ?>) siteObject;
             SiteModel site = new SiteModel();
             site.setSelfHostedSiteId(MapUtils.getMapInt(siteMap, "blogid", 1));
             site.setName(MapUtils.getMapStr(siteMap, "blogName"));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSit
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
+import org.wordpress.android.fluxc.utils.SiteErrorUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -129,9 +130,15 @@ public class SiteStore extends Store {
 
     public static class SiteError implements OnChangedError {
         public SiteErrorType type;
+        public String message;
 
         public SiteError(SiteErrorType type) {
+            this(type, "");
+        }
+
+        public SiteError(SiteErrorType type, String message) {
             this.type = type;
+            this.message = message;
         }
     }
 
@@ -259,7 +266,8 @@ public class SiteStore extends Store {
     public enum SiteErrorType {
         INVALID_SITE,
         DUPLICATE_SITE,
-        GENERIC_ERROR
+        INVALID_RESPONSE,
+        GENERIC_ERROR;
     }
 
     public enum SuggestDomainErrorType {
@@ -804,7 +812,7 @@ public class SiteStore extends Store {
         OnSiteChanged event = new OnSiteChanged(0);
         if (siteModel.isError()) {
             // TODO: what kind of error could we get here?
-            event.error = new SiteError(SiteErrorType.GENERIC_ERROR);
+            event.error = SiteErrorUtils.genericToSiteError(siteModel.error);
         } else {
             try {
                 event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
@@ -819,7 +827,7 @@ public class SiteStore extends Store {
         OnSiteChanged event = new OnSiteChanged(0);
         if (sitesModel.isError()) {
             // TODO: what kind of error could we get here?
-            event.error = new SiteError(SiteErrorType.GENERIC_ERROR);
+            event.error = SiteErrorUtils.genericToSiteError(sitesModel.error);
         } else {
             UpdateSitesResult res = createOrUpdateSites(sitesModel);
             event.rowsAffected = res.rowsAffected;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -73,6 +73,7 @@ public class SiteStore extends Store {
     public static class FetchedPostFormatsPayload extends Payload {
         public SiteModel site;
         public List<PostFormatModel> postFormats;
+        public PostFormatsError error;
         public FetchedPostFormatsPayload(@NonNull SiteModel site, @NonNull List<PostFormatModel> postFormats) {
             this.site = site;
             this.postFormats = postFormats;
@@ -144,9 +145,15 @@ public class SiteStore extends Store {
 
     public static class PostFormatsError implements OnChangedError {
         public PostFormatsErrorType type;
+        public String message;
 
         public PostFormatsError(PostFormatsErrorType type) {
+            this(type, "");
+        }
+
+        public PostFormatsError(PostFormatsErrorType type, String message) {
             this.type = type;
+            this.message = message;
         }
     }
 
@@ -290,7 +297,8 @@ public class SiteStore extends Store {
 
     public enum PostFormatsErrorType {
         INVALID_SITE,
-        GENERIC_ERROR
+        INVALID_RESPONSE,
+        GENERIC_ERROR;
     }
 
     public enum DeleteSiteErrorType {
@@ -841,8 +849,7 @@ public class SiteStore extends Store {
     private void updatePostFormats(FetchedPostFormatsPayload payload) {
         OnPostFormatsChanged event = new OnPostFormatsChanged(payload.site);
         if (payload.isError()) {
-            // TODO: what kind of error could we get here?
-            event.error = new PostFormatsError(PostFormatsErrorType.GENERIC_ERROR);
+            event.error = payload.error;
         } else {
             SiteSqlUtils.insertOrReplacePostFormats(payload.site, payload.postFormats);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/ErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/ErrorUtils.java
@@ -8,6 +8,9 @@ import java.util.Map;
 
 public class ErrorUtils {
     public static class OnUnexpectedError {
+        public static final String KEY_URL = "url";
+        public static final String KEY_RESPONSE = "response";
+
         public Exception exception;
         public String description;
         public Map<String, String> extras = new HashMap<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteErrorUtils.java
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.utils;
+
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
+import org.wordpress.android.fluxc.store.SiteStore.SiteError;
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
+
+public class SiteErrorUtils {
+    public static SiteError genericToSiteError(BaseNetworkError error) {
+        SiteErrorType errorType = SiteErrorType.GENERIC_ERROR;
+        if (error.isGeneric()) {
+            switch (error.type) {
+                case INVALID_RESPONSE:
+                    errorType = SiteErrorType.INVALID_RESPONSE;
+                    break;
+            }
+        }
+        return new SiteError(errorType, error.message);
+    }
+}


### PR DESCRIPTION
'Fixes' #456. The source of the crash was `wp.getOptions` returning a `String` instead of a `Map`. This probably means an irregular WP setup.

The app will no longer crash, and we'll now log the actual `String` response along with the site URL using `OnUnexpectedError`.

I broadened the fix a bit to apply to any XML-RPC site method that would throw a `ClassCastException`, handling it and logging the response. I also did the same for _any_ XML-RPC call that expects an `Object[]` but receives something else (all our fetch-list-of methods).

TODO:
* [x] Add some mocked `SiteXMLRPCClient` tests

cc @maxme