### PR TITLE
Plugin install/delete test & fixes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -120,7 +120,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
 
-        String pluginToInstall = "hello";
+        String pluginSlugToInstall = "buddypress";
 
         // Fetch the list of installed plugins to make sure `Hello Dolly` is not installed
 
@@ -134,14 +134,14 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         List<PluginModel> installedPlugins = mPluginStore.getSitePlugins(site);
         for (PluginModel installedPlugin : installedPlugins) {
-            if (installedPlugin.getName().equals(pluginToInstall)) {
+            if (installedPlugin.getSlug().equals(pluginSlugToInstall)) {
                 // delete plugin first
                 deleteSitePlugin(site, installedPlugin);
             }
         }
 
-        // Install the Hello Dolly plugin
-        installSitePlugin(site, pluginToInstall);
+        // Install the Buddypress plugin
+        installSitePlugin(site, pluginSlugToInstall);
     }
 
     @SuppressWarnings("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -101,8 +101,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     // It's both easier and more efficient to combine install & delete tests since we need to make sure we have the
     // plugin installed for the delete test and the plugin is not installed for the install test
     public void testInstallAndDeleteSitePlugin() throws InterruptedException {
-        String pluginSlugToInstall = "buddypress";
-        // Fetch the list of installed plugins to make sure `BuddyPress` is not installed
+        String pluginSlugToInstall = "react";
+        // Fetch the list of installed plugins to make sure `React` is not installed
         SiteModel site = fetchSingleJetpackSitePlugins();
 
         List<PluginModel> sitePlugins = mPluginStore.getSitePlugins(site);
@@ -113,13 +113,13 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
             }
         }
 
-        // Install the Buddypress plugin
+        // Install the React plugin
         installSitePlugin(site, pluginSlugToInstall);
 
         // mInstalledPlugin should be set in onSitePluginInstalled
         assertNotNull(mInstalledPlugin);
 
-        // Delete the newly installed Buddypress plugin
+        // Delete the newly installed React plugin
         deleteSitePlugin(site, mInstalledPlugin);
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -121,6 +121,11 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         // Delete the newly installed React plugin
         deleteSitePlugin(site, mInstalledPlugin);
