### PR TITLE
Refactor plugin method/action names

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -54,7 +54,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
-    public void testFetchPlugins() throws InterruptedException {
+    public void testFetchSitePlugins() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
 
@@ -72,7 +72,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
-    public void testUpdatePlugin() throws InterruptedException {
+    public void testUpdateSitePlugin() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -62,7 +62,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         SiteModel site = mSiteStore.getSites().get(0);
-        mDispatcher.dispatch(PluginActionBuilder.newFetchPluginsAction(site));
+        mDispatcher.dispatch(PluginActionBuilder.newFetchSitePluginsAction(site));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -84,7 +84,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         SiteModel site = mSiteStore.getSites().get(0);
-        mDispatcher.dispatch(PluginActionBuilder.newFetchPluginsAction(site));
+        mDispatcher.dispatch(PluginActionBuilder.newFetchSitePluginsAction(site));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -98,7 +98,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         UpdatePluginPayload payload = new UpdatePluginPayload(site, plugin);
-        mDispatcher.dispatch(PluginActionBuilder.newUpdatePluginAction(payload));
+        mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -66,7 +66,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        List<PluginModel> plugins = mPluginStore.getPlugins(site);
+        List<PluginModel> plugins = mPluginStore.getSitePlugins(site);
         assertTrue(plugins.size() > 0);
 
         signOutWPCom();
@@ -88,7 +88,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        List<PluginModel> plugins = mPluginStore.getPlugins(site);
+        List<PluginModel> plugins = mPluginStore.getSitePlugins(site);
         assertTrue(plugins.size() > 0);
         PluginModel plugin = plugins.get(0);
         boolean isActive = !plugin.isActive();
@@ -102,7 +102,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        PluginModel newPlugin = mPluginStore.getPluginByName(site, plugin.getName());
+        PluginModel newPlugin = mPluginStore.getSitePluginByName(site, plugin.getName());
         assertNotNull(newPlugin);
         assertEquals(newPlugin.isActive(), isActive);
 

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
@@ -51,12 +51,12 @@ public class PluginStoreUnitTest {
 
         // Set 3 plugins
         PluginSqlUtils.insertOrReplacePlugins(site, generatePlugins("akismet", "hello", "jetpack"));
-        List<PluginModel> plugins = mPluginStore.getPlugins(site);
+        List<PluginModel> plugins = mPluginStore.getSitePlugins(site);
         assertEquals(3, plugins.size());
 
         // Set 1 plugin
         PluginSqlUtils.insertOrReplacePlugins(site, generatePlugins("jetpack"));
-        plugins = mPluginStore.getPlugins(site);
+        plugins = mPluginStore.getSitePlugins(site);
         // make sure the previous plugins are removed
         assertEquals(1, plugins.size());
         assertEquals("jetpack", plugins.get(0).getName());
@@ -77,7 +77,7 @@ public class PluginStoreUnitTest {
 
         String name = "akismet/akismet";
         PluginSqlUtils.insertOrUpdatePlugin(site, generatePlugin(name));
-        PluginModel plugin = mPluginStore.getPluginByName(site, name);
+        PluginModel plugin = mPluginStore.getSitePluginByName(site, name);
         assertEquals(name, plugin.getName());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginStoreUnitTest.java
@@ -50,12 +50,12 @@ public class PluginStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(site);
 
         // Set 3 plugins
-        PluginSqlUtils.insertOrReplacePlugins(site, generatePlugins("akismet", "hello", "jetpack"));
+        PluginSqlUtils.insertOrReplaceSitePlugins(site, generatePlugins("akismet", "hello", "jetpack"));
         List<PluginModel> plugins = mPluginStore.getSitePlugins(site);
         assertEquals(3, plugins.size());
 
         // Set 1 plugin
-        PluginSqlUtils.insertOrReplacePlugins(site, generatePlugins("jetpack"));
+        PluginSqlUtils.insertOrReplaceSitePlugins(site, generatePlugins("jetpack"));
         plugins = mPluginStore.getSitePlugins(site);
         // make sure the previous plugins are removed
         assertEquals(1, plugins.size());
@@ -76,7 +76,7 @@ public class PluginStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(site);
 
         String name = "akismet/akismet";
-        PluginSqlUtils.insertOrUpdatePlugin(site, generatePlugin(name));
+        PluginSqlUtils.insertOrUpdateSitePlugin(site, generatePlugin(name));
         PluginModel plugin = mPluginStore.getSitePluginByName(site, name);
         assertEquals(name, plugin.getName());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -13,17 +13,17 @@ import org.wordpress.android.fluxc.store.PluginStore.UpdatedPluginPayload;
 public enum PluginAction implements IAction {
     // Remote actions
     @Action(payloadType = SiteModel.class)
-    FETCH_PLUGINS,
+    FETCH_SITE_PLUGINS,
     @Action(payloadType = String.class)
     FETCH_PLUGIN_INFO,
     @Action(payloadType = UpdatePluginPayload.class)
-    UPDATE_PLUGIN,
+    UPDATE_SITE_PLUGIN,
 
     // Remote responses
     @Action(payloadType = FetchedPluginsPayload.class)
-    FETCHED_PLUGINS,
+    FETCHED_SITE_PLUGINS,
     @Action(payloadType = FetchedPluginInfoPayload.class)
     FETCHED_PLUGIN_INFO,
     @Action(payloadType = UpdatedPluginPayload.class)
-    UPDATED_PLUGIN
+    UPDATED_SITE_PLUGIN
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -57,7 +57,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 plugins.add(pluginModelFromResponse(site, pluginResponse));
                             }
                         }
-                        mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginsAction(
+                        mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginsAction(
                                 new FetchedPluginsPayload(site, plugins)));
                     }
                 },
@@ -75,7 +75,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         }
                         fetchPluginsError.message = networkError.message;
                         FetchedPluginsPayload payload = new FetchedPluginsPayload(fetchPluginsError);
