### PR TITLE
Always populate the mimeType field in FetchMediaListResponsePayload

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -234,7 +234,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         } else {
                             AppLog.w(T.MEDIA, "could not parse Fetch all media response: " + response);
                             MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
-                            notifyMediaListFetched(site, error);
+                            notifyMediaListFetched(site, error, mimeType);
                         }
                     }
                 }, new BaseErrorListener() {
@@ -242,7 +242,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(T.MEDIA, "VolleyError Fetching media: " + error);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
-                        notifyMediaListFetched(site, mediaError);
+                        notifyMediaListFetched(site, mediaError, mimeType);
                     }
                 }
         ));
@@ -429,8 +429,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, MediaError error) {
-        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, error);
+    private void notifyMediaListFetched(SiteModel site, MediaError error, String mimeType) {
+        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, error, mimeType);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -268,7 +268,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                             AppLog.w(T.MEDIA, "could not parse XMLRPC.GET_MEDIA_LIBRARY response: "
                                     + Arrays.toString(response));
                             MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
-                            notifyMediaListFetched(site, error);
+                            notifyMediaListFetched(site, error, mimeType);
                         }
                     }
                 }, new BaseErrorListener() {
@@ -276,7 +276,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(T.MEDIA, "XMLRPC.GET_MEDIA_LIBRARY error response:", error.volleyError);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
-                        notifyMediaListFetched(site, mediaError);
+                        notifyMediaListFetched(site, mediaError, mimeType);
                     }
                 }
         ));
@@ -442,8 +442,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, MediaError error) {
-        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, error);
+    private void notifyMediaListFetched(SiteModel site, MediaError error, String mimeType) {
+        FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, error, mimeType);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -104,10 +104,13 @@ public class MediaStore extends Store {
             this.mimeType = mimeType;
         }
 
-        public FetchMediaListResponsePayload(SiteModel site, MediaError error) {
+        public FetchMediaListResponsePayload(SiteModel site,
+                                             MediaError error,
+                                             String mimeType) {
             this.mediaList = new ArrayList<>();
             this.site = site;
             this.error = error;
+            this.mimeType = mimeType;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -220,9 +220,10 @@ public class MediaStore extends Store {
             this.canLoadMore = canLoadMore;
             this.mimeType = mimeType;
         }
-        public OnMediaListFetched(SiteModel site, MediaError error) {
+        public OnMediaListFetched(SiteModel site, MediaError error, String mimeType) {
             this.site = site;
             this.error = error;
+            this.mimeType = mimeType;
         }
     }
 
@@ -724,7 +725,7 @@ public class MediaStore extends Store {
         OnMediaListFetched onMediaListFetched;
 
         if (payload.isError()) {
-            onMediaListFetched = new OnMediaListFetched(payload.site, payload.error);
+            onMediaListFetched = new OnMediaListFetched(payload.site, payload.error, payload.mimeType);
         } else {
             // Clear existing media if this is a fresh fetch (loadMore = false in the original request)
             // This is the simplest way of keeping our local media in sync with remote media (in case of deletions)


### PR DESCRIPTION
Fix #501 by including the mimeType of the request in case of errors retrieving the media list.

This info is required in wp-android to check that's the *current* media list request that it's failing. 