### PR TITLE
PluginStore: Fetch plugin info

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -43,4 +43,5 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_TaxonomyTestWPCom test);
     void inject(ReleaseStack_TaxonomyTestXMLRPC test);
     void inject(ReleaseStack_PluginTestJetpack test);
+    void inject(ReleaseStack_PluginInfoTest test);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginInfoTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginInfoTest.java
@@ -1,0 +1,57 @@
+package org.wordpress.android.fluxc.release;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.generated.PluginActionBuilder;
+import org.wordpress.android.fluxc.model.PluginInfoModel;
+import org.wordpress.android.fluxc.store.PluginStore;
+import org.wordpress.android.fluxc.store.PluginStore.OnPluginInfoChanged;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+public class ReleaseStack_PluginInfoTest extends ReleaseStack_Base {
+    @Inject PluginStore mPluginStore;
+
+    enum TestEvents {
+        NONE,
+        PLUGIN_INFO_FETCHED,
+    }
+
+    private TestEvents mNextEvent;
+    private final String mSlug = "akismet";
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mReleaseStackAppComponent.inject(this);
+        // Register
+        init();
+        // Reset expected test event
+        mNextEvent = TestEvents.NONE;
+    }
+
+    public void testFetchPlugins() throws InterruptedException {
+        mNextEvent = TestEvents.PLUGIN_INFO_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(PluginActionBuilder.newFetchPluginInfoAction(mSlug));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onPluginInfoChanged(OnPluginInfoChanged event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+
+        assertEquals(TestEvents.PLUGIN_INFO_FETCHED, mNextEvent);
+        PluginInfoModel pluginInfo = mPluginStore.getPluginInfoBySlug(mSlug);
+        assertNotNull(pluginInfo);
+        mCountDownLatch.countDown();
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
@@ -13,6 +13,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
@@ -28,7 +29,8 @@ import static org.wordpress.android.fluxc.plugin.PluginUtils.generatePlugins;
 
 @RunWith(RobolectricTestRunner.class)
 public class PluginStoreUnitTest {
-    private PluginStore mPluginStore = new PluginStore(new Dispatcher(), Mockito.mock(PluginRestClient.class));
+    private PluginStore mPluginStore = new PluginStore(new Dispatcher(),
+            Mockito.mock(PluginRestClient.class), Mockito.mock(PluginInfoClient.class));
 
     @Before
     public void setUp() {

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
@@ -25,6 +26,7 @@ import org.wordpress.android.fluxc.store.PluginStore;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.wordpress.android.fluxc.plugin.PluginUtils.generatePluginInfo;
 import static org.wordpress.android.fluxc.plugin.PluginUtils.generatePlugins;
 
 @RunWith(RobolectricTestRunner.class)
@@ -55,5 +57,13 @@ public class PluginStoreUnitTest {
         PluginSqlUtils.insertOrReplacePlugins(site, generatePlugins("jetpack"));
         plugins = mPluginStore.getPlugins(site);
         assertEquals("jetpack", plugins.get(0).getName());
+    }
+
+    @Test
+    public void testGetPluginInfo() {
+        String slug = "akismet";
+        PluginSqlUtils.insertOrUpdatePluginInfo(generatePluginInfo(slug));
+        PluginInfoModel pluginInfo = mPluginStore.getPluginInfoBySlug(slug);
+        assertEquals(slug, pluginInfo.getSlug());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginUtils.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.plugin;
 
+import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 
 import java.util.ArrayList;
@@ -14,5 +15,11 @@ class PluginUtils {
             res.add(pluginModel);
         }
         return res;
+    }
+
+    static PluginInfoModel generatePluginInfo(String slug) {
+        PluginInfoModel pluginInfo = new PluginInfoModel();
+        pluginInfo.setSlug(slug);
+        return pluginInfo;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -12,6 +12,8 @@ public enum PluginAction implements IAction {
     // Remote actions
     @Action(payloadType = SiteModel.class)
     FETCH_PLUGINS,
+    @Action(payloadType = String.class)
+    FETCH_PLUGIN_INFO,
 
     // Remote responses
     @Action(payloadType = FetchedPluginsPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginsPayload;
 
@@ -15,4 +16,6 @@ public enum PluginAction implements IAction {
     // Remote responses
     @Action(payloadType = FetchedPluginsPayload.class)
     FETCHED_PLUGINS,
+    @Action(payloadType = PluginInfoModel.class)
+    FETCHED_PLUGIN_INFO,
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -3,8 +3,8 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginsPayload;
 
 @ActionEnum
@@ -18,6 +18,6 @@ public enum PluginAction implements IAction {
     // Remote responses
     @Action(payloadType = FetchedPluginsPayload.class)
     FETCHED_PLUGINS,
-    @Action(payloadType = PluginInfoModel.class)
+    @Action(payloadType = FetchedPluginInfoPayload.class)
     FETCHED_PLUGIN_INFO,
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PluginInfoModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PluginInfoModel.java
@@ -14,6 +14,7 @@ public class PluginInfoModel implements Identifiable, Serializable {
     @Column private String mSlug;
     @Column private String mVersion;
     @Column private String mRating;
+    @Column private String mIcon;
 
     @Override
     public void setId(int id) {
@@ -55,5 +56,13 @@ public class PluginInfoModel implements Identifiable, Serializable {
 
     public void setRating(String rating) {
         mRating = rating;
+    }
+
+    public String getIcon() {
+        return mIcon;
+    }
+
+    public void setIcon(String icon) {
+        mIcon = icon;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PluginInfoModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PluginInfoModel.java
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.model;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.Table;
+
+import java.io.Serializable;
+
+@Table
+public class PluginInfoModel implements Identifiable, Serializable {
+    @PrimaryKey @Column private int mId;
+    @Column private String mName;
+    @Column private String mSlug;
+    @Column private String mVersion;
+    @Column private String mRating;
+
+    @Override
+    public void setId(int id) {
+        mId = id;
+    }
+
+    @Override
+    public int getId() {
+        return mId;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public void setName(String name) {
+        mName = name;
+    }
+
+    public String getSlug() {
+        return mSlug;
+    }
+
+    public void setSlug(String slug) {
+        mSlug = slug;
+    }
+
+    public String getVersion() {
+        return mVersion;
+    }
+
+    public void setVersion(String version) {
+        mVersion = version;
+    }
+
+    public String getRating() {
+        return mRating;
+    }
+
+    public void setRating(String rating) {
+        mRating = rating;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
@@ -202,6 +203,14 @@ public class ReleaseNetworkModule {
                                                     @Named("regular") RequestQueue requestQueue,
                                                     AccessToken token, UserAgent userAgent) {
         return new PluginRestClient(appContext, dispatcher, requestQueue, token, userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public PluginInfoClient providePluginInfoClient(Dispatcher dispatcher,
+                                                    @Named("regular") RequestQueue requestQueue,
+                                                    UserAgent userAgent) {
+        return new PluginInfoClient(dispatcher, requestQueue, userAgent);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseStoreModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseStoreModule.java
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
@@ -76,7 +77,8 @@ public class ReleaseStoreModule {
 
     @Provides
     @Singleton
-    public PluginStore providePluginStore(Dispatcher dispatcher, PluginRestClient pluginRestClient) {
-        return new PluginStore(dispatcher, pluginRestClient);
+    public PluginStore providePluginStore(Dispatcher dispatcher, PluginRestClient pluginRestClient,
+                                          PluginInfoClient pluginInfoClient) {
+        return new PluginStore(dispatcher, pluginRestClient, pluginInfoClient);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/FetchPluginInfoResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/FetchPluginInfoResponse.java
@@ -1,0 +1,7 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.plugin;
+
+public class FetchPluginInfoResponse {
+    public String name;
+    public String slug;
+    public String version;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/FetchPluginInfoResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/FetchPluginInfoResponse.java
@@ -20,15 +20,29 @@ public class FetchPluginInfoResponse {
 
 class PluginInfoDeserializer implements JsonDeserializer<FetchPluginInfoResponse> {
     @Override
-    public FetchPluginInfoResponse deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    public FetchPluginInfoResponse deserialize(JsonElement json, Type typeOfT,
+                                               JsonDeserializationContext context) throws JsonParseException {
         JsonObject jsonObject = json.getAsJsonObject();
         FetchPluginInfoResponse response = new FetchPluginInfoResponse();
-        response.name = jsonObject.get("name").getAsString();
-        response.slug = jsonObject.get("slug").getAsString();
-        response.version = jsonObject.get("version").getAsString();
-        response.rating = jsonObject.get("rating").getAsString();
-        JsonObject icons = jsonObject.get("icons").getAsJsonObject();
-        response.icon = (icons.has("2x") ? icons.get("2x") : icons.get("1x")).getAsString();
+        response.name = getStringFromJsonIfAvailable(jsonObject, "name");
+        response.slug = getStringFromJsonIfAvailable(jsonObject, "slug");
+        response.version = getStringFromJsonIfAvailable(jsonObject, "version");
+        response.rating = getStringFromJsonIfAvailable(jsonObject, "rating");
+        if (jsonObject.has("icons")) {
+            JsonObject icons = jsonObject.get("icons").getAsJsonObject();
+            if (icons.has("2x")) {
+                response.icon = icons.get("2x").getAsString();
+            } else if (icons.has("1x")) {
+                response.icon = icons.get("1x").getAsString();
+            }
+        }
         return response;
+    }
+
+    private String getStringFromJsonIfAvailable(JsonObject jsonObject, String property) {
+        if (jsonObject.has(property)) {
+            return jsonObject.get(property).getAsString();
+        }
+        return null;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/FetchPluginInfoResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/FetchPluginInfoResponse.java
@@ -1,8 +1,34 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.plugin;
 
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.annotations.JsonAdapter;
+
+import java.lang.reflect.Type;
+
+@JsonAdapter(PluginInfoDeserializer.class)
 public class FetchPluginInfoResponse {
     public String name;
     public String slug;
     public String version;
     public String rating;
+    public String icon;
+}
+
+class PluginInfoDeserializer implements JsonDeserializer<FetchPluginInfoResponse> {
+    @Override
+    public FetchPluginInfoResponse deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        FetchPluginInfoResponse response = new FetchPluginInfoResponse();
+        response.name = jsonObject.get("name").getAsString();
+        response.slug = jsonObject.get("slug").getAsString();
+        response.version = jsonObject.get("version").getAsString();
+        response.rating = jsonObject.get("rating").getAsString();
+        JsonObject icons = jsonObject.get("icons").getAsJsonObject();
+        response.icon = (icons.has("2x") ? icons.get("2x") : icons.get("1x")).getAsString();
+        return response;
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/FetchPluginInfoResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/FetchPluginInfoResponse.java
@@ -4,4 +4,5 @@ public class FetchPluginInfoResponse {
     public String name;
     public String slug;
     public String version;
+    public String rating;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginInfoClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginInfoClient.java
@@ -67,6 +67,7 @@ public class PluginInfoClient extends BaseWPAPIRestClient {
         pluginInfo.setRating(response.rating);
         pluginInfo.setSlug(response.slug);
         pluginInfo.setVersion(response.version);
+        pluginInfo.setIcon(response.icon);
         return pluginInfo;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginInfoClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginInfoClient.java
@@ -14,6 +14,9 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient;
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest;
+import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoError;
+import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoErrorType;
+import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -35,14 +38,18 @@ public class PluginInfoClient extends BaseWPAPIRestClient {
                         new Listener<FetchPluginInfoResponse>() {
                             @Override
                             public void onResponse(FetchPluginInfoResponse response) {
-                                mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginInfoAction(
-                                        pluginInfoModelFromResponse(response)));
+                                PluginInfoModel pluginInfoModel = pluginInfoModelFromResponse(response);
+                                FetchedPluginInfoPayload payload = new FetchedPluginInfoPayload(pluginInfoModel);
+                                mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginInfoAction(payload));
                             }
                         },
                         new BaseErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                                // TODO
+                                FetchPluginInfoError error = new FetchPluginInfoError(
+                                        FetchPluginInfoErrorType.GENERIC_ERROR);
+                                mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginInfoAction(
+                                        new FetchedPluginInfoPayload(error)));
                             }
                         }
                 );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginInfoClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginInfoClient.java
@@ -1,0 +1,18 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.plugin;
+
+import com.android.volley.RequestQueue;
+
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class PluginInfoClient extends BaseWPAPIRestClient {
+    @Inject
+    public PluginInfoClient(Dispatcher dispatcher, RequestQueue requestQueue, UserAgent userAgent) {
+        super(dispatcher, requestQueue, userAgent);
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginInfoClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginInfoClient.java
@@ -18,6 +18,9 @@ import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoError;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -33,8 +36,10 @@ public class PluginInfoClient extends BaseWPAPIRestClient {
 
     public void fetchPluginInfo(String plugin) {
         String url = "https://api.wordpress.org/plugins/info/1.0/" + plugin + ".json";
+        Map<String, String> params = new HashMap<>();
+        params.put("fields", "icons");
         final WPAPIGsonRequest<FetchPluginInfoResponse> request =
-                new WPAPIGsonRequest<>(Method.GET, url, null, null, FetchPluginInfoResponse.class,
+                new WPAPIGsonRequest<>(Method.GET, url, params, null, FetchPluginInfoResponse.class,
                         new Listener<FetchPluginInfoResponse>() {
                             @Override
                             public void onResponse(FetchPluginInfoResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -2,9 +2,11 @@ package org.wordpress.android.fluxc.persistence;
 
 import android.support.annotation.NonNull;
 
+import com.wellsql.generated.PluginInfoModelTable;
 import com.wellsql.generated.PluginModelTable;
 import com.yarolegovich.wellsql.WellSql;
 
+import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 
@@ -29,5 +31,28 @@ public class PluginSqlUtils {
             pluginModel.setLocalSiteId(site.getId());
         }
         WellSql.insert(plugins).execute();
+    }
+
+    public static int insertOrUpdatePluginInfo(PluginInfoModel pluginInfo) {
+        if (pluginInfo == null) {
+            return 0;
+        }
+
+        // Slug is the primary key in remote, so we should use that to identify PluginInfoModels
+        if (getPluginInfoBySlug(pluginInfo.getSlug()) == null) {
+            WellSql.insert(pluginInfo).execute();
+            return 1;
+        } else {
+            return WellSql.update(PluginInfoModel.class)
+                    .where().equals(PluginInfoModelTable.SLUG, pluginInfo.getSlug()).endWhere()
+                    .put(pluginInfo).execute();
+        }
+    }
+
+    public static PluginInfoModel getPluginInfoBySlug(String slug) {
+        List<PluginInfoModel> result = WellSql.select(PluginInfoModel.class)
+                .where().equals(PluginInfoModelTable.SLUG, slug)
+                .endWhere().getAsModel();
+        return result.isEmpty() ? null : result.get(0);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -129,7 +129,7 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 13:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE PluginInfoModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                        + "NAME TEXT,SLUG TEXT,VERSION TEXT,RATING TEXT)");
+                        + "NAME TEXT,SLUG TEXT,VERSION TEXT,RATING TEXT,ICON TEXT)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -13,6 +13,7 @@ import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.PostModel;
@@ -45,11 +46,12 @@ public class WellSqlConfig extends DefaultWellConfig {
         add(TermModel.class);
         add(RoleModel.class);
         add(PluginModel.class);
+        add(PluginInfoModel.class);
     }};
 
     @Override
     public int getDbVersion() {
-        return 13;
+        return 14;
     }
 
     @Override
@@ -123,6 +125,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("CREATE TABLE PluginModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
                         + "NAME TEXT,DISPLAY_NAME TEXT,PLUGIN_URL TEXT,VERSION TEXT,SLUG TEXT,DESCRIPTION TEXT,"
                         + "AUTHOR_NAME TEXT,AUTHOR_URL TEXT,IS_ACTIVE INTEGER,IS_AUTO_UPDATE_ENABLED INTEGER)");
+                oldVersion++;
+            case 13:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("CREATE TABLE PluginInfoModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                        + "NAME TEXT,SLUG TEXT,VERSION TEXT,RATING TEXT)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.util.AppLog;
@@ -63,11 +64,13 @@ public class PluginStore extends Store {
     }
 
     private final PluginRestClient mPluginRestClient;
+    private final PluginInfoClient mPluginInfoClient;
 
     @Inject
-    public PluginStore(Dispatcher dispatcher, PluginRestClient pluginRestClient) {
+    public PluginStore(Dispatcher dispatcher, PluginRestClient pluginRestClient, PluginInfoClient pluginInfoClient) {
         super(dispatcher);
         mPluginRestClient = pluginRestClient;
+        mPluginInfoClient = pluginInfoClient;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -135,6 +135,10 @@ public class PluginStore extends Store {
         return PluginSqlUtils.getPlugins(site);
     }
 
+    public PluginInfoModel getPluginInfoBySlug(String slug) {
+        return PluginSqlUtils.getPluginInfoBySlug(slug);
+    }
+
     private void fetchPlugins(SiteModel site) {
         if (site.isUsingWpComRestApi() && site.isJetpackConnected()) {
             mPluginRestClient.fetchPlugins(site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -89,6 +89,9 @@ public class PluginStore extends Store {
             case FETCH_PLUGINS:
                 fetchPlugins((SiteModel) action.getPayload());
                 break;
+            case FETCH_PLUGIN_INFO:
+                fetchPluginInfo((String) action.getPayload());
+                break;
             case FETCHED_PLUGINS:
                 fetchedPlugins((FetchedPluginsPayload) action.getPayload());
                 break;
@@ -107,6 +110,10 @@ public class PluginStore extends Store {
             FetchedPluginsPayload payload = new FetchedPluginsPayload(error);
             fetchedPlugins(payload);
         }
+    }
+
+    private void fetchPluginInfo(String plugin) {
+        mPluginInfoClient.fetchPluginInfo(plugin);
     }
 
     private void fetchedPlugins(FetchedPluginsPayload payload) {


### PR DESCRIPTION
This is a continuation of #531 which needs to be merged before the review. This PR adds the ability to fetch the plugin information from the public .org endpoint. It introduces the `PluginInfoModel` which is currently barebones as I am not 100% sure which fields we'll need. Since this is merging to the feature branch, I'll just update the model and the migration for it if necessary.

The only thing to note is that I was unable to use the Endpoint generator and hoping @aforcier can help with that as discussed on Slack. That shouldn't be a blocker for the PR though since this is merging to a feature branch as mentioned before.