-                        mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginsAction(payload));
+                        mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginsAction(payload));
                     }
                 }
         );
@@ -98,7 +98,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
                         PluginModel pluginModel = pluginModelFromResponse(site, response);
-                        mDispatcher.dispatch(PluginActionBuilder.newUpdatedPluginAction(
+                        mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(
                                 new UpdatedPluginPayload(site, pluginModel)));
                     }
                 },
@@ -116,7 +116,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         }
                         updatePluginError.message = networkError.message;
                         UpdatedPluginPayload payload = new UpdatedPluginPayload(site, updatePluginError);
-                        mDispatcher.dispatch(PluginActionBuilder.newUpdatedPluginAction(payload));
+                        mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -13,16 +13,16 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import java.util.List;
 
 public class PluginSqlUtils {
-    public static List<PluginModel> getPlugins(@NonNull SiteModel site) {
+    public static List<PluginModel> getSitePlugins(@NonNull SiteModel site) {
         return WellSql.select(PluginModel.class)
                 .where()
                 .equals(PluginModelTable.LOCAL_SITE_ID, site.getId())
                 .endWhere().getAsModel();
     }
 
-    public static void insertOrReplacePlugins(@NonNull SiteModel site, @NonNull List<PluginModel> plugins) {
+    public static void insertOrReplaceSitePlugins(@NonNull SiteModel site, @NonNull List<PluginModel> plugins) {
         // Remove previous plugins for this site
-        removePlugins(site);
+        removeSitePlugins(site);
         // Insert new plugins for this site
         for (PluginModel pluginModel : plugins) {
             pluginModel.setLocalSiteId(site.getId());
@@ -30,19 +30,19 @@ public class PluginSqlUtils {
         WellSql.insert(plugins).asSingleTransaction(true).execute();
     }
 
-    private static void removePlugins(@NonNull SiteModel site) {
+    private static void removeSitePlugins(@NonNull SiteModel site) {
         WellSql.delete(PluginModel.class)
                 .where()
                 .equals(PluginModelTable.LOCAL_SITE_ID, site.getId())
                 .endWhere().execute();
     }
 
-    public static int insertOrUpdatePlugin(SiteModel site, PluginModel plugin) {
+    public static int insertOrUpdateSitePlugin(SiteModel site, PluginModel plugin) {
         if (plugin == null) {
             return 0;
         }
 
-        PluginModel oldPlugin = getPluginByName(site, plugin.getName());
+        PluginModel oldPlugin = getSitePluginByName(site, plugin.getName());
         if (oldPlugin == null) {
             WellSql.insert(plugin).execute();
             return 1;
@@ -71,7 +71,7 @@ public class PluginSqlUtils {
         }
     }
 
-    public static PluginModel getPluginByName(SiteModel site, String name) {
+    public static PluginModel getSitePluginByName(SiteModel site, String name) {
         List<PluginModel> result = WellSql.select(PluginModel.class)
                 .where().equals(PluginModelTable.NAME, name)
                 .equals(PluginModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -186,11 +186,11 @@ public class PluginStore extends Store {
     }
 
     public List<PluginModel> getSitePlugins(SiteModel site) {
-        return PluginSqlUtils.getPlugins(site);
+        return PluginSqlUtils.getSitePlugins(site);
     }
 
     public PluginModel getSitePluginByName(SiteModel site, String name) {
-        return PluginSqlUtils.getPluginByName(site, name);
+        return PluginSqlUtils.getSitePluginByName(site, name);
     }
 
     public PluginInfoModel getPluginInfoBySlug(String slug) {
@@ -226,7 +226,7 @@ public class PluginStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            PluginSqlUtils.insertOrReplacePlugins(payload.site, payload.plugins);
+            PluginSqlUtils.insertOrReplaceSitePlugins(payload.site, payload.plugins);
         }
         emitChange(event);
     }
@@ -249,7 +249,7 @@ public class PluginStore extends Store {
         } else {
             payload.plugin.setLocalSiteId(payload.site.getId());
             event.plugin = payload.plugin;
-            PluginSqlUtils.insertOrUpdatePlugin(payload.site, payload.plugin);
+            PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -164,22 +164,22 @@ public class PluginStore extends Store {
             return;
         }
         switch ((PluginAction) actionType) {
-            case FETCH_PLUGINS:
+            case FETCH_SITE_PLUGINS:
                 fetchPlugins((SiteModel) action.getPayload());
                 break;
             case FETCH_PLUGIN_INFO:
                 fetchPluginInfo((String) action.getPayload());
                 break;
-            case UPDATE_PLUGIN:
+            case UPDATE_SITE_PLUGIN:
                 updatePlugin((UpdatePluginPayload) action.getPayload());
                 break;
-            case FETCHED_PLUGINS:
+            case FETCHED_SITE_PLUGINS:
                 fetchedPlugins((FetchedPluginsPayload) action.getPayload());
                 break;
             case FETCHED_PLUGIN_INFO:
                 fetchedPluginInfo((FetchedPluginInfoPayload) action.getPayload());
                 break;
-            case UPDATED_PLUGIN:
+            case UPDATED_SITE_PLUGIN:
                 updatedPlugin((UpdatedPluginPayload) action.getPayload());
                 break;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -165,31 +165,31 @@ public class PluginStore extends Store {
         }
         switch ((PluginAction) actionType) {
             case FETCH_SITE_PLUGINS:
-                fetchPlugins((SiteModel) action.getPayload());
+                fetchSitePlugins((SiteModel) action.getPayload());
                 break;
             case FETCH_PLUGIN_INFO:
                 fetchPluginInfo((String) action.getPayload());
                 break;
             case UPDATE_SITE_PLUGIN:
-                updatePlugin((UpdatePluginPayload) action.getPayload());
+                updateSitePlugin((UpdatePluginPayload) action.getPayload());
                 break;
             case FETCHED_SITE_PLUGINS:
-                fetchedPlugins((FetchedPluginsPayload) action.getPayload());
+                fetchedSitePlugins((FetchedPluginsPayload) action.getPayload());
                 break;
             case FETCHED_PLUGIN_INFO:
                 fetchedPluginInfo((FetchedPluginInfoPayload) action.getPayload());
                 break;
             case UPDATED_SITE_PLUGIN:
-                updatedPlugin((UpdatedPluginPayload) action.getPayload());
+                updatedSitePlugin((UpdatedPluginPayload) action.getPayload());
                 break;
         }
     }
 
-    public List<PluginModel> getPlugins(SiteModel site) {
+    public List<PluginModel> getSitePlugins(SiteModel site) {
         return PluginSqlUtils.getPlugins(site);
     }
 
-    public PluginModel getPluginByName(SiteModel site, String name) {
+    public PluginModel getSitePluginByName(SiteModel site, String name) {
         return PluginSqlUtils.getPluginByName(site, name);
     }
 
@@ -197,13 +197,13 @@ public class PluginStore extends Store {
         return PluginSqlUtils.getPluginInfoBySlug(slug);
     }
 
-    private void fetchPlugins(SiteModel site) {
+    private void fetchSitePlugins(SiteModel site) {
         if (site.isUsingWpComRestApi() && site.isJetpackConnected()) {
             mPluginRestClient.fetchPlugins(site);
         } else {
             FetchPluginsError error = new FetchPluginsError(FetchPluginsErrorType.NOT_AVAILABLE);
             FetchedPluginsPayload payload = new FetchedPluginsPayload(error);
-            fetchedPlugins(payload);
+            fetchedSitePlugins(payload);
         }
     }
 
@@ -211,17 +211,17 @@ public class PluginStore extends Store {
         mPluginWPOrgClient.fetchPluginInfo(plugin);
     }
 
-    private void updatePlugin(UpdatePluginPayload payload) {
+    private void updateSitePlugin(UpdatePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
             mPluginRestClient.updatePlugin(payload.site, payload.plugin);
         } else {
             UpdatePluginError error = new UpdatePluginError(UpdatePluginErrorType.NOT_AVAILABLE);
             UpdatedPluginPayload errorPayload = new UpdatedPluginPayload(payload.site, error);
-            updatedPlugin(errorPayload);
+            updatedSitePlugin(errorPayload);
         }
     }
 
-    private void fetchedPlugins(FetchedPluginsPayload payload) {
+    private void fetchedSitePlugins(FetchedPluginsPayload payload) {
         OnPluginsChanged event = new OnPluginsChanged(payload.site);
         if (payload.isError()) {
             event.error = payload.error;
@@ -242,7 +242,7 @@ public class PluginStore extends Store {
         emitChange(event);
     }
 
-    private void updatedPlugin(UpdatedPluginPayload payload) {
+    private void updatedSitePlugin(UpdatedPluginPayload payload) {
         OnPluginChanged event = new OnPluginChanged(payload.site);
         if (payload.isError()) {
             event.error = payload.error;


### PR DESCRIPTION
While I was working browse plugins, I renamed some methods & actions to better reflect what they are doing. I thought those changes would be merged before we needed to make any changes to the plugins which unfortunately is not the case right now. In order to avoid a merge hell later on, this is a very quick PR that improves the mentioned naming in `develop`.

/cc @tonyr59h 