### PR TITLE
Split up FETCHED_SITES action

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -46,6 +46,8 @@ public enum SiteAction implements IAction {
     // Remote responses
     @Action(payloadType = SitesModel.class)
     FETCHED_SITES,
+    @Action(payloadType = SitesModel.class)
+    FETCHED_SITES_XML_RPC,
     @Action(payloadType = NewSiteResponsePayload.class)
     CREATED_NEW_SITE,
     @Action(payloadType = FetchedPostFormatsPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -45,11 +45,11 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                     public void onResponse(Object response) {
                         SitesModel sites = sitesResponseToSitesModel(response, username, password);
                         if (sites != null) {
-                            mDispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sites));
+                            mDispatcher.dispatch(SiteActionBuilder.newFetchedSitesXmlRpcAction(sites));
                         } else {
                             sites = new SitesModel();
                             sites.error = new BaseNetworkError(GenericErrorType.INVALID_RESPONSE);
-                            mDispatcher.dispatch(SiteActionBuilder.newFetchedSitesAction(sites));
+                            mDispatcher.dispatch(SiteActionBuilder.newFetchedSitesXmlRpcAction(sites));
                         }
                     }
                 },
@@ -58,7 +58,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         SitesModel sites = new SitesModel();
                         sites.error = error;
-                        mDispatcher.dispatch(SiteActionBuilder.newFetchedSitesAction(sites));
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchedSitesXmlRpcAction(sites));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -671,8 +671,14 @@ public class SiteStore extends Store {
             case FETCH_SITES:
                 mSiteRestClient.fetchSites();
                 break;
+            case FETCHED_SITES:
+                handleFetchedSitesWPComRest((SitesModel) action.getPayload());
+                break;
             case FETCH_SITES_XML_RPC:
                 fetchSitesXmlRpc((RefreshSitesXMLRPCPayload) action.getPayload());
+                break;
+            case FETCHED_SITES_XML_RPC:
+                updateSites((SitesModel) action.getPayload());
                 break;
             case UPDATE_SITE:
                 updateSite((SiteModel) action.getPayload());
@@ -743,13 +749,10 @@ public class SiteStore extends Store {
             case SUGGESTED_DOMAINS:
                 handleSuggestedDomains((SuggestDomainsResponsePayload) action.getPayload());
                 break;
-            case FETCHED_SITES:
-                handleFetchedSites((SitesModel) action.getPayload());
-                break;
         }
     }
 
