### PR TITLE
resets the UploadState for a Post that is being registered

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -149,6 +149,7 @@ public class UploadStore extends Store {
         }
 
         postUploadModel.setAssociatedMediaIdSet(mediaIdSet);
+        postUploadModel.setUploadState(PostUploadModel.PENDING);
         UploadSqlUtils.insertOrUpdatePost(postUploadModel);
     }
 


### PR DESCRIPTION
This is an easy fix, to a hard to debug problem :)

If a Post is cancelled because of a media having failed in a previous attempt, the next time we try to upload a Post the `PostUploadModel` for such a Post is found and is cancelled, thus the record updated by `registerPostModel` is immediately deleted by the `handleUploadMedia` method.
That means, you can never keep up with failed uploads except for the first time, unless you give enough time between a new media item starts uploading and the corresponding associated Post model starts uploading. 
This was not apparent before but only now that we're automating the `Retry` functionality in WPAndroid. (https://github.com/wordpress-mobile/WordPress-Android/pull/6763)

cc @aforcier 🙇 