### PR TITLE
ThemeStore: Changes needed for WPAndroid integration

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -44,7 +44,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_Base {
         }
 
         if (mNextEvent == TestEvents.FETCHED_THEMES) {
-            assertTrue(mThemeStore.getWpThemes().size() > 0);
+            assertTrue(mThemeStore.getWpComThemes().size() > 0);
             mCountDownLatch.countDown();
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.java
@@ -63,7 +63,7 @@ public class ThemeFragment extends Fragment {
                     prependToLog("No WP.com site found, unable to test.");
                 } else {
                     ThemeModel theme = new ThemeModel();
-                    theme.setLocalSiteId(site.getSiteId());
+                    theme.setLocalSiteId(site.getId());
                     theme.setThemeId(id);
                     ThemeStore.ActivateThemePayload payload = new ThemeStore.ActivateThemePayload(site, theme);
                     mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
@@ -85,7 +85,7 @@ public class ThemeFragment extends Fragment {
                     prependToLog("No Jetpack connected site found, unable to test.");
                 } else {
                     ThemeModel theme = new ThemeModel();
-                    theme.setLocalSiteId(site.getSiteId());
+                    theme.setLocalSiteId(site.getId());
                     theme.setThemeId(id);
                     ThemeStore.ActivateThemePayload payload = new ThemeStore.ActivateThemePayload(site, theme);
                     mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
@@ -107,7 +107,7 @@ public class ThemeFragment extends Fragment {
                     prependToLog("No Jetpack connected site found, unable to test.");
                 } else {
                     ThemeModel theme = new ThemeModel();
-                    theme.setLocalSiteId(site.getSiteId());
+                    theme.setLocalSiteId(site.getId());
                     theme.setThemeId(id);
                     ThemeStore.ActivateThemePayload payload = new ThemeStore.ActivateThemePayload(site, theme);
                     mDispatcher.dispatch(ThemeActionBuilder.newInstallThemeAction(payload));
@@ -143,7 +143,7 @@ public class ThemeFragment extends Fragment {
                     prependToLog("No Jetpack connected site found, unable to test.");
                 } else {
                     ThemeModel theme = new ThemeModel();
-                    theme.setLocalSiteId(site.getSiteId());
+                    theme.setLocalSiteId(site.getId());
                     theme.setThemeId(id);
                     ThemeStore.ActivateThemePayload payload = new ThemeStore.ActivateThemePayload(site, theme);
                     mDispatcher.dispatch(ThemeActionBuilder.newDeleteThemeAction(payload));

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.java
@@ -237,7 +237,7 @@ public class ThemeFragment extends Fragment {
         if (event.isError()) {
             prependToLog("error: " + event.error.message);
         } else {
-            prependToLog("success: WP.com theme count = " + mThemeStore.getWpThemes().size());
+            prependToLog("success: WP.com theme count = " + mThemeStore.getWpComThemes().size());
             SiteModel jpSite = getJetpackConnectedSite();
             if (jpSite != null) {
                 List<ThemeModel> themes = mThemeStore.getThemesForSite(jpSite);

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -45,15 +45,15 @@ public class ThemeStoreUnitTest {
 
         // first add 20 themes and make sure the count is correct
         ThemeSqlUtils.insertOrReplaceWpThemes(firstTestThemes);
-        assertEquals(20, mThemeStore.getWpThemes().size());
+        assertEquals(20, mThemeStore.getWpComThemes().size());
 
         // next add a larger list of themes (with 20 being duplicates) and make sure the count is correct
         ThemeSqlUtils.insertOrReplaceWpThemes(secondTestThemes);
-        assertEquals(30, mThemeStore.getWpThemes().size());
+        assertEquals(30, mThemeStore.getWpComThemes().size());
 
         // lastly add a smaller list of themes (all duplicates) and make sure count is correct
         ThemeSqlUtils.insertOrReplaceWpThemes(thirdTestThemes);
-        assertEquals(10, mThemeStore.getWpThemes().size());
+        assertEquals(10, mThemeStore.getWpComThemes().size());
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -44,15 +44,15 @@ public class ThemeStoreUnitTest {
         final List<ThemeModel> thirdTestThemes = generateThemesTestList(10);
 
         // first add 20 themes and make sure the count is correct
-        ThemeSqlUtils.insertOrReplaceWpThemes(firstTestThemes);
+        ThemeSqlUtils.insertOrReplaceWpComThemes(firstTestThemes);
         assertEquals(20, mThemeStore.getWpComThemes().size());
 
         // next add a larger list of themes (with 20 being duplicates) and make sure the count is correct
-        ThemeSqlUtils.insertOrReplaceWpThemes(secondTestThemes);
+        ThemeSqlUtils.insertOrReplaceWpComThemes(secondTestThemes);
         assertEquals(30, mThemeStore.getWpComThemes().size());
 
         // lastly add a smaller list of themes (all duplicates) and make sure count is correct
-        ThemeSqlUtils.insertOrReplaceWpThemes(thirdTestThemes);
+        ThemeSqlUtils.insertOrReplaceWpComThemes(thirdTestThemes);
         assertEquals(10, mThemeStore.getWpComThemes().size());
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -32,6 +32,9 @@ public class ThemeModel implements Identifiable, Serializable {
     @Column private boolean mAutoUpdate;
     @Column private boolean mAutoUpdateTranslation;
 
+    // local use only
+    @Column private boolean mIsWpComTheme;
+
     @Override
     public int getId() {
         return mId;
@@ -66,7 +69,8 @@ public class ThemeModel implements Identifiable, Serializable {
                 && getPrice() == otherTheme.getPrice()
                 && getActive() == otherTheme.getActive()
                 && getAutoUpdate() == otherTheme.getAutoUpdate()
-                && getAutoUpdateTranslation() == otherTheme.getAutoUpdateTranslation();
+                && getAutoUpdateTranslation() == otherTheme.getAutoUpdateTranslation()
+                && isWpComTheme() == otherTheme.isWpComTheme();
     }
 
     public int getLocalSiteId() {
@@ -211,5 +215,13 @@ public class ThemeModel implements Identifiable, Serializable {
 
     public void setAutoUpdateTranslation(boolean autoUpdateTranslation) {
         mAutoUpdateTranslation = autoUpdateTranslation;
+    }
+
+    public boolean isWpComTheme() {
+        return mIsWpComTheme;
+    }
+
+    public void setIsWpComTheme(boolean isWpComTheme) {
+        mIsWpComTheme = isWpComTheme;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -26,6 +26,7 @@ public class ThemeModel implements Identifiable, Serializable {
     @Column private String mDemoUrl;
     @Column private String mDownloadUrl;
     @Column private String mStylesheet;
+    @Column private String mCurrency;
     @Column private float mPrice;
     @Column private boolean mActive;
     @Column private boolean mAutoUpdate;
@@ -61,6 +62,7 @@ public class ThemeModel implements Identifiable, Serializable {
                 && StringUtils.equals(getSlug(), otherTheme.getSlug())
                 && StringUtils.equals(getDownloadUrl(), otherTheme.getDownloadUrl())
                 && StringUtils.equals(getStylesheet(), otherTheme.getStylesheet())
+                && StringUtils.equals(getCurrency(), otherTheme.getCurrency())
                 && getPrice() == otherTheme.getPrice()
                 && getActive() == otherTheme.getActive()
                 && getAutoUpdate() == otherTheme.getAutoUpdate()
@@ -169,6 +171,14 @@ public class ThemeModel implements Identifiable, Serializable {
 
     public void setStylesheet(String stylesheet) {
         mStylesheet = stylesheet;
+    }
+
+    public String getCurrency() {
+        return mCurrency;
+    }
+
+    public void setCurrency(String currency) {
+        mCurrency = currency;
     }
 
     public float getPrice() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -13,7 +13,7 @@ import java.io.Serializable;
 public class ThemeModel implements Identifiable, Serializable {
     @PrimaryKey @Column private int mId;
 
-    @Column private long mLocalSiteId;
+    @Column private int mLocalSiteId;
     @Column private String mThemeId;
     @Column private String mName;
     @Column private String mDescription;
@@ -67,11 +67,11 @@ public class ThemeModel implements Identifiable, Serializable {
                 && getAutoUpdateTranslation() == otherTheme.getAutoUpdateTranslation();
     }
 
-    public long getLocalSiteId() {
+    public int getLocalSiteId() {
         return mLocalSiteId;
     }
 
-    public void setLocalSiteId(long localSiteId) {
+    public void setLocalSiteId(int localSiteId) {
         this.mLocalSiteId = localSiteId;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -54,6 +54,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onResponse(ThemeJetpackResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme deletion request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
+                        responseTheme.setId(theme.getId());
                         ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -72,8 +72,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     /** Endpoint: v1.1/site/$siteId/themes/$themeId/install */
     public void installTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
-        String themeIdWIthSuffix = getThemeIdWithWpComSuffix(theme);
-        String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(themeIdWIthSuffix).install.getUrlV1_1();
+        theme.setThemeId(getThemeIdWithWpComSuffix(theme));
+        String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(theme.getThemeId()).install.getUrlV1_1();
         add(WPComGsonRequest.buildPostRequest(url, null, ThemeJetpackResponse.class,
                 new Response.Listener<ThemeJetpackResponse>() {
                     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -314,7 +314,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     private @NonNull String getThemeIdWithWpComSuffix(ThemeModel theme) {
         if (theme == null || theme.getThemeId() == null) {
             return "";
+        } else if (theme.getThemeId().endsWith("-wpcom")) {
+            return theme.getThemeId();
         }
+
         return theme.getThemeId() + "-wpcom";
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -256,6 +256,9 @@ public class ThemeRestClient extends BaseWPComRestClient {
         theme.setScreenshotUrl(response.screenshot);
         theme.setDescription(response.description);
         theme.setDownloadUrl(response.download_uri);
+        if (response.price != null) {
+            theme.setPrice(response.price.value);
+        }
         return theme;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -73,8 +73,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     /** Endpoint: v1.1/site/$siteId/themes/$themeId/install */
     public void installTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
-        theme.setThemeId(getThemeIdWithWpComSuffix(theme));
-        String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(theme.getThemeId()).install.getUrlV1_1();
+        String themeId = getThemeIdWithWpComSuffix(theme);
+        String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(themeId).install.getUrlV1_1();
         add(WPComGsonRequest.buildPostRequest(url, null, ThemeJetpackResponse.class,
                 new Response.Listener<ThemeJetpackResponse>() {
                     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -274,7 +274,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
         // the screenshot field in Jetpack responses does not contain a protocol so we'll prepend 'https'
         String screenshotUrl = response.screenshot;
         if (screenshotUrl != null && screenshotUrl.startsWith("//")) {
-            screenshotUrl = "https" + screenshotUrl;
+            screenshotUrl = "https:" + screenshotUrl;
         }
         theme.setScreenshotUrl(screenshotUrl);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -257,6 +257,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
         theme.setDescription(response.description);
         theme.setDownloadUrl(response.download_uri);
         if (response.price != null) {
+            theme.setCurrency(response.price.currency);
             theme.setPrice(response.price.value);
         }
         return theme;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -55,6 +55,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme deletion request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
                         responseTheme.setId(theme.getId());
+                        responseTheme.setLocalSiteId(site.getId());
                         ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }
@@ -80,6 +81,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onResponse(ThemeJetpackResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme installation request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
+                        responseTheme.setLocalSiteId(site.getId());
                         ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
@@ -13,6 +13,12 @@ public class ThemeWPComResponse {
         public List<ThemeWPComResponse> themes;
     }
 
+    public class Price {
+        public int value;
+        public String currency;
+        public String display;
+    }
+
     public String id;
     public String slug;
     public String stylesheet;
@@ -29,6 +35,7 @@ public class ThemeWPComResponse {
     public String date_updated;
     public String language;
     public String download_uri;
+    public Price price;
     public int rank_popularity;
     public int rank_trending;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -94,6 +94,13 @@ public class ThemeSqlUtils {
      * Retrieves themes associated with a given site. Installed themes (for Jetpack sites) are the only themes
      * targeted for now.
      */
+    public static Cursor getThemesForSiteAsCursor(@NonNull SiteModel site) {
+        return WellSql.select(ThemeModel.class)
+                .where()
+                .equals(ThemeModelTable.LOCAL_SITE_ID, site.getId())
+                .endWhere().getAsCursor();
+    }
+
     public static List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {
         return WellSql.select(ThemeModel.class)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -95,7 +95,7 @@ public class ThemeSqlUtils {
         removeThemes(site.getId());
     }
 
-    private static void removeThemesWithNoSite() {
+    public static void removeThemesWithNoSite() {
         // Remove themes whose localSiteId is 0
         removeThemes(0);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -27,7 +27,7 @@ public class ThemeSqlUtils {
         }
     }
 
-    public static void insertOrReplaceWpThemes(@NonNull List<ThemeModel> themes) {
+    public static void insertOrReplaceWpComThemes(@NonNull List<ThemeModel> themes) {
         // remove existing WP.com themes
         removeWpComThemes();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -67,6 +67,22 @@ public class ThemeSqlUtils {
                 .endWhere().getAsModel();
     }
 
+    /**
+     * @return the first theme that matches a given theme ID; null if none found
+     */
+    public static ThemeModel getThemeWithId(@NonNull String themeId) {
+        List<ThemeModel> matches = WellSql.select(ThemeModel.class)
+                .where()
+                .equals(ThemeModelTable.THEME_ID, themeId)
+                .endWhere().getAsModel();
+
+        if (matches == null || matches.isEmpty()) {
+            return null;
+        }
+
+        return matches.get(0);
+    }
+
     public static void removeThemes(@NonNull SiteModel site) {
         removeThemes(site.getId());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -116,6 +116,13 @@ public class ThemeSqlUtils {
         return matches.get(0);
     }
 
+    public static void removeTheme(@NonNull ThemeModel theme) {
+        WellSql.delete(ThemeModel.class)
+                .where()
+                .equals(ThemeModelTable.ID, theme.getId())
+                .endWhere().execute();
+    }
+
     public static void removeThemes(@NonNull SiteModel site) {
         removeThemes(site.getId());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.persistence;
 
+import android.database.Cursor;
 import android.support.annotation.NonNull;
 
 import com.wellsql.generated.ThemeModelTable;
@@ -47,6 +48,13 @@ public class ThemeSqlUtils {
         WellSql.insert(themes).asSingleTransaction(true).execute();
 
         return themes.size();
+    }
+
+    public static Cursor getThemesWithNoSiteAsCursor() {
+        return WellSql.select(ThemeModel.class)
+                .where()
+                .equals(ThemeModelTable.LOCAL_SITE_ID, 0)
+                .endWhere().getAsCursor();
     }
 
     public static List<ThemeModel> getThemesWithNoSite() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -12,11 +12,12 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import java.util.List;
 
 public class ThemeSqlUtils {
-    public static void insertOrUpdateTheme(@NonNull ThemeModel theme) {
+    public static void insertOrUpdateThemeForSite(@NonNull ThemeModel theme) {
         List<ThemeModel> existing = WellSql.select(ThemeModel.class)
-                .where()
+                .where().beginGroup()
                 .equals(ThemeModelTable.THEME_ID, theme.getThemeId())
-                .endWhere().getAsModel();
+                .equals(ThemeModelTable.LOCAL_SITE_ID, theme.getLocalSiteId())
+                .endGroup().endWhere().getAsModel();
 
         if (existing.isEmpty()) {
             WellSql.insert(theme).asSingleTransaction(true).execute();
@@ -64,7 +65,7 @@ public class ThemeSqlUtils {
 
         // make sure active flag is set then add to db
         theme.setActive(true);
-        insertOrUpdateTheme(theme);
+        insertOrUpdateThemeForSite(theme);
     }
 
     public static List<ThemeModel> getActiveThemeForSite(@NonNull SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -29,19 +29,21 @@ public class ThemeSqlUtils {
 
     public static void insertOrReplaceWpThemes(@NonNull List<ThemeModel> themes) {
         // remove existing WP.com themes
-        removeThemesWithNoSite();
+        removeWpComThemes();
 
+        // ensure WP.com flag is set before inserting
         for (ThemeModel theme : themes) {
-            theme.setLocalSiteId(0);
+            theme.setIsWpComTheme(true);
         }
 
         WellSql.insert(themes).asSingleTransaction(true).execute();
     }
 
     public static int insertOrReplaceInstalledThemes(@NonNull SiteModel site, @NonNull List<ThemeModel> themes) {
-        // Remove existing installed themes
+        // remove existing installed themes
         removeThemes(site);
 
+        // ensure site ID is set before inserting
         for (ThemeModel theme : themes) {
             theme.setLocalSiteId(site.getId());
         }
@@ -76,17 +78,17 @@ public class ThemeSqlUtils {
                 .endGroup().endWhere().getAsModel();
     }
 
-    public static Cursor getThemesWithNoSiteAsCursor() {
+    public static Cursor getWpComThemesCursor() {
         return WellSql.select(ThemeModel.class)
                 .where()
-                .equals(ThemeModelTable.LOCAL_SITE_ID, 0)
+                .equals(ThemeModelTable.IS_WP_COM_THEME, true)
                 .endWhere().getAsCursor();
     }
 
-    public static List<ThemeModel> getThemesWithNoSite() {
+    public static List<ThemeModel> getWpComThemes() {
         return WellSql.select(ThemeModel.class)
                 .where()
-                .equals(ThemeModelTable.LOCAL_SITE_ID, 0)
+                .equals(ThemeModelTable.IS_WP_COM_THEME, true)
                 .endWhere().getAsModel();
     }
 
@@ -124,6 +126,13 @@ public class ThemeSqlUtils {
         return matches.get(0);
     }
 
+    public static void removeWpComThemes() {
+        WellSql.delete(ThemeModel.class)
+                .where()
+                .equals(ThemeModelTable.IS_WP_COM_THEME, true)
+                .endWhere().execute();
+    }
+
     public static void removeTheme(@NonNull ThemeModel theme) {
         WellSql.delete(ThemeModel.class)
                 .where()
@@ -133,11 +142,6 @@ public class ThemeSqlUtils {
 
     public static void removeThemes(@NonNull SiteModel site) {
         removeThemes(site.getId());
-    }
-
-    public static void removeThemesWithNoSite() {
-        // Remove themes whose localSiteId is 0
-        removeThemes(0);
     }
 
     private static void removeThemes(int localSiteId) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -113,11 +113,11 @@ public class ThemeSqlUtils {
     /**
      * @return the first theme that matches a given theme ID; null if none found
      */
-    public static ThemeModel getThemeByThemeId(@NonNull String themeId, boolean wpCom) {
+    public static ThemeModel getThemeByThemeId(@NonNull String themeId, boolean isWpComTheme) {
         List<ThemeModel> matches = WellSql.select(ThemeModel.class)
                 .where().beginGroup()
                 .equals(ThemeModelTable.THEME_ID, themeId)
-                .equals(ThemeModelTable.IS_WP_COM_THEME, wpCom)
+                .equals(ThemeModelTable.IS_WP_COM_THEME, isWpComTheme)
                 .endGroup().endWhere().getAsModel();
 
         if (matches == null || matches.isEmpty()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -113,11 +113,12 @@ public class ThemeSqlUtils {
     /**
      * @return the first theme that matches a given theme ID; null if none found
      */
-    public static ThemeModel getThemeWithId(@NonNull String themeId) {
+    public static ThemeModel getThemeByThemeId(@NonNull String themeId, boolean wpCom) {
         List<ThemeModel> matches = WellSql.select(ThemeModel.class)
-                .where()
+                .where().beginGroup()
                 .equals(ThemeModelTable.THEME_ID, themeId)
-                .endWhere().getAsModel();
+                .equals(ThemeModelTable.IS_WP_COM_THEME, wpCom)
+                .endGroup().endWhere().getAsModel();
 
         if (matches == null || matches.isEmpty()) {
             return null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -58,7 +58,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 15;
+        return 16;
     }
 
     @Override
@@ -145,6 +145,13 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("CREATE TABLE PostUploadModel (_id INTEGER PRIMARY KEY,UPLOAD_STATE INTEGER,"
                         + "ASSOCIATED_MEDIA_IDS TEXT,ERROR_TYPE TEXT,ERROR_MESSAGE TEXT,FOREIGN KEY(_id) REFERENCES "
                         + "PostModel(_id) ON DELETE CASCADE)");
+                oldVersion++;
+            case 15:
+                db.execSQL("CREATE TABLE ThemeModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "THEME_ID TEXT,NAME TEXT,DESCRIPTION TEXT,SLUG TEXT,VERSION TEXT,AUTHOR_NAME TEXT,"
+                        + "AUTHOR_URL TEXT,THEME_URL TEXT,SCREENSHOT_URL TEXT,DEMO_URL TEXT,DOWNLOAD_URL TEXT,"
+                        + "STYLESHEET TEXT,CURRENCY TEXT,PRICE REAL,ACTIVE INTEGER,AUTO_UPDATE INTEGER,"
+                        + "AUTO_UPDATE_TRANSLATION INTEGER,IS_WP_COM_THEME INTEGER)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -137,6 +137,7 @@ public class ThemeStore extends Store {
 
     public static class OnThemesChanged extends OnChanged<FetchThemesError> {
         public SiteModel site;
+        public ThemeAction origin;
 
         public OnThemesChanged(SiteModel site) {
             this.site = site;
@@ -267,6 +268,7 @@ public class ThemeStore extends Store {
 
     private void handleWpThemesFetched(@NonNull FetchedThemesPayload payload) {
         OnThemesChanged event = new OnThemesChanged(payload.site);
+        event.origin = ThemeAction.FETCH_WP_COM_THEMES;
         if (payload.isError()) {
             event.error = payload.error;
         } else {
@@ -287,6 +289,7 @@ public class ThemeStore extends Store {
 
     private void handleInstalledThemesFetched(@NonNull FetchedThemesPayload payload) {
         OnThemesChanged event = new OnThemesChanged(payload.site);
+        event.origin = ThemeAction.FETCH_INSTALLED_THEMES;
         if (payload.isError()) {
             event.error = payload.error;
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -246,11 +246,11 @@ public class ThemeStore extends Store {
     }
 
     public List<ThemeModel> getWpComThemes() {
-        return ThemeSqlUtils.getThemesWithNoSite();
+        return ThemeSqlUtils.getWpComThemes();
     }
 
     public Cursor getWpComThemesCursor() {
-        return ThemeSqlUtils.getThemesWithNoSiteAsCursor();
+        return ThemeSqlUtils.getWpComThemesCursor();
     }
 
     public Cursor getThemesCursorForSite(@NonNull SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -245,11 +245,11 @@ public class ThemeStore extends Store {
         AppLog.d(AppLog.T.API, "ThemeStore onRegister");
     }
 
-    public List<ThemeModel> getWpThemes() {
+    public List<ThemeModel> getWpComThemes() {
         return ThemeSqlUtils.getThemesWithNoSite();
     }
 
-    public Cursor getWpThemesCursor() {
+    public Cursor getWpComThemesCursor() {
         return ThemeSqlUtils.getThemesWithNoSiteAsCursor();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -363,7 +363,6 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            payload.theme.setLocalSiteId(payload.site.getId());
             ThemeSqlUtils.insertOrUpdateThemeForSite(payload.theme);
         }
         emitChange(event);
@@ -398,7 +397,6 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            payload.theme.setLocalSiteId(payload.site.getId());
             ThemeSqlUtils.removeTheme(payload.theme);
         }
         emitChange(event);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store;
 
+import android.database.Cursor;
 import android.support.annotation.NonNull;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -243,6 +244,10 @@ public class ThemeStore extends Store {
 
     public List<ThemeModel> getWpThemes() {
         return ThemeSqlUtils.getThemesWithNoSite();
+    }
+
+    public Cursor getWpThemesCursor() {
+        return ThemeSqlUtils.getThemesWithNoSiteAsCursor();
     }
 
     public List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -262,6 +262,15 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getThemeWithId(themeId);
     }
 
+    public ThemeModel getActiveThemeForSite(@NonNull SiteModel site) {
+        List<ThemeModel> activeTheme = ThemeSqlUtils.getActiveThemeForSite(site);
+        return activeTheme.isEmpty() ? null : activeTheme.get(0);
+    }
+
+    public void setActiveThemeForSite(@NonNull SiteModel site, @NonNull ThemeModel theme) {
+        ThemeSqlUtils.insertOrReplaceActiveThemeForSite(site, theme);
+    }
+
     private void fetchWpThemes() {
         mThemeRestClient.fetchWpComThemes();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -58,10 +58,6 @@ public class ThemeStore extends Store {
         public SearchThemesPayload(@NonNull String searchTerm) {
             this.searchTerm = searchTerm;
         }
-
-        public SearchThemesPayload(FetchThemesError error) {
-            this.error = error;
-        }
     }
 
     public static class SearchedThemesPayload extends Payload<FetchThemesError> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -257,11 +257,11 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getThemesForSite(site);
     }
 
-    public ThemeModel getThemeByThemeId(String themeId) {
+    public ThemeModel getThemeByThemeId(String themeId, boolean wpCom) {
         if (themeId == null || themeId.isEmpty()) {
             return null;
         }
-        return ThemeSqlUtils.getThemeWithId(themeId);
+        return ThemeSqlUtils.getThemeByThemeId(themeId, wpCom);
     }
 
     public ThemeModel getActiveThemeForSite(@NonNull SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -251,6 +251,10 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getThemesWithNoSiteAsCursor();
     }
 
+    public Cursor getThemesCursorForSite(@NonNull SiteModel site) {
+        return ThemeSqlUtils.getThemesForSiteAsCursor(site);
+    }
+
     public List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {
         return ThemeSqlUtils.getThemesForSite(site);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -257,11 +257,11 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getThemesForSite(site);
     }
 
-    public ThemeModel getThemeByThemeId(String themeId, boolean wpCom) {
+    public ThemeModel getThemeByThemeId(String themeId, boolean isWpComTheme) {
         if (themeId == null || themeId.isEmpty()) {
             return null;
         }
-        return ThemeSqlUtils.getThemeByThemeId(themeId, wpCom);
+        return ThemeSqlUtils.getThemeByThemeId(themeId, isWpComTheme);
     }
 
     public ThemeModel getActiveThemeForSite(@NonNull SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -261,7 +261,7 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getThemesForSite(site);
     }
 
-    public ThemeModel getThemeWithId(String themeId) {
+    public ThemeModel getThemeByThemeId(String themeId) {
         if (themeId == null || themeId.isEmpty()) {
             return null;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -191,10 +191,10 @@ public class ThemeStore extends Store {
         }
         switch ((ThemeAction) actionType) {
             case FETCH_WP_COM_THEMES:
-                fetchWpThemes();
+                fetchWpComThemes();
                 break;
             case FETCHED_WP_COM_THEMES:
-                handleWpThemesFetched((FetchedThemesPayload) action.getPayload());
+                handleWpComThemesFetched((FetchedThemesPayload) action.getPayload());
                 break;
             case FETCH_INSTALLED_THEMES:
                 fetchInstalledThemes((SiteModel) action.getPayload());
@@ -277,17 +277,17 @@ public class ThemeStore extends Store {
         ThemeSqlUtils.insertOrReplaceActiveThemeForSite(site, theme);
     }
 
-    private void fetchWpThemes() {
+    private void fetchWpComThemes() {
         mThemeRestClient.fetchWpComThemes();
     }
 
-    private void handleWpThemesFetched(@NonNull FetchedThemesPayload payload) {
+    private void handleWpComThemesFetched(@NonNull FetchedThemesPayload payload) {
         OnThemesChanged event = new OnThemesChanged(payload.site);
         event.origin = ThemeAction.FETCH_WP_COM_THEMES;
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.insertOrReplaceWpThemes(payload.themes);
+            ThemeSqlUtils.insertOrReplaceWpComThemes(payload.themes);
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -249,6 +249,13 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getThemesForSite(site);
     }
 
+    public ThemeModel getThemeWithId(String themeId) {
+        if (themeId == null || themeId.isEmpty()) {
+            return null;
+        }
+        return ThemeSqlUtils.getThemeWithId(themeId);
+    }
+
     private void fetchWpThemes() {
         mThemeRestClient.fetchWpComThemes();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -322,7 +322,7 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.insertOrUpdateTheme(payload.theme);
+            ThemeSqlUtils.insertOrUpdateThemeForSite(payload.theme);
         }
         emitChange(event);
     }
@@ -337,7 +337,7 @@ public class ThemeStore extends Store {
             event.error = payload.error;
         } else {
             for (ThemeModel theme : payload.themes) {
-                ThemeSqlUtils.insertOrUpdateTheme(theme);
+                ThemeSqlUtils.insertOrUpdateThemeForSite(theme);
             }
         }
         emitChange(event);
@@ -357,7 +357,8 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.insertOrUpdateTheme(payload.theme);
+            payload.theme.setLocalSiteId(payload.site.getId());
+            ThemeSqlUtils.insertOrUpdateThemeForSite(payload.theme);
         }
         emitChange(event);
     }
@@ -391,6 +392,7 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
+            payload.theme.setLocalSiteId(payload.site.getId());
             ThemeSqlUtils.removeTheme(payload.theme);
         }
         emitChange(event);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -354,7 +354,11 @@ public class ThemeStore extends Store {
 
     private void handleThemeInstalled(@NonNull ActivateThemePayload payload) {
         OnThemeActivated event = new OnThemeActivated(payload.site, payload.theme);
-        event.error = payload.error;
+        if (payload.isError()) {
+            event.error = payload.error;
+        } else {
+            ThemeSqlUtils.insertOrUpdateTheme(payload.theme);
+        }
         emitChange(event);
     }
 
@@ -384,7 +388,11 @@ public class ThemeStore extends Store {
 
     private void handleThemeDeleted(@NonNull ActivateThemePayload payload) {
         OnThemeActivated event = new OnThemeActivated(payload.site, payload.theme);
-        event.error = payload.error;
+        if (payload.isError()) {
+            event.error = payload.error;
+        } else {
+            ThemeSqlUtils.removeTheme(payload.theme);
+        }
         emitChange(event);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -19,7 +19,9 @@ import org.wordpress.android.util.AppLog;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class ThemeStore extends Store {
     // Payloads
     public static class FetchedCurrentThemePayload extends Payload<FetchThemesError> {


### PR DESCRIPTION
Since #572 is such a massive changeset I'm separating all the new tests out into a separate PR along with this one which has all the changes needed in WPAndroid.

To test:
* run the example app and test the various theme actions, be sure to sign into an account with a Jetpack site _and_ WP.com site

cc @oguzkocer 