### PR TITLE
CommentStore: Request 'i_like' flag in fetch request

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -48,6 +48,7 @@ public class CommentRestClient extends BaseWPComRestClient {
         params.put("status", status.toString());
         params.put("offset", String.valueOf(offset));
         params.put("number", String.valueOf(number));
+        params.put("force", "wpcom");
         final WPComGsonRequest<CommentsWPComRestResponse> request = WPComGsonRequest.buildGetRequest(
                 url, params, CommentsWPComRestResponse.class,
                 new Listener<CommentsWPComRestResponse>() {


### PR DESCRIPTION
[Reference](https://github.com/wordpress-mobile/WordPress-Android/issues/5618#issuecomment-338810034).

Adds parameter `force=wpcom` to site comments fetch request. This parameter is needed to ensure the `i_like` field is returned.