### PR TITLE
Issue/489 media mime fetch

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -35,6 +35,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         CANCELED_MEDIA,
         DELETED_MEDIA,
         FETCHED_MEDIA_LIST,
+        FETCHED_MEDIA_IMAGE_LIST,
         FETCHED_KNOWN_IMAGES,
         PUSHED_MEDIA,
         REMOVED_MEDIA,
@@ -96,6 +97,14 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
         fetchMediaList();
         assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+
+        // remove all media again, fetch only images, verify store is not empty and contains only images
+        mNextEvent = TestEvents.FETCHED_MEDIA_IMAGE_LIST;
+        removeAllSiteMedia();
+        fetchMediaImageList();
+        List<MediaModel> mediaList = mMediaStore.getSiteImages(sSite);
+        assertFalse(mediaList.isEmpty());
+        assertTrue(mMediaStore.getSiteMediaCount(sSite) == mediaList.size());
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -449,7 +458,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
             return;
         }
         if (event.cause == MediaAction.FETCHED_MEDIA_LIST) {
-            assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
+            boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
+                    || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
+            assertTrue(isMediaListEvent);
         } else if (event.cause == MediaAction.FETCH_MEDIA) {
             if (eventHasKnownImages(event)) {
                 assertEquals(TestEvents.FETCHED_KNOWN_IMAGES, mNextEvent);
@@ -470,7 +481,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
+        boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
+                || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
+        assertTrue(isMediaListEvent);
         mCountDownLatch.countDown();
     }
 
@@ -521,6 +534,13 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
     private void fetchMediaList() throws InterruptedException {
         FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void fetchMediaImageList() throws InterruptedException {
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false, MediaUtils.MIME_TYPE_IMAGE);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -98,9 +98,13 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         fetchMediaList();
         assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
-        // remove all media again, fetch only images, verify store is not empty and contains only images
-        mNextEvent = TestEvents.FETCHED_MEDIA_IMAGE_LIST;
+        // remove all media again
+        mNextEvent = TestEvents.REMOVED_MEDIA;
         removeAllSiteMedia();
+        assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+
+        // fetch only images, verify store is not empty and contains only images
+        mNextEvent = TestEvents.FETCHED_MEDIA_IMAGE_LIST;
         fetchMediaImageList();
         List<MediaModel> mediaList = mMediaStore.getSiteImages(sSite);
         assertFalse(mediaList.isEmpty());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -46,6 +46,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         CANCELED_MEDIA,
         DELETED_MEDIA,
         FETCHED_MEDIA_LIST,
+        FETCHED_MEDIA_IMAGE_LIST,
         FETCHED_MEDIA,
         PUSHED_MEDIA,
         REMOVED_MEDIA,
@@ -117,6 +118,14 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
         fetchMediaList();
         assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+
+        // remove all media again, fetch only images, verify store is not empty and contains only images
+        mNextEvent = TestEvents.FETCHED_MEDIA_IMAGE_LIST;
+        removeAllSiteMedia();
+        fetchMediaImageList();
+        List<MediaModel> mediaList = mMediaStore.getSiteImages(sSite);
+        assertFalse(mediaList.isEmpty());
+        assertTrue(mMediaStore.getSiteMediaCount(sSite) == mediaList.size());
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -546,6 +555,10 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
             } else if (event.cause == MediaAction.DELETE_MEDIA) {
                 assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
+            } else if (event.cause == MediaAction.FETCHED_MEDIA_LIST) {
+                boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
+                        || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
+                assertTrue(isMediaListEvent);
             }
         }
         mCountDownLatch.countDown();
@@ -557,7 +570,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
+        boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
+                || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
+        assertTrue(isMediaListEvent);
         mCountDownLatch.countDown();
     }
 
