### PR TITLE
Add getPostByRemotePostId in PostStore

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -192,6 +192,17 @@ public class PostStoreUnitTest {
     }
 
     @Test
+    public void testGetPostByRemoteId() {
+        PostModel post = PostTestUtils.generateSampleUploadedPost();
+        PostSqlUtils.insertPostForResult(post);
+
+        SiteModel site = new SiteModel();
+        site.setId(6);
+
+        assertEquals(post, mPostStore.getPostByRemotePostId(post.getRemotePostId(), site));
+    }
+
+    @Test
     public void testDeleteUploadedPosts() {
         SiteModel site = new SiteModel();
         site.setId(6);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -333,6 +333,22 @@ public class PostStore extends Store {
         }
     }
 
+    /**
+     * Given a remote ID for a post and the site to which it belongs, returns that post as a {@link PostModel}.
+     */
+    public PostModel getPostByRemotePostId(long remoteId, SiteModel site) {
+        List<PostModel> result = WellSql.select(PostModel.class)
+                .where().equals(PostModelTable.REMOTE_POST_ID, remoteId)
+                .equals(PostModelTable.LOCAL_SITE_ID, site.getId()).endWhere()
+                .getAsModel();
+
+        if (result.isEmpty()) {
+            return null;
+        } else {
+            return result.get(0);
+        }
+    }
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
     public void onAction(Action action) {


### PR DESCRIPTION
This PR adds the ability to obtain a `PostModel` from the `PostStore` given the `remote postId` is known as well as the `SiteModel` to which such a post belongs to.