### PR TITLE
Feature/add social connect

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -29,6 +29,8 @@ public enum AccountAction implements IAction {
     @Action(payloadType = PushSocialAuthPayload.class)
     PUSH_SOCIAL_AUTH,      // request social auth remotely
     @Action(payloadType = PushSocialLoginPayload.class)
+    PUSH_SOCIAL_CONNECT,    // request social connect remotely
+    @Action(payloadType = PushSocialLoginPayload.class)
     PUSH_SOCIAL_LOGIN,      // request social login remotely
     @Action(payloadType = NewAccountPayload.class)
     CREATE_NEW_ACCOUNT,     // create a new account (can be used to validate the account before creating it)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -75,6 +75,8 @@ public class AccountRestClient extends BaseWPComRestClient {
         public AccountPushSocialResponsePayload(BaseNetworkError error) {
             this.error = new AccountSocialError(error.volleyError.networkResponse.data);
         }
+        public AccountPushSocialResponsePayload() {
+        }
         public List<String> twoStepTypes;
         public String bearerToken;
         public String twoStepNonceAuthenticator;
@@ -313,7 +315,8 @@ public class AccountRestClient extends BaseWPComRestClient {
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AccountPushSocialResponsePayload payload = new AccountPushSocialResponsePayload(error);
+                        AccountPushSocialResponsePayload payload = new AccountPushSocialResponsePayload();
+                        payload.error = new AccountSocialError(((WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newPushedSocialAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -281,6 +281,46 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     /**
+     * Performs an HTTP POST call to the v1.1 /me/social-login/connect/ endpoint.  Upon receiving a
+     * response (success or error) a {@link AccountAction#PUSHED_SOCIAL} action is dispatched with a
+     * payload of type {@link AccountPushSocialResponsePayload}.
+     *
+     * {@link AccountPushSocialResponsePayload#isError()} can be used to check the request result.
+     *
+     * No HTTP POST call is made if the given parameter map is null or contains no entries.
+     *
+     * @param idToken       OpenID Connect Token (JWT) from the service the user is using to
+     *                      authenticate their account.
+     * @param service       Slug representing the service for the given token (e.g. google).
+     */
+    public void pushSocialConnect(@NonNull String idToken, @NonNull String service) {
+        String url = WPCOMREST.me.social_login.connect.getUrlV1_1();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("id_token", idToken);
+        params.put("service", service);
+        params.put("client_id", mAppSecrets.getAppId());
+        params.put("client_secret", mAppSecrets.getAppSecret());
+
+        add(WPComGsonRequest.buildPostRequest(url, params, AccountSocialResponse.class,
+                new Listener<AccountSocialResponse>() {
+                    @Override
+                    public void onResponse(AccountSocialResponse response) {
+                        AccountPushSocialResponsePayload payload = new AccountPushSocialResponsePayload(response);
+                        mDispatcher.dispatch(AccountActionBuilder.newPushedSocialAction(payload));
+                    }
+                },
+                new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                        AccountPushSocialResponsePayload payload = new AccountPushSocialResponsePayload(error);
+                        mDispatcher.dispatch(AccountActionBuilder.newPushedSocialAction(payload));
+                    }
+                }
+        ));
+    }
+
+    /**
      * Performs an HTTP POST call to https://wordpress.com/wp-login.php with social-login-endpoint action.  Upon
      * receiving a response (success or error) a {@link AccountAction#PUSHED_SOCIAL} action is dispatched with a
      * payload of type {@link AccountPushSocialResponsePayload}.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.account;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
@@ -99,6 +100,10 @@ public class AccountRestClient extends BaseWPComRestClient {
             }
 
             return list;
+        }
+
+        public boolean hasToken() {
+            return !TextUtils.isEmpty(this.bearerToken);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -105,6 +105,10 @@ public class AccountRestClient extends BaseWPComRestClient {
         public boolean hasToken() {
             return !TextUtils.isEmpty(this.bearerToken);
         }
+
+        public boolean hasTwoStepTypes() {
+            return this.twoStepTypes != null && this.twoStepTypes.size() > 0;
+        }
     }
 
     public static class NewAccountResponsePayload extends Payload<NewUserError> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -274,11 +274,18 @@ public class AccountStore extends Store {
             try {
                 String responseBody = new String(response, "UTF-8");
                 JSONObject object = new JSONObject(responseBody);
-                JSONObject data = object.getJSONObject("data");
-                this.nonce = data.optString("two_step_nonce");
-                JSONArray errors = data.getJSONArray("errors");
-                this.type = AccountSocialErrorType.fromString(errors.getJSONObject(0).getString("code"));
-                this.message = errors.getJSONObject(0).getString("message");
+                String error = object.optString("error");
+
+                if (TextUtils.isEmpty(error)) {
+                    this.type = AccountSocialErrorType.fromString(error);
+                    this.message = object.optString("message");
+                } else {
+                    JSONObject data = object.getJSONObject("data");
+                    this.nonce = data.optString("two_step_nonce");
+                    JSONArray errors = data.getJSONArray("errors");
+                    this.type = AccountSocialErrorType.fromString(errors.getJSONObject(0).getString("code"));
+                    this.message = errors.getJSONObject(0).getString("message");
+                }
             } catch (UnsupportedEncodingException | JSONException exception) {
                 AppLog.e(T.API, "Unable to parse social error response: " + exception.getMessage());
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -135,6 +135,7 @@ public class AccountStore extends Store {
         public String nonceSms;
         public String notificationSent;
         public String userId;
+        public boolean requiresTwoStepAuth;
 
         public OnSocialChanged() {
         }
@@ -146,6 +147,7 @@ public class AccountStore extends Store {
             this.nonceSms = payload.twoStepNonceSms;
             this.notificationSent = payload.twoStepNotificationSent;
             this.userId = payload.userId;
+            this.requiresTwoStepAuth = true;
         }
     }
 
@@ -596,7 +598,7 @@ public class AccountStore extends Store {
             OnSocialChanged event = new OnSocialChanged();
             event.error = payload.error;
             emitChange(event);
-        // No error, but two-factor authentication is required; emit only social change.
+        // No error, but either two-factor authentication or social connect is required; emit only social change.
         } else if (!payload.hasToken()) {
             OnSocialChanged event = new OnSocialChanged(payload);
             emitChange(event);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -279,18 +279,11 @@ public class AccountStore extends Store {
             try {
                 String responseBody = new String(response, "UTF-8");
                 JSONObject object = new JSONObject(responseBody);
-                String error = object.optString("error");
-
-                if (!TextUtils.isEmpty(error)) {
-                    this.type = AccountSocialErrorType.fromString(error);
-                    this.message = object.optString("message");
-                } else {
-                    JSONObject data = object.getJSONObject("data");
-                    this.nonce = data.optString("two_step_nonce");
-                    JSONArray errors = data.getJSONArray("errors");
-                    this.type = AccountSocialErrorType.fromString(errors.getJSONObject(0).getString("code"));
-                    this.message = errors.getJSONObject(0).getString("message");
-                }
+                JSONObject data = object.getJSONObject("data");
+                this.nonce = data.optString("two_step_nonce");
+                JSONArray errors = data.getJSONArray("errors");
+                this.type = AccountSocialErrorType.fromString(errors.getJSONObject(0).getString("code"));
+                this.message = errors.getJSONObject(0).getString("message");
             } catch (UnsupportedEncodingException | JSONException exception) {
                 AppLog.e(T.API, "Unable to parse social error response: " + exception.getMessage());
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.store;
 
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
 
 import com.android.volley.VolleyError;
 
@@ -598,7 +597,7 @@ public class AccountStore extends Store {
             event.error = payload.error;
             emitChange(event);
         // No error, but two-factor authentication is required; emit only social change.
-        } else if (TextUtils.isEmpty(payload.bearerToken)) {
+        } else if (!payload.hasToken()) {
             OnSocialChanged event = new OnSocialChanged(payload);
             emitChange(event);
         // No error and two-factor authentication is not required; emit only authentication change.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -276,7 +276,7 @@ public class AccountStore extends Store {
                 JSONObject object = new JSONObject(responseBody);
                 String error = object.optString("error");
 
-                if (TextUtils.isEmpty(error)) {
+                if (!TextUtils.isEmpty(error)) {
                     this.type = AccountSocialErrorType.fromString(error);
                     this.message = object.optString("message");
                 } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -270,6 +270,11 @@ public class AccountStore extends Store {
         public String message;
         public String nonce;
 
+        public AccountSocialError(@NonNull String type, @NonNull String message) {
+            this.type = AccountSocialErrorType.fromString(type);
+            this.message = message;
+        }
+
         public AccountSocialError(@NonNull byte[] response) {
             try {
                 String responseBody = new String(response, "UTF-8");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -288,7 +288,9 @@ public class AccountStore extends Store {
     public enum AccountSocialErrorType {
         INVALID_TOKEN,
         INVALID_TWO_STEP_CODE,
+        UNABLE_CONNECT,
         UNKNOWN_USER,
+        USER_ALREADY_ASSOCIATED,
         USER_EXISTS,
         GENERIC_ERROR;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -147,7 +147,6 @@ public class AccountStore extends Store {
             this.nonceSms = payload.twoStepNonceSms;
             this.notificationSent = payload.twoStepNotificationSent;
             this.userId = payload.userId;
-            this.requiresTwoStepAuth = true;
         }
     }
 
@@ -601,6 +600,7 @@ public class AccountStore extends Store {
         // No error, but either two-factor authentication or social connect is required; emit only social change.
         } else if (!payload.hasToken()) {
             OnSocialChanged event = new OnSocialChanged(payload);
+            event.requiresTwoStepAuth = payload.hasTwoStepTypes();
             emitChange(event);
         // No error and two-factor authentication is not required; emit only authentication change.
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -440,6 +440,7 @@ public class AccountStore extends Store {
                 createPushSocialAuth((PushSocialAuthPayload) payload);
                 break;
             case PUSH_SOCIAL_CONNECT:
+                createPushSocialConnect((PushSocialLoginPayload) payload);
                 break;
             case PUSH_SOCIAL_LOGIN:
                 createPushSocialLogin((PushSocialLoginPayload) payload);
@@ -638,6 +639,10 @@ public class AccountStore extends Store {
 
     private void createPushSocialAuth(PushSocialAuthPayload payload) {
         mAccountRestClient.pushSocialAuth(payload.userId, payload.type, payload.nonce, payload.code);
+    }
+
+    private void createPushSocialConnect(PushSocialLoginPayload payload) {
+        mAccountRestClient.pushSocialConnect(payload.idToken, payload.service);
     }
 
     private void createPushSocialLogin(PushSocialLoginPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -430,6 +430,8 @@ public class AccountStore extends Store {
             case PUSH_SOCIAL_AUTH:
                 createPushSocialAuth((PushSocialAuthPayload) payload);
                 break;
+            case PUSH_SOCIAL_CONNECT:
+                break;
             case PUSH_SOCIAL_LOGIN:
                 createPushSocialLogin((PushSocialLoginPayload) payload);
                 break;

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -11,6 +11,7 @@
 /me/settings/
 /me/sites/
 /me/send-verification-email/
+/me/social-login/connect/
 
 /read/feed/$feed_url_or_id#long,String
 


### PR DESCRIPTION
Add a method for social login to connect a social account with a WordPress.com account, `pushSocialConnect`.  It requires similar parameters to the `pushSocialAuth` and `pushSocialLogin` methods, but uses the `/me/social-login/connect/` authenticated endpoint.