### PR TITLE
Browse plugin 0.1

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginInfoTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginInfoTest.java
@@ -50,6 +50,8 @@ public class ReleaseStack_PluginInfoTest extends ReleaseStack_Base {
 
         BrowsePluginPayload payload = new BrowsePluginPayload();
         mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginsAction(payload));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginInfoTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginInfoTest.java
@@ -4,6 +4,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.model.PluginInfoModel;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient.BrowsePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore;
 import org.wordpress.android.fluxc.store.PluginStore.OnPluginInfoChanged;
 
@@ -18,6 +19,7 @@ public class ReleaseStack_PluginInfoTest extends ReleaseStack_Base {
     enum TestEvents {
         NONE,
         PLUGIN_INFO_FETCHED,
+        WPORG_PLUGINS_FETCHED
     }
 
     private TestEvents mNextEvent;
@@ -40,6 +42,14 @@ public class ReleaseStack_PluginInfoTest extends ReleaseStack_Base {
         mDispatcher.dispatch(PluginActionBuilder.newFetchPluginInfoAction(mSlug));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    public void testFetchPlugins() throws InterruptedException {
+        mNextEvent = TestEvents.WPORG_PLUGINS_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        BrowsePluginPayload payload = new BrowsePluginPayload();
+        mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginsAction(payload));
     }
 
     @SuppressWarnings("unused")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -5,8 +5,8 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient.BrowsePluginPayload;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatePluginPayload;
-import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginsPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedPluginPayload;
 
@@ -32,5 +32,5 @@ public enum PluginAction implements IAction {
 
     // Remote WPORG responses
     @Action(payloadType = FetchedPluginInfoPayload.class)
-    FETCHED_PLUGIN_INFO
+    FETCHED_PLUGIN_INFO,
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient.BrowsePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginsPayload;
@@ -11,19 +12,25 @@ import org.wordpress.android.fluxc.store.PluginStore.UpdatedPluginPayload;
 
 @ActionEnum
 public enum PluginAction implements IAction {
-    // Remote actions
+    // Remote REST actions
     @Action(payloadType = SiteModel.class)
     FETCH_PLUGINS,
-    @Action(payloadType = String.class)
-    FETCH_PLUGIN_INFO,
     @Action(payloadType = UpdatePluginPayload.class)
     UPDATE_PLUGIN,
 
-    // Remote responses
+    // REMOTE WPORG actions
+    @Action(payloadType = String.class)
+    FETCH_PLUGIN_INFO,
+    @Action(payloadType = BrowsePluginPayload.class)
+    FETCH_WPORG_PLUGINS,
+
+    // Remote REST responses
     @Action(payloadType = FetchedPluginsPayload.class)
     FETCHED_PLUGINS,
-    @Action(payloadType = FetchedPluginInfoPayload.class)
-    FETCHED_PLUGIN_INFO,
     @Action(payloadType = UpdatedPluginPayload.class)
-    UPDATED_PLUGIN
+    UPDATED_PLUGIN,
+
+    // Remote WPORG responses
+    @Action(payloadType = FetchedPluginInfoPayload.class)
+    FETCHED_PLUGIN_INFO
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/FetchPluginInfoResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/FetchPluginInfoResponse.java
@@ -8,9 +8,20 @@ import com.google.gson.JsonParseException;
 import com.google.gson.annotations.JsonAdapter;
 
 import java.lang.reflect.Type;
+import java.util.List;
 
 @JsonAdapter(PluginInfoDeserializer.class)
 public class FetchPluginInfoResponse {
+    public class BrowsePluginResponse {
+        public BrowsePluginResponseInfo info;
+        public List<FetchPluginInfoResponse> plugins;
+    }
+
+    public class BrowsePluginResponseInfo {
+        public int page;
+        public int pages;
+    }
+
     public String name;
     public String slug;
     public String version;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.wporg.BaseWPOrgAPIClient;
 import org.wordpress.android.fluxc.network.wporg.WPOrgAPIGsonRequest;
+import org.wordpress.android.fluxc.network.wporg.plugin.FetchPluginInfoResponse.BrowsePluginResponse;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoError;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
@@ -31,6 +32,17 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     private final Dispatcher mDispatcher;
 
     public static class BrowsePluginPayload extends Payload {
+        public int page;
+
+        public BrowsePluginPayload() {
+            page = 1;
+        }
+
+        private Map<String, String> getParams() {
+            Map<String, String> params = new HashMap<>();
+            params.put("page", String.valueOf(page));
+            return params;
+        }
     }
 
     @Inject
@@ -60,6 +72,24 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                                         FetchPluginInfoErrorType.GENERIC_ERROR);
                                 mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginInfoAction(
                                         new FetchedPluginInfoPayload(error)));
+                            }
+                        }
+                );
+        add(request);
+    }
+
+    public void fetchPlugins(BrowsePluginPayload payload) {
+        String url = "https://api.wordpress.org/plugins/info/1.1/?action=query_plugins";
+        final WPOrgAPIGsonRequest<BrowsePluginResponse> request =
+                new WPOrgAPIGsonRequest<>(Method.GET, url, payload.getParams(), null, BrowsePluginResponse.class,
+                        new Listener<BrowsePluginResponse>() {
+                            @Override
+                            public void onResponse(BrowsePluginResponse response) {
+                            }
+                        },
+                        new BaseErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                             }
                         }
                 );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -7,6 +7,7 @@ import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPORGAPI;
 import org.wordpress.android.fluxc.model.PluginInfoModel;