+
+        List<PluginModel> updatedPlugins = mPluginStore.getSitePlugins(site);
+        for (PluginModel sitePlugin : updatedPlugins) {
+            assertFalse(sitePlugin.getSlug().equals(pluginSlugToInstall));
+        }
     }
 
     @SuppressWarnings("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -62,16 +62,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     }
 
     public void testFetchSitePlugins() throws InterruptedException {
-        authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
-                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
-
-        mNextEvent = TestEvents.PLUGINS_FETCHED;
-        mCountDownLatch = new CountDownLatch(1);
-
-        SiteModel site = mSiteStore.getSites().get(0);
-        mDispatcher.dispatch(PluginActionBuilder.newFetchSitePluginsAction(site));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        SiteModel site = fetchSingleJetpackSitePlugins();
 
         List<PluginModel> plugins = mPluginStore.getSitePlugins(site);
         assertTrue(plugins.size() > 0);
@@ -80,20 +71,10 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     }
 
     public void testUpdateSitePlugin() throws InterruptedException {
-        authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
-                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
-
         // In order to have a reliable test, let's first fetch the list of plugins, pick the first plugin
         // and change it's active status, so we can make sure when we run the test multiple times, each time
         // an action is actually taken. This wouldn't be the case if we always activate the plugin.
-
-        mNextEvent = TestEvents.PLUGINS_FETCHED;
-        mCountDownLatch = new CountDownLatch(1);
-
-        SiteModel site = mSiteStore.getSites().get(0);
-        mDispatcher.dispatch(PluginActionBuilder.newFetchSitePluginsAction(site));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        SiteModel site = fetchSingleJetpackSitePlugins();
 
         List<PluginModel> plugins = mPluginStore.getSitePlugins(site);
         assertTrue(plugins.size() > 0);
@@ -117,20 +98,9 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     }
 
     public void testInstallSitePlugin() throws InterruptedException {
-        authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
-                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
-
         String pluginSlugToInstall = "buddypress";
-
-        // Fetch the list of installed plugins to make sure `Hello Dolly` is not installed
-
-        mNextEvent = TestEvents.PLUGINS_FETCHED;
-        mCountDownLatch = new CountDownLatch(1);
-
-        SiteModel site = mSiteStore.getSites().get(0);
-        mDispatcher.dispatch(PluginActionBuilder.newFetchSitePluginsAction(site));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // Fetch the list of installed plugins to make sure `BuddyPress` is not installed
+        SiteModel site = fetchSingleJetpackSitePlugins();
 
         List<PluginModel> installedPlugins = mPluginStore.getSitePlugins(site);
         for (PluginModel installedPlugin : installedPlugins) {
@@ -265,6 +235,21 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private SiteModel fetchSingleJetpackSitePlugins() throws InterruptedException {
+        authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
+                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
+
+        mNextEvent = TestEvents.PLUGINS_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        SiteModel site = mSiteStore.getSites().get(0);
+        mDispatcher.dispatch(PluginActionBuilder.newFetchSitePluginsAction(site));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        return site;
     }
 
     private void deleteSitePlugin(SiteModel site, PluginModel plugin) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.PluginStore;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginChanged;
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginsChanged;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
@@ -33,7 +34,8 @@ import javax.inject.Inject;
 public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;
-    @Inject PluginStore mPluginStore;
+    @Inject
+    PluginStore mPluginStore;
 
     enum TestEvents {
         NONE,
@@ -200,6 +202,18 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
                     + event.error.type);
         }
         assertEquals(mNextEvent, TestEvents.UPDATED_PLUGIN);
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onSitePluginDeleted(OnSitePluginDeleted event) {
+        AppLog.i(T.API, "Received onSitePluginDeleted");
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred in onSitePluginDeleted with type: "
+                    + event.error.type);
+        }
+        assertEquals(mNextEvent, TestEvents.DELETED_PLUGIN);
         mCountDownLatch.countDown();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -184,11 +184,14 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 = new InstallSitePluginError(InstallSitePluginErrorType.GENERIC_ERROR);
                         if (networkError instanceof WPComGsonNetworkError) {
                             switch (((WPComGsonNetworkError) networkError).apiError) {
-                                case "unauthorized":
-                                    installPluginError.type = InstallSitePluginErrorType.UNAUTHORIZED;
-                                    break;
                                 case "install_failure":
                                     installPluginError.type = InstallSitePluginErrorType.INSTALL_FAILURE;
+                                    break;
+                                case "plugin_already_installed":
+                                    installPluginError.type = InstallSitePluginErrorType.ALREADY_INSTALLED;
+                                    break;
+                                case "unauthorized":
+                                    installPluginError.type = InstallSitePluginErrorType.UNAUTHORIZED;
                                     break;
                             }
                         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -130,7 +130,7 @@ public class PluginRestClient extends BaseWPComRestClient {
 
     public void deleteSitePlugin(@NonNull final SiteModel site, @NonNull final PluginModel plugin) {
         String url = WPCOMREST.sites.site(site.getSiteId()).
-                plugins.name(getEncodedPluginName(plugin)).delete.getUrlV1_2();
+                plugins.name(getEncodedPluginName(plugin)).delete.getUrlV1_1();
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 PluginWPComRestResponse.class,
                 new Listener<PluginWPComRestResponse>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -108,14 +108,14 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 = new UpdateSitePluginError(UpdateSitePluginErrorType.GENERIC_ERROR);
                         if (networkError instanceof WPComGsonNetworkError) {
                             switch (((WPComGsonNetworkError) networkError).apiError) {
-                                case "unauthorized":
-                                    updatePluginError.type = UpdateSitePluginErrorType.UNAUTHORIZED;
-                                    break;
                                 case "activation_error":
                                     updatePluginError.type = UpdateSitePluginErrorType.ACTIVATION_ERROR;
                                     break;
                                 case "deactivation_error":
                                     updatePluginError.type = UpdateSitePluginErrorType.DEACTIVATION_ERROR;
+                                    break;
+                                case "unauthorized":
+                                    updatePluginError.type = UpdateSitePluginErrorType.UNAUTHORIZED;
                                     break;
                             }
                         }
@@ -187,8 +187,17 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 case "install_failure":
                                     installPluginError.type = InstallSitePluginErrorType.INSTALL_FAILURE;
                                     break;
+                                case "local_file_does_not_exist":
+                                    installPluginError.type = InstallSitePluginErrorType.LOCAL_FILE_DOES_NOT_EXIST;
+                                    break;
+                                case "no_package":
+                                    installPluginError.type = InstallSitePluginErrorType.NO_PACKAGE;
+                                    break;
+                                case "no_plugin_installed":
+                                    installPluginError.type = InstallSitePluginErrorType.NO_PLUGIN_INSTALLED;
+                                    break;
                                 case "plugin_already_installed":
-                                    installPluginError.type = InstallSitePluginErrorType.ALREADY_INSTALLED;
+                                    installPluginError.type = InstallSitePluginErrorType.PLUGIN_ALREADY_INSTALLED;
                                     break;
                                 case "unauthorized":
                                     installPluginError.type = InstallSitePluginErrorType.UNAUTHORIZED;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -130,7 +130,7 @@ public class PluginRestClient extends BaseWPComRestClient {
 
     public void deleteSitePlugin(@NonNull final SiteModel site, @NonNull final PluginModel plugin) {
         String url = WPCOMREST.sites.site(site.getSiteId()).
-                plugins.name(getEncodedPluginName(plugin)).delete.getUrlV1_1();
+                plugins.name(getEncodedPluginName(plugin)).delete.getUrlV1_2();
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 PluginWPComRestResponse.class,
                 new Listener<PluginWPComRestResponse>() {
@@ -166,7 +166,7 @@ public class PluginRestClient extends BaseWPComRestClient {
     }
 
     public void installSitePlugin(@NonNull final SiteModel site, String pluginName) {
-        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(pluginName).install.getUrlV1_1();
+        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(pluginName).install.getUrlV1_2();
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 PluginWPComRestResponse.class,
                 new Listener<PluginWPComRestResponse>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -53,13 +53,16 @@ public class PluginSqlUtils {
         }
     }
 
-    public static int deleteSitePlugin(PluginModel plugin) {
+    public static int deleteSitePlugin(SiteModel site, PluginModel plugin) {
         if (plugin == null) {
             return 0;
         }
+        // The local id of the plugin might not be set if it's coming from a network request,
+        // using site id and slug is a safer approach here
         return WellSql.delete(PluginModel.class)
                 .where()
-                .equals(PluginModelTable.ID, plugin.getId())
+                .equals(PluginModelTable.SLUG, plugin.getSlug())
+                .equals(PluginModelTable.LOCAL_SITE_ID, site.getId())
                 .endWhere().execute();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -201,10 +201,13 @@ public class PluginStore extends Store {
 
     public enum InstallSitePluginErrorType {
         GENERIC_ERROR,
-        UNAUTHORIZED,
-        ALREADY_INSTALLED,
         INSTALL_FAILURE,
-        NOT_AVAILABLE // Return for non-jetpack sites
+        LOCAL_FILE_DOES_NOT_EXIST,
+        NO_PACKAGE,
+        NO_PLUGIN_INSTALLED,
+        NOT_AVAILABLE, // Return for non-jetpack sites
+        PLUGIN_ALREADY_INSTALLED,
+        UNAUTHORIZED
     }
 
     public enum UpdateSitePluginErrorType {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -202,6 +202,7 @@ public class PluginStore extends Store {
     public enum InstallSitePluginErrorType {
         GENERIC_ERROR,
         UNAUTHORIZED,
+        ALREADY_INSTALLED,
         INSTALL_FAILURE,
         NOT_AVAILABLE // Return for non-jetpack sites
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -407,7 +407,7 @@ public class PluginStore extends Store {
         } else {
             payload.plugin.setLocalSiteId(payload.site.getId());
             event.plugin = payload.plugin;
-            PluginSqlUtils.deleteSitePlugin(payload.plugin);
+            PluginSqlUtils.deleteSitePlugin(payload.site, payload.plugin);
         }
         emitChange(event);
     }


### PR DESCRIPTION
This PR changes a few things that should hopefully come close to finalizing the Plugin Management on FluxC:

1. Use v1.2 for all endpoints so the response json is consistent (due to the naming change)
2. Add a few custom error types for installation (pending verification from server side)
3. Adds a test that will fetch all plugins on a site, remove the BuddyPress plugin if it exists, install it and delete it. I've added a comment why I opted to add this test in this way. Let me know if it's not clear enough

In order to test:
* The test should be done using the beta jetpack site credentials, however it might not always work. The fetch v1.2 is a bit delayed for some reason and which is currently being investigated. However, this only affects the first step of the test and as long as you can uninstall the plugin before testing, it should(!) work everytime since we install and then delete the plugin leaving it in the same state.

Note that we might need to make some small changes or add more tests soon, but I think it's ready to be merged to develop. Once this PR is merged, I'll open a PR to merge the master branch to be merged into `develop` and then use the hash to update the WPAndroid side.

/cc @tonyr59h 