### PR TITLE
Bumping OkHttp version to 3.8.1

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -73,8 +73,8 @@ dependencies {
 
     // External libs
     compile 'org.greenrobot:eventbus:3.0.0'
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.4.1'
+    compile 'com.squareup.okhttp3:okhttp:3.8.1'
+    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.8.1'
     compile 'com.android.volley:volley:1.0.0'
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.google.dagger:dagger:2.0.2'


### PR DESCRIPTION
This is needed in order to take advantage of some [important bugfixes since 3.4.1](https://github.com/square/okhttp/blob/master/CHANGELOG.md) 

These are of particular interest: 

> 3.6.0
> Fix: Calling disconnect() on a connecting HttpUrlConnection could cause it to retry in an infinite loop! This regression was introduced in OkHttp 2.7.0.

and

> 3.8.1
> Fix: Recover gracefully from stale coalesced connections. We had a bug where connection coalescing (introduced in OkHttp 3.7.0) and stale connection recovery could interact to cause a NoSuchElementException crash in the RouteSelector.

See [related WPAndroid issue ](https://github.com/wordpress-mobile/WordPress-Android/issues/6155)

cc @aforcier 