### PR TITLE
ThemeStore: Resolve type mismatch in search response

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeSearchWPComResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeSearchWPComResponse.java
@@ -1,0 +1,27 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.theme;
+
+import java.util.List;
+
+public class ThemeSearchWPComResponse {
+    public class ThemeSearchArrayResponse {
+        public List<ThemeSearchWPComResponse> themes;
+    }
+
+    public String id;
+    public String slug;
+    public String stylesheet;
+    public String name;
+    public String author;
+    public String author_uri;
+    public String theme_uri;
+    public String demo_uri;
+    public String version;
+    public String template;
+    public String screenshot;
+    public String description;
+    public String date_launched;
+    public String date_updated;
+    public String language;
+    public String download_uri;
+    public String price;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
@@ -1,16 +1,11 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 
-import java.util.List;
 import java.util.Map;
 
 public class ThemeWPComResponse {
     public class MultipleWPComThemesResponse {
         public Map<String, ThemeWPComResponse> themes;
         public int count;
-    }
-
-    public class ThemeArrayResponse {
-        public List<ThemeWPComResponse> themes;
     }
 
     public class Price {


### PR DESCRIPTION
@kwonye found a bug while reviewing the WPAndroid ThemeStore integration branch. Apparently search results return prices as `String` and other endpoints return an `Object`. So we have to create an entirely separate response class for the search results, that's what this PR does.

To test:
* Search `twenty` in the example app and expect 8 results
* Search `fifteen` and expect 2
* No crashes