### PR TITLE
Issue/496 media fetch clear mime type

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -212,7 +212,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * NOTE: Only media item data is gathered, the actual media file can be downloaded from the URL
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
-    public void fetchMediaList(final SiteModel site, final int offset, String mimeType) {
+    public void fetchMediaList(final SiteModel site, final int offset, final String mimeType) {
         final Map<String, String> params = new HashMap<>();
         params.put("number", String.valueOf(MediaStore.NUM_MEDIA_PER_FETCH));
         if (offset > 0) {
@@ -230,7 +230,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         if (mediaList != null) {
                             AppLog.v(T.MEDIA, "Fetched media list for site with size: " + mediaList.size());
                             boolean canLoadMore = mediaList.size() == MediaStore.NUM_MEDIA_PER_FETCH;
-                            notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore);
+                            notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore, mimeType);
                         } else {
                             AppLog.w(T.MEDIA, "could not parse Fetch all media response: " + response);
                             MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
@@ -419,10 +419,13 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, @NonNull List<MediaModel> media,
-                                        boolean loadedMore, boolean canLoadMore) {
+    private void notifyMediaListFetched(SiteModel site,
+                                        @NonNull List<MediaModel> media,
+                                        boolean loadedMore,
+                                        boolean canLoadMore,
+                                        String mimeType) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
-                loadedMore, canLoadMore);
+                loadedMore, canLoadMore, mimeType);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -243,7 +243,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     /**
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
-    public void fetchMediaList(final SiteModel site, final int offset, String mimeType) {
+    public void fetchMediaList(final SiteModel site, final int offset, final String mimeType) {
         List<Object> params = getBasicParams(site, null);
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("number", MediaStore.NUM_MEDIA_PER_FETCH);
@@ -263,7 +263,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         if (mediaList != null) {
                             AppLog.v(T.MEDIA, "Fetched media list for site via XMLRPC.GET_MEDIA_LIBRARY");
                             boolean canLoadMore = mediaList.size() == MediaStore.NUM_MEDIA_PER_FETCH;
-                            notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore);
+                            notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore, mimeType);
                         } else {
                             AppLog.w(T.MEDIA, "could not parse XMLRPC.GET_MEDIA_LIBRARY response: "
                                     + Arrays.toString(response));
@@ -432,10 +432,13 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, @NonNull List<MediaModel> media,
-                                        boolean loadedMore, boolean canLoadMore) {
+    private void notifyMediaListFetched(SiteModel site,
+                                        @NonNull List<MediaModel> media,
+                                        boolean loadedMore,
+                                        boolean canLoadMore,
+                                        String mimeType) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
-                loadedMore, canLoadMore);
+                loadedMore, canLoadMore, mimeType);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -346,6 +346,15 @@ public class MediaSqlUtils {
                 .endGroup().endWhere().execute();
     }
 
+    public static int deleteAllUploadedSiteMediaWithMimeType(SiteModel siteModel, String mimeType) {
+        return WellSql.delete(MediaModel.class)
+                .where().beginGroup()
+                .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
+                .equals(MediaModelTable.UPLOAD_STATE, MediaUploadState.UPLOADED.toString())
+                .contains(MediaModelTable.MIME_TYPE, mimeType)
+                .endGroup().endWhere().execute();
+    }
+
     public static int deleteAllMedia() {
         return WellSql.delete(MediaModel.class).execute();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -724,7 +724,11 @@ public class MediaStore extends Store {
             // Clear existing media if this is a fresh fetch (loadMore = false in the original request)
             // This is the simplest way of keeping our local media in sync with remote media (in case of deletions)
             if (!payload.loadedMore) {
-                MediaSqlUtils.deleteAllUploadedSiteMedia(payload.site);
+                if (TextUtils.isEmpty(payload.mimeType)) {
+                    MediaSqlUtils.deleteAllUploadedSiteMedia(payload.site);
+                } else {
+                    MediaSqlUtils.deleteAllUploadedSiteMediaWithMimeType(payload.site, payload.mimeType);
+                }
             }
             if (!payload.mediaList.isEmpty()) {
                 for (MediaModel media : payload.mediaList) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -211,9 +211,11 @@ public class MediaStore extends Store {
     public static class OnMediaListFetched extends OnChanged<MediaError> {
         public SiteModel site;
         public boolean canLoadMore;
-        public OnMediaListFetched(SiteModel site, boolean canLoadMore) {
+        public String mimeType;
+        public OnMediaListFetched(SiteModel site, boolean canLoadMore, String mimeType) {
             this.site = site;
             this.canLoadMore = canLoadMore;
+            this.mimeType = mimeType;
         }
         public OnMediaListFetched(SiteModel site, MediaError error) {
             this.site = site;
@@ -735,7 +737,7 @@ public class MediaStore extends Store {
                     updateMedia(media, false);
                 }
             }
-            onMediaListFetched = new OnMediaListFetched(payload.site, payload.canLoadMore);
+            onMediaListFetched = new OnMediaListFetched(payload.site, payload.canLoadMore, payload.mimeType);
         }
 
         emitChange(onMediaListFetched);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -91,12 +91,17 @@ public class MediaStore extends Store {
         public List<MediaModel> mediaList;
         public boolean loadedMore;
         public boolean canLoadMore;
-        public FetchMediaListResponsePayload(SiteModel site, @NonNull List<MediaModel> mediaList, boolean loadedMore,
-                                             boolean canLoadMore) {
+        public String mimeType;
+        public FetchMediaListResponsePayload(SiteModel site,
+                                             @NonNull List<MediaModel> mediaList,
+                                             boolean loadedMore,
+                                             boolean canLoadMore,
+                                             String mimeType) {
             this.site = site;
             this.mediaList = mediaList;
             this.loadedMore = loadedMore;
             this.canLoadMore = canLoadMore;
+            this.mimeType = mimeType;
         }
 
         public FetchMediaListResponsePayload(SiteModel site, MediaError error) {


### PR DESCRIPTION
Fixes #496 - prior to this PR we were clearing the media store after the media list was fetched, this PR changes it to only clear the store of media matching the requested mime type. I also updated `OnMediaListFetched` to include the requested mime type so that WPAndroid would know what mime type was requested.