@@ -28,6 +29,9 @@ import javax.inject.Singleton;
 @Singleton
 public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     private final Dispatcher mDispatcher;
+
+    public static class BrowsePluginPayload extends Payload {
+    }
 
     @Inject
     public PluginWPOrgClient(Dispatcher dispatcher, RequestQueue requestQueue, UserAgent userAgent) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.network.wporg.WPOrgAPIGsonRequest;
 import org.wordpress.android.fluxc.network.wporg.plugin.FetchPluginInfoResponse.BrowsePluginResponse;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoError;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginInfoErrorType;
-import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +29,19 @@ import javax.inject.Singleton;
 @Singleton
 public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     private final Dispatcher mDispatcher;
+
+    public static class FetchedPluginInfoPayload extends Payload {
+        public PluginInfoModel pluginInfo;
+        public FetchPluginInfoError error;
+
+        FetchedPluginInfoPayload(FetchPluginInfoError error) {
+            this.error = error;
+        }
+
+        FetchedPluginInfoPayload(PluginInfoModel pluginInfo) {
+            this.pluginInfo = pluginInfo;
+        }
+    }
 
     public static class BrowsePluginPayload extends Payload {
         public int page;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -33,15 +33,11 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
 
     public static class BrowsePluginPayload extends Payload {
         public int page;
+        public int pageSize;
 
         public BrowsePluginPayload() {
             page = 1;
-        }
-
-        private Map<String, String> getParams() {
-            Map<String, String> params = new HashMap<>();
-            params.put("page", String.valueOf(page));
-            return params;
+            pageSize = 30;
         }
     }
 
@@ -79,9 +75,10 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     }
 
     public void fetchPlugins(BrowsePluginPayload payload) {
-        String url = "https://api.wordpress.org/plugins/info/1.1/?action=query_plugins";
+        String url = WPORGAPI.plugins.info.version("1.1").getUrl();
+        Map<String, String> params = getBrowsePluginParams(payload);
         final WPOrgAPIGsonRequest<BrowsePluginResponse> request =
-                new WPOrgAPIGsonRequest<>(Method.GET, url, payload.getParams(), null, BrowsePluginResponse.class,
+                new WPOrgAPIGsonRequest<>(Method.GET, url, params, null, BrowsePluginResponse.class,
                         new Listener<BrowsePluginResponse>() {
                             @Override
                             public void onResponse(BrowsePluginResponse response) {
@@ -94,6 +91,16 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                         }
                 );
         add(request);
+    }
+
+    private Map<String, String> getBrowsePluginParams(BrowsePluginPayload payload) {
+        Map<String, String> params = new HashMap<>();
+        // This parameter is necessary for browse plugin actions
+        params.put("action", "query_plugins");
+        params.put("page", String.valueOf(payload.page));
+        params.put("per_page", String.valueOf(payload.pageSize));
+        params.put("fields", "icons");
+        return params;
     }
 
     private PluginInfoModel pluginInfoModelFromResponse(FetchPluginInfoResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient.BrowsePluginPayload;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.util.AppLog;
 
@@ -164,23 +165,30 @@ public class PluginStore extends Store {
             return;
         }
         switch ((PluginAction) actionType) {
+            // REST actions
             case FETCH_PLUGINS:
                 fetchPlugins((SiteModel) action.getPayload());
-                break;
-            case FETCH_PLUGIN_INFO:
-                fetchPluginInfo((String) action.getPayload());
                 break;
             case UPDATE_PLUGIN:
                 updatePlugin((UpdatePluginPayload) action.getPayload());
                 break;
+            // WPORG actions
+            case FETCH_PLUGIN_INFO:
+                fetchPluginInfo((String) action.getPayload());
+                break;
+            case FETCH_WPORG_PLUGINS:
+                fetchWpOrgPlugins((BrowsePluginPayload) action.getPayload());
+                break;
+            // REST responses
             case FETCHED_PLUGINS:
                 fetchedPlugins((FetchedPluginsPayload) action.getPayload());
                 break;
-            case FETCHED_PLUGIN_INFO:
-                fetchedPluginInfo((FetchedPluginInfoPayload) action.getPayload());
-                break;
             case UPDATED_PLUGIN:
                 updatedPlugin((UpdatedPluginPayload) action.getPayload());
+                break;
+            // WPORG responses
+            case FETCHED_PLUGIN_INFO:
+                fetchedPluginInfo((FetchedPluginInfoPayload) action.getPayload());
                 break;
         }
     }
@@ -207,10 +215,6 @@ public class PluginStore extends Store {
         }
     }
 
-    private void fetchPluginInfo(String plugin) {
-        mPluginWPOrgClient.fetchPluginInfo(plugin);
-    }
-
     private void updatePlugin(UpdatePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
             mPluginRestClient.updatePlugin(payload.site, payload.plugin);
@@ -219,6 +223,13 @@ public class PluginStore extends Store {
             UpdatedPluginPayload errorPayload = new UpdatedPluginPayload(payload.site, error);
             updatedPlugin(errorPayload);
         }
+    }
+
+    private void fetchPluginInfo(String plugin) {
+        mPluginWPOrgClient.fetchPluginInfo(plugin);
+    }
+
+    private void fetchWpOrgPlugins(BrowsePluginPayload payload) {
     }
 
     private void fetchedPlugins(FetchedPluginsPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
 import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient.BrowsePluginPayload;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.util.AppLog;
 
@@ -46,19 +47,6 @@ public class PluginStore extends Store {
         public FetchedPluginsPayload(@NonNull SiteModel site, @NonNull List<PluginModel> plugins) {
             this.site = site;
             this.plugins = plugins;
-        }
-    }
-
-    public static class FetchedPluginInfoPayload extends Payload {
-        public PluginInfoModel pluginInfo;
-        public FetchPluginInfoError error;
-
-        public FetchedPluginInfoPayload(FetchPluginInfoError error) {
-            this.error = error;
-        }
-
-        public FetchedPluginInfoPayload(PluginInfoModel pluginInfo) {
-            this.pluginInfo = pluginInfo;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -230,6 +230,7 @@ public class PluginStore extends Store {
     }
 
     private void fetchWpOrgPlugins(BrowsePluginPayload payload) {
+        mPluginWPOrgClient.fetchPlugins(payload);
     }
 
     private void fetchedPlugins(FetchedPluginsPayload payload) {


### PR DESCRIPTION
We have a rename PR coming up for plugins and it'll have a larger change set which would be very noisy to review inside another PR. So, what we are doing is opening this skeleton PR for browsing to a master branch and once this is merged, we'll send the rename & organize PR alone, so it's much easier to review. This PR alone should make sense, it's just not yet completed.

/cc @tonyr59h 