### PR TITLE
text hints are defined as non nullable string in ThreeEditTextDialog.…

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -122,7 +122,7 @@ public class MediaFragment extends Fragment {
                             fetchMedia(mSite, media);
                         }
                     }
-                }, "comma-separate media IDs", null, null);
+                }, "comma-separate media IDs", "", "");
                 dialog.show(getFragmentManager(), "media-ids-dialog");
             }
         });


### PR DESCRIPTION
…newInstance (Kotlin) definition - results in a crash when it's called with a null argument from Java

