### PR TITLE
Fix the possibility of false positives in Taxonomy connected tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -279,7 +279,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
                 mCountDownLatch.countDown();
                 return;
             }
-            throw new AssertionError("Unexpected error occured with type: " + event.error.type);
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertEquals(TestEvents.FETCHED_WPCOM_SITE_BY_URL, mNextEvent);
         mCountDownLatch.countDown();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -210,14 +210,17 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
                 assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
                 assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
                 assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             }
-            return;
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         switch (event.causeOfChange) {
             case FETCH_CATEGORIES:
@@ -256,17 +259,21 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
                 assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_DUPLICATE)) {
                 assertEquals(TaxonomyErrorType.DUPLICATE, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
                 assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
                 assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             }
-            return;
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertEquals(TestEvents.TERM_UPLOADED, mNextEvent);
         assertNotSame(0, event.term.getRemoteTermId());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -226,14 +226,17 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
                 assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
                 assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
                 assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             }
-            return;
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         switch (event.causeOfChange) {
             case FETCH_CATEGORIES:
@@ -273,17 +276,21 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
                 assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_DUPLICATE)) {
                 assertEquals(TaxonomyErrorType.DUPLICATE, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
                 assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
                 assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
+                return;
             }
-            return;
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertEquals(TestEvents.TERM_UPLOADED, mNextEvent);
         assertNotSame(0, event.term.getRemoteTermId());


### PR DESCRIPTION
In `ReleaseStack_TaxonomyTestWPCom` and `ReleaseStack_TaxonomyTestXMLRPC` we were ignoring the unexpected errors which this PR fixes. Fortunately there were actually no false positive tests. This PR also brings the Taxonomy tests inline with other stores.