### PR TITLE
Drop name() from IAction

### DIFF
--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/action/IAction.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/action/IAction.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.annotations.action;
 
 public interface IAction {
-    String name();
     String toString();
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/Dispatcher.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/Dispatcher.java
@@ -33,7 +33,7 @@ public class Dispatcher {
 
     public void dispatch(Action action) {
         AppLog.d(T.API, "Dispatching action: " + action.getType().getClass().getSimpleName()
-                + "-" + action.getType().name());
+                + "-" + action.getType().toString());
         post(action);
     }
 


### PR DESCRIPTION
This is a prerequisite for being able to write new `Action` classes in Kotlin - see item 3 in https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/547.

cc @maxme