### PR TITLE
Add generated WPORGAPI endpoint class

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/WPOrgAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPOrgAPIEndpointTest.java
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.wordpress.android.fluxc.generated.endpoint.WPORGAPI;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class WPOrgAPIEndpointTest {
+    @Test
+    public void testAllEndpoints() {
+        // Plugins info
+        assertEquals("/plugins/info/1.0/akismet/", WPORGAPI.plugins.info.version("1.0").slug("akismet").getEndpoint());
+    }
+
+    @Test
+    public void testUrls() {
+        assertEquals("https://api.wordpress.org/plugins/info/1.0/akismet.json",
+                WPORGAPI.plugins.info.version("1.0").slug("akismet").getUrl());
+    }
+}

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/EndpointNode.java
@@ -72,7 +72,7 @@ public class EndpointNode {
             // For 'mixed' endpoints, e.g. item:$theItem, return the label part ('item')
             return getLocalEndpoint().substring(0, getLocalEndpoint().indexOf(":")).replaceAll("-", "_");
         } else {
-            return getLocalEndpoint().replaceAll("/|\\$|#.*|(?<!_or)(_ID|_id)|<|>", "").replaceAll("-", "_");
+            return getLocalEndpoint().replaceAll("/|\\$|#.*|(?<!_or)(_ID|_id)|<|>|\\{|\\}", "").replaceAll("-", "_");
         }
     }
 

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPOrgAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPOrgAPIEndpoint.java
@@ -1,0 +1,32 @@
+package org.wordpress.android.fluxc.annotations.endpoint;
+
+public class WPOrgAPIEndpoint {
+    private static final String WPORG_API_PREFIX = "https://api.wordpress.org";
+
+    private final String mEndpoint;
+
+    public WPOrgAPIEndpoint(String endpoint) {
+        mEndpoint = endpoint;
+    }
+
+    public WPOrgAPIEndpoint(String endpoint, long id) {
+        this(endpoint + id + "/");
+    }
+
+    public WPOrgAPIEndpoint(String endpoint, String value) {
+        this(endpoint + value + "/");
+    }
+
+    public String getEndpoint() {
+        return mEndpoint;
+    }
+
+    public String getUrl() {
+        if (mEndpoint.contains("plugins/info/")) {
+            // For the plugins-info endpoint specifically, we want to request JSON data
+            // All other WP.org endpoints either return JSON by default, or their newest endpoint version does
+            return WPORG_API_PREFIX + mEndpoint.substring(0, mEndpoint.length() - 1) + ".json";
+        }
+        return WPORG_API_PREFIX + mEndpoint;
+    }
+}

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.annotations.endpoint.EndpointNode;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointTreeGenerator;
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint;
 import org.wordpress.android.fluxc.annotations.endpoint.WPComEndpoint;
+import org.wordpress.android.fluxc.annotations.endpoint.WPOrgAPIEndpoint;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,9 +33,11 @@ public class EndpointProcessor extends AbstractProcessor {
     private static final String WPCOMREST_ENDPOINT_FILE = "fluxc/src/main/tools/wp-com-endpoints.txt";
     private static final String XMLRPC_ENDPOINT_FILE = "fluxc/src/main/tools/xmlrpc-endpoints.txt";
     private static final String WPAPI_ENDPOINT_FILE = "fluxc/src/main/tools/wp-api-endpoints.txt";
+    private static final String WPORG_API_ENDPOINT_FILE = "fluxc/src/main/tools/wporg-api-endpoints.txt";
 
     private static final Pattern WPCOMREST_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("\\$");
     private static final Pattern WPAPI_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("^<.*>/$");
+    private static final Pattern WPORG_API_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("^\\{.*\\}");
 
     private static final Map<String, List<String>> XML_RPC_ALIASES;
     static {
@@ -62,6 +65,7 @@ public class EndpointProcessor extends AbstractProcessor {
             generateWPCOMRESTEndpointFile();
             generateXMLRPCEndpointFile();
             generateWPAPIEndpointFile();
+            generateWPORGAPIEndpointFile();
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -94,6 +98,15 @@ public class EndpointProcessor extends AbstractProcessor {
 
         TypeSpec endpointClass = RESTPoet.generate(rootNode, "WPAPI", WPAPIEndpoint.class,
                 WPAPI_VARIABLE_ENDPOINT_PATTERN);
+        writeEndpointClassToFile(endpointClass);
+    }
+
+    private void generateWPORGAPIEndpointFile() throws IOException {
+        File file = new File(WPORG_API_ENDPOINT_FILE);
+        EndpointNode rootNode = EndpointTreeGenerator.process(file);
+
+        TypeSpec endpointClass = RESTPoet.generate(rootNode, "WPORGAPI", WPOrgAPIEndpoint.class,
+                WPORG_API_VARIABLE_ENDPOINT_PATTERN);
         writeEndpointClassToFile(endpointClass);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -8,6 +8,7 @@ import com.android.volley.Response.Listener;
 
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
+import org.wordpress.android.fluxc.generated.endpoint.WPORGAPI;
 import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
@@ -35,7 +36,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     }
 
     public void fetchPluginInfo(String plugin) {
-        String url = "https://api.wordpress.org/plugins/info/1.0/" + plugin + ".json";
+        String url = WPORGAPI.plugins.info.version("1.0").slug(plugin).getUrl();
         Map<String, String> params = new HashMap<>();
         params.put("fields", "icons");
         final WPOrgAPIGsonRequest<FetchPluginInfoResponse> request =

--- a/fluxc/src/main/tools/wporg-api-endpoints.txt
+++ b/fluxc/src/main/tools/wporg-api-endpoints.txt
@@ -1,0 +1,1 @@
+/plugins/info/{version}#String/{slug}#String


### PR DESCRIPTION
Adds a new endpoint family for [api.wordpress.org endpoints](https://codex.wordpress.org/WordPress.org_API) under `tools/wporg-api-endpoints.txt`, and adds code generation like the other endpoints (this one becomes `WPORGAPI`).

`plugins/info` seems, to our bad luck, to be the only endpoint that requires a `.json` suffix - the rest either return JSON by default, or have a specific version that does. Since it's an edge case, I opted for the simpler route of [making this an exception in the `getUrl()` method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7d3a08d29bafdd353cdad3534d789f98da7c46e0/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPOrgAPIEndpoint.java#L25-L29) rather than handling it inside the code generation.

Note: #534 should be reviewed and merged first, and the target branch of this PR updated to `feature/plugins`.

cc @oguzkocer