### PR TITLE
added isRegisteredPostModel method to UploadStore

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -124,6 +124,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         List<MediaModel> mediaModelList = new ArrayList<>();
         mediaModelList.add(testMedia);
         mUploadStore.registerPostModel(mPost, mediaModelList);
+        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
 
         // PostUploadModel exists and has correct state and associated media
         assertEquals(1, mUploadStore.getPendingPosts().size());
@@ -218,6 +219,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         List<MediaModel> mediaModelList = new ArrayList<>();
         mediaModelList.add(testMedia);
         mUploadStore.registerPostModel(mPost, mediaModelList);
+        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
 
         mNextEvent = TestEvents.CANCELLED_POST;
         mDispatcher.dispatch(UploadActionBuilder.newCancelPostAction(mPost));
@@ -282,6 +284,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         List<MediaModel> mediaModelList = new ArrayList<>();
         mediaModelList.add(testMedia);
         mUploadStore.registerPostModel(mPost, mediaModelList);
+        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
 
         // MediaUploadModel exists and has correct state
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
@@ -337,6 +340,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         List<MediaModel> mediaModelList = new ArrayList<>();
         mediaModelList.add(testMedia);
         mUploadStore.registerPostModel(mPost, mediaModelList);
+        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
 
         // MediaUploadModel exists and has correct state
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -199,6 +199,11 @@ public class UploadStore extends Store {
         return postUploadModel != null && postUploadModel.getUploadState() == PostUploadModel.CANCELLED;
     }
 
+    public boolean isRegisteredPostModel(PostModel post) {
+        PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(post.getId());
+        return postUploadModel != null;
+    }
+
     /**
      * If the {@code postModel} has been registered as uploading with the UploadStore, this will return the associated
      * {@link PostError}, if any.


### PR DESCRIPTION
Adds a method `isRegisteredPostModel` in the UploadStore

cc @aforcier 