### PR TITLE
ThemeStore: Add search actions

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.java
@@ -115,6 +115,20 @@ public class ThemeFragment extends Fragment {
             }
         });
 
+        view.findViewById(R.id.search_themes).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                String term = getThemeIdFromInput(view);
+                if (TextUtils.isEmpty(term)) {
+                    prependToLog("Please enter a search term");
+                    return;
+                }
+
+                ThemeStore.SearchThemesPayload payload = new ThemeStore.SearchThemesPayload(term);
+                mDispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(payload));
+            }
+        });
+
         view.findViewById(R.id.fetch_wpcom_themes).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -180,6 +194,17 @@ public class ThemeFragment extends Fragment {
             prependToLog("error: " + event.error.message);
         } else {
             prependToLog("success: theme = " + event.theme.getName());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onThemesSearched(ThemeStore.OnThemesSearched event) {
+        prependToLog("onThemesSearched: ");
+        if (event.isError()) {
+            prependToLog("error: " + event.error.message);
+        } else {
+            prependToLog("success: result count = " + event.searchResults.size());
         }
     }
 

--- a/example/src/main/res/layout/fragment_themes.xml
+++ b/example/src/main/res/layout/fragment_themes.xml
@@ -30,6 +30,12 @@
         android:layout_height="wrap_content"
         android:text="Fetch current theme WP.com" />
 
+    <Button
+        android:id="@+id/search_themes"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Search Themes" />
+
     <EditText
         android:id="@+id/theme_id"
         android:layout_width="match_parent"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.ThemeStore.SearchThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
@@ -19,6 +20,8 @@ public enum ThemeAction implements IAction {
     FETCH_PURCHASED_THEMES,
     @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
+    @Action(payloadType = SearchThemesPayload.class)
+    SEARCH_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATE_THEME,
     @Action(payloadType = ActivateThemePayload.class)
@@ -33,6 +36,8 @@ public enum ThemeAction implements IAction {
     FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
+    @Action(payloadType = FetchedThemesPayload.class)
+    SEARCHED_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATED_THEME,
     @Action(payloadType = ActivateThemePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.ThemeStore.SearchThemesPayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
@@ -36,7 +37,7 @@ public enum ThemeAction implements IAction {
     FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
-    @Action(payloadType = FetchedThemesPayload.class)
+    @Action(payloadType = SearchedThemesPayload.class)
     SEARCHED_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATED_THEME,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeWPComResponse.ThemeArrayResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeWPComResponse.MultipleWPComThemesResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeJetpackResponse.MultipleJetpackThemesResponse;
+import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchThemesError;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
@@ -192,16 +193,16 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** v1.2/site/$siteId/themes?search=$term */
-    public void searchThemes(@NonNull final SiteModel site, @NonNull final String searchTerm) {
-        String url = WPCOMREST.sites.site(site.getSiteId()).themes.getUrlV1_2() + "?search=" + searchTerm;
+    /** v1.2/themes?search=$term */
+    public void searchThemes(@NonNull final String searchTerm) {
+        String url = WPCOMREST.themes.getUrlV1_2() + "?search=" + searchTerm;
         add(WPComGsonRequest.buildGetRequest(url, null, ThemeArrayResponse.class,
                 new Response.Listener<ThemeArrayResponse>() {
                     @Override
                     public void onResponse(ThemeArrayResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to search themes request.");
-                        FetchedThemesPayload payload =
-                                new FetchedThemesPayload(site, createThemeListFromArrayResponse(response));
+                        SearchedThemesPayload payload =
+                                new SearchedThemesPayload(searchTerm, createThemeListFromArrayResponse(response));
                         mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));
                     }
                 }, new BaseRequest.BaseErrorListener() {
@@ -210,7 +211,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         AppLog.e(AppLog.T.API, "Received error response to search themes request.");
                         FetchThemesError themeError = new FetchThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
-                        FetchedThemesPayload payload = new FetchedThemesPayload(themeError);
+                        SearchedThemesPayload payload = new SearchedThemesPayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));
                     }
                 }));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
@@ -1,11 +1,16 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 
+import java.util.List;
 import java.util.Map;
 
 public class ThemeWPComResponse {
     public class MultipleWPComThemesResponse {
         public Map<String, ThemeWPComResponse> themes;
         public int count;
+    }
+
+    public class ThemeArrayResponse {
+        public List<ThemeWPComResponse> themes;
     }
 
     public String id;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -49,6 +49,20 @@ public class ThemeStore extends Store {
         }
     }
 
+    public static class SearchThemesPayload extends Payload<FetchThemesError> {
+        public SiteModel site;
+        public String searchTerm;
+
+        public SearchThemesPayload(@NonNull SiteModel site, @NonNull String searchTerm) {
+            this.site = site;
+            this.searchTerm = searchTerm;
+        }
+
+        public SearchThemesPayload(FetchThemesError error) {
+            this.error = error;
+        }
+    }
+
     public static class ActivateThemePayload extends Payload<ActivateThemeError> {
         public SiteModel site;
         public ThemeModel theme;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -309,7 +309,7 @@ public class ThemeStore extends Store {
 
     private void handleSearchedThemes(@NonNull SearchedThemesPayload payload) {
         OnThemesSearched event = new OnThemesSearched(payload.themes);
-        if (event.isError()) {
+        if (payload.isError()) {
             event.error = payload.error;
         } else {
             for (ThemeModel theme : payload.themes) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -139,6 +139,16 @@ public class ThemeStore extends Store {
         }
     }
 
+    public static class OnThemesSearched extends OnChanged<FetchThemesError> {
+        public SiteModel site;
+        public List<ThemeModel> searchResults;
+
+        public OnThemesSearched(SiteModel site, List<ThemeModel> searchResults) {
+            this.site = site;
+            this.searchResults = searchResults;
+        }
+    }
+
     public static class OnThemeActivated extends OnChanged<ActivateThemeError> {
         public SiteModel site;
         public ThemeModel theme;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -213,7 +213,7 @@ public class ThemeStore extends Store {
                 searchThemes(searchPayload.searchTerm);
                 break;
             case SEARCHED_THEMES:
-                handleThemesSearched((SearchedThemesPayload) action.getPayload());
+                handleSearchedThemes((SearchedThemesPayload) action.getPayload());
                 break;
             case ACTIVATE_THEME:
                 activateTheme((ActivateThemePayload) action.getPayload());
@@ -307,7 +307,7 @@ public class ThemeStore extends Store {
         mThemeRestClient.searchThemes(searchTerm);
     }
 
-    private void handleThemesSearched(@NonNull SearchedThemesPayload payload) {
+    private void handleSearchedThemes(@NonNull SearchedThemesPayload payload) {
         OnThemesSearched event = new OnThemesSearched(payload.themes);
         if (event.isError()) {
             event.error = payload.error;


### PR DESCRIPTION
_sigh_ This one is actually required for feature parity with the existing theme browser in WPAndroid.

To test:
* Go to theme screen in example app
* Type your search term into the `EditText` and search
* Make sure the results are correct (added to log output in example app)

For example: `twenty` -> 8 matches, `edin` -> 1 match
You can set a break point to verify the data

cc @aforcier or @maxme, could one of you grab this one ASAP as it's blocking the last of the WPAndroid integration.