### PR TITLE
Add checkstyle rule colons in for-each statements

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -153,6 +153,7 @@
         <module name="WhitespaceAround">
           <property name="allowEmptyTypes" value="true"/>
           <property name="allowEmptyConstructors" value="true"/>
+          <property name="ignoreEnhancedForColon" value="false"/>
         </module>
         <module name="NoWhitespaceAfter">
           <property name="tokens"

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -64,7 +64,7 @@ public class SitesFragment extends Fragment {
         view.findViewById(R.id.update_all_sites).setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                for (SiteModel site: mSiteStore.getSites()) {
+                for (SiteModel site : mSiteStore.getSites()) {
                     mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site));
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -18,7 +18,7 @@ public class MediaModel extends Payload implements Identifiable, Serializable {
 
         public static MediaUploadState fromString(String stringState) {
             if (stringState != null) {
-                for (MediaUploadState state: MediaUploadState.values()) {
+                for (MediaUploadState state : MediaUploadState.values()) {
                     if (stringState.equalsIgnoreCase(state.toString())) {
                         return state;
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -310,7 +310,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
             return comments;
         }
         Object[] responseArray = (Object[]) response;
-        for (Object commentObject: responseArray) {
+        for (Object commentObject : responseArray) {
             CommentModel commentModel = commentResponseToComment(commentObject, site);
             if (commentModel != null) {
                 comments.add(commentModel);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -152,7 +152,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         if (response == null) return null;
 
         List<SiteModel> siteArray = new ArrayList<>();
-        for (Object siteObject: response) {
+        for (Object siteObject : response) {
             if (!(siteObject instanceof Map)) {
                 continue;
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -374,7 +374,7 @@ public class MediaSqlUtils {
         }
 
         List<Integer> idList = new ArrayList<>();
-        for (MediaModel media: mediaList) {
+        for (MediaModel media : mediaList) {
             idList.add(media.getId());
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -736,7 +736,7 @@ public class MediaStore extends Store {
     private void updateFetchedMediaList(@NonNull FetchMediaListResponsePayload payload) {
         // if we loaded another page, simply add the fetched media and be done
         if (payload.loadedMore) {
-            for (MediaModel media: payload.mediaList) {
+            for (MediaModel media : payload.mediaList) {
                 updateMedia(media, false);
             }
             return;
@@ -745,7 +745,7 @@ public class MediaStore extends Store {
         // build separate lists of existing and new media
         List<MediaModel> existingMediaList = new ArrayList<>();
         List<MediaModel> newMediaList = new ArrayList<>();
-        for (MediaModel fetchedMedia: payload.mediaList) {
+        for (MediaModel fetchedMedia : payload.mediaList) {
             MediaModel media = getSiteMediaWithId(payload.site, fetchedMedia.getMediaId());
             if (media != null) {
                 // retain the local ID, then update this media item


### PR DESCRIPTION
Enforces a space on both sides of the colon in for-each statements, and updates pre-existing usages that are now in conflict.

The new rule will flag this:
```java
for (Object object: objectList) {
    ...
}
```

And will allow this:
```java
for (Object object : objectList) {
    ...
}
```

(Debate with @maxme over which format to standardize was settled by the Android Studio auto-formatter, which defaults to the whitespace on both sides format.)