### PR TITLE
issue/499-request-48-media

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
@@ -134,7 +134,8 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
         mCountDownLatch = new CountDownLatch(1);
 
-        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(site, false);
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(
+                site, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -537,14 +537,16 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     }
 
     private void fetchMediaList() throws InterruptedException {
-        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false);
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(
+                sSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchMediaImageList() throws InterruptedException {
-        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false, MediaUtils.MIME_TYPE_IMAGE);
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(
+                sSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false, MediaUtils.MIME_TYPE_IMAGE);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -616,14 +616,16 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     private void fetchMediaList() throws InterruptedException {
-        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false);
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(
+                sSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchMediaImageList() throws InterruptedException {
-        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(sSite, false, MediaUtils.MIME_TYPE_IMAGE);
+        FetchMediaListPayload fetchPayload = new FetchMediaListPayload(
+                sSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false, MediaUtils.MIME_TYPE_IMAGE);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -255,7 +255,7 @@ public class MediaFragment extends Fragment {
     }
 
     private void fetchMediaList(@NonNull SiteModel site) {
-        FetchMediaListPayload payload = new FetchMediaListPayload(site, false);
+        FetchMediaListPayload payload = new FetchMediaListPayload(site, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload));
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -255,7 +255,8 @@ public class MediaFragment extends Fragment {
     }
 
     private void fetchMediaList(@NonNull SiteModel site) {
-        FetchMediaListPayload payload = new FetchMediaListPayload(site, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
+        FetchMediaListPayload payload = new FetchMediaListPayload(
+                site, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -57,7 +57,7 @@ import okhttp3.ResponseBody;
  *
  * <ul>
  *     <li>Fetch existing media from a WP.com site
- *     (via {@link #fetchMediaList(SiteModel, int, String)} and {@link #fetchMedia(SiteModel, MediaModel)}</li>
+ *     (via {@link #fetchMediaList(SiteModel, int, int, String)} and {@link #fetchMedia(SiteModel, MediaModel)}</li>
  *     <li>Push new media to a WP.com site
  *     (via {@link #uploadMedia(SiteModel, MediaModel)})</li>
  *     <li>Push updates to existing media to a WP.com site
@@ -220,9 +220,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * NOTE: Only media item data is gathered, the actual media file can be downloaded from the URL
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
-    public void fetchMediaList(final SiteModel site, final int offset, final String mimeType) {
+    public void fetchMediaList(final SiteModel site, final int number, final int offset, final String mimeType) {
         final Map<String, String> params = new HashMap<>();
-        params.put("number", String.valueOf(MediaStore.NUM_MEDIA_PER_FETCH));
+        params.put("number", String.valueOf(number));
         if (offset > 0) {
             params.put("offset", String.valueOf(offset));
         }
@@ -237,7 +237,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         List<MediaModel> mediaList = getMediaListFromRestResponse(response, site.getId());
                         if (mediaList != null) {
                             AppLog.v(T.MEDIA, "Fetched media list for site with size: " + mediaList.size());
-                            boolean canLoadMore = mediaList.size() == MediaStore.NUM_MEDIA_PER_FETCH;
+                            boolean canLoadMore = mediaList.size() == number;
                             notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore, mimeType);
                         } else {
                             AppLog.w(T.MEDIA, "could not parse Fetch all media response: " + response);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -26,7 +26,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaWPComRestResponse.MultipleMediaResponse;
-import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -26,7 +26,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaWPComRestResponse.MultipleMediaResponse;
-import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
@@ -56,7 +55,7 @@ import okhttp3.Response;
  *
  * <ul>
  *     <li>Fetch existing media from a WP.com site
- *     (via {@link #fetchMediaList(SiteModel, int)} and {@link #fetchMedia(SiteModel, MediaModel)}</li>
+ *     (via {@link #fetchMediaList(SiteModel, int, int, String)} and {@link #fetchMedia(SiteModel, MediaModel)}</li>
  *     <li>Push new media to a WP.com site
  *     (via {@link #uploadMedia(SiteModel, MediaModel)})</li>
  *     <li>Push updates to existing media to a WP.com site
@@ -212,9 +211,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * NOTE: Only media item data is gathered, the actual media file can be downloaded from the URL
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
-    public void fetchMediaList(final SiteModel site, final int offset, final String mimeType) {
+    public void fetchMediaList(final SiteModel site, final int number, final int offset, final String mimeType) {
         final Map<String, String> params = new HashMap<>();
-        params.put("number", String.valueOf(MediaStore.NUM_MEDIA_PER_FETCH));
+        params.put("number", String.valueOf(number));
         if (offset > 0) {
             params.put("offset", String.valueOf(offset));
         }
@@ -229,7 +228,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         List<MediaModel> mediaList = getMediaListFromRestResponse(response, site.getId());
                         if (mediaList != null) {
                             AppLog.v(T.MEDIA, "Fetched media list for site with size: " + mediaList.size());
-                            boolean canLoadMore = mediaList.size() == MediaStore.NUM_MEDIA_PER_FETCH;
+                            boolean canLoadMore = mediaList.size() == number;
                             notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore, mimeType);
                         } else {
                             AppLog.w(T.MEDIA, "could not parse Fetch all media response: " + response);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCException;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCFault;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLSerializerUtils;
-import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
@@ -243,10 +242,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     /**
      * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
-    public void fetchMediaList(final SiteModel site, final int offset, final String mimeType) {
+    public void fetchMediaList(final SiteModel site, final int number, final int offset, final String mimeType) {
         List<Object> params = getBasicParams(site, null);
         Map<String, Object> queryParams = new HashMap<>();
-        queryParams.put("number", MediaStore.NUM_MEDIA_PER_FETCH);
+        queryParams.put("number", number);
         if (offset > 0) {
             queryParams.put("offset", offset);
         }
@@ -262,7 +261,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         List<MediaModel> mediaList = getMediaListFromXmlrpcResponse(response, site.getId());
                         if (mediaList != null) {
                             AppLog.v(T.MEDIA, "Fetched media list for site via XMLRPC.GET_MEDIA_LIBRARY");
-                            boolean canLoadMore = mediaList.size() == MediaStore.NUM_MEDIA_PER_FETCH;
+                            boolean canLoadMore = mediaList.size() == number;
                             notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore, mimeType);
                         } else {
                             AppLog.w(T.MEDIA, "could not parse XMLRPC.GET_MEDIA_LIBRARY response: "

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -35,7 +35,7 @@ import javax.inject.Singleton;
 
 @Singleton
 public class MediaStore extends Store {
-    public static final int NUM_MEDIA_PER_FETCH = 48;
+    public static final int DEFAULT_NUM_MEDIA_PER_FETCH = 50;
 
     //
     // Payloads
@@ -65,20 +65,23 @@ public class MediaStore extends Store {
         public SiteModel site;
         public boolean loadMore;
         public String mimeType;
+        public int number = DEFAULT_NUM_MEDIA_PER_FETCH;
 
         public FetchMediaListPayload(SiteModel site) {
             this.site = site;
         }
 
-        public FetchMediaListPayload(SiteModel site, boolean loadMore) {
+        public FetchMediaListPayload(SiteModel site, int number, boolean loadMore) {
             this.site = site;
             this.loadMore = loadMore;
+            this.number = number;
         }
 
-        public FetchMediaListPayload(SiteModel site, boolean loadMore, String mimeType) {
+        public FetchMediaListPayload(SiteModel site, int number, boolean loadMore, String mimeType) {
             this.site = site;
             this.loadMore = loadMore;
             this.mimeType = mimeType;
+            this.number = number;
         }
     }
 
@@ -633,9 +636,9 @@ public class MediaStore extends Store {
             }
         }
         if (payload.site.isUsingWpComRestApi()) {
-            mMediaRestClient.fetchMediaList(payload.site, offset, payload.mimeType);
+            mMediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
         } else {
-            mMediaXmlrpcClient.fetchMediaList(payload.site, offset, payload.mimeType);
+            mMediaXmlrpcClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -35,7 +35,7 @@ import javax.inject.Singleton;
 
 @Singleton
 public class MediaStore extends Store {
-    public static final int NUM_MEDIA_PER_FETCH = 50;
+    public static final int NUM_MEDIA_PER_FETCH = 48;
 
     //
     // Payloads


### PR DESCRIPTION
Fixes #499 - fetches media 48 at a time so it's a multiple of the column count in WPAndroid (3 in portrait, 4 in landscape).