### PR TITLE
Make Comment, Plugin, and Taxonomy stores Singletons

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -57,10 +57,16 @@
         <property name="severity" value="error"/>
     </module>
 
+    <!-- Specific to FluxC -->
     <module name="RegexpSingleline">
         <property name="format" value="extends Payload[^&lt;]"/>
         <property name="message" value="Payload should not be used as a raw type"/>
         <property name="severity" value="error"/>
+    </module>
+
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Store[\s{]"/>
+        <property name="message" value="Stores must be annotated with @Singleton"/>
     </module>
 
     <!-- Specific to FluxC / WordPress -->

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -69,6 +69,11 @@
         <property name="message" value="Stores must be annotated with @Singleton"/>
     </module>
 
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends \w.*Client[\s{]"/>
+        <property name="message" value="Network clients must be annotated with @Singleton"/>
+    </module>
+
     <!-- Specific to FluxC / WordPress -->
     <module name="RegexpSingleline">
       <property name="format" value=".*dotcom(?!.*checkstyle ignore)"/>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -32,7 +32,9 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class CommentRestClient extends BaseWPComRestClient {
     @Inject
     public CommentRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.inject.Singleton;
+
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
@@ -67,6 +69,7 @@ import okhttp3.ResponseBody;
  *     (via {@link #deleteMedia(SiteModel, MediaModel)})</li>
  * </ul>
  */
+@Singleton
 public class MediaRestClient extends BaseWPComRestClient implements ProgressListener {
     private OkHttpClient mOkHttpClient;
     // this will hold which media is being uploaded by which call, in order to be able

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -35,7 +35,9 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class CommentXMLRPCClient extends BaseXMLRPCClient {
     @Inject
     public CommentXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, UserAgent userAgent,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -55,6 +55,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.inject.Singleton;
+
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.HttpUrl;
@@ -64,6 +66,7 @@ import okhttp3.Request.Builder;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
+@Singleton
 public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListener {
     private static final String[] REQUIRED_UPLOAD_RESPONSE_FIELDS = {
             "attachment_id", "parent", "title", "caption", "description", "thumbnail", "date_created_gmt", "link"};

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -43,6 +43,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Singleton;
+
+@Singleton
 public class PostXMLRPCClient extends BaseXMLRPCClient {
     public PostXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, UserAgent userAgent,
                             HTTPAuthManager httpAuthManager) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -30,6 +30,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Singleton;
+
+@Singleton
 public class SiteXMLRPCClient extends BaseXMLRPCClient {
     public SiteXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, UserAgent userAgent,
                             HTTPAuthManager httpAuthManager) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -32,6 +32,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Singleton;
+
+@Singleton
 public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
     public TaxonomyXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, UserAgent userAgent,
                                 HTTPAuthManager httpAuthManager) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -29,10 +29,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class CommentStore extends Store {
-    CommentRestClient mCommentRestClient;
-    CommentXMLRPCClient mCommentXMLRPCClient;
+    private final CommentRestClient mCommentRestClient;
+    private final CommentXMLRPCClient mCommentXMLRPCClient;
 
     // Payloads
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -21,7 +21,9 @@ import org.wordpress.android.util.AppLog;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class PluginStore extends Store {
     // Payloads
     public static class UpdatePluginPayload extends Payload<BaseNetworkError> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -23,7 +23,9 @@ import org.wordpress.android.util.AppLog;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class TaxonomyStore extends Store {
     public static final String DEFAULT_TAXONOMY_CATEGORY = "category";
     public static final String DEFAULT_TAXONOMY_TAG = "post_tag";


### PR DESCRIPTION
We missed the `@Singleton` annotation on a few stores, which made it possible for several instances of those stores to exist at once, with all of them receiving actions.

This manifested in the WPAndroid app as duplicate comments being created when replying to a post or comments - the number of duplicates depended on your navigation history through the app, which would create multiple `CommentStore`s.

In this PR I made all stores `@Singleton`s, as well as all network clients, and added Checkstyle rules enforcing both.

To test this PR:

1. Checkout `develop`
2. Run the FluxC example app
3. Hook up your network sniffer of choice
4. Open the 'Comments' view and fetch comments
5. Notice one fetch request sent in the network sniffer
6. Return to the main view and re-open the 'Comments' view a few times
7. Fetch comments again
8. Notice multiple (duplicate) requests are sent

This should no longer happen in this branch.

cc @maxme