### PR TITLE
ThemeStore: Add actions for removing themes from local database

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -75,12 +75,9 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     public void testFetchCurrentTheme() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
-        // fetch current theme
-        mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(jetpackSite));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // fetch active theme
+        fetchCurrentThemes(jetpackSite);
+        assertNotNull(mCurrentTheme);
 
         signOutWPCom();
     }
@@ -95,10 +92,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         List<ThemeModel> themes = mThemeStore.getThemesForSite(jetpackSite);
         assertTrue(themes.size() > 1);
 
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(jetpackSite));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // fetch active theme
+        fetchCurrentThemes(jetpackSite);
         assertNotNull(mCurrentTheme);
 
         // select a different theme to activate
@@ -190,11 +185,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             assertNotNull(listTheme);
         }
 
-        // get active theme
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(jetpackSite));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // fetch active theme
+        fetchCurrentThemes(jetpackSite);
 
         // if Edin is active update site's active theme to something else
         if (themeId.equals(mCurrentTheme.getThemeId())) {
@@ -426,6 +418,13 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_INSTALLED_THEMES;
         mDispatcher.dispatch(ThemeActionBuilder.newFetchInstalledThemesAction(jetpackSite));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void fetchCurrentThemes(@NonNull SiteModel jetpackSite) throws InterruptedException {
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
+        mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(jetpackSite));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -165,7 +165,7 @@ public class ThemeStoreUnitTest {
     }
 
     @Test
-    public void testRemoveSiteThemes() throws SiteSqlUtils.DuplicateSiteException {
+    public void testRemoveInstalledSiteThemes() throws SiteSqlUtils.DuplicateSiteException {
         final SiteModel site = SiteUtils.generateJetpackSiteOverRestOnly();
         SiteSqlUtils.insertOrUpdateSite(site);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.ThemeStore.SearchThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
@@ -46,5 +47,11 @@ public enum ThemeAction implements IAction {
     @Action(payloadType = ActivateThemePayload.class)
     INSTALLED_THEME,
     @Action(payloadType = ActivateThemePayload.class)
-    DELETED_THEME
+    DELETED_THEME,
+
+    // Local actions
+    @Action(payloadType = ThemeModel.class)
+    REMOVE_THEME,
+    @Action(payloadType = SiteModel.class)
+    REMOVE_SITE_THEMES
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -157,6 +157,14 @@ public class ThemeStore extends Store {
         }
     }
 
+    public static class OnThemeRemoved extends OnChanged<ThemesError> {
+        public ThemeModel theme;
+
+        public OnThemeRemoved(ThemeModel theme) {
+            this.theme = theme;
+        }
+    }
+
     public static class OnThemeDeleted extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -239,6 +247,12 @@ public class ThemeStore extends Store {
                 break;
             case DELETED_THEME:
                 handleThemeDeleted((ActivateThemePayload) action.getPayload());
+                break;
+            case REMOVE_THEME:
+                removeTheme((ThemeModel) action.getPayload());
+                break;
+            case REMOVE_SITE_THEMES:
+                removeSiteThemes((SiteModel) action.getPayload());
                 break;
         }
     }
@@ -425,5 +439,22 @@ public class ThemeStore extends Store {
             ThemeSqlUtils.removeTheme(payload.theme);
         }
         emitChange(event);
+    }
+
+    private void removeTheme(ThemeModel theme) {
+        if (theme != null) {
+            ThemeSqlUtils.removeTheme(theme);
+        }
+        emitChange(new OnThemeRemoved(theme));
+    }
+
+    private void removeSiteThemes(SiteModel site) {
+        final List<ThemeModel> themes = getThemesForSite(site);
+        if (!themes.isEmpty()) {
+            for (ThemeModel theme : themes) {
+                ThemeSqlUtils.removeTheme(theme);
+            }
+        }
+        emitChange(new OnThemesChanged(site));
     }
 }


### PR DESCRIPTION
Simple patch since we don't need to deal with network calls and response action handling. This PR just adds `REMOVE_THEME` action for removing a single specific theme and `REMOVE_SITE_THEMES` action for removing all themes associated with a site (via local site ID).

I've tested this in WPAndroid and it's worked without a problem thus far. Tests coming in different PR.

cc @kwonye or @oguzkocer 