### PR TITLE
Moving media from FAILED to UPLOADING should reset any errors

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -360,6 +360,7 @@ public class UploadStore extends Store {
             case MediaUploadModel.FAILED:
                 if (newUploadState == MediaUploadState.UPLOADING || newUploadState == MediaUploadState.QUEUED) {
                     mediaUploadModel.setUploadState(MediaUploadModel.UPLOADING);
+                    mediaUploadModel.setMediaError(null); // clear any previous errors
                     UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel);
                 }
                 break;


### PR DESCRIPTION
This PR does this by resetting any previous error when moving a Media item from `FAILED` to `QUEUED`/`UPLOADING`