### PR TITLE
Bump Dagger to 2.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,6 @@
 allprojects {
     apply plugin: 'checkstyle'
 
-    ext.kotlin_version = '1.1.51'
-
     repositories {
         jcenter()
     }
@@ -42,4 +40,11 @@ subprojects {
         classpath = configurations.ktlint
         args "-F", "src/**/*.kt"
     }
+}
+
+ext {
+    kotlinVersion = '1.1.51'
+
+    daggerVersion = '2.11'
+    supportLibraryVersion = '25.3.1'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 
@@ -73,14 +73,14 @@ kapt {
 dependencies {
     compile project(':fluxc');
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
 
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
+    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
+    compile "com.android.support:support-v4:$supportLibraryVersion"
 
     // Dagger
-    compile 'com.google.dagger:dagger:2.11'
-    kapt 'com.google.dagger:dagger-compiler:2.11'
+    compile "com.google.dagger:dagger:$daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
     testCompile 'junit:junit:4.12'
@@ -89,7 +89,7 @@ dependencies {
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    kaptAndroidTest 'com.google.dagger:dagger-compiler:2.11'
+    kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
 
     // Debug dependencies
     debugCompile 'com.facebook.stetho:stetho:1.5.0'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -73,10 +73,15 @@ kapt {
 dependencies {
     compile project(':fluxc');
 
-    compile 'com.google.dagger:dagger:2.0.2'
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:support-v4:25.3.1'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+
+    // Dagger
+    compile 'com.google.dagger:dagger:2.11'
+    kapt 'com.google.dagger:dagger-compiler:2.11'
+    provided 'org.glassfish:javax.annotation:10.0-b28'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
@@ -84,8 +89,7 @@ dependencies {
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    kapt 'com.google.dagger:dagger-compiler:2.0.2'
-    provided 'org.glassfish:javax.annotation:10.0-b28'
+    kaptAndroidTest 'com.google.dagger:dagger-compiler:2.11'
 
     // Debug dependencies
     debugCompile 'com.facebook.stetho:stetho:1.5.0'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
@@ -63,7 +63,9 @@ kapt {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+
+    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
 
     // WordPress libs
     compile ('org.wordpress:utils:1.16.0') {
@@ -85,12 +87,11 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp-urlconnection:3.8.1'
     compile 'com.android.volley:volley:1.0.0'
     compile 'com.google.code.gson:gson:2.7'
-    compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'org.apache.commons:commons-text:1.1'
 
     // Dagger
-    compile 'com.google.dagger:dagger:2.11'
-    kapt 'com.google.dagger:dagger-compiler:2.11'
+    compile "com.google.dagger:dagger:$daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     provided 'org.glassfish:javax.annotation:10.0-b28'
 }
 

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -85,11 +85,13 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp-urlconnection:3.8.1'
     compile 'com.android.volley:volley:1.0.0'
     compile 'com.google.code.gson:gson:2.7'
-    compile 'com.google.dagger:dagger:2.0.2'
-    kapt 'com.google.dagger:dagger-compiler:2.0.2'
-    provided 'org.glassfish:javax.annotation:10.0-b28'
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'org.apache.commons:commons-text:1.1'
+
+    // Dagger
+    compile 'com.google.dagger:dagger:2.11'
+    kapt 'com.google.dagger:dagger-compiler:2.11'
+    provided 'org.glassfish:javax.annotation:10.0-b28'
 }
 
 version = android.defaultConfig.versionName

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -50,13 +50,16 @@ android.buildTypes.all { buildType ->
 dependencies {
     compile project(':fluxc');
 
-    compile 'com.google.dagger:dagger:2.0.2'
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:support-v4:25.3.1'
     compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
     compile 'com.squareup.picasso:picasso:2.5.2'
-    kapt 'com.google.dagger:dagger-compiler:2.0.2'
+
+    // Dagger
+    compile 'com.google.dagger:dagger:2.11'
+    kapt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 }

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 
@@ -50,16 +50,16 @@ android.buildTypes.all { buildType ->
 dependencies {
     compile project(':fluxc');
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
 
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
+    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
+    compile "com.android.support:support-v4:$supportLibraryVersion"
+    compile "com.android.support:recyclerview-v7:$supportLibraryVersion"
 
     compile 'com.squareup.picasso:picasso:2.5.2'
 
     // Dagger
-    compile 'com.google.dagger:dagger:2.11'
-    kapt 'com.google.dagger:dagger-compiler:2.11'
+    compile "com.google.dagger:dagger:$daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     provided 'org.glassfish:javax.annotation:10.0-b28'
 }


### PR DESCRIPTION
Bumps our dagger version to `2.11`, which is a prerequisite for eventually using [`dagger-android`](https://google.github.io/dagger/android.html) to simplify injections for activities/fragments/services, both in the example app and the real FluxC clients. (We have an issue open for this: https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/495.)

A follow-up PR will actually use `dagger-android` and overhaul injection in the example app.

I also took the opportunity to centralize our dagger and support library versions (https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/3c598e8f305b0346a4fb84e94e0c097f7fe28df5). We could do this for other dependencies too, but I just picked these two as we use them in multiple places and they should always be using the same version.

### Notes

1. ~#580 should be reviewed and merged first - it turns out using the newer `kapt` plugin form is required to play nice with `dagger-android`.~ There are issues with using the new `kapt` plugin, and it turns out not to be necessary to use `dagger-android`, so we're going to proceed without updating `kapt` for now.

2. Also, a PR in WPAndroid is required, bumping the `Dagger` version there to `2.11` and updating the FluxC hash (no other changes should be required in WPAndroid).

cc @maxme