### PR TITLE
Install plugin network call

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -4,12 +4,13 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
-import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
+import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginPayload;
 
 @ActionEnum
@@ -34,5 +35,7 @@ public enum PluginAction implements IAction {
     @Action(payloadType = UpdatedSitePluginPayload.class)
     UPDATED_SITE_PLUGIN,
     @Action(payloadType = DeletedSitePluginPayload.class)
-    DELETED_SITE_PLUGIN
+    DELETED_SITE_PLUGIN,
+    @Action(payloadType = InstalledSitePluginPayload.class)
+    INSTALLED_SITE_PLUGIN
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
@@ -22,6 +23,8 @@ public enum PluginAction implements IAction {
     UPDATE_SITE_PLUGIN,
     @Action(payloadType = DeleteSitePluginPayload.class)
     DELETE_SITE_PLUGIN,
+    @Action(payloadType = InstallSitePluginPayload.class)
+    INSTALL_SITE_PLUGIN,
 
     // Remote responses
     @Action(payloadType = FetchedSitePluginsPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -162,6 +162,9 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void installSitePlugin(@NonNull final SiteModel site, String pluginName) {
+
+    }
 
     private PluginModel pluginModelFromResponse(SiteModel siteModel, PluginWPComRestResponse response) {
         PluginModel pluginModel = new PluginModel();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -172,25 +172,28 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
+                        PluginModel pluginModel = pluginModelFromResponse(site, response);
+                        mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(
+                                new InstalledSitePluginPayload(site, pluginModel)));
                     }
                 },
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        InstallSitePluginError installSitePluginError
+                        InstallSitePluginError installPluginError
                                 = new InstallSitePluginError(InstallSitePluginErrorType.GENERIC_ERROR);
                         if (networkError instanceof WPComGsonNetworkError) {
                             switch (((WPComGsonNetworkError) networkError).apiError) {
                                 case "unauthorized":
-                                    installSitePluginError.type = InstallSitePluginErrorType.UNAUTHORIZED;
+                                    installPluginError.type = InstallSitePluginErrorType.UNAUTHORIZED;
                                     break;
                                 case "install_failure":
-                                    installSitePluginError.type = InstallSitePluginErrorType.INSTALL_FAILURE;
+                                    installPluginError.type = InstallSitePluginErrorType.INSTALL_FAILURE;
                                     break;
                             }
                         }
-                        installSitePluginError.message = networkError.message;
-                        InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, installSitePluginError);
+                        installPluginError.message = networkError.message;
+                        InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, installPluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -116,6 +116,11 @@ public class PluginStore extends Store {
         public SiteModel site;
         public PluginModel plugin;
 
+        public InstalledSitePluginPayload(SiteModel site, PluginModel plugin) {
+            this.site = site;
+            this.plugin = plugin;
+        }
+
         public InstalledSitePluginPayload(SiteModel site, InstallSitePluginError error) {
             this.site = site;
             this.error = error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -239,6 +239,9 @@ public class PluginStore extends Store {
             case DELETE_SITE_PLUGIN:
                 deleteSitePlugin((DeleteSitePluginPayload) action.getPayload());
                 break;
+            case INSTALL_SITE_PLUGIN:
+                installSitePlugin((InstallSitePluginPayload) action.getPayload());
+                break;
             case FETCHED_SITE_PLUGINS:
                 fetchedSitePlugins((FetchedSitePluginsPayload) action.getPayload());
                 break;
@@ -297,6 +300,12 @@ public class PluginStore extends Store {
             DeleteSitePluginError error = new DeleteSitePluginError(DeleteSitePluginErrorType.NOT_AVAILABLE);
             DeletedSitePluginPayload errorPayload = new DeletedSitePluginPayload(payload.site, error);
             deletedSitePlugin(errorPayload);
+        }
+    }
+
+    private void installSitePlugin(InstallSitePluginPayload payload) {
+        if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
+            mPluginRestClient.installSitePlugin(payload.site, payload.pluginName);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -197,6 +197,9 @@ public class PluginStore extends Store {
     }
 
     public enum InstallSitePluginErrorType {
+        GENERIC_ERROR,
+        UNAUTHORIZED,
+        INSTALL_FAILURE,
         NOT_AVAILABLE // Return for non-jetpack sites
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -235,6 +235,14 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class OnSitePluginInstalled extends OnChanged<InstallSitePluginError> {
+        public SiteModel site;
+        public PluginModel plugin;
+        public OnSitePluginInstalled(SiteModel site) {
+            this.site = site;
+        }
+    }
+
     private final PluginRestClient mPluginRestClient;
     private final PluginWPOrgClient mPluginWPOrgClient;
 
@@ -284,6 +292,9 @@ public class PluginStore extends Store {
                 break;
             case DELETED_SITE_PLUGIN:
                 deletedSitePlugin((DeletedSitePluginPayload) action.getPayload());
+                break;
+            case INSTALLED_SITE_PLUGIN:
+                installedSitePlugin((InstalledSitePluginPayload) action.getPayload());
                 break;
         }
     }
@@ -390,6 +401,14 @@ public class PluginStore extends Store {
     }
 
     private void installedSitePlugin(InstalledSitePluginPayload payload) {
-
+        OnSitePluginInstalled event = new OnSitePluginInstalled(payload.site);
+        if (payload.isError()) {
+            event.error = payload.error;
+        } else {
+            payload.plugin.setLocalSiteId(payload.site.getId());
+            event.plugin = payload.plugin;
+            PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
+        }
+        emitChange(event);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -46,6 +46,16 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class InstallSitePluginPayload extends Payload<BaseNetworkError> {
+        public SiteModel site;
+        public String pluginName;
+
+        public InstallSitePluginPayload(SiteModel site, String pluginName) {
+            this.site = site;
+            this.pluginName = pluginName;
+        }
+    }
+
     public static class FetchedSitePluginsPayload extends Payload<FetchSitePluginsError> {
         public SiteModel site;
         public List<PluginModel> plugins;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -112,6 +112,16 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class InstalledSitePluginPayload extends Payload<InstallSitePluginError> {
+        public SiteModel site;
+        public PluginModel plugin;
+
+        public InstalledSitePluginPayload(SiteModel site, InstallSitePluginError error) {
+            this.site = site;
+            this.error = error;
+        }
+    }
+
     public static class FetchSitePluginsError implements OnChangedError {
         public FetchSitePluginsErrorType type;
         public String message;
@@ -152,6 +162,15 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class InstallSitePluginError implements OnChangedError {
+        public InstallSitePluginErrorType type;
+        public String message;
+
+        public InstallSitePluginError(InstallSitePluginErrorType type) {
+            this.type = type;
+        }
+    }
+
     public enum FetchSitePluginsErrorType {
         GENERIC_ERROR,
         UNAUTHORIZED,
@@ -174,6 +193,10 @@ public class PluginStore extends Store {
         GENERIC_ERROR,
         UNAUTHORIZED,
         DELETE_PLUGIN_ERROR,
+        NOT_AVAILABLE // Return for non-jetpack sites
+    }
+
+    public enum InstallSitePluginErrorType {
         NOT_AVAILABLE // Return for non-jetpack sites
     }
 
@@ -306,6 +329,10 @@ public class PluginStore extends Store {
     private void installSitePlugin(InstallSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
             mPluginRestClient.installSitePlugin(payload.site, payload.pluginName);
+        } else {
+            InstallSitePluginError error = new InstallSitePluginError(InstallSitePluginErrorType.NOT_AVAILABLE);
+            InstalledSitePluginPayload errorPayload = new InstalledSitePluginPayload(payload.site, error);
+            installedSitePlugin(errorPayload);
         }
     }
 
@@ -352,5 +379,9 @@ public class PluginStore extends Store {
             PluginSqlUtils.deleteSitePlugin(payload.plugin);
         }
         emitChange(event);
+    }
+
+    private void installedSitePlugin(InstalledSitePluginPayload payload) {
+
     }
 }


### PR DESCRIPTION
This PR is continuation of #602 and adds the install plugin action and it's network call. I wanted to add a test for delete plugins, however we need the install action first to be able to install a random plugin and then delete it. So in all likelyhood it's going to be a combined test at least for the successful path. The changes in this PR should be very similar to #602.

/cc @tonyr59h 