### PR TITLE
Issue/update checkstyle readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ We have some tests connecting to real HTTP servers, URL and credentials are defi
 
 The FluxC project uses [Checkstyle](http://checkstyle.sourceforge.net/). You can run checkstyle using `./gradlew checkstyle`.
 
-You can also install the Checkstyle plugin for Android Studio, which will allow checkstyle errors and warnings to be displayed in the editor in realtime. Once installed, you can configure the checkstyle plugin here:
+You can also view errors and warnings in realtime by installing the CheckStyle-IDEA plugin in Android Studio here:
 
-`Preferences > Other Settings > Checkstyle`
+`Android Studio > Preferences... > Plugins > CheckStyle-IDEA`
+
+Once installed, you can configure the plugin here:
+
+`Android Studio > Preferences... > Other Settings > Checkstyle`
 
 From there, add and enable the configuration file for FluxC, located [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/config/checkstyle.xml).
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,19 @@ Once installed, you can configure the plugin here:
 
 `Android Studio > Preferences... > Other Settings > Checkstyle`
 
-From there, add and enable the configuration file for FluxC, located [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/config/checkstyle.xml).
+From there, add and enable the configuration file for FluxC, located at [config/checkstyle.xml](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/config/checkstyle.xml).
+
+### Compatibility
+
+Checkstyle 8.1 breaks backward compatibility with previous versions including the current configuration file.  Be sure to target Checkstyle 8.0 or lower when configuring the CheckStyle-IDEA plugin in Android Studio. If you see the following error(s), check your plugin target.
+
+    org.infernus.idea.checkstyle.exception.CheckStylePluginException: <html><b>The Checkstyle rules file could not be parsed.</b><br>SuppressionCommentFilter is not allowed as a child in Checker<br>The file has been blacklisted for 60s.</html>
+	    at org.infernus.idea.checkstyle.checker.CheckerFactory.blacklistAndShowMessage(CheckerFactory.java:197)
+	    at org.infernus.idea.checkstyle.checker.CheckerFactory.blacklistAndShowMessage(CheckerFactory.java:213)
+	    at org.infernus.idea.checkstyle.checker.CheckerFactory.createChecker(CheckerFactory.java:145)
+	    ...
+
+<img src="https://user-images.githubusercontent.com/3827611/29678543-38a5d492-88bc-11e7-8271-45c7d4946fd4.png" alt="Android Studio Checkstyle Error Message" width="400" />
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ We have some tests connecting to real HTTP servers, URL and credentials are defi
 
 ## Setting up Checkstyle
 
-The FluxC project uses [Checkstyle](http://checkstyle.sourceforge.net/). You can run checkstyle using `./gradlew checkstyle`.
+The FluxC project uses [Checkstyle](http://checkstyle.sourceforge.net/). You can run checkstyle using `./gradlew checkstyle`.  You can also view errors and warnings in realtime with the Checkstyle plugin.  When importing the project into Android Studio, Checkstyle should be set up automatically.  If it is not, follow the steps below.
 
-You can also view errors and warnings in realtime by installing the CheckStyle-IDEA plugin in Android Studio here:
+You can install the CheckStyle-IDEA plugin in Android Studio here:
 
 `Android Studio > Preferences... > Plugins > CheckStyle-IDEA`
 


### PR DESCRIPTION
Update the ***Setting up Checkstyle*** section to include details about installing the CheckStyle-IDEA plugin through Android Studio and add a note about targeting Checkstyle 8.0 or lower in the ***Compatibility*** subsection of the `README.md` file.