### PR TITLE
issue/511-media-video-thumbs

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -500,7 +500,11 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         media.setDescription(from.description);
         media.setAlt(from.alt);
         if (from.thumbnails != null) {
-            media.setThumbnailUrl(from.thumbnails.thumbnail);
+            if (!TextUtils.isEmpty(from.thumbnails.fmt_std)) {
+                media.setThumbnailUrl(from.thumbnails.fmt_std);
+            } else {
+                media.setThumbnailUrl(from.thumbnails.thumbnail);
+            }
         }
         media.setHeight(from.height);
         media.setWidth(from.width);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
@@ -23,6 +23,7 @@ public class MediaWPComRestResponse implements Response {
         public String medium;
         public String large;
         public String post_thumbnail;
+        public String fmt_std;
     }
 
     public long ID;


### PR DESCRIPTION
Fixes #511 - when parsing the `thumbnails` section of the media list response, we now use `fmt_std` as the thumbnail URL when it exists in order to support video thumbnails (which is consistent with iOS).