### PR TITLE
Issue/513 media smarter update

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -364,8 +364,13 @@ public class MediaSqlUtils {
 
     public static int deleteUploadedSiteMediaNotInList(
             SiteModel site, List<MediaModel> mediaList, String mimeType) {
+
         if (mediaList.isEmpty()) {
-            return 0;
+            if (!TextUtils.isEmpty(mimeType)) {
+                return MediaSqlUtils.deleteAllUploadedSiteMediaWithMimeType(site, mimeType);
+            } else {
+                return MediaSqlUtils.deleteAllUploadedSiteMedia(site);
+            }
         }
 
         List<Integer> idList = new ArrayList<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -362,9 +362,7 @@ public class MediaSqlUtils {
         return WellSql.delete(MediaModel.class).execute();
     }
 
-    public static int deleteUploadedSiteMediaNotInList(
-            SiteModel site, List<MediaModel> mediaList, String mimeType) {
-
+    public static int deleteUploadedSiteMediaNotInList(SiteModel site, List<MediaModel> mediaList, String mimeType) {
         if (mediaList.isEmpty()) {
             if (!TextUtils.isEmpty(mimeType)) {
                 return MediaSqlUtils.deleteAllUploadedSiteMediaWithMimeType(site, mimeType);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -364,15 +364,19 @@ public class MediaSqlUtils {
 
     public static int deleteUploadedSiteMediaNotInList(
             SiteModel site, List<MediaModel> mediaList, String mimeType) {
-        List<Integer> existingIds = new ArrayList<>();
-        for (MediaModel existing: mediaList) {
-            existingIds.add(existing.getId());
+        if (mediaList.isEmpty()) {
+            return 0;
+        }
+
+        List<Integer> idList = new ArrayList<>();
+        for (MediaModel media: mediaList) {
+            idList.add(media.getId());
         }
 
         if (!TextUtils.isEmpty(mimeType)) {
             return WellSql.delete(MediaModel.class)
                     .where().beginGroup()
-                    .isNotIn(MediaModelTable.ID, existingIds)
+                    .isNotIn(MediaModelTable.ID, idList)
                     .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
                     .equals(MediaModelTable.UPLOAD_STATE, MediaUploadState.UPLOADED.toString())
                     .contains(MediaModelTable.MIME_TYPE, mimeType)
@@ -381,7 +385,7 @@ public class MediaSqlUtils {
         } else {
             return WellSql.delete(MediaModel.class)
                     .where().beginGroup()
-                    .isNotIn(MediaModelTable.ID, existingIds)
+                    .isNotIn(MediaModelTable.ID, idList)
                     .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
                     .equals(MediaModelTable.UPLOAD_STATE, MediaUploadState.UPLOADED.toString())
                     .endGroup().endWhere()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -743,8 +743,8 @@ public class MediaStore extends Store {
         }
 
         // build separate lists of existing and new media
-        List <MediaModel> existingMediaList = new ArrayList<>();
-        List <MediaModel> newMediaList = new ArrayList<>();
+        List<MediaModel> existingMediaList = new ArrayList<>();
+        List<MediaModel> newMediaList = new ArrayList<>();
         for (MediaModel fetchedMedia: payload.mediaList) {
             MediaModel media = getSiteMediaWithId(payload.site, fetchedMedia.getMediaId());
             if (media != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -742,43 +742,28 @@ public class MediaStore extends Store {
             return;
         }
 
-        // otherwise, build separate lists of existing and new media
+        // build separate lists of existing and new media
         List <MediaModel> existingMediaList = new ArrayList<>();
         List <MediaModel> newMediaList = new ArrayList<>();
         for (MediaModel fetchedMedia: payload.mediaList) {
             MediaModel media = getSiteMediaWithId(payload.site, fetchedMedia.getMediaId());
             if (media != null) {
-                // retain the local ID
+                // retain the local ID, then update this media item
                 fetchedMedia.setId(media.getId());
                 existingMediaList.add(fetchedMedia);
+                updateMedia(fetchedMedia, false);
             } else {
                 newMediaList.add(fetchedMedia);
             }
         }
 
-        if (existingMediaList.isEmpty()) {
-            // no existing media, so clear everything
-            if (!TextUtils.isEmpty(payload.mimeType)) {
-                MediaSqlUtils.deleteAllUploadedSiteMediaWithMimeType(payload.site, payload.mimeType);
-            } else {
-                MediaSqlUtils.deleteAllUploadedSiteMedia(payload.site);
-            }
-        } else {
-            // update the existing media
-            for (MediaModel media : existingMediaList) {
-                updateMedia(media, false);
-            }
-
-            // delete media that's NOT in the existing list
-            MediaSqlUtils.deleteUploadedSiteMediaNotInList(
-                    payload.site, existingMediaList, payload.mimeType);
-        }
+        // remove media that is NOT in the existing list
+        MediaSqlUtils.deleteUploadedSiteMediaNotInList(
+                payload.site, existingMediaList, payload.mimeType);
 
         // add new media
-        if (!newMediaList.isEmpty()) {
-            for (MediaModel media : newMediaList) {
-                updateMedia(media, false);
-            }
+        for (MediaModel media : newMediaList) {
+            updateMedia(media, false);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -756,18 +756,29 @@ public class MediaStore extends Store {
             }
         }
 
-        // update the existing media
-        for (MediaModel media: existingMediaList) {
-            updateMedia(media, false);
+        if (existingMediaList.isEmpty()) {
+            // no existing media, so clear everything
+            if (!TextUtils.isEmpty(payload.mimeType)) {
+                MediaSqlUtils.deleteAllUploadedSiteMediaWithMimeType(payload.site, payload.mimeType);
+            } else {
+                MediaSqlUtils.deleteAllUploadedSiteMedia(payload.site);
+            }
+        } else {
+            // update the existing media
+            for (MediaModel media : existingMediaList) {
+                updateMedia(media, false);
+            }
+
+            // delete media that's NOT in the existing list
+            MediaSqlUtils.deleteUploadedSiteMediaNotInList(
+                    payload.site, existingMediaList, payload.mimeType);
         }
 
-        // delete media that's NOT in the existing list
-        MediaSqlUtils.deleteUploadedSiteMediaNotInList(
-                payload.site, existingMediaList, payload.mimeType);
-
         // add new media
-        for (MediaModel media : newMediaList) {
-            updateMedia(media, false);
+        if (!newMediaList.isEmpty()) {
+            for (MediaModel media : newMediaList) {
+                updateMedia(media, false);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #513 - after fetching a site's media list, rather than delete all existing media before inserting the fetched list we now retain existing media (and preserve their local IDs), clear everything else out, then insert new media.

Note that the biggest benefit of this PR is that local IDs are retained rather than reset after each fetch. This is important because we want to use the local IDs in WPAndroid as the media grid adapter's `getItemId()` to make updating recycler's more efficient and flicker-free.

You can test using [this WPAndroid branch](https://github.com/wordpress-mobile/WordPress-Android/tree/nbradbury/media-refresh-fluxc), which [writes to the log](https://github.com/wordpress-mobile/WordPress-Android/blob/nbradbury/media-refresh-fluxc/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java#L114) to let us know whether the list has changed. In most cases it will have changed, but it should not have changed when doing a PTR unless new media have been added.