### PR TITLE
Remove activation & deactivation errors from update plugin call

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -76,9 +76,9 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
 
-        // If a plugin is active and we try to activate it, we'll get an error. If it's not active and we try to
-        // deactivate it, we'll again get an error. So, in order to have a reliable test, we have to fetch the
-        // plugins first, select one and change the activation status and verify that it went through.
+        // In order to have a reliable test, let's first fetch the list of plugins, pick the first plugin
+        // and change it's active status, so we can make sure when we run the test multiple times, each time
+        // an action is actually taken. This wouldn't be the case if we always activate the plugin.
 
         mNextEvent = TestEvents.PLUGINS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -112,12 +112,6 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 case "unauthorized":
                                     updatePluginError.type = UpdatePluginErrorType.UNAUTHORIZED;
                                     break;
-                                case "activation_error":
-                                    updatePluginError.type = UpdatePluginErrorType.ACTIVATION_ERROR;
-                                    break;
-                                case "deactivation_error":
-                                    updatePluginError.type = UpdatePluginErrorType.DEACTIVATION_ERROR;
-                                    break;
                             }
                         }
                         updatePluginError.message = networkError.message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -119,8 +119,6 @@ public class PluginStore extends Store {
     public enum UpdatePluginErrorType {
         GENERIC_ERROR,
         UNAUTHORIZED,
-        ACTIVATION_ERROR, // plugin is already enabled
-        DEACTIVATION_ERROR, // plugin is already disabled
         NOT_AVAILABLE // Return for non-jetpack sites
     }
 


### PR DESCRIPTION
Since the API is going to be updated soon, we don't need these errors anymore. With that, the previous comment I had about the activation/deactivation doesn't make sense. However, I still want to keep the test as is and I explained my reasoning in the updated comment. Hope that makes sense.

/cc @tonyr59h 