### PR TITLE
Plugin delete call and small fixes

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
@@ -28,5 +29,7 @@ public enum PluginAction implements IAction {
     @Action(payloadType = FetchedPluginInfoPayload.class)
     FETCHED_PLUGIN_INFO,
     @Action(payloadType = UpdatedSitePluginPayload.class)
-    UPDATED_SITE_PLUGIN
+    UPDATED_SITE_PLUGIN,
+    @Action(payloadType = DeletedSitePluginPayload.class)
+    DELETED_SITE_PLUGIN
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
@@ -18,6 +19,8 @@ public enum PluginAction implements IAction {
     FETCH_PLUGIN_INFO,
     @Action(payloadType = UpdateSitePluginPayload.class)
     UPDATE_SITE_PLUGIN,
+    @Action(payloadType = DeleteSitePluginPayload.class)
+    DELETE_SITE_PLUGIN,
 
     // Remote responses
     @Action(payloadType = FetchedSitePluginsPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -129,6 +129,11 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void deleteSitePlugin(@NonNull final SiteModel site, @NonNull final PluginModel plugin) {
+
+    }
+
+
     private PluginModel pluginModelFromResponse(SiteModel siteModel, PluginWPComRestResponse response) {
         PluginModel pluginModel = new PluginModel();
         pluginModel.setLocalSiteId(siteModel.getId());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -133,6 +133,9 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
+                        PluginModel pluginModel = pluginModelFromResponse(site, response);
+                        mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(
+                                new DeletedSitePluginPayload(site, pluginModel)));
                     }
                 },
                 new BaseErrorListener() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -112,6 +112,12 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 case "unauthorized":
                                     updatePluginError.type = UpdateSitePluginErrorType.UNAUTHORIZED;
                                     break;
+                                case "activation_error":
+                                    updatePluginError.type = UpdateSitePluginErrorType.ACTIVATION_ERROR;
+                                    break;
+                                case "deactivation_error":
+                                    updatePluginError.type = UpdateSitePluginErrorType.DEACTIVATION_ERROR;
+                                    break;
                             }
                         }
                         updatePluginError.message = networkError.message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -83,14 +83,7 @@ public class PluginRestClient extends BaseWPComRestClient {
     }
 
     public void updateSitePlugin(@NonNull final SiteModel site, @NonNull final PluginModel plugin) {
-        String name;
-        try {
-            // We need to encode plugin name otherwise names like "akismet/akismet" would fail
-            name = URLEncoder.encode(plugin.getName(), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            name = plugin.getName();
-        }
-        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(name).getUrlV1_2();
+        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(getEncodedPluginName(plugin)).getUrlV1_2();
         Map<String, Object> params = paramsFromPluginModel(plugin);
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, params,
                 PluginWPComRestResponse.class,
@@ -130,7 +123,22 @@ public class PluginRestClient extends BaseWPComRestClient {
     }
 
     public void deleteSitePlugin(@NonNull final SiteModel site, @NonNull final PluginModel plugin) {
-
+        String url = WPCOMREST.sites.site(site.getSiteId()).
+                plugins.name(getEncodedPluginName(plugin)).delete.getUrlV1_2();
+        final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
+                PluginWPComRestResponse.class,
+                new Listener<PluginWPComRestResponse>() {
+                    @Override
+                    public void onResponse(PluginWPComRestResponse response) {
+                    }
+                },
+                new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseNetworkError networkError) {
+                    }
+                }
+        );
+        add(request);
     }
 
 
