### PR TITLE
Improve RoleModel's equals method

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/RoleModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/RoleModel.java
@@ -5,6 +5,8 @@ import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
+import org.wordpress.android.util.StringUtils;
+
 import java.io.Serializable;
 
 @Table
@@ -56,6 +58,9 @@ public class RoleModel implements Identifiable, Serializable {
         if (other == null || !(other instanceof RoleModel)) return false;
 
         RoleModel otherRole = (RoleModel) other;
-        return getName().equals(otherRole.getName());
+        return getId() == otherRole.getId()
+                && getSiteId() == otherRole.getSiteId()
+                && StringUtils.equals(getName(), otherRole.getName())
+                && StringUtils.equals(getDisplayName(), otherRole.getDisplayName());
     }
 }


### PR DESCRIPTION
I had some wrong assumptions when I first worked on the `RoleModel` regarding the role of `equals` method. I don't think it has resulted in any known errors about the usage of the class, but since I now realize that those assumptions were wrong, I wanted to fix the method both for consistency and to avoid any possible future problems.

P.S: I think @tonyr59h asked about this method in his review but I misunderstood the question due to mentioned assumptions.