### PR TITLE
Don't upload files too close to the memory limit (Jetpack) 

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -36,7 +36,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
 
     private enum TestEvents {
         MEDIA_UPLOADED,
-        ERROR_REQUEST_TOO_LARGE,
+        ERROR_EXCEEDS_FILESIZE_LIMIT,
         SITE_CHANGED,
         SITE_REMOVED,
         NONE
@@ -66,7 +66,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
 
         // Attempt to upload an image that exceeds the site's maximum upload_max_filesize or post_max_size
         MediaModel testMedia = newMediaModel(site, BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
-        mNextEvent = TestEvents.ERROR_REQUEST_TOO_LARGE;
+        mNextEvent = TestEvents.ERROR_EXCEEDS_FILESIZE_LIMIT;
         uploadMedia(site, testMedia);
 
         signOutWPCom();
@@ -76,8 +76,8 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
     @Subscribe
     public void onMediaUploaded(OnMediaUploaded event) {
         if (event.isError()) {
-            if (event.error.type == MediaErrorType.REQUEST_TOO_LARGE) {
-                assertEquals(TestEvents.ERROR_REQUEST_TOO_LARGE, mNextEvent);
+            if (event.error.type == MediaErrorType.EXCEEDS_FILESIZE_LIMIT) {
+                assertEquals(TestEvents.ERROR_EXCEEDS_FILESIZE_LIMIT, mNextEvent);
                 mCountDownLatch.countDown();
                 return;
             }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -37,6 +37,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
     private enum TestEvents {
         MEDIA_UPLOADED,
         ERROR_EXCEEDS_FILESIZE_LIMIT,
+        ERROR_EXCEEDS_MEMORY_LIMIT,
         SITE_CHANGED,
         SITE_REMOVED,
         NONE
@@ -54,7 +55,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
-    public void testUploadMediaLowUploadLimit() throws InterruptedException {
+    public void testUploadMediaLowFilesizeLimit() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_JETPACK_UPLOAD_LIMIT,
                 BuildConfig.TEST_WPCOM_PASSWORD_JETPACK_UPLOAD_LIMIT);
 
@@ -72,12 +73,35 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    public void testUploadMediaLowMemoryLimit() throws InterruptedException {
+        authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
+                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
+
+        SiteModel site = mSiteStore.getSites().get(0);
+
+        // Make a call to /sites/$site/ to pull all the Jetpack options
+        fetchSite(site);
+        site = mSiteStore.getSites().get(0);
+        site.setMemoryLimit(1985); // Artificially set the site's memory limit, in bytes
+
+        // Attempt to upload an image that exceeds the site's memory limit
+        MediaModel testMedia = newMediaModel(site, BuildConfig.TEST_LOCAL_IMAGE, MediaUtils.MIME_TYPE_IMAGE);
+        mNextEvent = TestEvents.ERROR_EXCEEDS_MEMORY_LIMIT;
+        uploadMedia(site, testMedia);
+
+        signOutWPCom();
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onMediaUploaded(OnMediaUploaded event) {
         if (event.isError()) {
             if (event.error.type == MediaErrorType.EXCEEDS_FILESIZE_LIMIT) {
                 assertEquals(TestEvents.ERROR_EXCEEDS_FILESIZE_LIMIT, mNextEvent);
+                mCountDownLatch.countDown();
+                return;
+            } else if (event.error.type == MediaErrorType.EXCEEDS_MEMORY_LIMIT) {
+                assertEquals(TestEvents.ERROR_EXCEEDS_MEMORY_LIMIT, mNextEvent);
                 mCountDownLatch.countDown();
                 return;
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -47,6 +47,7 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
     @Column private String mTimezone; // Expressed as an offset relative to GMT (e.g. '-8')
     @Column private String mFrameNonce; // only wpcom and Jetpack sites
     @Column private long mMaxUploadSize; // only set for Jetpack sites
+    @Column private long mMemoryLimit; // only set for Jetpack sites
     @Column private int mOrigin = ORIGIN_UNKNOWN; // Does this site come from a WPCOM REST or XMLRPC fetch_sites call?
 
     // Self hosted specifics
@@ -427,6 +428,18 @@ public class SiteModel extends Payload implements Identifiable, Serializable {
 
     public boolean hasMaxUploadSize() {
         return mMaxUploadSize > 0;
+    }
+
+    public long getMemoryLimit() {
+        return mMemoryLimit;
+    }
+
+    public void setMemoryLimit(long memoryLimit) {
+        mMemoryLimit = memoryLimit;
+    }
+
+    public boolean hasMemoryLimit() {
+        return mMemoryLimit > 0;
     }
 
     public String getPlanShortName() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -144,7 +144,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         if (site.hasMaxUploadSize() && body.contentLength() > site.getMaxUploadSize()) {
             AppLog.d(T.MEDIA, "Media size of " + body.contentLength() + " exceeds site limit of "
                     + site.getMaxUploadSize());
-            MediaError error = new MediaError(MediaErrorType.REQUEST_TOO_LARGE);
+            MediaError error = new MediaError(MediaErrorType.EXCEEDS_FILESIZE_LIMIT);
             notifyMediaUploaded(media, error);
             return;
         }
@@ -154,7 +154,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         if (site.hasMemoryLimit() && body.contentLength() > maxFilesizeForMemoryLimit) {
             AppLog.d(T.MEDIA, "Media size of " + body.contentLength() + " exceeds safe memory limit of "
                     + maxFilesizeForMemoryLimit + " for this site");
-            MediaError error = new MediaError(MediaErrorType.REQUEST_TOO_LARGE);
+            MediaError error = new MediaError(MediaErrorType.EXCEEDS_MEMORY_LIMIT);
             notifyMediaUploaded(media, error);
             return;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -19,6 +19,8 @@ public class SiteWPComRestResponse implements Response {
         public String frame_nonce;
         public String unmapped_url;
         public String max_upload_size;
+        public String wp_max_memory_limit;
+        public String wp_memory_limit;
     }
 
     public class Plan {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -45,7 +45,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 10;
+        return 11;
     }
 
     @Override
@@ -104,6 +104,10 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 9:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add MAX_UPLOAD_SIZE integer;");
+                oldVersion++;
+            case 10:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SiteModel add MEMORY_LIMIT integer;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -256,6 +256,8 @@ public class MediaStore extends Store {
         NULL_MEDIA_ARG,
         MALFORMED_MEDIA_ARG,
         DB_QUERY_FAILURE,
+        EXCEEDS_FILESIZE_LIMIT,
+        EXCEEDS_MEMORY_LIMIT,
 
         // network errors, occur in response to network requests
         AUTHORIZATION_REQUIRED,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -5,6 +5,8 @@ import android.text.TextUtils;
 import java.io.File;
 
 public class MediaUtils {
+    public static final double MEMORY_LIMIT_FILESIZE_MULTIPLIER = 0.75D;
+
     //
     // MIME types
     //
@@ -126,5 +128,12 @@ public class MediaUtils {
         if (TextUtils.isEmpty(filePath) || !filePath.contains("/")) return null;
         if (filePath.lastIndexOf("/") + 1 >= filePath.length()) return null;
         return filePath.substring(filePath.lastIndexOf("/") + 1);
+    }
+
+    /**
+     * Given the memory limit for media for a site, returns the maximum 'safe' file size we can upload to that site.
+     */
+    public static double getMaxFilesizeForMemoryLimit(double mediaMemoryLimit) {
+        return MEMORY_LIMIT_FILESIZE_MULTIPLIER * mediaMemoryLimit;
     }
 }


### PR DESCRIPTION
Addresses #485. Stores the new `wp_memory_limit` and `wp_max_memory_limit` site options as a single overall memory limit, and prevents uploading media larger than `0.75` times that limit.

cc @daniloercoli could you give this a spin? Also what do you think about a hard `0.75 * memory-limit` as the ceiling for media uploads? I get failures if I upload files with sizes too close to the real memory limit.

**Note:** There's an issue here in that `/me/sites/` and `/sites/$site/` don't return the same response for Jetpack sites. There are a few discrepancies, but relevant to this PR is that `wp_memory_limit` and `wp_max_memory_limit` aren't set for `/me/sites/`. If we make a `FETCH_SITES` call after tha last `FETCH_SITE` call for a site, we'll replace the stored memory limit in the DB with `0`, until the next `FETCH_SITE` call updates it. From WPAndroid, we're most likely to have called `FETCH_SITE` most recently, but this can still be an issue.

I'm going to open an issue to track this, either getting an API fix or excluding certain fields from being updated by a `FETCH_SITES` call here in FluxC.