### PR TITLE
Omit token for 'public' endpoints

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -56,18 +56,30 @@ public class BaseWPComRestClient {
             request.addQueryParameter("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
         }
         // TODO: If !mAccountToken.exists() then trigger the mOnAuthFailedListener
-        return mRequestQueue.add(setRequestAuthParams(request));
+        return mRequestQueue.add(setRequestAuthParams(request, true));
+    }
+
+    public Request addUnauthedRequest(WPComGsonRequest request) {
+        // Add "locale=xx_XX" query parameter to all request by default
+        return addUnauthedRequest(request, true);
+    }
+
+    public Request addUnauthedRequest(WPComGsonRequest request, boolean addLocaleParameter) {
+        if (addLocaleParameter) {
+            request.addQueryParameter("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
+        }
+        return mRequestQueue.add(setRequestAuthParams(request, false));
     }
 
     protected AccessToken getAccessToken() {
         return mAccessToken;
     }
 
-    private WPComGsonRequest setRequestAuthParams(WPComGsonRequest request) {
+    private WPComGsonRequest setRequestAuthParams(WPComGsonRequest request, boolean shouldAuth) {
         request.setOnAuthFailedListener(mOnAuthFailedListener);
         request.setOnParseErrorListener(mOnParseErrorListener);
         request.setUserAgent(mUserAgent.getUserAgent());
-        request.setAccessToken(mAccessToken.get());
+        request.setAccessToken(shouldAuth ? mAccessToken.get() : null);
         return request;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -78,10 +78,6 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         return url;
     }
 
-    public void removeAccessToken() {
-        setAccessToken(null);
-    }
-
     public void setAccessToken(String token) {
         if (token == null) {
             mHeaders.remove(REST_AUTHORIZATION_HEADER);
@@ -89,7 +85,6 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
             mHeaders.put(REST_AUTHORIZATION_HEADER, String.format(REST_AUTHORIZATION_FORMAT, token));
         }
     }
-
     @Override
     public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
         WPComGsonNetworkError returnedError = new WPComGsonNetworkError(error);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -157,7 +157,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 }
         );
-        add(request);
+        addUnauthedRequest(request);
     }
 
     public void fetchWPComSiteByUrl(@NonNull final String siteUrl) {
@@ -208,7 +208,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 }
         );
-        add(request);
+        addUnauthedRequest(request);
     }
 
     public void checkUrlIsWPCom(@NonNull final String testedUrl) {
@@ -242,7 +242,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 }
         );
-        add(request);
+        addUnauthedRequest(request);
     }
 
     public void fetchSite(final SiteModel site) {
@@ -423,7 +423,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 }
         );
-        add(request);
+        addUnauthedRequest(request);
     }
 
     private SiteModel siteResponseToSiteModel(SiteWPComRestResponse from) {


### PR DESCRIPTION
Modifies the `FETCH_CONNECT_SITE_INFO`, `FETCH_WPCOM_SITE_BY_URL`, `IS_WPCOM_URL` and `SUGGEST_DOMAINS` actions to always make unauthenticated requests to WP.com (that is to say, not use a token even if it exists).

(`FETCH_WPCOM_SITE_BY_URL` calls `/sites/$siteUrl/`, which is not necessarily 'public', as a token matching the site would retrieve more information from the API - but we're using it exclusively for login/discovery for the foreseeable future.)

@hypest pointed out that if FluxC has an invalid token, requests to these endpoints will return an error, when omitting the token altogether would've given a successful response.

Note: #474 should be merged before this PR and the base branch updated..