### PR TITLE
Use kapt plugin

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -15,6 +15,7 @@ repositories {
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 25
@@ -64,10 +65,6 @@ android.buildTypes.all { buildType ->
     testProperties.any { property ->
         buildType.buildConfigField "String", property.key.replace(".", "_").toUpperCase(), "\"${property.value}\""
     }
-}
-
-kapt {
-    generateStubs = true
 }
 
 dependencies {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.dcendents.android-maven'
 
 repositories {
@@ -56,10 +57,6 @@ android.buildTypes.all { buildType ->
                     "\"${property.value}\""
         }
     }
-}
-
-kapt {
-    generateStubs = true
 }
 
 dependencies {

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -14,6 +14,7 @@ repositories {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 25


### PR DESCRIPTION
Updates to use the [kapt plugin](https://kotlinlang.org/docs/reference/kapt.html), allowing us drop the `generateStubs = true` config (and silence a `Original kapt is deprecated. Please add "apply plugin: 'kotlin-kapt'" to your build.gradle.` compiler warning).

Explicitly declaring a `kaptAndroidTest` dependency for the connected tests appears to be required as a result - the linked article above seems to say otherwise, but it doesn't seem to be the case.

cc @maxme