### PR TITLE
Feature/add social 2fa

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.NewAccountResponsePayload;
 import org.wordpress.android.fluxc.store.AccountStore.NewAccountPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushAccountSettingsPayload;
+import org.wordpress.android.fluxc.store.AccountStore.PushSocialAuthPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialLoginPayload;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload;
 
@@ -25,6 +26,8 @@ public enum AccountAction implements IAction {
     SEND_VERIFICATION_EMAIL, // request verification email for unverified accounts
     @Action(payloadType = PushAccountSettingsPayload.class)
     PUSH_SETTINGS,          // request saving Account Settings remotely
+    @Action(payloadType = PushSocialAuthPayload.class)
+    PUSH_SOCIAL_AUTH,      // request social auth remotely
     @Action(payloadType = PushSocialLoginPayload.class)
     PUSH_SOCIAL_LOGIN,      // request social login remotely
     @Action(payloadType = NewAccountPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -8,6 +8,7 @@ import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
 
 import org.apache.commons.text.StringEscapeUtils;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -31,6 +32,7 @@ import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,19 +69,33 @@ public class AccountRestClient extends BaseWPComRestClient {
             this.twoStepNonceBackup = response.two_step_nonce_backup;
             this.twoStepNonceSms = response.two_step_nonce_sms;
             this.twoStepNotificationSent = response.two_step_notification_sent;
-            this.twoStepType = response.two_step_type;
+            this.twoStepTypes = convertJsonArrayToStringList(response.two_step_supported_auth_types);
             this.userId = response.user_id;
         }
         public AccountPushSocialResponsePayload(BaseNetworkError error) {
             this.error = new AccountSocialError(error.volleyError.networkResponse.data);
         }
+        public List<String> twoStepTypes;
         public String bearerToken;
         public String twoStepNonceAuthenticator;
         public String twoStepNonceBackup;
         public String twoStepNonceSms;
         public String twoStepNotificationSent;
-        public String twoStepType;
         public String userId;
+
+        private List<String> convertJsonArrayToStringList(JSONArray array) {
+            List<String> list = new ArrayList<>();
+
+            try {
+                for (int i = 0; i < array.length(); i++) {
+                    list.add(array.getString(i));
+                }
+            } catch (JSONException exception) {
+                AppLog.e(T.API, "Unable to parse two step types: " + exception.getMessage());
+            }
+
+            return list;
+        }
     }
 
     public static class NewAccountResponsePayload extends Payload<NewUserError> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.account;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 import com.android.volley.VolleyError;
@@ -38,9 +37,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import static com.android.volley.DefaultRetryPolicy.DEFAULT_BACKOFF_MULT;
-import static org.wordpress.android.fluxc.network.BaseRequest.DEFAULT_REQUEST_TIMEOUT;
 
 @Singleton
 public class AccountRestClient extends BaseWPComRestClient {
@@ -262,7 +258,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     }
                 }
         );
-        request.setRetryPolicy(new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT, 0, DEFAULT_BACKOFF_MULT));
+        request.disableRetries();
         addUnauthedRequest(request);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -90,7 +90,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                 for (int i = 0; i < array.length(); i++) {
                     list.add(array.getString(i));
                 }
