### PR TITLE
Media connected test tweaks

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import android.annotation.SuppressLint;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
@@ -23,11 +25,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+@SuppressLint("UseSparseArrays")
 public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     @Inject MediaStore mMediaStore;
 
@@ -49,7 +53,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     private long mLastUploadedId = -1L;
 
     private List<Long> mUploadedIds = new ArrayList<>();
-    private HashMap<Integer, MediaModel> mUploadedMediaModels = new HashMap<>();
+    private Map<Integer, MediaModel> mUploadedMediaModels = new HashMap<>();
 
     @Override
     protected void setUp() throws Exception {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -461,11 +461,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
             mCountDownLatch.countDown();
             return;
         }
-        if (event.cause == MediaAction.FETCHED_MEDIA_LIST) {
-            boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
-                    || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
-            assertTrue(isMediaListEvent);
-        } else if (event.cause == MediaAction.FETCH_MEDIA) {
+        if (event.cause == MediaAction.FETCH_MEDIA) {
             if (eventHasKnownImages(event)) {
                 assertEquals(TestEvents.FETCHED_KNOWN_IMAGES, mNextEvent);
             }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -475,6 +475,8 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
             assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
         } else if (event.cause == MediaAction.REMOVE_MEDIA) {
             assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
+        } else {
+            throw new AssertionError("Unexpected event: " + event.cause);
         }
         mCountDownLatch.countDown();
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import android.annotation.SuppressLint;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
@@ -27,11 +29,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+@SuppressLint("UseSparseArrays")
 public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @SuppressWarnings("unused")
     @Inject AccountStore mAccountStore;
@@ -62,7 +66,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private long mLastUploadedId = -1L;
 
     private List<Long> mUploadedIds = new ArrayList<>();
-    private HashMap<Integer, MediaModel> mUploadedMediaModels = new HashMap<>();
+    private Map<Integer, MediaModel> mUploadedMediaModels = new HashMap<>();
 
     @Override
     protected void setUp() throws Exception {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -559,10 +559,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
             } else if (event.cause == MediaAction.DELETE_MEDIA) {
                 assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
-            } else if (event.cause == MediaAction.FETCHED_MEDIA_LIST) {
-                boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
-                        || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
-                assertTrue(isMediaListEvent);
             } else if (event.cause == MediaAction.REMOVE_MEDIA) {
                 assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
             } else {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -563,6 +563,10 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
                         || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
                 assertTrue(isMediaListEvent);
+            } else if (event.cause == MediaAction.REMOVE_MEDIA) {
+                assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
+            } else {
+                throw new AssertionError("Unexpected event: " + event.cause);
             }
         }
         mCountDownLatch.countDown();

--- a/example/tests.properties-example
+++ b/example/tests.properties-example
@@ -177,7 +177,10 @@ TEST_WPCOM_USERNAME_JETPACK_UPLOAD_LIMIT = FIXME
 TEST_WPCOM_PASSWORD_JETPACK_UPLOAD_LIMIT = FIXME
 
 ## Local
+# These files should be at least 500KB, otherwise they may cause cancellation tests to fail on fast enough connections
 
-# Local image to test upload
+# Path (on device) to a test image for uploading, e.g. /sdcard/Pictures/flux-capacitor-schematics.png
 TEST_LOCAL_IMAGE = FIXME
+
+# Path (on device) to a test video for uploading, e.g. /sdcard/Video/1985-10-26-Einstein-temporal-experiment.mp4
 TEST_LOCAL_VIDEO = FIXME

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -56,7 +56,7 @@ import okhttp3.Response;
  *
  * <ul>
  *     <li>Fetch existing media from a WP.com site
- *     (via {@link #fetchMediaList(SiteModel, int)} and {@link #fetchMedia(SiteModel, MediaModel)}</li>
+ *     (via {@link #fetchMediaList(SiteModel, int, String)} and {@link #fetchMedia(SiteModel, MediaModel)}</li>
  *     <li>Push new media to a WP.com site
  *     (via {@link #uploadMedia(SiteModel, MediaModel)})</li>
  *     <li>Push updates to existing media to a WP.com site


### PR DESCRIPTION
Some small tweaks/cleanup for our connected media tests:

* Drop some unused test event matching
* Stricter matching of event cause when receiving an `OnMediaChanged`
* Add some explanatory notes to `tests.properties-example` about the test media files
* Suppress annoying `SparseArray` warnings - it's not an optimization we really need, and iterating through the keys would turn out to be pretty clunky (it lacks a `values()` implementation)

cc @mzorz 