### PR TITLE
Add user roles

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -101,7 +101,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         // Get the first site
         SiteModel firstSite = mSiteStore.getSites().get(0);
 
-        // Fetch post formats
+        // Fetch user roles
         mDispatcher.dispatch(SiteActionBuilder.newFetchUserRolesAction(firstSite));
         mNextEvent = TestEvents.USER_ROLES_CHANGED;
         mCountDownLatch = new CountDownLatch(1);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPCo
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
@@ -30,6 +31,8 @@ public enum SiteAction implements IAction {
     CREATE_NEW_SITE,
     @Action(payloadType = SiteModel.class)
     FETCH_POST_FORMATS,
+    @Action(payloadType = SiteModel.class)
+    FETCH_USER_ROLES,
     @Action(payloadType = SiteModel.class)
     DELETE_SITE,
     @Action(payloadType = SiteModel.class)
@@ -52,6 +55,8 @@ public enum SiteAction implements IAction {
     CREATED_NEW_SITE,
     @Action(payloadType = FetchedPostFormatsPayload.class)
     FETCHED_POST_FORMATS,
+    @Action(payloadType = FetchedUserRolesPayload.class)
+    FETCHED_USER_ROLES,
     @Action(payloadType = DeleteSiteResponsePayload.class)
     DELETED_SITE,
     @Action(payloadType = ExportSiteResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/RoleModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/RoleModel.java
@@ -47,4 +47,13 @@ public class RoleModel implements Identifiable {
     public void setDisplayName(String displayName) {
         mDisplayName = displayName;
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || !(other instanceof RoleModel)) return false;
+
+        RoleModel otherRole = (RoleModel) other;
+        return getName().equals(otherRole.getName());
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/RoleModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/RoleModel.java
@@ -1,0 +1,50 @@
+package org.wordpress.android.fluxc.model;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.Table;
+
+@Table
+public class RoleModel implements Identifiable {
+    @PrimaryKey @Column private int mId;
+
+    // Site Id Foreign Key
+    @Column private int mSiteId;
+
+    // Role attributes
+    @Column private String mName;
+    @Column private String mDisplayName;
+
+    public int getId() {
+        return mId;
+    }
+
+    public void setId(int id) {
+        mId = id;
+    }
+
+    public int getSiteId() {
+        return mSiteId;
+    }
+
+    public void setSiteId(int siteId) {
+        mSiteId = siteId;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public void setName(String name) {
+        mName = name;
+    }
+
+    public String getDisplayName() {
+        return mDisplayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        mDisplayName = displayName;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/RoleModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/RoleModel.java
@@ -5,8 +5,10 @@ import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
+import java.io.Serializable;
+
 @Table
-public class RoleModel implements Identifiable {
+public class RoleModel implements Identifiable, Serializable {
     @PrimaryKey @Column private int mId;
 
     // Site Id Foreign Key

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/UserRoleWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/UserRoleWPComRestResponse.java
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import java.util.List;
+
+class UserRoleWPComRestResponse {
+    class UserRolesResponse {
+        List<UserRoleWPComRestResponse> roles;
+    }
+    String name;
+    String display_name;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/UserRoleWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/UserRoleWPComRestResponse.java
@@ -2,10 +2,10 @@ package org.wordpress.android.fluxc.network.rest.wpcom.site;
 
 import java.util.List;
 
-class UserRoleWPComRestResponse {
-    class UserRolesResponse {
-        List<UserRoleWPComRestResponse> roles;
+public class UserRoleWPComRestResponse {
+    public class UserRolesResponse {
+        public List<UserRoleWPComRestResponse> roles;
     }
-    String name;
-    String display_name;
+    public String name;
+    public String display_name;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -256,7 +256,7 @@ public class SiteSqlUtils {
         WellSql.insert(postFormats).execute();
     }
 
-    public static List<RoleModel> getRoles(@NonNull SiteModel site) {
+    public static List<RoleModel> getUserRoles(@NonNull SiteModel site) {
         return WellSql.select(RoleModel.class)
                 .where()
                 .equals(RoleModelTable.SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -263,7 +263,7 @@ public class SiteSqlUtils {
                 .endWhere().getAsModel();
     }
 
-    public static void insertOrReplaceRoles(@NonNull SiteModel site, @NonNull List<RoleModel> roles) {
+    public static void insertOrUserReplaceRoles(@NonNull SiteModel site, @NonNull List<RoleModel> roles) {
         // Remove previous roles for this site
         WellSql.delete(RoleModel.class)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 
 import com.wellsql.generated.AccountModelTable;
 import com.wellsql.generated.PostFormatModelTable;
+import com.wellsql.generated.RoleModelTable;
 import com.wellsql.generated.SiteModelTable;
 import com.yarolegovich.wellsql.SelectQuery;
 import com.yarolegovich.wellsql.WellSql;
@@ -13,6 +14,7 @@ import com.yarolegovich.wellsql.mapper.InsertMapper;
 
 import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.PostFormatModel;
+import org.wordpress.android.fluxc.model.RoleModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -252,6 +254,26 @@ public class SiteSqlUtils {
             postFormat.setSiteId(site.getId());
         }
         WellSql.insert(postFormats).execute();
+    }
+
+    public static List<RoleModel> getRoles(@NonNull SiteModel site) {
+        return WellSql.select(RoleModel.class)
+                .where()
+                .equals(RoleModelTable.SITE_ID, site.getId())
+                .endWhere().getAsModel();
+    }
+
+    public static void insertOrReplaceRoles(@NonNull SiteModel site, @NonNull List<RoleModel> roles) {
+        // Remove previous roles for this site
+        WellSql.delete(RoleModel.class)
+                .where()
+                .equals(PostFormatModelTable.SITE_ID, site.getId())
+                .endWhere().execute();
+        // Insert new post formats for this site
+        for (RoleModel role : roles) {
+            role.setSiteId(site.getId());
+        }
+        WellSql.insert(roles).execute();
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -263,13 +263,13 @@ public class SiteSqlUtils {
                 .endWhere().getAsModel();
     }
 
-    public static void insertOrUserReplaceRoles(@NonNull SiteModel site, @NonNull List<RoleModel> roles) {
+    public static void insertOrReplaceUserRoles(@NonNull SiteModel site, @NonNull List<RoleModel> roles) {
         // Remove previous roles for this site
         WellSql.delete(RoleModel.class)
                 .where()
-                .equals(PostFormatModelTable.SITE_ID, site.getId())
+                .equals(RoleModelTable.SITE_ID, site.getId())
                 .endWhere().execute();
-        // Insert new post formats for this site
+        // Insert new user roles for this site
         for (RoleModel role : roles) {
             role.setSiteId(site.getId());
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -111,7 +111,8 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 11:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("CREATE TABLE RoleModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,SITE_ID INTEGER,NAME TEXT,DISPLAY_NAME TEXT)");
+                db.execSQL("CREATE TABLE RoleModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,SITE_ID INTEGER,"
+                        + "NAME TEXT,DISPLAY_NAME TEXT)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.RoleModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
@@ -41,6 +42,7 @@ public class WellSqlConfig extends DefaultWellConfig {
         add(SiteModel.class);
         add(TaxonomyModel.class);
         add(TermModel.class);
+        add(RoleModel.class);
     }};
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -45,7 +45,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 11;
+        return 12;
     }
 
     @Override
@@ -108,6 +108,10 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 10:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add MEMORY_LIMIT integer;");
+                oldVersion++;
+            case 11:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("CREATE TABLE RoleModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,SITE_ID INTEGER,NAME TEXT,DISPLAY_NAME TEXT)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -991,7 +991,7 @@ public class SiteStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            SiteSqlUtils.insertOrUserReplaceRoles(payload.site, payload.roles);
+            SiteSqlUtils.insertOrReplaceUserRoles(payload.site, payload.roles);
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.action.SiteAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PostFormatModel;
+import org.wordpress.android.fluxc.model.RoleModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
@@ -78,6 +79,16 @@ public class SiteStore extends Store {
         public FetchedPostFormatsPayload(@NonNull SiteModel site, @NonNull List<PostFormatModel> postFormats) {
             this.site = site;
             this.postFormats = postFormats;
+        }
+    }
+
+    public static class FetchedUserRolesPayload extends Payload {
+        public SiteModel site;
+        public List<RoleModel> roles;
+        public UserRolesError error;
+        public FetchedUserRolesPayload(@NonNull SiteModel site, @NonNull List<RoleModel> roles) {
+            this.site = site;
+            this.roles = roles;
         }
     }
 
@@ -154,6 +165,20 @@ public class SiteStore extends Store {
         }
 
         public PostFormatsError(PostFormatsErrorType type, String message) {
+            this.type = type;
+            this.message = message;
+        }
+    }
+
+    public static class UserRolesError implements OnChangedError {
+        public UserRolesErrorType type;
+        public String message;
+
+        public UserRolesError(UserRolesErrorType type) {
+            this(type, "");
+        }
+
+        UserRolesError(UserRolesErrorType type, String message) {
             this.type = type;
             this.message = message;
         }
@@ -312,6 +337,10 @@ public class SiteStore extends Store {
         INVALID_SITE,
         INVALID_RESPONSE,
         GENERIC_ERROR;
+    }
+
+    public enum UserRolesErrorType {
+        GENERIC_ERROR
     }
 
     public enum DeleteSiteErrorType {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -259,6 +259,13 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class OnUserRolesChanged extends OnChanged<UserRolesError> {
+        public SiteModel site;
+        public OnUserRolesChanged(SiteModel site) {
+            this.site = site;
+        }
+    }
+
     public static class OnURLChecked extends OnChanged<SiteError> {
         public String url;
         public boolean isWPCom;
@@ -767,11 +774,14 @@ public class SiteStore extends Store {
             case FETCH_POST_FORMATS:
                 fetchPostFormats((SiteModel) action.getPayload());
                 break;
+            case FETCHED_POST_FORMATS:
+                updatePostFormats((FetchedPostFormatsPayload) action.getPayload());
+                break;
             case FETCH_USER_ROLES:
                 fetchUserRoles((SiteModel) action.getPayload());
                 break;
-            case FETCHED_POST_FORMATS:
-                updatePostFormats((FetchedPostFormatsPayload) action.getPayload());
+            case FETCHED_USER_ROLES:
+                updateUserRoles((FetchedUserRolesPayload) action.getPayload());
                 break;
             case FETCH_CONNECT_SITE_INFO:
                 fetchConnectSiteInfo((String) action.getPayload());
@@ -970,6 +980,16 @@ public class SiteStore extends Store {
         if (site.isUsingWpComRestApi()) {
             mSiteRestClient.fetchUserRoles(site);
         }
+    }
+
+    private void updateUserRoles(FetchedUserRolesPayload payload) {
+        OnUserRolesChanged event = new OnUserRolesChanged(payload.site);
+        if (payload.isError()) {
+            event.error = payload.error;
+        } else {
+            SiteSqlUtils.insertOrUserReplaceRoles(payload.site, payload.roles);
+        }
+        emitChange(event);
     }
 
     private int removeSites(List<SiteModel> sites) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -708,6 +708,10 @@ public class SiteStore extends Store {
         return SiteSqlUtils.getPostFormats(site);
     }
 
+    public List<RoleModel> getUserRoles(SiteModel site) {
+        return SiteSqlUtils.getUserRoles(site);
+    }
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
     public void onAction(Action action) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -767,6 +767,9 @@ public class SiteStore extends Store {
             case FETCH_POST_FORMATS:
                 fetchPostFormats((SiteModel) action.getPayload());
                 break;
+            case FETCH_USER_ROLES:
+                fetchUserRoles((SiteModel) action.getPayload());
+                break;
             case FETCHED_POST_FORMATS:
                 updatePostFormats((FetchedPostFormatsPayload) action.getPayload());
                 break;
@@ -961,6 +964,12 @@ public class SiteStore extends Store {
             SiteSqlUtils.insertOrReplacePostFormats(payload.site, payload.postFormats);
         }
         emitChange(event);
+    }
+
+    private void fetchUserRoles(SiteModel site) {
+        if (site.isUsingWpComRestApi()) {
+            mSiteRestClient.fetchUserRoles(site);
+        }
     }
 
     private int removeSites(List<SiteModel> sites) {

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -20,6 +20,7 @@
 /sites/$site/delete
 /sites/$site/exports/start
 /sites/$site/post-formats/
+/sites/$site/roles
 /sites/new/
 
 /sites/$site/comments/


### PR DESCRIPTION
Fixes #260. This PR adds the ability to fetch and store user roles for a site. It works similar to post formats. It's only supported through the REST API, so no self-hosted sites.

To test:
* Run the testFetchUserRoles and preferably put a breakpoint before `assertNotSame(0, roles.size());` and check the `roles` array