-            } catch (JSONException exception) {
+            } catch (NullPointerException | JSONException exception) {
                 AppLog.e(T.API, "Unable to parse two step types: " + exception.getMessage());
             }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -62,11 +62,23 @@ public class AccountRestClient extends BaseWPComRestClient {
     public static class AccountPushSocialResponsePayload extends Payload<AccountSocialError> {
         public AccountPushSocialResponsePayload(AccountSocialResponse response) {
             this.bearerToken = response.bearer_token;
+            this.twoStepNonceAuthenticator = response.two_step_nonce_authenticator;
+            this.twoStepNonceBackup = response.two_step_nonce_backup;
+            this.twoStepNonceSms = response.two_step_nonce_sms;
+            this.twoStepNotificationSent = response.two_step_notification_sent;
+            this.twoStepType = response.two_step_type;
+            this.userId = response.user_id;
         }
         public AccountPushSocialResponsePayload(BaseNetworkError error) {
             this.error = new AccountSocialError(error.volleyError.networkResponse.data);
         }
         public String bearerToken;
+        public String twoStepNonceAuthenticator;
+        public String twoStepNonceBackup;
+        public String twoStepNonceSms;
+        public String twoStepNotificationSent;
+        public String twoStepType;
+        public String userId;
     }
 
     public static class NewAccountResponsePayload extends Payload<NewUserError> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -86,12 +86,14 @@ public class AccountRestClient extends BaseWPComRestClient {
         private List<String> convertJsonArrayToStringList(JSONArray array) {
             List<String> list = new ArrayList<>();
 
-            try {
-                for (int i = 0; i < array.length(); i++) {
-                    list.add(array.getString(i));
+            if (array != null) {
+                try {
+                    for (int i = 0; i < array.length(); i++) {
+                        list.add(array.getString(i));
+                    }
+                } catch (JSONException exception) {
+                    AppLog.e(T.API, "Unable to parse two step types: " + exception.getMessage());
                 }
-            } catch (NullPointerException | JSONException exception) {
-                AppLog.e(T.API, "Unable to parse two step types: " + exception.getMessage());
             }
 
             return list;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialRequest.java
@@ -56,6 +56,12 @@ public class AccountSocialRequest extends BaseRequest<AccountSocialResponse> {
             JSONObject object = new JSONObject(responseBody);
             JSONObject data = object.getJSONObject("data");
             parsed.bearer_token = data.optString("bearer_token");
+            parsed.two_step_supported_auth_types = data.optJSONArray("two_step_supported_auth_types");
+            parsed.two_step_nonce_authenticator = data.optString("two_step_nonce_authenticator");
+            parsed.two_step_nonce_backup = data.optString("two_step_nonce_backup");
+            parsed.two_step_nonce_sms = data.optString("two_step_nonce_sms");
+            parsed.two_step_notification_sent = data.optString("two_step_notification_sent");
+            parsed.user_id = data.optString("user_id");
             return Response.success(parsed, null);
         } catch (JSONException exception) {
             AppLog.e(T.API, "Unable to parse network response: " + exception.getMessage());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
@@ -1,7 +1,15 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.account;
 
+import org.json.JSONArray;
 import org.wordpress.android.fluxc.network.Response;
 
 public class AccountSocialResponse implements Response {
+    public JSONArray two_step_supported_auth_types;
     public String bearer_token;
+    public String two_step_nonce_authenticator;
+    public String two_step_nonce_backup;
+    public String two_step_nonce_sms;
+    public String two_step_notification_sent;
+    public String two_step_type;
+    public String user_id;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
@@ -10,6 +10,5 @@ public class AccountSocialResponse implements Response {
     public String two_step_nonce_backup;
     public String two_step_nonce_sms;
     public String two_step_notification_sent;
-    public String two_step_type;
     public String user_id;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -84,6 +84,20 @@ public class AccountStore extends Store {
         }
     }
 
+    public static class PushSocialAuthPayload extends Payload<BaseNetworkError> {
+        public String code;
+        public String nonce;
+        public String type;
+        public String userId;
+        public PushSocialAuthPayload(@NonNull String userId, @NonNull String type, @NonNull String nonce,
+                                     @NonNull String code) {
+            this.userId = userId;
+            this.type = type;
+            this.nonce = nonce;
+            this.code = code;
+        }
+    }
+
     public static class NewAccountPayload extends Payload<BaseNetworkError> {
         public String username;
         public String password;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -267,17 +267,8 @@ public class AccountStore extends Store {
 
     public static class AccountSocialError implements OnChangedError {
         public AccountSocialErrorType type;
-        public List<String> twoStepTypes;
         public String message;
         public String nonce;
-
-        public AccountSocialError(AccountSocialErrorType type, @NonNull String message, String nonce,
-                                  List<String> twoStepTypes) {
-            this.type = type;
-            this.message = message;
-            this.nonce = nonce;
-            this.twoStepTypes = twoStepTypes;
-        }
 
         public AccountSocialError(@NonNull byte[] response) {
             try {
@@ -594,8 +585,7 @@ public class AccountStore extends Store {
         // Error; emit only social change.
         if (payload.isError()) {
             OnSocialChanged event = new OnSocialChanged();
-            event.error = new AccountSocialError(payload.error.type, payload.error.message, payload.error.nonce,
-                    payload.error.twoStepTypes);
+            event.error = payload.error;
             emitChange(event);
         // No error, but two-factor authentication is required; emit only social change.
         } else if (TextUtils.isEmpty(payload.bearerToken)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -129,6 +129,24 @@ public class AccountStore extends Store {
     public static class OnAuthenticationChanged extends OnChanged<AuthenticationError> {}
 
     public static class OnSocialChanged extends OnChanged<AccountSocialError> {
+        public String nonceAuthenticator;
+        public String nonceBackup;
+        public String nonceSms;
+        public String notificationSent;
+        public String twoStepType;
+        public String userId;
+
+        public OnSocialChanged() {
+        }
+
+        public OnSocialChanged(@NonNull AccountPushSocialResponsePayload payload) {
+            this.nonceAuthenticator = payload.twoStepNonceAuthenticator;
+            this.nonceBackup = payload.twoStepNonceBackup;
+            this.nonceSms = payload.twoStepNonceSms;
+            this.notificationSent = payload.twoStepNotificationSent;
+            this.twoStepType = payload.twoStepType;
+            this.userId = payload.userId;
+        }
     }
 
     public static class OnDiscoveryResponse extends OnChanged<DiscoveryError> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -130,22 +130,22 @@ public class AccountStore extends Store {
     public static class OnAuthenticationChanged extends OnChanged<AuthenticationError> {}
 
     public static class OnSocialChanged extends OnChanged<AccountSocialError> {
+        public List<String> twoStepTypes;
         public String nonceAuthenticator;
         public String nonceBackup;
         public String nonceSms;
         public String notificationSent;
-        public String twoStepType;
         public String userId;
 
         public OnSocialChanged() {
         }
 
         public OnSocialChanged(@NonNull AccountPushSocialResponsePayload payload) {
+            this.twoStepTypes = payload.twoStepTypes;
             this.nonceAuthenticator = payload.twoStepNonceAuthenticator;
             this.nonceBackup = payload.twoStepNonceBackup;
             this.nonceSms = payload.twoStepNonceSms;
             this.notificationSent = payload.twoStepNotificationSent;
-            this.twoStepType = payload.twoStepType;
             this.userId = payload.userId;
         }
     }
@@ -267,13 +267,16 @@ public class AccountStore extends Store {
 
     public static class AccountSocialError implements OnChangedError {
         public AccountSocialErrorType type;
+        public List<String> twoStepTypes;
         public String message;
         public String nonce;
 
-        public AccountSocialError(AccountSocialErrorType type, @NonNull String message, String nonce) {
+        public AccountSocialError(AccountSocialErrorType type, @NonNull String message, String nonce,
+                                  List<String> twoStepTypes) {
             this.type = type;
             this.message = message;
             this.nonce = nonce;
+            this.twoStepTypes = twoStepTypes;
         }
 
         public AccountSocialError(@NonNull byte[] response) {
@@ -591,7 +594,8 @@ public class AccountStore extends Store {
         // Error; emit only social change.
         if (payload.isError()) {
             OnSocialChanged event = new OnSocialChanged();
-            event.error = new AccountSocialError(payload.error.type, payload.error.message, payload.error.nonce);
+            event.error = new AccountSocialError(payload.error.type, payload.error.message, payload.error.nonce,
+                    payload.error.twoStepTypes);
             emitChange(event);
         // No error, but two-factor authentication is required; emit only social change.
         } else if (TextUtils.isEmpty(payload.bearerToken)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -414,6 +414,9 @@ public class AccountStore extends Store {
             case PUSH_SETTINGS:
                 mAccountRestClient.pushAccountSettings(((PushAccountSettingsPayload) payload).params);
                 break;
+            case PUSH_SOCIAL_AUTH:
+                createPushSocialAuth((PushSocialAuthPayload) payload);
+                break;
             case PUSH_SOCIAL_LOGIN:
                 createPushSocialLogin((PushSocialLoginPayload) payload);
                 break;
@@ -601,6 +604,10 @@ public class AccountStore extends Store {
 
     private void createNewAccount(NewAccountPayload payload) {
         mAccountRestClient.newAccount(payload.username, payload.password, payload.email, payload.dryRun);
+    }
+
+    private void createPushSocialAuth(PushSocialAuthPayload payload) {
+        mAccountRestClient.pushSocialAuth(payload.userId, payload.type, payload.nonce, payload.code);
     }
 
     private void createPushSocialLogin(PushSocialLoginPayload payload) {


### PR DESCRIPTION
Add a method for WordPress.com social login two-factor authentication, `pushSocialAuth`.  The endpoint has a similar structure to `pushSocialLogin`, but requires different parameters and returns different values.  Because of that, I considered created new response, payload, and error classes, but I decided to update the existing classes instead to consolidate REST-like API calls.