### PR TITLE
Add BaseWPOrgAPIClient and use it for plugin info

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
@@ -14,8 +14,8 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
@@ -32,7 +32,7 @@ import static org.wordpress.android.fluxc.plugin.PluginTestUtils.generatePlugins
 @RunWith(RobolectricTestRunner.class)
 public class PluginStoreUnitTest {
     private PluginStore mPluginStore = new PluginStore(new Dispatcher(),
-            Mockito.mock(PluginRestClient.class), Mockito.mock(PluginInfoClient.class));
+            Mockito.mock(PluginRestClient.class), Mockito.mock(PluginWPOrgClient.class));
 
     @Before
     public void setUp() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -20,11 +20,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
@@ -207,10 +207,10 @@ public class ReleaseNetworkModule {
 
     @Singleton
     @Provides
-    public PluginInfoClient providePluginInfoClient(Dispatcher dispatcher,
-                                                    @Named("regular") RequestQueue requestQueue,
-                                                    UserAgent userAgent) {
-        return new PluginInfoClient(dispatcher, requestQueue, userAgent);
+    public PluginWPOrgClient providePluginInfoClient(Dispatcher dispatcher,
+                                                     @Named("regular") RequestQueue requestQueue,
+                                                     UserAgent userAgent) {
+        return new PluginWPOrgClient(dispatcher, requestQueue, userAgent);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseStoreModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseStoreModule.java
@@ -7,11 +7,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
 import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
@@ -78,7 +78,7 @@ public class ReleaseStoreModule {
     @Provides
     @Singleton
     public PluginStore providePluginStore(Dispatcher dispatcher, PluginRestClient pluginRestClient,
-                                          PluginInfoClient pluginInfoClient) {
-        return new PluginStore(dispatcher, pluginRestClient, pluginInfoClient);
+                                          PluginWPOrgClient pluginWPOrgClient) {
+        return new PluginStore(dispatcher, pluginRestClient, pluginWPOrgClient);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/BaseWPOrgAPIClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/BaseWPOrgAPIClient.java
@@ -1,0 +1,42 @@
+package org.wordpress.android.fluxc.network.wporg;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.network.BaseRequest;
+import org.wordpress.android.fluxc.network.BaseRequest.OnAuthFailedListener;
+import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
+
+public abstract class BaseWPOrgAPIClient {
+    private final RequestQueue mRequestQueue;
+    private final Dispatcher mDispatcher;
+    private UserAgent mUserAgent;
+
+    private OnAuthFailedListener mOnAuthFailedListener;
+
+    public BaseWPOrgAPIClient(Dispatcher dispatcher, RequestQueue requestQueue,
+                              UserAgent userAgent) {
+        mDispatcher = dispatcher;
+        mRequestQueue = requestQueue;
+        mUserAgent = userAgent;
+        mOnAuthFailedListener = new OnAuthFailedListener() {
+            @Override
+            public void onAuthFailed(AuthenticateErrorPayload authError) {
+                mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateErrorAction(authError));
+            }
+        };
+    }
+
+    protected Request add(WPOrgAPIGsonRequest request) {
+        return mRequestQueue.add(setRequestAuthParams(request));
+    }
+
+    private BaseRequest setRequestAuthParams(BaseRequest request) {
+        request.setOnAuthFailedListener(mOnAuthFailedListener);
+        request.setUserAgent(mUserAgent.getUserAgent());
+        return request;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/WPOrgAPIGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/WPOrgAPIGsonRequest.java
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.network.wporg;
+
+import android.support.annotation.NonNull;
+
+import com.android.volley.Response.Listener;
+
+import org.wordpress.android.fluxc.network.rest.GsonRequest;
+
+import java.util.Map;
+
+public class WPOrgAPIGsonRequest<T> extends GsonRequest<T> {
+    public WPOrgAPIGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
+                               Class<T> clazz, Listener<T> listener, BaseErrorListener errorListener) {
+        super(method, params, body, url, clazz, null, listener, errorListener);
+        // If it's a GET request, add the parameters to the URL
+        if (method == Method.GET) {
+            addQueryParameters(params);
+        }
+    }
+
+    @Override
+    public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
+        return error;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/FetchPluginInfoResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/FetchPluginInfoResponse.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.plugin;
+package org.wordpress.android.fluxc.network.wporg.plugin;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.plugin;
+package org.wordpress.android.fluxc.network.wporg.plugin;
 
 import android.support.annotation.NonNull;
 
@@ -12,8 +12,8 @@ import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
-import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient;
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest;
+import org.wordpress.android.fluxc.network.wporg.BaseWPOrgAPIClient;
+import org.wordpress.android.fluxc.network.wporg.WPOrgAPIGsonRequest;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoError;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
@@ -25,11 +25,11 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public class PluginInfoClient extends BaseWPAPIRestClient {
+public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     private final Dispatcher mDispatcher;
 
     @Inject
-    public PluginInfoClient(Dispatcher dispatcher, RequestQueue requestQueue, UserAgent userAgent) {
+    public PluginWPOrgClient(Dispatcher dispatcher, RequestQueue requestQueue, UserAgent userAgent) {
         super(dispatcher, requestQueue, userAgent);
         mDispatcher = dispatcher;
     }
@@ -38,8 +38,8 @@ public class PluginInfoClient extends BaseWPAPIRestClient {
         String url = "https://api.wordpress.org/plugins/info/1.0/" + plugin + ".json";
         Map<String, String> params = new HashMap<>();
         params.put("fields", "icons");
-        final WPAPIGsonRequest<FetchPluginInfoResponse> request =
-                new WPAPIGsonRequest<>(Method.GET, url, params, null, FetchPluginInfoResponse.class,
+        final WPOrgAPIGsonRequest<FetchPluginInfoResponse> request =
+                new WPOrgAPIGsonRequest<>(Method.GET, url, params, null, FetchPluginInfoResponse.class,
                         new Listener<FetchPluginInfoResponse>() {
                             @Override
                             public void onResponse(FetchPluginInfoResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -12,8 +12,8 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginInfoClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.util.AppLog;
 
@@ -94,13 +94,13 @@ public class PluginStore extends Store {
     }
 
     private final PluginRestClient mPluginRestClient;
-    private final PluginInfoClient mPluginInfoClient;
+    private final PluginWPOrgClient mPluginWPOrgClient;
 
     @Inject
-    public PluginStore(Dispatcher dispatcher, PluginRestClient pluginRestClient, PluginInfoClient pluginInfoClient) {
+    public PluginStore(Dispatcher dispatcher, PluginRestClient pluginRestClient, PluginWPOrgClient pluginWPOrgClient) {
         super(dispatcher);
         mPluginRestClient = pluginRestClient;
-        mPluginInfoClient = pluginInfoClient;
+        mPluginWPOrgClient = pluginWPOrgClient;
     }
 
     @Override
@@ -150,7 +150,7 @@ public class PluginStore extends Store {
     }
 
     private void fetchPluginInfo(String plugin) {
-        mPluginInfoClient.fetchPluginInfo(plugin);
+        mPluginWPOrgClient.fetchPluginInfo(plugin);
     }
 
     private void fetchedPlugins(FetchedPluginsPayload payload) {


### PR DESCRIPTION
As discussed with @oguzkocer, updates the `PluginInfoClient` (now `PluginWPOrgClient`) to extend a new `BaseWPOrgAPIClient` instead of the existing `BaseWPAPIRestClient`.

The reasoning is that the `BaseWPAPIRestClient` is meant to target endpoints on individual sites, while the `PluginInfoClient` uses a public endpoint from `api.wordpress.org`. Eventually, the `BaseWPAPIRestClient` will have auth info attached, and it makes extra sense to separate the two to avoid sending individual site credentials in requests to `api.wordpress.org`.

A separate PR will add a new endpoint group, `WPORGAPI`, and move the endpoint used by the plugin info client there.

Note: The [BaseWPOrgAPIClient](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/2b84ce097a697c20f79afaf3a897a5fcff0e3e31/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/BaseWPOrgAPIClient.java) is set up a little differently from the other base clients. I'm using the approach from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/522 (currently under review).

cc @oguzkocer 