### PR TITLE
Feature/add social sms

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.store.AccountStore.NewAccountPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushAccountSettingsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialAuthPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialLoginPayload;
+import org.wordpress.android.fluxc.store.AccountStore.PushSocialSmsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload;
 
 @ActionEnum
@@ -32,7 +33,7 @@ public enum AccountAction implements IAction {
     PUSH_SOCIAL_CONNECT,    // request social connect remotely
     @Action(payloadType = PushSocialLoginPayload.class)
     PUSH_SOCIAL_LOGIN,      // request social login remotely
-    @Action(payloadType = PushSocialAuthPayload.class)
+    @Action(payloadType = PushSocialSmsPayload.class)
     PUSH_SOCIAL_SMS,      // request social sms remotely
     @Action(payloadType = NewAccountPayload.class)
     CREATE_NEW_ACCOUNT,     // create a new account (can be used to validate the account before creating it)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -32,6 +32,8 @@ public enum AccountAction implements IAction {
     PUSH_SOCIAL_CONNECT,    // request social connect remotely
     @Action(payloadType = PushSocialLoginPayload.class)
     PUSH_SOCIAL_LOGIN,      // request social login remotely
+    @Action(payloadType = PushSocialAuthPayload.class)
+    PUSH_SOCIAL_SMS,      // request social sms remotely
     @Action(payloadType = NewAccountPayload.class)
     CREATE_NEW_ACCOUNT,     // create a new account (can be used to validate the account before creating it)
     @Action(payloadType = String.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -67,6 +67,8 @@ public class AccountRestClient extends BaseWPComRestClient {
     public static class AccountPushSocialResponsePayload extends Payload<AccountSocialError> {
         public AccountPushSocialResponsePayload(AccountSocialResponse response) {
             this.bearerToken = response.bearer_token;
+            this.phoneNumber = response.phone_number;
+            this.twoStepNonce = response.two_step_nonce;
             this.twoStepNonceAuthenticator = response.two_step_nonce_authenticator;
             this.twoStepNonceBackup = response.two_step_nonce_backup;
             this.twoStepNonceSms = response.two_step_nonce_sms;
@@ -81,6 +83,8 @@ public class AccountRestClient extends BaseWPComRestClient {
         }
         public List<String> twoStepTypes;
         public String bearerToken;
+        public String phoneNumber;
+        public String twoStepNonce;
         public String twoStepNonceAuthenticator;
         public String twoStepNonceBackup;
         public String twoStepNonceSms;
@@ -101,6 +105,10 @@ public class AccountRestClient extends BaseWPComRestClient {
             }
 
             return list;
+        }
+
+        public boolean hasPhoneNumber() {
+            return !TextUtils.isEmpty(this.phoneNumber);
         }
 
         public boolean hasToken() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialRequest.java
@@ -56,6 +56,8 @@ public class AccountSocialRequest extends BaseRequest<AccountSocialResponse> {
             JSONObject object = new JSONObject(responseBody);
             JSONObject data = object.getJSONObject("data");
             parsed.bearer_token = data.optString("bearer_token");
+            parsed.phone_number = data.optString("phone_number");
+            parsed.two_step_nonce = data.optString("two_step_nonce");
             parsed.two_step_supported_auth_types = data.optJSONArray("two_step_supported_auth_types");
             parsed.two_step_nonce_authenticator = data.optString("two_step_nonce_authenticator");
             parsed.two_step_nonce_backup = data.optString("two_step_nonce_backup");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
@@ -6,6 +6,8 @@ import org.wordpress.android.fluxc.network.Response;
 public class AccountSocialResponse implements Response {
     public JSONArray two_step_supported_auth_types;
     public String bearer_token;
+    public String phone_number;
+    public String two_step_nonce;
     public String two_step_nonce_authenticator;
     public String two_step_nonce_backup;
     public String two_step_nonce_sms;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -130,10 +130,12 @@ public class AccountStore extends Store {
 
     public static class OnSocialChanged extends OnChanged<AccountSocialError> {
         public List<String> twoStepTypes;
+        public String nonce;
         public String nonceAuthenticator;
         public String nonceBackup;
         public String nonceSms;
         public String notificationSent;
+        public String phoneNumber;
         public String userId;
         public boolean requiresTwoStepAuth;
 
@@ -142,10 +144,12 @@ public class AccountStore extends Store {
 
         public OnSocialChanged(@NonNull AccountPushSocialResponsePayload payload) {
             this.twoStepTypes = payload.twoStepTypes;
+            this.nonce = payload.twoStepNonce;
             this.nonceAuthenticator = payload.twoStepNonceAuthenticator;
             this.nonceBackup = payload.twoStepNonceBackup;
             this.nonceSms = payload.twoStepNonceSms;
             this.notificationSent = payload.twoStepNotificationSent;
+            this.phoneNumber = payload.phoneNumber;
             this.userId = payload.userId;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -98,6 +98,15 @@ public class AccountStore extends Store {
         }
     }
 
+    public static class PushSocialSmsPayload extends Payload<BaseNetworkError> {
+        public String nonce;
+        public String userId;
+        public PushSocialSmsPayload(@NonNull String userId, @NonNull String nonce) {
+            this.userId = userId;
+            this.nonce = nonce;
+        }
+    }
+
     public static class NewAccountPayload extends Payload<BaseNetworkError> {
         public String username;
         public String password;
@@ -452,7 +461,7 @@ public class AccountStore extends Store {
                 createPushSocialLogin((PushSocialLoginPayload) payload);
                 break;
             case PUSH_SOCIAL_SMS:
-                createPushSocialSms((PushSocialAuthPayload) payload);
+                createPushSocialSms((PushSocialSmsPayload) payload);
                 break;
             case UPDATE_ACCOUNT:
                 updateDefaultAccount((AccountModel) payload, AccountAction.UPDATE_ACCOUNT);
@@ -663,7 +672,7 @@ public class AccountStore extends Store {
         mAccountRestClient.pushSocialLogin(payload.idToken, payload.service);
     }
 
-    private void createPushSocialSms(PushSocialAuthPayload payload) {
+    private void createPushSocialSms(PushSocialSmsPayload payload) {
         mAccountRestClient.pushSocialSms(payload.userId, payload.nonce);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -608,6 +608,10 @@ public class AccountStore extends Store {
             OnSocialChanged event = new OnSocialChanged();
             event.error = payload.error;
             emitChange(event);
+        // No error and two-factor authentication code sent via SMS; emit only social change.
+        } else if (payload.hasPhoneNumber()) {
+            OnSocialChanged event = new OnSocialChanged(payload);
+            emitChange(event);
         // No error, but either two-factor authentication or social connect is required; emit only social change.
         } else if (!payload.hasToken()) {
             OnSocialChanged event = new OnSocialChanged(payload);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -293,6 +293,10 @@ public class AccountStore extends Store {
     public enum AccountSocialErrorType {
         INVALID_TOKEN,
         INVALID_TWO_STEP_CODE,
+        INVALID_TWO_STEP_NONCE,
+        NO_PHONE_NUMBER_FOR_ACCOUNT,
+        SMS_AUTHENTICATION_UNAVAILABLE,
+        SMS_CODE_THROTTLED,
         UNABLE_CONNECT,
         UNKNOWN_USER,
         USER_ALREADY_ASSOCIATED,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -443,6 +443,8 @@ public class AccountStore extends Store {
             case PUSH_SOCIAL_LOGIN:
                 createPushSocialLogin((PushSocialLoginPayload) payload);
                 break;
+            case PUSH_SOCIAL_SMS:
+                break;
             case UPDATE_ACCOUNT:
                 updateDefaultAccount((AccountModel) payload, AccountAction.UPDATE_ACCOUNT);
                 break;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -448,6 +448,7 @@ public class AccountStore extends Store {
                 createPushSocialLogin((PushSocialLoginPayload) payload);
                 break;
             case PUSH_SOCIAL_SMS:
+                createPushSocialSms((PushSocialAuthPayload) payload);
                 break;
             case UPDATE_ACCOUNT:
                 updateDefaultAccount((AccountModel) payload, AccountAction.UPDATE_ACCOUNT);
@@ -652,6 +653,10 @@ public class AccountStore extends Store {
 
     private void createPushSocialLogin(PushSocialLoginPayload payload) {
         mAccountRestClient.pushSocialLogin(payload.idToken, payload.service);
+    }
+
+    private void createPushSocialSms(PushSocialAuthPayload payload) {
+        mAccountRestClient.pushSocialSms(payload.userId, payload.nonce);
     }
 
     private void signOut() {


### PR DESCRIPTION
Add a method for WordPress.com social login to send a two-factor authentication code via SMS, `pushSocialSms`.  The endpoint has a similar structure to `pushSocialAuth` and `pushSocialLogin`, but requires different parameters and returns different values.  Because of that, I decided to update the existing classes instead to consolidate REST-like API calls.