### PR TITLE
Generify Payload

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -57,6 +57,12 @@
         <property name="severity" value="error"/>
     </module>
 
+    <module name="RegexpSingleline">
+        <property name="format" value="extends Payload[^&lt;]"/>
+        <property name="message" value="Payload should not be used as a raw type"/>
+        <property name="severity" value="error"/>
+    </module>
+
     <!-- Specific to FluxC / WordPress -->
     <module name="RegexpSingleline">
       <property name="format" value="dotcom"/>

--- a/example/src/test/java/org/wordpress/android/fluxc/PayloadTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/PayloadTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.network.BaseRequest;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -12,7 +13,7 @@ import static org.junit.Assert.assertNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class PayloadTest {
-    private class CloneablePayload extends Payload implements Cloneable {
+    private class CloneablePayload extends Payload<BaseNetworkError> implements Cloneable {
         @Override
         public CloneablePayload clone() {
             try {
@@ -37,7 +38,7 @@ public class PayloadTest {
         // Cloning payload with error field
         CloneablePayload errorPayload = new CloneablePayload();
 
-        errorPayload.error = new BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.SERVER_ERROR);
+        errorPayload.error = new BaseNetworkError(BaseRequest.GenericErrorType.SERVER_ERROR);
 
         CloneablePayload errorClone = errorPayload.clone();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/FluxCError.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/FluxCError.java
@@ -1,0 +1,3 @@
+package org.wordpress.android.fluxc;
+
+public interface FluxCError {}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/Payload.java
@@ -1,20 +1,12 @@
 package org.wordpress.android.fluxc;
 
-import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
-import java.lang.reflect.Field;
-
-public abstract class Payload {
-    public BaseNetworkError error;
+public abstract class Payload<T extends FluxCError> {
+    public T error;
 
     public boolean isError() {
-        try {
-            Field field = getClass().getField("error");
-            return field.get(this) != null;
-        } catch (Exception e) {
-            return true;
-        }
+        return error != null;
     }
 
     @Override
@@ -26,8 +18,8 @@ public abstract class Payload {
         Payload clonedPayload = (Payload) super.clone();
 
         // Clone non-primitive, mutable fields
-        if (this.error != null) {
-            clonedPayload.error = new BaseRequest.BaseNetworkError(this.error);
+        if (error != null && error instanceof BaseNetworkError) {
+            clonedPayload.error = new BaseNetworkError((BaseNetworkError) error);
         }
 
         return clonedPayload;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -6,10 +6,11 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.util.StringUtils;
 
 @Table
-public class AccountModel extends Payload implements Identifiable {
+public class AccountModel extends Payload<BaseNetworkError> implements Identifiable {
     @PrimaryKey(autoincrement = false)
     @Column private int mId;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
@@ -6,11 +6,12 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
 import java.io.Serializable;
 
 @Table
-public class CommentModel extends Payload implements Identifiable, Serializable {
+public class CommentModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     // Ids
     @PrimaryKey
     @Column private int mId;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -6,13 +6,14 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.StringUtils;
 
 import java.io.Serializable;
 
 @Table
-public class MediaModel extends Payload implements Identifiable, Serializable {
+public class MediaModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     public enum MediaUploadState {
         QUEUED, UPLOADING, DELETING, DELETED, FAILED, UPLOADED;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -14,6 +14,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.model.post.PostLocation;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 
@@ -23,7 +24,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Table
-public class PostModel extends Payload implements Cloneable, Identifiable, Serializable {
+public class PostModel extends Payload<BaseNetworkError> implements Cloneable, Identifiable, Serializable {
     private static final long LATITUDE_REMOVED_VALUE = 8888;
     private static final long LONGITUDE_REMOVED_VALUE = 8888;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostsModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostsModel.java
@@ -3,11 +3,12 @@ package org.wordpress.android.fluxc.model;
 import android.support.annotation.NonNull;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class PostsModel extends Payload {
+public class PostsModel extends Payload<BaseNetworkError> {
     private List<PostModel> mPosts;
 
     public PostsModel() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -10,6 +10,7 @@ import com.yarolegovich.wellsql.core.annotation.RawConstraints;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -22,7 +23,7 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
-public class SiteModel extends Payload implements Identifiable, Serializable {
+public class SiteModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     @Retention(SOURCE)
     @IntDef({ORIGIN_UNKNOWN, ORIGIN_WPCOM_REST, ORIGIN_XMLRPC})
     public @interface SiteOrigin {}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
@@ -3,11 +3,12 @@ package org.wordpress.android.fluxc.model;
 import android.support.annotation.NonNull;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class SitesModel extends Payload {
+public class SitesModel extends Payload<BaseNetworkError> {
     private List<SiteModel> mSites;
 
     public SitesModel() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
@@ -6,12 +6,13 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.util.StringUtils;
 
 import java.io.Serializable;
 
 @Table
-public class TaxonomyModel extends Payload implements Identifiable, Serializable {
+public class TaxonomyModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     @PrimaryKey
     @Column private int mId;
     @Column private int mLocalSiteId;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
@@ -6,12 +6,13 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.util.StringUtils;
 
 import java.io.Serializable;
 
 @Table
-public class TermModel extends Payload implements Identifiable, Serializable {
+public class TermModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     @PrimaryKey
     @Column private int mId;
     @Column private int mLocalSiteId;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermsModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermsModel.java
@@ -3,11 +3,12 @@ package org.wordpress.android.fluxc.model;
 import android.support.annotation.NonNull;
 
 import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class TermsModel extends Payload {
+public class TermsModel extends Payload<BaseNetworkError> {
     private List<TermModel> mTerms;
 
     public TermsModel() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -14,6 +14,7 @@ import com.android.volley.Request;
 import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 
+import org.wordpress.android.fluxc.FluxCError;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError;
 import org.wordpress.android.util.AppLog;
@@ -45,7 +46,7 @@ public abstract class BaseRequest<T> extends Request<T> {
     protected final Map<String, String> mHeaders = new HashMap<>(2);
     private BaseErrorListener mErrorListener;
 
-    public static class BaseNetworkError {
+    public static class BaseNetworkError implements FluxCError {
         public GenericErrorType type;
         public String message;
         public VolleyError volleyError;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -8,7 +8,6 @@ import org.wordpress.android.fluxc.BuildConfig;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.store.Store.OnChangedError;
 import org.wordpress.android.fluxc.utils.WPUrlUtils;
 import org.wordpress.android.util.AppLog;
@@ -51,10 +50,9 @@ public class SelfHostedEndpointFinder {
         }
     }
 
-    public static class DiscoveryResultPayload extends Payload<BaseNetworkError> {
+    public static class DiscoveryResultPayload extends Payload<DiscoveryError> {
         public String xmlRpcEndpoint;
         public String wpRestEndpoint;
-        public DiscoveryError discoveryError;
         public String failedEndpoint;
 
         public DiscoveryResultPayload(String xmlRpcEndpoint, String wpRestEndpoint) {
@@ -63,12 +61,8 @@ public class SelfHostedEndpointFinder {
         }
 
         public DiscoveryResultPayload(DiscoveryError discoveryError, String failedEndpoint) {
-            this.discoveryError = discoveryError;
+            this.error = discoveryError;
             this.failedEndpoint = failedEndpoint;
-        }
-
-        public boolean isDiscoveryError() {
-            return discoveryError != null;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.BuildConfig;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.store.Store.OnChangedError;
 import org.wordpress.android.fluxc.utils.WPUrlUtils;
 import org.wordpress.android.util.AppLog;
@@ -50,7 +51,7 @@ public class SelfHostedEndpointFinder {
         }
     }
 
-    public static class DiscoveryResultPayload extends Payload {
+    public static class DiscoveryResultPayload extends Payload<BaseNetworkError> {
         public String xmlRpcEndpoint;
         public String wpRestEndpoint;
         public DiscoveryError discoveryError;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -41,7 +41,7 @@ import javax.inject.Singleton;
 public class AccountRestClient extends BaseWPComRestClient {
     private final AppSecrets mAppSecrets;
 
-    public static class AccountRestPayload extends Payload {
+    public static class AccountRestPayload extends Payload<BaseNetworkError> {
         public AccountRestPayload(AccountModel account, BaseNetworkError error) {
             this.account = account;
             this.error = error;
@@ -49,24 +49,22 @@ public class AccountRestClient extends BaseWPComRestClient {
         public AccountModel account;
     }
 
-    public static class AccountPushSettingsResponsePayload extends Payload {
+    public static class AccountPushSettingsResponsePayload extends Payload<BaseNetworkError> {
         public AccountPushSettingsResponsePayload(BaseNetworkError error) {
             this.error = error;
         }
         public Map<String, Object> settings;
     }
 
-    public static class NewAccountResponsePayload extends Payload {
-        public NewUserError error;
+    public static class NewAccountResponsePayload extends Payload<NewUserError> {
         public boolean dryRun;
     }
 
-    public static class IsAvailableResponsePayload extends Payload {
+    public static class IsAvailableResponsePayload extends Payload<IsAvailableError> {
         public IsAvailable type;
         public String value;
         public boolean isAvailable;
         public List<String> suggestions;
-        public IsAvailableError error;
     }
 
     public enum IsAvailable {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -66,8 +66,7 @@ public class Authenticator {
     public interface ErrorListener extends Response.ErrorListener {
     }
 
-    public static class AuthEmailResponsePayload extends Payload {
-        public AuthEmailError error;
+    public static class AuthEmailResponsePayload extends Payload<AuthEmailError> {
         public AuthEmailResponsePayload() {}
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -68,38 +68,31 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     private final AppSecrets mAppSecrets;
 
-    public static class NewSiteResponsePayload extends Payload {
-        public NewSiteResponsePayload() {
-        }
+    public static class NewSiteResponsePayload extends Payload<NewSiteError> {
+        public NewSiteResponsePayload() {}
         public long newSiteRemoteId;
-        public NewSiteError error;
         public boolean dryRun;
     }
 
-    public static class DeleteSiteResponsePayload extends Payload {
-        public DeleteSiteResponsePayload() {
-        }
+    public static class DeleteSiteResponsePayload extends Payload<DeleteSiteError> {
+        public DeleteSiteResponsePayload() {}
         public SiteModel site;
-        public DeleteSiteError error;
     }
 
-    public static class ExportSiteResponsePayload extends Payload {
-        public ExportSiteResponsePayload() {
-        }
+    public static class ExportSiteResponsePayload extends Payload<BaseNetworkError> {
+        public ExportSiteResponsePayload() {}
     }
 
-    public static class IsWPComResponsePayload extends Payload {
-        public IsWPComResponsePayload() {
-        }
+    public static class IsWPComResponsePayload extends Payload<BaseNetworkError> {
+        public IsWPComResponsePayload() {}
         public String url;
         public boolean isWPCom;
     }
 
-    public static class FetchWPComSiteResponsePayload extends Payload {
+    public static class FetchWPComSiteResponsePayload extends Payload<SiteError> {
         public FetchWPComSiteResponsePayload() {}
         public String checkedUrl;
         public SiteModel site;
-        public SiteError error;
     }
 
     @Inject

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.action.AuthenticationAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.AccountModel;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryError;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryResultPayload;
@@ -42,7 +43,7 @@ import javax.inject.Singleton;
 @Singleton
 public class AccountStore extends Store {
     // Payloads
-    public static class AuthenticatePayload extends Payload {
+    public static class AuthenticatePayload extends Payload<BaseNetworkError> {
         public String username;
         public String password;
         public String twoStepCode;
@@ -54,8 +55,7 @@ public class AccountStore extends Store {
         }
     }
 
-    public static class AuthenticateErrorPayload extends Payload {
-        public AuthenticationError error;
+    public static class AuthenticateErrorPayload extends Payload<AuthenticationError> {
         public AuthenticateErrorPayload(@NonNull AuthenticationError error) {
             this.error = error;
         }
@@ -64,13 +64,13 @@ public class AccountStore extends Store {
         }
     }
 
-    public static class PushAccountSettingsPayload extends Payload {
+    public static class PushAccountSettingsPayload extends Payload<BaseNetworkError> {
         public Map<String, Object> params;
         public PushAccountSettingsPayload() {
         }
     }
 
-    public static class NewAccountPayload extends Payload {
+    public static class NewAccountPayload extends Payload<BaseNetworkError> {
         public String username;
         public String password;
         public String email;
@@ -84,7 +84,7 @@ public class AccountStore extends Store {
         }
     }
 
-    public static class UpdateTokenPayload extends Payload {
+    public static class UpdateTokenPayload extends Payload<BaseNetworkError> {
         public UpdateTokenPayload(String token) {
             this.token = token;
         }
@@ -98,8 +98,7 @@ public class AccountStore extends Store {
         public AccountAction causeOfChange;
     }
 
-    public static class OnAuthenticationChanged extends OnChanged<AuthenticationError> {
-    }
+    public static class OnAuthenticationChanged extends OnChanged<AuthenticationError> {}
 
     public static class OnDiscoveryResponse extends OnChanged<DiscoveryError> {
         public String xmlRpcEndpoint;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -418,10 +418,7 @@ public class AccountStore extends Store {
     private void discoveryResult(DiscoveryResultPayload payload) {
         OnDiscoveryResponse discoveryResponse = new OnDiscoveryResponse();
         if (payload.isError()) {
-            discoveryResponse.error = DiscoveryError.GENERIC_ERROR;
-            discoveryResponse.failedEndpoint = payload.failedEndpoint;
-        } else if (payload.isDiscoveryError()) {
-            discoveryResponse.error = payload.discoveryError;
+            discoveryResponse.error = payload.error;
             discoveryResponse.failedEndpoint = payload.failedEndpoint;
         } else {
             discoveryResponse.xmlRpcEndpoint = payload.xmlRpcEndpoint;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.CommentSqlUtils;
@@ -35,7 +36,7 @@ public class CommentStore extends Store {
 
     // Payloads
 
-    public static class FetchCommentsPayload extends Payload {
+    public static class FetchCommentsPayload extends Payload<BaseNetworkError> {
         @NonNull public final SiteModel site;
         @NonNull public final CommentStatus status;
         public final int number;
@@ -56,7 +57,7 @@ public class CommentStore extends Store {
         }
     }
 
-    public static class RemoteCommentPayload extends Payload {
+    public static class RemoteCommentPayload extends Payload<BaseNetworkError> {
         @NonNull public final SiteModel site;
         @Nullable public final CommentModel comment;
         public final long remoteCommentId;
@@ -87,12 +88,11 @@ public class CommentStore extends Store {
         }
     }
 
-    public static class FetchCommentsResponsePayload extends Payload {
+    public static class FetchCommentsResponsePayload extends Payload<CommentError> {
         @NonNull public final List<CommentModel> comments;
         @NonNull public final SiteModel site;
         public final int number;
         public final int offset;
-        public CommentError error;
 
         public FetchCommentsResponsePayload(@NonNull List<CommentModel> comments, @NonNull SiteModel site, int number,
                                             int offset) {
@@ -103,21 +103,19 @@ public class CommentStore extends Store {
         }
     }
 
-    public static class RemoteCommentResponsePayload extends Payload {
+    public static class RemoteCommentResponsePayload extends Payload<CommentError> {
         @Nullable public final CommentModel comment;
-        public CommentError error;
         public RemoteCommentResponsePayload(@Nullable CommentModel comment) {
             this.comment = comment;
         }
     }
 
-    public static class RemoteCreateCommentPayload extends Payload {
+    public static class RemoteCreateCommentPayload extends Payload<CommentError> {
         public final SiteModel site;
         public final CommentModel comment;
         public final CommentModel reply;
         public final PostModel post;
 
-        public CommentError error;
         public RemoteCreateCommentPayload(@NonNull SiteModel site, @NonNull PostModel post,
                                           @NonNull CommentModel comment) {
             this.site = site;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -17,7 +17,7 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.network.BaseRequest;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.BaseUploadRequestBody;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
@@ -46,9 +46,8 @@ public class MediaStore extends Store {
     /**
      * Actions: FETCH(ED)_MEDIA, PUSH(ED)_MEDIA, UPLOAD(ED)_MEDIA, DELETE(D)_MEDIA, UPDATE_MEDIA, and REMOVE_MEDIA
      */
-    public static class MediaPayload extends Payload {
+    public static class MediaPayload extends Payload<MediaError> {
         public SiteModel site;
-        public MediaError error;
         public MediaModel media;
         public MediaPayload(SiteModel site, MediaModel media) {
             this(site, media, null);
@@ -63,7 +62,7 @@ public class MediaStore extends Store {
     /**
      * Actions: FETCH_MEDIA_LIST
      */
-    public static class FetchMediaListPayload extends Payload {
+    public static class FetchMediaListPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public boolean loadMore;
         public String mimeType;
@@ -90,9 +89,8 @@ public class MediaStore extends Store {
     /**
      * Actions: FETCHED_MEDIA_LIST
      */
-    public static class FetchMediaListResponsePayload extends Payload {
+    public static class FetchMediaListResponsePayload extends Payload<MediaError> {
         public SiteModel site;
-        public MediaError error;
         public List<MediaModel> mediaList;
         public boolean loadedMore;
         public boolean canLoadMore;
@@ -109,9 +107,7 @@ public class MediaStore extends Store {
             this.mimeType = mimeType;
         }
 
-        public FetchMediaListResponsePayload(SiteModel site,
-                                             MediaError error,
-                                             String mimeType) {
+        public FetchMediaListResponsePayload(SiteModel site, MediaError error, String mimeType) {
             this.mediaList = new ArrayList<>();
             this.site = site;
             this.error = error;
@@ -122,12 +118,11 @@ public class MediaStore extends Store {
     /**
      * Actions: UPLOADED_MEDIA, CANCELED_MEDIA_UPLOAD
      */
-    public static class ProgressPayload extends Payload {
+    public static class ProgressPayload extends Payload<MediaError> {
         public MediaModel media;
         public float progress;
         public boolean completed;
         public boolean canceled;
-        public MediaError error;
         public ProgressPayload(MediaModel media, float progress, boolean completed, boolean canceled) {
             this(media, progress, completed, null);
             this.canceled = canceled;
@@ -143,7 +138,7 @@ public class MediaStore extends Store {
     /**
      * Actions: CANCEL_MEDIA_UPLOAD
      */
-    public static class CancelMediaPayload extends Payload {
+    public static class CancelMediaPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public MediaModel media;
         public boolean delete;
@@ -278,7 +273,7 @@ public class MediaStore extends Store {
         // unknown/unspecified
         GENERIC_ERROR;
 
-        public static MediaErrorType fromBaseNetworkError(BaseRequest.BaseNetworkError baseError) {
+        public static MediaErrorType fromBaseNetworkError(BaseNetworkError baseError) {
             switch (baseError.type) {
                 case NOT_FOUND:
                     return MediaErrorType.NOT_FOUND;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
@@ -23,7 +24,7 @@ import javax.inject.Inject;
 
 public class PluginStore extends Store {
     // Payloads
-    public static class UpdatePluginPayload extends Payload {
+    public static class UpdatePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public PluginModel plugin;
 
@@ -33,10 +34,9 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class FetchedPluginsPayload extends Payload {
+    public static class FetchedPluginsPayload extends Payload<FetchPluginsError> {
         public SiteModel site;
         public List<PluginModel> plugins;
-        public FetchPluginsError error;
 
         public FetchedPluginsPayload(FetchPluginsError error) {
             this.error = error;
@@ -48,9 +48,8 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class FetchedPluginInfoPayload extends Payload {
+    public static class FetchedPluginInfoPayload extends Payload<FetchPluginInfoError> {
         public PluginInfoModel pluginInfo;
-        public FetchPluginInfoError error;
 
         public FetchedPluginInfoPayload(FetchPluginInfoError error) {
             this.error = error;
@@ -61,10 +60,9 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class UpdatedPluginPayload extends Payload {
+    public static class UpdatedPluginPayload extends Payload<UpdatePluginError> {
         public SiteModel site;
         public PluginModel plugin;
-        public UpdatePluginError error;
 
         public UpdatedPluginPayload(SiteModel site, PluginModel plugin) {
             this.site = site;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.PostSqlUtils;
@@ -40,7 +41,7 @@ public class PostStore extends Store {
             PostStatus.PUBLISHED,
             PostStatus.SCHEDULED));
 
-    public static class FetchPostsPayload extends Payload {
+    public static class FetchPostsPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public boolean loadMore;
 
@@ -54,7 +55,7 @@ public class PostStore extends Store {
         }
     }
 
-    public static class SearchPostsPayload extends Payload {
+    public static class SearchPostsPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public String searchTerm;
         public int offset;
@@ -70,8 +71,7 @@ public class PostStore extends Store {
         }
     }
 
-    public static class SearchPostsResponsePayload extends Payload {
-        public PostError error;
+    public static class SearchPostsResponsePayload extends Payload<PostError> {
         public PostsModel posts;
         public SiteModel site;
         public String searchTerm;
@@ -97,8 +97,7 @@ public class PostStore extends Store {
         }
     }
 
-    public static class FetchPostsResponsePayload extends Payload {
-        public PostError error;
+    public static class FetchPostsResponsePayload extends Payload<PostError> {
         public PostsModel posts;
         public SiteModel site;
         public boolean isPages;
@@ -119,8 +118,7 @@ public class PostStore extends Store {
         }
     }
 
-    public static class RemotePostPayload extends Payload {
-        public PostError error;
+    public static class RemotePostPayload extends Payload<PostError> {
         public PostModel post;
         public SiteModel site;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -49,14 +49,14 @@ import javax.inject.Singleton;
 @Singleton
 public class SiteStore extends Store {
     // Payloads
-    public static class RefreshSitesXMLRPCPayload extends Payload {
+    public static class RefreshSitesXMLRPCPayload extends Payload<BaseNetworkError> {
         public RefreshSitesXMLRPCPayload() {}
         public String username;
         public String password;
         public String url;
     }
 
-    public static class NewSitePayload extends Payload {
+    public static class NewSitePayload extends Payload<BaseNetworkError> {
         public String siteName;
         public String siteTitle;
         public String language;
@@ -72,27 +72,25 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class FetchedPostFormatsPayload extends Payload {
+    public static class FetchedPostFormatsPayload extends Payload<PostFormatsError> {
         public SiteModel site;
         public List<PostFormatModel> postFormats;
-        public PostFormatsError error;
         public FetchedPostFormatsPayload(@NonNull SiteModel site, @NonNull List<PostFormatModel> postFormats) {
             this.site = site;
             this.postFormats = postFormats;
         }
     }
 
-    public static class FetchedUserRolesPayload extends Payload {
+    public static class FetchedUserRolesPayload extends Payload<UserRolesError> {
         public SiteModel site;
         public List<RoleModel> roles;
-        public UserRolesError error;
         public FetchedUserRolesPayload(@NonNull SiteModel site, @NonNull List<RoleModel> roles) {
             this.site = site;
             this.roles = roles;
         }
     }
 
-    public static class SuggestDomainsPayload extends Payload {
+    public static class SuggestDomainsPayload extends Payload<BaseNetworkError> {
         public String query;
         public boolean includeWordpressCom;
         public boolean includeDotBlogSubdomain;
@@ -106,7 +104,7 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class SuggestDomainsResponsePayload extends Payload {
+    public static class SuggestDomainsResponsePayload extends Payload<BaseNetworkError> {
         public String query;
         public List<DomainSuggestionResponse> suggestions;
         public SuggestDomainsResponsePayload(@NonNull String query, BaseNetworkError error) {
@@ -121,7 +119,7 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class ConnectSiteInfoPayload extends Payload {
+    public static class ConnectSiteInfoPayload extends Payload<SiteError> {
         public String url;
         public boolean exists;
         public boolean isWordPress;
@@ -129,7 +127,6 @@ public class SiteStore extends Store {
         public boolean isJetpackActive;
         public boolean isJetpackConnected;
         public boolean isWPCom;
-        public SiteError error;
 
         public ConnectSiteInfoPayload(@NonNull String url, SiteError error) {
             this.url = url;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/Store.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.store;
 
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.FluxCError;
 import org.wordpress.android.fluxc.annotations.action.Action;
 
 public abstract class Store {
@@ -11,7 +12,7 @@ public abstract class Store {
         mDispatcher.register(this);
     }
 
-    public interface OnChangedError {}
+    public interface OnChangedError extends FluxCError {}
 
     public static class OnChanged<T extends OnChangedError> {
         public T error = null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.model.TermsModel;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.TaxonomySqlUtils;
@@ -27,7 +28,7 @@ public class TaxonomyStore extends Store {
     public static final String DEFAULT_TAXONOMY_CATEGORY = "category";
     public static final String DEFAULT_TAXONOMY_TAG = "post_tag";
 
-    public static class FetchTermsPayload extends Payload {
+    public static class FetchTermsPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public TaxonomyModel taxonomy;
 
@@ -37,8 +38,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    public static class FetchTermsResponsePayload extends Payload {
-        public TaxonomyError error;
+    public static class FetchTermsResponsePayload extends Payload<TaxonomyError> {
         public TermsModel terms;
         public SiteModel site;
         public String taxonomy;
@@ -55,8 +55,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    public static class RemoteTermPayload extends Payload {
-        public TaxonomyError error;
+    public static class RemoteTermPayload extends Payload<TaxonomyError> {
         public TermModel term;
         public SiteModel site;
 


### PR DESCRIPTION
Updates `Payload` to take a generic parameter, which represents the error type that `Payload` can have. Subclasses of `Payload` should always set the parameter - either to a custom error type or to `BaseNetworkError` (to reproduce the previous default behavior).

This PR also adds a Checkstyle rule to enforce that anything extending `Payload` supplies a parameter.

This is a prerequisite for Kotlin support - see #547 for more background detail.

cc @maxme