@@ -155,5 +163,14 @@ public class PluginRestClient extends BaseWPComRestClient {
         params.put("active", pluginModel.isActive());
         params.put("autoupdate", pluginModel.isAutoUpdateEnabled());
         return params;
+    }
+
+    private String getEncodedPluginName(PluginModel plugin) {
+        try {
+            // We need to encode plugin name otherwise names like "akismet/akismet" would fail
+            return URLEncoder.encode(plugin.getName(), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return plugin.getName();
+        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -53,6 +53,16 @@ public class PluginSqlUtils {
         }
     }
 
+    public static int deleteSitePlugin(PluginModel plugin) {
+        if (plugin == null) {
+            return 0;
+        }
+        return WellSql.delete(PluginModel.class)
+                .where()
+                .equals(PluginModelTable.ID, plugin.getId())
+                .endWhere().execute();
+    }
+
     public static int insertOrUpdatePluginInfo(PluginInfoModel pluginInfo) {
         if (pluginInfo == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -86,6 +86,16 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class DeletedSitePluginPayload extends Payload<DeleteSitePluginError> {
+        public SiteModel site;
+        public PluginModel plugin;
+
+        public DeletedSitePluginPayload(SiteModel site, DeleteSitePluginError error) {
+            this.site = site;
+            this.error = error;
+        }
+    }
+
     public static class FetchSitePluginsError implements OnChangedError {
         public FetchSitePluginsErrorType type;
         public String message;
@@ -117,6 +127,15 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class DeleteSitePluginError implements OnChangedError {
+        public DeleteSitePluginErrorType type;
+        public String message;
+
+        public DeleteSitePluginError(DeleteSitePluginErrorType type) {
+            this.type = type;
+        }
+    }
+
     public enum FetchSitePluginsErrorType {
         GENERIC_ERROR,
         UNAUTHORIZED,
@@ -132,6 +151,10 @@ public class PluginStore extends Store {
         UNAUTHORIZED,
         ACTIVATION_ERROR,
         DEACTIVATION_ERROR,
+        NOT_AVAILABLE // Return for non-jetpack sites
+    }
+
+    public enum DeleteSitePluginErrorType {
         NOT_AVAILABLE // Return for non-jetpack sites
     }
 
@@ -240,6 +263,10 @@ public class PluginStore extends Store {
     private void deleteSitePlugin(DeleteSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
             mPluginRestClient.deleteSitePlugin(payload.site, payload.plugin);
+        } else {
+            DeleteSitePluginError error = new DeleteSitePluginError(DeleteSitePluginErrorType.NOT_AVAILABLE);
+            DeletedSitePluginPayload errorPayload = new DeletedSitePluginPayload(payload.site, error);
+            deletedSitePlugin(errorPayload);
         }
     }
 
@@ -274,5 +301,9 @@ public class PluginStore extends Store {
             PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
         }
         emitChange(event);
+    }
+
+    private void deletedSitePlugin(DeletedSitePluginPayload payload) {
+        // no-op
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -186,6 +186,14 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class OnSitePluginDeleted extends OnChanged<DeleteSitePluginError> {
+        public SiteModel site;
+        public PluginModel plugin;
+        public OnSitePluginDeleted(SiteModel site) {
+            this.site = site;
+        }
+    }
+
     private final PluginRestClient mPluginRestClient;
     private final PluginWPOrgClient mPluginWPOrgClient;
 
@@ -316,6 +324,14 @@ public class PluginStore extends Store {
     }
 
     private void deletedSitePlugin(DeletedSitePluginPayload payload) {
-        // no-op
+        OnSitePluginDeleted event = new OnSitePluginDeleted(payload.site);
+        if (payload.isError()) {
+            event.error = payload.error;
+        } else {
+            payload.plugin.setLocalSiteId(payload.site.getId());
+            event.plugin = payload.plugin;
+            PluginSqlUtils.deleteSitePlugin(payload.plugin);
+        }
+        emitChange(event);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -120,6 +120,8 @@ public class PluginStore extends Store {
     public enum UpdateSitePluginErrorType {
         GENERIC_ERROR,
         UNAUTHORIZED,
+        ACTIVATION_ERROR,
+        DEACTIVATION_ERROR,
         NOT_AVAILABLE // Return for non-jetpack sites
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -91,6 +91,11 @@ public class PluginStore extends Store {
         public SiteModel site;
         public PluginModel plugin;
 
+        public DeletedSitePluginPayload(SiteModel site, PluginModel plugin) {
+            this.site = site;
+            this.plugin = plugin;
+        }
+
         public DeletedSitePluginPayload(SiteModel site, DeleteSitePluginError error) {
             this.site = site;
             this.error = error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -82,6 +82,7 @@ public class PluginStore extends Store {
         }
 
         public UpdatedSitePluginPayload(SiteModel site, UpdateSitePluginError error) {
+            this.site = site;
             this.error = error;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -156,6 +156,9 @@ public class PluginStore extends Store {
     }
 
     public enum DeleteSitePluginErrorType {
+        GENERIC_ERROR,
+        UNAUTHORIZED,
+        DELETE_PLUGIN_ERROR,
         NOT_AVAILABLE // Return for non-jetpack sites
     }
 
@@ -221,6 +224,9 @@ public class PluginStore extends Store {
                 break;
             case UPDATED_SITE_PLUGIN:
                 updatedSitePlugin((UpdatedSitePluginPayload) action.getPayload());
+                break;
+            case DELETED_SITE_PLUGIN:
+                deletedSitePlugin((DeletedSitePluginPayload) action.getPayload());
                 break;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -36,6 +36,16 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class DeleteSitePluginPayload extends Payload<BaseNetworkError> {
+        public SiteModel site;
+        public PluginModel plugin;
+
+        public DeleteSitePluginPayload(SiteModel site, PluginModel plugin) {
+            this.site = site;
+            this.plugin = plugin;
+        }
+    }
+
     public static class FetchedSitePluginsPayload extends Payload<FetchSitePluginsError> {
         public SiteModel site;
         public List<PluginModel> plugins;
@@ -176,6 +186,9 @@ public class PluginStore extends Store {
             case UPDATE_SITE_PLUGIN:
                 updateSitePlugin((UpdateSitePluginPayload) action.getPayload());
                 break;
+            case DELETE_SITE_PLUGIN:
+                deleteSitePlugin((DeleteSitePluginPayload) action.getPayload());
+                break;
             case FETCHED_SITE_PLUGINS:
                 fetchedSitePlugins((FetchedSitePluginsPayload) action.getPayload());
                 break;
@@ -221,6 +234,12 @@ public class PluginStore extends Store {
             UpdateSitePluginError error = new UpdateSitePluginError(UpdateSitePluginErrorType.NOT_AVAILABLE);
             UpdatedSitePluginPayload errorPayload = new UpdatedSitePluginPayload(payload.site, error);
             updatedSitePlugin(errorPayload);
+        }
+    }
+
+    private void deleteSitePlugin(DeleteSitePluginPayload payload) {
+        if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
+            mPluginRestClient.deleteSitePlugin(payload.site, payload.plugin);
         }
     }
 


### PR DESCRIPTION
This PR adds the delete call to PluginRestClient. This PR is targeted against a WIP branch in an attempt to keep the keep the PRs small. We should have everything ready to make delete calls for plugins, however there is not a good way to test it in the current PR. Another PR will be opened soon which should add some tests for the delete action, both success and error paths and we can test the feature in that PR easily.

I've also added activation and deactivation errors to the update plugin callback. I still need to figure these out and add some tests for them if possible.

/cc @tonyr59h 