@@ -598,6 +613,13 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     private void fetchMediaList() throws InterruptedException {
         FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void fetchMediaImageList() throws InterruptedException {
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false, MediaUtils.MIME_TYPE_IMAGE);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -119,9 +119,13 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         fetchMediaList();
         assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
-        // remove all media again, fetch only images, verify store is not empty and contains only images
-        mNextEvent = TestEvents.FETCHED_MEDIA_IMAGE_LIST;
+        // remove all media again
+        mNextEvent = TestEvents.REMOVED_MEDIA;
         removeAllSiteMedia();
+        assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+
+        // fetch only images, verify store is not empty and contains only images
+        mNextEvent = TestEvents.FETCHED_MEDIA_IMAGE_LIST;
         fetchMediaImageList();
         List<MediaModel> mediaList = mMediaStore.getSiteImages(sSite);
         assertFalse(mediaList.isEmpty());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -218,7 +218,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         if (offset > 0) {
             params.put("offset", String.valueOf(offset));
         }
-        if (mimeType != null && mimeType.length() > 0) {
+        if (!TextUtils.isEmpty(mimeType)) {
             params.put("mime_type", mimeType);
         }
         String url = WPCOMREST.sites.site(site.getSiteId()).media.getUrlV1_1();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.media;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.android.volley.RequestQueue;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.media;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.android.volley.RequestQueue;
@@ -213,10 +214,16 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
     public void fetchMediaList(final SiteModel site, final int offset) {
+        fetchMediaList(site, offset, null);
+    }
+    public void fetchMediaList(final SiteModel site, final int offset, @Nullable String mimeType) {
         final Map<String, String> params = new HashMap<>();
         params.put("number", String.valueOf(MediaStore.NUM_MEDIA_PER_FETCH));
         if (offset > 0) {
             params.put("offset", String.valueOf(offset));
+        }
+        if (mimeType != null && mimeType.length() > 0) {
+            params.put("mime_type", mimeType);
         }
         String url = WPCOMREST.sites.site(site.getSiteId()).media.getUrlV1_1();
         add(WPComGsonRequest.buildGetRequest(url, params, MultipleMediaResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -213,10 +213,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * NOTE: Only media item data is gathered, the actual media file can be downloaded from the URL
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
-    public void fetchMediaList(final SiteModel site, final int offset) {
-        fetchMediaList(site, offset, null);
-    }
-    public void fetchMediaList(final SiteModel site, final int offset, @Nullable String mimeType) {
+    public void fetchMediaList(final SiteModel site, final int offset, String mimeType) {
         final Map<String, String> params = new HashMap<>();
         params.put("number", String.valueOf(MediaStore.NUM_MEDIA_PER_FETCH));
         if (offset > 0) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network.xmlrpc.media;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Base64;
 
@@ -244,10 +243,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     /**
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
-    public void fetchMediaList(final SiteModel site, final int offset) {
-        fetchMediaList(site, offset, null);
-    }
-    public void fetchMediaList(final SiteModel site, final int offset, @Nullable String mimeType) {
+    public void fetchMediaList(final SiteModel site, final int offset, String mimeType) {
         List<Object> params = getBasicParams(site, null);
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("number", MediaStore.NUM_MEDIA_PER_FETCH);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -250,7 +250,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         if (offset > 0) {
             queryParams.put("offset", offset);
         }
-        if (mimeType != null && mimeType.length() > 0) {
+        if (!TextUtils.isEmpty(mimeType)) {
             queryParams.put("mime_type", mimeType);
         }
         params.add(queryParams);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.xmlrpc.media;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Base64;
 
@@ -244,11 +245,17 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
     public void fetchMediaList(final SiteModel site, final int offset) {
+        fetchMediaList(site, offset, null);
+    }
+    public void fetchMediaList(final SiteModel site, final int offset, @Nullable String mimeType) {
         List<Object> params = getBasicParams(site, null);
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("number", MediaStore.NUM_MEDIA_PER_FETCH);
         if (offset > 0) {
             queryParams.put("offset", offset);
+        }
+        if (mimeType != null && mimeType.length() > 0) {
+            queryParams.put("mime_type", mimeType);
         }
         params.add(queryParams);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -29,6 +29,17 @@ public class MediaSqlUtils {
         return getMediaWithStatesQuery(site, uploadStates).getAsCursor();
     }
 
+    public static List<MediaModel> getMediaWithStatesAndMimeType(SiteModel site, List<String> uploadStates, String mimeType) {
+        return WellSql.select(MediaModel.class)
+                .where().beginGroup()
+                .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
+                .contains(MediaModelTable.MIME_TYPE, mimeType)
+                .isIn(MediaModelTable.UPLOAD_STATE, uploadStates)
+                .endGroup().endWhere()
+                .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING)
+                .getAsModel();
+    }
+
     public static WellCursor<MediaModel> getImagesWithStatesAsCursor(SiteModel site, List<String> uploadStates) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -29,7 +29,9 @@ public class MediaSqlUtils {
         return getMediaWithStatesQuery(site, uploadStates).getAsCursor();
     }
 
-    public static List<MediaModel> getMediaWithStatesAndMimeType(SiteModel site, List<String> uploadStates, String mimeType) {
+    public static List<MediaModel> getMediaWithStatesAndMimeType(SiteModel site,
+                                                                 List<String> uploadStates,
+                                                                 String mimeType) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -619,7 +619,11 @@ public class MediaStore extends Store {
         if (payload.loadMore) {
             List<String> list = new ArrayList<>();
             list.add(MediaUploadState.UPLOADED.toString());
-            offset = MediaSqlUtils.getMediaWithStates(payload.site, list).size();
+            if (!TextUtils.isEmpty(payload.mimeType)) {
+                offset = MediaSqlUtils.getMediaWithStatesAndMimeType(payload.site, list, payload.mimeType).size();
+            } else {
+                offset = MediaSqlUtils.getMediaWithStates(payload.site, list).size();
+            }
         }
         if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.fetchMediaList(payload.site, offset, payload.mimeType);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -64,6 +64,7 @@ public class MediaStore extends Store {
     public static class FetchMediaListPayload extends Payload {
         public SiteModel site;
         public boolean loadMore;
+        public String mimeType;
 
         public FetchMediaListPayload(SiteModel site) {
             this.site = site;
@@ -72,6 +73,12 @@ public class MediaStore extends Store {
         public FetchMediaListPayload(SiteModel site, boolean loadMore) {
             this.site = site;
             this.loadMore = loadMore;
+        }
+
+        public FetchMediaListPayload(SiteModel site, boolean loadMore, String mimeType) {
+            this.site = site;
+            this.loadMore = loadMore;
+            this.mimeType = mimeType;
         }
     }
 
@@ -615,9 +622,9 @@ public class MediaStore extends Store {
             offset = MediaSqlUtils.getMediaWithStates(payload.site, list).size();
         }
         if (payload.site.isUsingWpComRestApi()) {
-            mMediaRestClient.fetchMediaList(payload.site, offset);
+            mMediaRestClient.fetchMediaList(payload.site, offset, payload.mimeType);
         } else {
-            mMediaXmlrpcClient.fetchMediaList(payload.site, offset);
+            mMediaXmlrpcClient.fetchMediaList(payload.site, offset, payload.mimeType);
         }
     }
 


### PR DESCRIPTION
Fixes #489 - Adds a mime type parameter when fetching a media list. Note that both the REST and xmlrpc endpoints support partial matching, ie: we can use "image/" to fetch all images or "video/" to fetch all videos.