### PR TITLE
Themes: Various bug fixes

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -67,8 +67,9 @@ public class ThemeSqlUtils {
             }
         }
 
-        // make sure active flag is set then add to db
+        // make sure active flag and local site ID are set then add to db
         theme.setActive(true);
+        theme.setLocalSiteId(site.getId());
         insertOrUpdateThemeForSite(theme);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -20,8 +20,10 @@ public class ThemeSqlUtils {
                 .endGroup().endWhere().getAsModel();
 
         if (existing.isEmpty()) {
+            // theme is not in the local DB so we insert it
             WellSql.insert(theme).asSingleTransaction(true).execute();
         } else {
+            // theme already exists in the local DB so we update the existing row with the passed theme
             WellSql.update(ThemeModel.class).whereId(existing.get(0).getId())
                     .put(theme, new UpdateAllExceptId<>(ThemeModel.class)).execute();
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -398,6 +398,7 @@ public class ThemeStore extends Store {
                 activatedTheme = getInstalledThemeByThemeId(payload.theme.getThemeId());
             } else {
                 activatedTheme = getWpComThemeByThemeId(payload.theme.getThemeId());
+                // Remove WP.com flag to store as site-associate theme
                 activatedTheme.setIsWpComTheme(false);
             }
             if (activatedTheme != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -397,9 +397,9 @@ public class ThemeStore extends Store {
                 activatedTheme = getInstalledThemeByThemeId(payload.theme.getThemeId());
             } else {
                 activatedTheme = getWpComThemeByThemeId(payload.theme.getThemeId());
+                activatedTheme.setIsWpComTheme(false);
             }
             if (activatedTheme != null) {
-                activatedTheme.setActive(true);
                 setActiveThemeForSite(payload.site, payload.theme);
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -392,7 +392,16 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.insertOrReplaceActiveThemeForSite(payload.site, payload.theme);
+            ThemeModel activatedTheme;
+            if (payload.site.isJetpackConnected()) {
+                activatedTheme = getInstalledThemeByThemeId(payload.theme.getThemeId());
+            } else {
+                activatedTheme = getWpComThemeByThemeId(payload.theme.getThemeId());
+            }
+            if (activatedTheme != null) {
+                activatedTheme.setActive(true);
+                setActiveThemeForSite(payload.site, payload.theme);
+            }
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -393,6 +393,7 @@ public class ThemeStore extends Store {
             event.error = payload.error;
         } else {
             ThemeModel activatedTheme;
+            // payload theme doesn't have all the data so we grab a copy of the database theme and update active flag
             if (payload.site.isJetpackConnected()) {
                 activatedTheme = getInstalledThemeByThemeId(payload.theme.getThemeId());
             } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -338,7 +338,7 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.insertOrUpdateThemeForSite(payload.theme);
+            ThemeSqlUtils.insertOrReplaceActiveThemeForSite(payload.site, payload.theme);
         }
         emitChange(event);
     }
@@ -389,7 +389,11 @@ public class ThemeStore extends Store {
 
     private void handleThemeActivated(@NonNull ActivateThemePayload payload) {
         OnThemeActivated event = new OnThemeActivated(payload.site, payload.theme);
-        event.error = payload.error;
+        if (payload.isError()) {
+            event.error = payload.error;
+        } else {
+            ThemeSqlUtils.insertOrReplaceActiveThemeForSite(payload.site, payload.theme);
+        }
         emitChange(event);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -400,7 +400,7 @@ public class ThemeStore extends Store {
                 activatedTheme.setIsWpComTheme(false);
             }
             if (activatedTheme != null) {
-                setActiveThemeForSite(payload.site, payload.theme);
+                setActiveThemeForSite(payload.site, activatedTheme);
             }
         }
         emitChange(event);


### PR DESCRIPTION
The major changes are:

1. `theme.setLocalSiteId(site.getId())` which ensure's the theme has the site associated when storing the active theme
2. Successful theme activations now update only the active flag of an existing row rather than the whole row. This prevents other fields from being inadvertently overwritten (as was the case)

cc @oguzkocer 