### PR TITLE
Clean up redundant media error type assignment

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -378,13 +378,12 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     private MediaError parseUploadError(Response response, SiteModel siteModel) {
         MediaError mediaError = new MediaError(MediaErrorType.fromHttpStatusCode(response.code()));
 
-        if (response.code() == 403) {
-            mediaError.type = MediaErrorType.AUTHORIZATION_REQUIRED;
-        } else if (response.code() == 413) {
-            mediaError.type = MediaErrorType.REQUEST_TOO_LARGE;
+        if (mediaError.type == MediaErrorType.REQUEST_TOO_LARGE) {
+            // 413 (Request too large) errors are coming from the web server and are not an API response like the rest
             mediaError.message = response.message();
             return mediaError;
         }
+
         try {
             ResponseBody responseBody = response.body();
             if (responseBody == null) {


### PR DESCRIPTION
@daniloercoli pointed out that we're incorrectly setting the `MediaErrorType` to `AUTHORIZATION_REQUIRED` on `403` errors (for WP.com media uploads), when it should be `NOT_AUTHENTICATED`. It's actually also redundant, since we're doing this right after a call to `MediaErrorType.fromHttpStatusCode(response.code())` correctly sets the type.

So I cleaned up the handling to not re-set the error type, and to only handle the special 413 `REQUEST_TOO_LARGE` case.

cc @daniloercoli