-    private void handleFetchedSites(SitesModel fetchedSites) {
+    private void handleFetchedSitesWPComRest(SitesModel fetchedSites) {
         OnSiteChanged event = new OnSiteChanged(0);
         if (fetchedSites.isError()) {
             // TODO: what kind of error could we get here?

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -689,8 +689,14 @@ public class SiteStore extends Store {
             case DELETE_SITE:
                 deleteSite((SiteModel) action.getPayload());
                 break;
+            case DELETED_SITE:
+                handleDeletedSite((DeleteSiteResponsePayload) action.getPayload());
+                break;
             case EXPORT_SITE:
                 exportSite((SiteModel) action.getPayload());
+                break;
+            case EXPORTED_SITE:
+                handleExportedSite((ExportSiteResponsePayload) action.getPayload());
                 break;
             case REMOVE_SITE:
                 removeSite((SiteModel) action.getPayload());
@@ -710,18 +716,6 @@ public class SiteStore extends Store {
             case CREATE_NEW_SITE:
                 createNewSite((NewSitePayload) action.getPayload());
                 break;
-            case FETCH_CONNECT_SITE_INFO:
-                fetchConnectSiteInfo((String) action.getPayload());
-                break;
-            case FETCH_WPCOM_SITE_BY_URL:
-                fetchWPComSiteByUrl((String) action.getPayload());
-                break;
-            case IS_WPCOM_URL:
-                checkUrlIsWPCom((String) action.getPayload());
-                break;
-            case SUGGEST_DOMAINS:
-                suggestDomains((SuggestDomainsPayload) action.getPayload());
-                break;
             case CREATED_NEW_SITE:
                 handleCreateNewSiteCompleted((NewSiteResponsePayload) action.getPayload());
                 break;
@@ -731,73 +725,31 @@ public class SiteStore extends Store {
             case FETCHED_POST_FORMATS:
                 updatePostFormats((FetchedPostFormatsPayload) action.getPayload());
                 break;
-            case DELETED_SITE:
-                handleDeletedSite((DeleteSiteResponsePayload) action.getPayload());
-                break;
-            case EXPORTED_SITE:
-                handleExportedSite((ExportSiteResponsePayload) action.getPayload());
+            case FETCH_CONNECT_SITE_INFO:
+                fetchConnectSiteInfo((String) action.getPayload());
                 break;
             case FETCHED_CONNECT_SITE_INFO:
                 handleFetchedConnectSiteInfo((ConnectSiteInfoPayload) action.getPayload());
                 break;
+            case FETCH_WPCOM_SITE_BY_URL:
+                fetchWPComSiteByUrl((String) action.getPayload());
+                break;
             case FETCHED_WPCOM_SITE_BY_URL:
                 handleFetchedWPComSiteByUrl((FetchWPComSiteResponsePayload) action.getPayload());
                 break;
+            case IS_WPCOM_URL:
+                checkUrlIsWPCom((String) action.getPayload());
+                break;
             case CHECKED_IS_WPCOM_URL:
                 handleCheckedIsWPComUrl((IsWPComResponsePayload) action.getPayload());
+                break;
+            case SUGGEST_DOMAINS:
+                suggestDomains((SuggestDomainsPayload) action.getPayload());
                 break;
             case SUGGESTED_DOMAINS:
                 handleSuggestedDomains((SuggestDomainsResponsePayload) action.getPayload());
                 break;
         }
-    }
-
-    private void handleFetchedSitesWPComRest(SitesModel fetchedSites) {
-        OnSiteChanged event = new OnSiteChanged(0);
-        if (fetchedSites.isError()) {
-            // TODO: what kind of error could we get here?
-            event.error = new SiteError(SiteErrorType.GENERIC_ERROR);
-        } else {
-            UpdateSitesResult res = createOrUpdateSites(fetchedSites);
-            event.rowsAffected = res.rowsAffected;
-            if (res.duplicateSiteFound) {
-                event.error = new SiteError(SiteErrorType.DUPLICATE_SITE);
-            }
-            SiteSqlUtils.removeWPComRestSitesAbsentFromList(fetchedSites.getSites());
-        }
-        emitChange(event);
-    }
-
-    private void removeSite(SiteModel site) {
-        int rowsAffected = SiteSqlUtils.deleteSite(site);
-        emitChange(new OnSiteRemoved(rowsAffected));
-    }
-
-    private void removeAllSites() {
-        int rowsAffected = SiteSqlUtils.deleteAllSites();
-        OnAllSitesRemoved event = new OnAllSitesRemoved(rowsAffected);
-        emitChange(event);
-    }
-
-    private void removeWPComAndJetpackSites() {
-        // Logging out of WP.com. Drop all WP.com sites, and all Jetpack sites that were fetched over the WP.com
-        // REST API only (they don't have a .org site id)
-        List<SiteModel> wpcomAndJetpackSites = SiteSqlUtils.getSitesAccessedViaWPComRest().getAsModel();
-        int rowsAffected = removeSites(wpcomAndJetpackSites);
-        emitChange(new OnSiteRemoved(rowsAffected));
-    }
-
-    private void createNewSite(NewSitePayload payload) {
-        mSiteRestClient.newSite(payload.siteName, payload.siteTitle, payload.language, payload.visibility,
-                payload.dryRun);
-    }
-
-    private void handleCreateNewSiteCompleted(NewSiteResponsePayload payload) {
-        OnNewSiteCreated onNewSiteCreated = new OnNewSiteCreated();
-        onNewSiteCreated.error = payload.error;
-        onNewSiteCreated.dryRun = payload.dryRun;
-        onNewSiteCreated.newSiteRemoteId = payload.newSiteRemoteId;
-        emitChange(onNewSiteCreated);
     }
 
     private void fetchSite(SiteModel site) {
@@ -810,35 +762,6 @@ public class SiteStore extends Store {
 
     private void fetchSitesXmlRpc(RefreshSitesXMLRPCPayload payload) {
         mSiteXMLRPCClient.fetchSites(payload.url, payload.username, payload.password);
-    }
-
-    private void fetchPostFormats(SiteModel site) {
-        if (site.isUsingWpComRestApi()) {
-            mSiteRestClient.fetchPostFormats(site);
-        } else {
-            mSiteXMLRPCClient.fetchPostFormats(site);
-        }
-    }
-
-    private void deleteSite(SiteModel site) {
-        // Not available for Jetpack sites
-        if (!site.isWPCom()) {
-            OnSiteDeleted event = new OnSiteDeleted(new DeleteSiteError(DeleteSiteErrorType.INVALID_SITE));
-            emitChange(event);
-            return;
-        }
-        mSiteRestClient.deleteSite(site);
-    }
-
-    private void exportSite(SiteModel site) {
-        // Not available for Jetpack sites
-        if (!site.isWPCom()) {
-            OnSiteExported event = new OnSiteExported();
-            event.error = new ExportSiteError(ExportSiteErrorType.INVALID_SITE);
-            emitChange(event);
-            return;
-        }
-        mSiteRestClient.exportSite(site);
     }
 
     private void updateSite(SiteModel siteModel) {
@@ -871,6 +794,120 @@ public class SiteStore extends Store {
         emitChange(event);
     }
 
+    private void handleFetchedSitesWPComRest(SitesModel fetchedSites) {
+        OnSiteChanged event = new OnSiteChanged(0);
+        if (fetchedSites.isError()) {
+            // TODO: what kind of error could we get here?
+            event.error = new SiteError(SiteErrorType.GENERIC_ERROR);
+        } else {
+            UpdateSitesResult res = createOrUpdateSites(fetchedSites);
+            event.rowsAffected = res.rowsAffected;
+            if (res.duplicateSiteFound) {
+                event.error = new SiteError(SiteErrorType.DUPLICATE_SITE);
+            }
+            SiteSqlUtils.removeWPComRestSitesAbsentFromList(fetchedSites.getSites());
+        }
+        emitChange(event);
+    }
+
+    private UpdateSitesResult createOrUpdateSites(SitesModel sites) {
+        UpdateSitesResult result = new UpdateSitesResult();
+        for (SiteModel site : sites.getSites()) {
+            try {
+                result.rowsAffected += SiteSqlUtils.insertOrUpdateSite(site);
+            } catch (DuplicateSiteException caughtException) {
+                result.duplicateSiteFound = true;
+            }
+        }
+        return result;
+    }
+
+    private void deleteSite(SiteModel site) {
+        // Not available for Jetpack sites
+        if (!site.isWPCom()) {
+            OnSiteDeleted event = new OnSiteDeleted(new DeleteSiteError(DeleteSiteErrorType.INVALID_SITE));
+            emitChange(event);
+            return;
+        }
+        mSiteRestClient.deleteSite(site);
+    }
+
+    private void handleDeletedSite(DeleteSiteResponsePayload payload) {
+        OnSiteDeleted event = new OnSiteDeleted(payload.error);
+        if (!payload.isError()) {
+            SiteSqlUtils.deleteSite(payload.site);
+        }
+        emitChange(event);
+    }
+
+    private void exportSite(SiteModel site) {
+        // Not available for Jetpack sites
+        if (!site.isWPCom()) {
+            OnSiteExported event = new OnSiteExported();
+            event.error = new ExportSiteError(ExportSiteErrorType.INVALID_SITE);
+            emitChange(event);
+            return;
+        }
+        mSiteRestClient.exportSite(site);
+    }
+
+    private void handleExportedSite(ExportSiteResponsePayload payload) {
+        OnSiteExported event = new OnSiteExported();
+        if (payload.isError()) {
+            // TODO: what kind of error could we get here?
+            event.error = new ExportSiteError(ExportSiteErrorType.GENERIC_ERROR);
+        }
+        emitChange(event);
+    }
+
+    private void removeSite(SiteModel site) {
+        int rowsAffected = SiteSqlUtils.deleteSite(site);
+        emitChange(new OnSiteRemoved(rowsAffected));
+    }
+
+    private void removeAllSites() {
+        int rowsAffected = SiteSqlUtils.deleteAllSites();
+        OnAllSitesRemoved event = new OnAllSitesRemoved(rowsAffected);
+        emitChange(event);
+    }
+
+    private void removeWPComAndJetpackSites() {
+        // Logging out of WP.com. Drop all WP.com sites, and all Jetpack sites that were fetched over the WP.com
+        // REST API only (they don't have a .org site id)
+        List<SiteModel> wpcomAndJetpackSites = SiteSqlUtils.getSitesAccessedViaWPComRest().getAsModel();
+        int rowsAffected = removeSites(wpcomAndJetpackSites);
+        emitChange(new OnSiteRemoved(rowsAffected));
+    }
+
+    private int toggleSitesVisibility(SitesModel sites, boolean visible) {
+        int rowsAffected = 0;
+        for (SiteModel site : sites.getSites()) {
+            rowsAffected += SiteSqlUtils.setSiteVisibility(site, visible);
+        }
+        return rowsAffected;
+    }
+
+    private void createNewSite(NewSitePayload payload) {
+        mSiteRestClient.newSite(payload.siteName, payload.siteTitle, payload.language, payload.visibility,
+                payload.dryRun);
+    }
+
+    private void handleCreateNewSiteCompleted(NewSiteResponsePayload payload) {
+        OnNewSiteCreated onNewSiteCreated = new OnNewSiteCreated();
+        onNewSiteCreated.error = payload.error;
+        onNewSiteCreated.dryRun = payload.dryRun;
+        onNewSiteCreated.newSiteRemoteId = payload.newSiteRemoteId;
+        emitChange(onNewSiteCreated);
+    }
+
+    private void fetchPostFormats(SiteModel site) {
+        if (site.isUsingWpComRestApi()) {
+            mSiteRestClient.fetchPostFormats(site);
+        } else {
+            mSiteXMLRPCClient.fetchPostFormats(site);
+        }
+    }
+
     private void updatePostFormats(FetchedPostFormatsPayload payload) {
         OnPostFormatsChanged event = new OnPostFormatsChanged(payload.site);
         if (payload.isError()) {
@@ -882,21 +919,12 @@ public class SiteStore extends Store {
         emitChange(event);
     }
 
-    private void handleDeletedSite(DeleteSiteResponsePayload payload) {
-        OnSiteDeleted event = new OnSiteDeleted(payload.error);
-        if (!payload.isError()) {
-            SiteSqlUtils.deleteSite(payload.site);
+    private int removeSites(List<SiteModel> sites) {
+        int rowsAffected = 0;
+        for (SiteModel site : sites) {
+            rowsAffected += SiteSqlUtils.deleteSite(site);
         }
-        emitChange(event);
-    }
-
-    private void handleExportedSite(ExportSiteResponsePayload payload) {
-        OnSiteExported event = new OnSiteExported();
-        if (payload.isError()) {
-            // TODO: what kind of error could we get here?
-            event.error = new ExportSiteError(ExportSiteErrorType.GENERIC_ERROR);
-        }
-        emitChange(event);
+        return rowsAffected;
     }
 
     private void fetchConnectSiteInfo(String payload) {
@@ -932,34 +960,6 @@ public class SiteStore extends Store {
         }
         event.isWPCom = payload.isWPCom;
         emitChange(event);
-    }
-
-    private UpdateSitesResult createOrUpdateSites(SitesModel sites) {
-        UpdateSitesResult result = new UpdateSitesResult();
-        for (SiteModel site : sites.getSites()) {
-            try {
-                result.rowsAffected += SiteSqlUtils.insertOrUpdateSite(site);
-            } catch (DuplicateSiteException caughtException) {
-                result.duplicateSiteFound = true;
-            }
-        }
-        return result;
-    }
-
-    private int removeSites(List<SiteModel> sites) {
-        int rowsAffected = 0;
-        for (SiteModel site : sites) {
-            rowsAffected += SiteSqlUtils.deleteSite(site);
-        }
-        return rowsAffected;
-    }
-
-    private int toggleSitesVisibility(SitesModel sites, boolean visible) {
-        int rowsAffected = 0;
-        for (SiteModel site : sites.getSites()) {
-            rowsAffected += SiteSqlUtils.setSiteVisibility(site, visible);
-        }
-        return rowsAffected;
     }
 
     private void suggestDomains(SuggestDomainsPayload payload) {


### PR DESCRIPTION
Since https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/469, a successful `FETCHED_SITES` will call [SiteSqlUtils.removeWPComRestSitesAbsentFromList()](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/2ce630682e0205857158cef45d6be3c75c48663a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java#L763), regardless of whether the fetch was WP.com or XML-RPC.

Currently this doesn't break anything, as we're calling `UPDATE_SITES` instead on success from XML-RPC, but we could conceivably change things in the future and end up removing WP.com sites on XML-RPC fetches.

To prevent this, there are now two distinct actions, and `SiteSqlUtils.removeWPComRestSitesAbsentFromList()` can only be called as a result of `FETCH_SITES` - not `FETCH_SITES_XML_RPC`.

Note: c4e22fc is the main event - the other commit is just regrouping cases and methods in `SiteStore` so things are grouped together a little better.

cc @tonyr59h