### PR TITLE
Plugin endpoints improvements and additions

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -35,6 +35,10 @@ public class WPComEndpointTest {
         // Plugins
         assertEquals("/sites/56/plugins/", WPCOMREST.sites.site(56).plugins.getEndpoint());
         assertEquals("/sites/56/plugins/akismet/", WPCOMREST.sites.site(56).plugins.name("akismet").getEndpoint());
+        assertEquals("/sites/56/plugins/akismet/install/", WPCOMREST.sites.site(56).plugins.name("akismet")
+                .install.getEndpoint());
+        assertEquals("/sites/56/plugins/akismet/delete/", WPCOMREST.sites.site(56).plugins.name("akismet")
+                .delete.getEndpoint());
 
         // Sites - Taxonomies
         assertEquals("/sites/56/taxonomies/category/terms/",

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -32,6 +32,10 @@ public class WPComEndpointTest {
         assertEquals("/sites/56/media/78/delete/", WPCOMREST.sites.site(56).media.item(78).delete.getEndpoint());
         assertEquals("/sites/56/media/new/", WPCOMREST.sites.site(56).media.new_.getEndpoint());
 
+        // Plugins
+        assertEquals("/sites/56/plugins/", WPCOMREST.sites.site(56).plugins.getEndpoint());
+        assertEquals("/sites/56/plugins/akismet/", WPCOMREST.sites.site(56).plugins.name("akismet").getEndpoint());
+
         // Sites - Taxonomies
         assertEquals("/sites/56/taxonomies/category/terms/",
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.getEndpoint());

--- a/example/src/test/java/org/wordpress/android/fluxc/WPOrgAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPOrgAPIEndpointTest.java
@@ -13,11 +13,14 @@ public class WPOrgAPIEndpointTest {
     public void testAllEndpoints() {
         // Plugins info
         assertEquals("/plugins/info/1.0/akismet/", WPORGAPI.plugins.info.version("1.0").slug("akismet").getEndpoint());
+        assertEquals("/plugins/info/1.1/", WPORGAPI.plugins.info.version("1.1").getEndpoint());
     }
 
     @Test
     public void testUrls() {
         assertEquals("https://api.wordpress.org/plugins/info/1.0/akismet.json",
                 WPORGAPI.plugins.info.version("1.0").slug("akismet").getUrl());
+        assertEquals("https://api.wordpress.org/plugins/info/1.1/",
+                WPORGAPI.plugins.info.version("1.1").getUrl());
     }
 }

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPOrgAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPOrgAPIEndpoint.java
@@ -22,8 +22,8 @@ public class WPOrgAPIEndpoint {
     }
 
     public String getUrl() {
-        if (mEndpoint.contains("plugins/info/")) {
-            // For the plugins-info endpoint specifically, we want to request JSON data
+        if (mEndpoint.contains("plugins/info/1.0")) {
+            // For the plugins-info endpoint for 1.0 specifically, we want to request JSON data
             // All other WP.org endpoints either return JSON by default, or their newest endpoint version does
             return WPORG_API_PREFIX + mEndpoint.substring(0, mEndpoint.length() - 1) + ".json";
         }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -23,11 +23,6 @@
 /sites/$site/roles
 /sites/new/
 
-/sites/$site/plugins
-/sites/$site/plugins/$name#String
-/sites/$site/plugins/$name#String/install
-/sites/$site/plugins/$name#String/delete
-
 /sites/$site/comments/
 /sites/$site/comments/$comment_ID
 /sites/$site/comments/$comment_ID/delete
@@ -39,6 +34,11 @@
 /sites/$site/media/$media_ID/
 /sites/$site/media/$media_ID/delete/
 /sites/$site/media/new/
+
+/sites/$site/plugins
+/sites/$site/plugins/$name#String
+/sites/$site/plugins/$name#String/delete
+/sites/$site/plugins/$name#String/install
 
 /sites/$site/posts/
 /sites/$site/posts/$post_ID/

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -19,11 +19,14 @@
 /sites/
 /sites/$site/delete
 /sites/$site/exports/start
-/sites/$site/plugins
-/sites/$site/plugins/$name#String
 /sites/$site/post-formats/
 /sites/$site/roles
 /sites/new/
+
+/sites/$site/plugins
+/sites/$site/plugins/$name#String
+/sites/$site/plugins/$name#String/install
+/sites/$site/plugins/$name#String/delete
 
 /sites/$site/comments/
 /sites/$site/comments/$comment_ID

--- a/fluxc/src/main/tools/wporg-api-endpoints.txt
+++ b/fluxc/src/main/tools/wporg-api-endpoints.txt
@@ -1,2 +1,2 @@
-/plugins/info/{version}#String/{slug}#String
 /plugins/info/{version}#String/
+/plugins/info/{version}#String/{slug}#String

--- a/fluxc/src/main/tools/wporg-api-endpoints.txt
+++ b/fluxc/src/main/tools/wporg-api-endpoints.txt
@@ -1,1 +1,2 @@
 /plugins/info/{version}#String/{slug}#String
+/plugins/info/{version}#String/


### PR DESCRIPTION
This PR adds a couple endpoints that we'll be using soon as well as adding a couple of tests for previously added plugin endpoints. It also makes a slight change to how the plugin info endpoint is generated since that special case only seems to be happening in the 1.0 version of the API.

/cc @aforcier 