### PR TITLE
ThemeStore: Split overloaded OnThemeActivated event

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -149,7 +149,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             themeToInstall.setId(listTheme.getId());
             deleteTheme(jetpackSite, themeToInstall);
 
-            // mActivatedTheme is set in onThemeActivated
+            // mDeletedTheme is set in onThemeDeleted
             assertNotNull(mDeletedTheme);
             assertEquals(themeId, mDeletedTheme.getThemeId());
 
@@ -188,7 +188,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (listTheme == null) {
             installTheme(jetpackSite, themeToDelete);
 
-            // mActivatedTheme is set in onThemeActivated
+            // mInstalledTheme is set in onThemeInstalled
             assertNotNull(mInstalledTheme);
             assertEquals(themeId, mInstalledTheme.getThemeId());
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -38,6 +38,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     @Inject ThemeStore mThemeStore;
     private ThemeModel mCurrentTheme;
     private ThemeModel mActivatedTheme;
+    private ThemeModel mInstalledTheme;
+    private ThemeModel mDeletedTheme;
 
     private TestEvents mNextEvent;
 
@@ -148,8 +150,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             deleteTheme(jetpackSite, themeToInstall);
 
             // mActivatedTheme is set in onThemeActivated
-            assertNotNull(mActivatedTheme);
-            assertEquals(themeId, mActivatedTheme.getThemeId());
+            assertNotNull(mDeletedTheme);
+            assertEquals(themeId, mDeletedTheme.getThemeId());
 
             // make sure theme is no longer available for site (delete was successful)
             assertFalse(listContainsThemeWithId(mThemeStore.getThemesForSite(jetpackSite), themeId));
@@ -187,8 +189,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             installTheme(jetpackSite, themeToDelete);
 
             // mActivatedTheme is set in onThemeActivated
-            assertNotNull(mActivatedTheme);
-            assertEquals(themeId, mActivatedTheme.getThemeId());
+            assertNotNull(mInstalledTheme);
+            assertEquals(themeId, mInstalledTheme.getThemeId());
 
             // make sure theme is available for site (install was successful)
             listTheme = getThemeFromList(mThemeStore.getThemesForSite(jetpackSite), themeId);
@@ -247,10 +249,30 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME
-                || mNextEvent == TestEvents.INSTALLED_THEME
-                || mNextEvent == TestEvents.DELETED_THEME);
+        assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME);
         mActivatedTheme = event.theme;
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onThemeInstalled(ThemeStore.OnThemeInstalled event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertTrue(mNextEvent == TestEvents.INSTALLED_THEME);
+        mInstalledTheme = event.theme;
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onThemeDeleted(ThemeStore.OnThemeDeleted event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertTrue(mNextEvent == TestEvents.DELETED_THEME);
+        mDeletedTheme = event.theme;
         mCountDownLatch.countDown();
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.java
@@ -199,6 +199,28 @@ public class ThemeFragment extends Fragment {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onThemeInstalled(ThemeStore.OnThemeInstalled event) {
+        prependToLog("onThemeInstalled: ");
+        if (event.isError()) {
+            prependToLog("error: " + event.error.message);
+        } else {
+            prependToLog("success: theme = " + event.theme.getThemeId());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onThemeDeleted(ThemeStore.OnThemeDeleted event) {
+        prependToLog("onThemeDeleted: ");
+        if (event.isError()) {
+            prependToLog("error: " + event.error.message);
+        } else {
+            prependToLog("success: theme = " + event.theme.getThemeId());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
     public void onThemeActivated(ThemeStore.OnThemeActivated event) {
         prependToLog("onThemeActivated: ");
         if (event.isError()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -20,12 +20,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeWPComResponse.ThemeArrayResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeWPComResponse.MultipleWPComThemesResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeJetpackResponse.MultipleJetpackThemesResponse;
+import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
 import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.FetchThemesError;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemeError;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 
@@ -64,7 +63,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme deletion request.");
                         ActivateThemePayload payload = new ActivateThemePayload(site, theme);
-                        payload.error = new ActivateThemeError(
+                        payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }
@@ -90,7 +89,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme installation request.");
                         ActivateThemePayload payload = new ActivateThemePayload(site, theme);
-                        payload.error = new ActivateThemeError(
+                        payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
                     }
@@ -117,7 +116,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to theme activation request.");
                         ActivateThemePayload payload = new ActivateThemePayload(site, theme);
-                        payload.error = new ActivateThemeError(
+                        payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newActivatedThemeAction(payload));
                     }
@@ -140,7 +139,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to WP.com themes fetch request.");
-                        FetchThemesError themeError = new FetchThemesError(
+                        ThemesError themeError = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         FetchedThemesPayload payload = new FetchedThemesPayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
@@ -164,7 +163,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to Jetpack installed themes fetch request.");
-                        FetchThemesError themeError = new FetchThemesError(
+                        ThemesError themeError = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         FetchedThemesPayload payload = new FetchedThemesPayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedInstalledThemesAction(payload));
@@ -188,7 +187,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to themes fetch request for WP.com site.");
-                        FetchThemesError themeError = new FetchThemesError(
+                        ThemesError themeError = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         FetchedThemesPayload payload = new FetchedThemesPayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
@@ -212,7 +211,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to current theme fetch request.");
-                        FetchThemesError themeError = new FetchThemesError(
+                        ThemesError themeError = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedCurrentThemeAction(payload));
@@ -236,7 +235,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to search themes request.");
-                        FetchThemesError themeError = new FetchThemesError(
+                        ThemesError themeError = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         SearchedThemesPayload payload = new SearchedThemesPayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -119,7 +119,8 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class OnThemesChanged extends OnChanged<FetchThemesError> {
+    // OnChanged events
+    public static class OnThemesChanged extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeAction origin;
 
@@ -151,6 +152,26 @@ public class ThemeStore extends Store {
         public ThemeModel theme;
 
         public OnThemeActivated(SiteModel site, ThemeModel theme) {
+            this.site = site;
+            this.theme = theme;
+        }
+    }
+
+    public static class OnThemeDeleted extends OnChanged<ThemesError> {
+        public SiteModel site;
+        public ThemeModel theme;
+
+        public OnThemeDeleted(SiteModel site, ThemeModel theme) {
+            this.site = site;
+            this.theme = theme;
+        }
+    }
+
+    public static class OnThemeInstalled extends OnChanged<ThemesError> {
+        public SiteModel site;
+        public ThemeModel theme;
+
+        public OnThemeInstalled(SiteModel site, ThemeModel theme) {
             this.site = site;
             this.theme = theme;
         }
@@ -341,7 +362,7 @@ public class ThemeStore extends Store {
     }
 
     private void handleThemeInstalled(@NonNull ActivateThemePayload payload) {
-        OnThemeActivated event = new OnThemeActivated(payload.site, payload.theme);
+        OnThemeInstalled event = new OnThemeInstalled(payload.site, payload.theme);
         if (payload.isError()) {
             event.error = payload.error;
         } else {
@@ -375,7 +396,7 @@ public class ThemeStore extends Store {
     }
 
     private void handleThemeDeleted(@NonNull ActivateThemePayload payload) {
-        OnThemeActivated event = new OnThemeActivated(payload.site, payload.theme);
+        OnThemeDeleted event = new OnThemeDeleted(payload.site, payload.theme);
         if (payload.isError()) {
             event.error = payload.error;
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -24,11 +24,11 @@ import javax.inject.Singleton;
 @Singleton
 public class ThemeStore extends Store {
     // Payloads
-    public static class FetchedCurrentThemePayload extends Payload<FetchThemesError> {
+    public static class FetchedCurrentThemePayload extends Payload<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
 
-        public FetchedCurrentThemePayload(FetchThemesError error) {
+        public FetchedCurrentThemePayload(ThemesError error) {
             this.error = error;
         }
 
@@ -38,11 +38,11 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class FetchedThemesPayload extends Payload<FetchThemesError> {
+    public static class FetchedThemesPayload extends Payload<ThemesError> {
         public SiteModel site;
         public List<ThemeModel> themes;
 
-        public FetchedThemesPayload(FetchThemesError error) {
+        public FetchedThemesPayload(ThemesError error) {
             this.error = error;
         }
 
@@ -52,7 +52,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class SearchThemesPayload extends Payload<FetchThemesError> {
+    public static class SearchThemesPayload extends Payload<ThemesError> {
         public String searchTerm;
 
         public SearchThemesPayload(@NonNull String searchTerm) {
@@ -60,7 +60,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class SearchedThemesPayload extends Payload<FetchThemesError> {
+    public static class SearchedThemesPayload extends Payload<ThemesError> {
         public String searchTerm;
         public List<ThemeModel> themes;
 
@@ -69,12 +69,12 @@ public class ThemeStore extends Store {
             this.themes = themes;
         }
 
-        public SearchedThemesPayload(FetchThemesError error) {
+        public SearchedThemesPayload(ThemesError error) {
             this.error = error;
         }
     }
 
-    public static class ActivateThemePayload extends Payload<ActivateThemeError> {
+    public static class ActivateThemePayload extends Payload<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
 
@@ -105,30 +105,16 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class FetchThemesError implements OnChangedError {
+    public static class ThemesError implements OnChangedError {
         public ThemeErrorType type;
         public String message;
 
-        public FetchThemesError(String type, String message) {
+        public ThemesError(String type, String message) {
             this.type = ThemeErrorType.fromString(type);
             this.message = message;
         }
 
-        public FetchThemesError(ThemeErrorType type) {
-            this.type = type;
-        }
-    }
-
-    public static class ActivateThemeError implements OnChangedError {
-        public ThemeErrorType type;
-        public String message;
-
-        public ActivateThemeError(String type, String message) {
-            this.type = ThemeErrorType.fromString(type);
-            this.message = message;
-        }
-
-        public ActivateThemeError(ThemeErrorType type) {
+        public ThemesError(ThemeErrorType type) {
             this.type = type;
         }
     }
@@ -142,7 +128,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class OnCurrentThemeFetched extends OnChanged<FetchThemesError> {
+    public static class OnCurrentThemeFetched extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
 
@@ -152,7 +138,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class OnThemesSearched extends OnChanged<FetchThemesError> {
+    public static class OnThemesSearched extends OnChanged<ThemesError> {
         public List<ThemeModel> searchResults;
 
         public OnThemesSearched(List<ThemeModel> searchResults) {
@@ -160,7 +146,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class OnThemeActivated extends OnChanged<ActivateThemeError> {
+    public static class OnThemeActivated extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
 
@@ -292,7 +278,7 @@ public class ThemeStore extends Store {
         if (site.isJetpackConnected() && site.isUsingWpComRestApi()) {
             mThemeRestClient.fetchJetpackInstalledThemes(site);
         } else {
-            FetchThemesError error = new FetchThemesError(ThemeErrorType.NOT_AVAILABLE);
+            ThemesError error = new ThemesError(ThemeErrorType.NOT_AVAILABLE);
             FetchedThemesPayload payload = new FetchedThemesPayload(error);
             handleInstalledThemesFetched(payload);
         }
@@ -313,7 +299,7 @@ public class ThemeStore extends Store {
         if (site.isUsingWpComRestApi()) {
             mThemeRestClient.fetchCurrentTheme(site);
         } else {
-            FetchThemesError error = new FetchThemesError(ThemeErrorType.NOT_AVAILABLE);
+            ThemesError error = new ThemesError(ThemeErrorType.NOT_AVAILABLE);
             FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(error);
             handleCurrentThemeFetched(payload);
         }
@@ -349,7 +335,7 @@ public class ThemeStore extends Store {
         if (payload.site.isJetpackConnected() && payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.installTheme(payload.site, payload.theme);
         } else {
-            payload.error = new ActivateThemeError(ThemeErrorType.NOT_AVAILABLE);
+            payload.error = new ThemesError(ThemeErrorType.NOT_AVAILABLE);
             handleThemeInstalled(payload);
         }
     }
@@ -368,7 +354,7 @@ public class ThemeStore extends Store {
         if (payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.activateTheme(payload.site, payload.theme);
         } else {
-            payload.error = new ActivateThemeError(ThemeErrorType.NOT_AVAILABLE);
+            payload.error = new ThemesError(ThemeErrorType.NOT_AVAILABLE);
             handleThemeActivated(payload);
         }
     }
@@ -383,7 +369,7 @@ public class ThemeStore extends Store {
         if (payload.site.isJetpackConnected() && payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.deleteTheme(payload.site, payload.theme);
         } else {
-            payload.error = new ActivateThemeError(ThemeErrorType.NOT_AVAILABLE);
+            payload.error = new ThemesError(ThemeErrorType.NOT_AVAILABLE);
             handleThemeDeleted(payload);
         }
     }


### PR DESCRIPTION
This PR is against #584 (relevant discussion there). It adds new OnChanged events for delete and install actions, updates the tests+example, and removes unnecessary error class.

cc @oguzkocer 