### PR TITLE
Media client linting

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseUploadRequestBody.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network;
 
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import org.wordpress.android.fluxc.model.MediaModel;
@@ -100,7 +101,7 @@ public abstract class BaseUploadRequestBody extends RequestBody {
         }
 
         @Override
-        public void write(Buffer source, long byteCount) throws IOException {
+        public void write(@NonNull Buffer source, long byteCount) throws IOException {
             super.write(source, byteCount);
             mBytesWritten += byteCount;
             long currentTimeMillis = System.currentTimeMillis();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -162,7 +162,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         AppLog.d(T.MEDIA, "starting upload for: " + media.getId());
         call.enqueue(new Callback() {
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
+            public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
                 if (response.isSuccessful()) {
                     AppLog.d(T.MEDIA, "media upload successful: " + response);
                     String jsonBody = response.body().string();
@@ -190,7 +190,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
             }
 
             @Override
-            public void onFailure(Call call, IOException e) {
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
                 AppLog.w(T.MEDIA, "media upload failed: " + e);
                 if (!mCurrentUploadCalls.containsKey(media.getId())) {
                     // This call has already been removed from the in-progress list - probably because it was cancelled

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -49,6 +49,7 @@ import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 /**
  * MediaRestClient provides an interface for manipulating a WP.com site's media. It provides
@@ -164,8 +165,15 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
             @Override
             public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
                 if (response.isSuccessful()) {
+                    ResponseBody responseBody = response.body();
+                    if (responseBody == null) {
+                        AppLog.e(T.MEDIA, "error uploading media, response body was empty " + response);
+                        notifyMediaUploaded(media, new MediaError(MediaErrorType.PARSE_ERROR));
+                        return;
+                    }
+
                     AppLog.d(T.MEDIA, "media upload successful: " + response);
-                    String jsonBody = response.body().string();
+                    String jsonBody = responseBody.string();
 
                     Gson gson = new Gson();
                     JsonReader reader = new JsonReader(new StringReader(jsonBody));
@@ -365,7 +373,13 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
             return mediaError;
         }
         try {
-            JSONObject body = new JSONObject(response.body().string());
+            ResponseBody responseBody = response.body();
+            if (responseBody == null) {
+                AppLog.e(T.MEDIA, "error uploading media, response body was empty " + response);
+                mediaError.type = MediaErrorType.PARSE_ERROR;
+                return mediaError;
+            }
+            JSONObject body = new JSONObject(responseBody.string());
             // Can be an array or errors
             if (body.has("errors")) {
                 JSONArray errors = body.getJSONArray("errors");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media;
 
+import android.support.annotation.NonNull;
+
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.network.BaseUploadRequestBody;
 import org.wordpress.android.util.AppLog;
@@ -54,7 +56,7 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
     }
 
     @Override
-    public void writeTo(BufferedSink sink) throws IOException {
+    public void writeTo(@NonNull BufferedSink sink) throws IOException {
         CountingSink countingSink = new CountingSink(sink);
         BufferedSink bufferedSink = Okio.buffer(countingSink);
         mMultipartBody.writeTo(bufferedSink);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -183,7 +183,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         AppLog.d(T.MEDIA, "starting upload for: " + media.getId());
         call.enqueue(new Callback() {
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
+            public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
                 if (response.code() == HttpURLConnection.HTTP_OK) {
                     // HTTP_OK code doesn't mean the upload is successful, XML-RPC API returns code 200 with an
                     // xml field "faultCode" on error.
@@ -226,7 +226,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             }
 
             @Override
-            public void onFailure(Call call, IOException e) {
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
                 AppLog.w(T.MEDIA, "media upload failed: " + e);
                 if (!mCurrentUploadCalls.containsKey(media.getId())) {
                     // This call has already been removed from the in-progress list - probably because it was cancelled

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.xmlrpc.media;
 
+import android.support.annotation.NonNull;
 import android.util.Base64;
 
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -95,7 +96,7 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
     }
 
     @Override
-    public void writeTo(BufferedSink sink) throws IOException {
+    public void writeTo(@NonNull BufferedSink sink) throws IOException {
         CountingSink countingSink = new CountingSink(sink);
         BufferedSink bufferedSink = Okio.buffer(countingSink);
 


### PR DESCRIPTION
Fixes a few nullability lint warnings coming from [updating to OkHttp 3.8.1](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/494).

cc @mzorz