### PR TITLE
Plugin endpoint changes

### DIFF
--- a/example/tests.properties-example
+++ b/example/tests.properties-example
@@ -182,6 +182,10 @@ TEST_WPORG_PASSWORD_JETPACK_SUBFOLDER = FIXME
 TEST_WPORG_URL_JETPACK_SUBFOLDER = FIXME
 TEST_WPORG_URL_JETPACK_SUBFOLDER_ENDPOINT = FIXME
 
+# WP.com - Account with only one site: a Jetpack site with beta versions enabled: http://do.wpmt.co/jp-beta/
+TEST_WPCOM_USERNAME_JETPACK_BETA_SITE = FIXME
+TEST_WPCOM_PASSWORD_JETPACK_BETA_SITE = FIXME
+
 ## Local
 # These files should be at least 500KB, otherwise they may cause cancellation tests to fail on fast enough connections
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -45,7 +45,7 @@ public class PluginRestClient extends BaseWPComRestClient {
     }
 
     public void fetchSitePlugins(@NonNull final SiteModel site) {
-        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.getUrlV1_1();
+        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.getUrlV1_2();
         final WPComGsonRequest<FetchPluginsResponse> request = WPComGsonRequest.buildGetRequest(url, null,
                 FetchPluginsResponse.class,
                 new Listener<FetchPluginsResponse>() {
@@ -90,7 +90,7 @@ public class PluginRestClient extends BaseWPComRestClient {
         } catch (UnsupportedEncodingException e) {
             name = plugin.getName();
         }
-        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(name).getUrlV1_1();
+        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(name).getUrlV1_2();
         Map<String, Object> params = paramsFromPluginModel(plugin);
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, params,
                 PluginWPComRestResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -126,8 +126,8 @@ public class PluginRestClient extends BaseWPComRestClient {
     private PluginModel pluginModelFromResponse(SiteModel siteModel, PluginWPComRestResponse response) {
         PluginModel pluginModel = new PluginModel();
         pluginModel.setLocalSiteId(siteModel.getId());
-        pluginModel.setName(response.id);
-        pluginModel.setDisplayName(response.name);
+        pluginModel.setName(response.name);
+        pluginModel.setDisplayName(response.display_name);
         pluginModel.setAuthorName(response.author);
         pluginModel.setAuthorUrl(response.author_url);
         pluginModel.setDescription(response.description);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginWPComRestResponse.java
@@ -7,12 +7,12 @@ public class PluginWPComRestResponse {
         public List<PluginWPComRestResponse> plugins;
     }
 
-    public String id;
     public boolean active;
     public String author;
     public String author_url;
     public boolean autoupdate;
     public String description;
+    public String display_name;
     public String name;
     public String plugin_url;
     public String slug;


### PR DESCRIPTION
This PR makes the necessary updates to the plugins feature for the new v1.2 endpoint changes. Fortunately, I already used `name` & `displayName` properties in `PluginModel` in anticipation of the changes, so we don't actually need to update the model and write a migration for it.

To test the changes, `ReleaseStack_PluginTestJetpack` should be used by updating the credentials used with `TEST_WPCOM_USERNAME_JETPACK_BETA_SITE` and `TEST_WPCOM_PASSWORD_JETPACK_BETA_SITE`, because v1.2 endpoint only works on the current beta version of Jetpack for now. Please DM me for the credentials for it if you don't have such a site setup.

/cc @tonyr59h 