### PR TITLE
ThemeStore: Use GET v1.2/themes endpoint to fetch themes

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
@@ -257,9 +258,9 @@ public class ThemeRestClient extends BaseWPComRestClient {
         theme.setScreenshotUrl(response.screenshot);
         theme.setDescription(response.description);
         theme.setDownloadUrl(response.download_uri);
-        if (response.price != null) {
-            theme.setCurrency(response.price.currency);
-            theme.setPrice(response.price.value);
+        if (!TextUtils.isEmpty(response.price)) {
+            theme.setCurrency(response.price.substring(0, 1));
+            theme.setPrice(Integer.valueOf(response.price.substring(1)));
         }
         return theme;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -127,13 +127,13 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** [Undocumented!] Endpoint: v1.2/themes */
     public void fetchWpComThemes() {
         String url = WPCOMREST.themes.getUrlV1_2() + "?number=500";
-        add(WPComGsonRequest.buildGetRequest(url, null, MultipleWPComThemesResponse.class,
-                new Response.Listener<MultipleWPComThemesResponse>() {
+        add(WPComGsonRequest.buildGetRequest(url, null, ThemeArrayResponse.class,
+                new Response.Listener<ThemeArrayResponse>() {
                     @Override
-                    public void onResponse(MultipleWPComThemesResponse response) {
+                    public void onResponse(ThemeArrayResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to WP.com themes fetch request.");
                         FetchedThemesPayload payload = new FetchedThemesPayload(null);
-                        payload.themes = createThemeListFromWPComResponse(response);
+                        payload.themes = createThemeListFromArrayResponse(response);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
                     }
                 }, new BaseRequest.BaseErrorListener() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -124,9 +124,9 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** Endpoint: v1.1/themes */
+    /** [Undocumented!] Endpoint: v1.2/themes */
     public void fetchWpComThemes() {
-        String url = WPCOMREST.themes.getUrlV1_1();
+        String url = WPCOMREST.themes.getUrlV1_2() + "?number=500";
         add(WPComGsonRequest.buildGetRequest(url, null, MultipleWPComThemesResponse.class,
                 new Response.Listener<MultipleWPComThemesResponse>() {
                     @Override
@@ -220,7 +220,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** v1.2/themes?search=$term */
+    /** [Undocumented!] Endpoint: v1.2/themes?search=$term */
     public void searchThemes(@NonNull final String searchTerm) {
         String url = WPCOMREST.themes.getUrlV1_2() + "?search=" + searchTerm;
         add(WPComGsonRequest.buildGetRequest(url, null, ThemeArrayResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -39,6 +39,8 @@ import javax.inject.Singleton;
 
 @Singleton
 public class ThemeRestClient extends BaseWPComRestClient {
+    private static final String WP_THEME_FETCH_NUMBER_PARAM = "number=500";
+
     @Inject
     public ThemeRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
                            AccessToken accessToken, UserAgent userAgent) {
@@ -126,7 +128,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     /** [Undocumented!] Endpoint: v1.2/themes */
     public void fetchWpComThemes() {
-        String url = WPCOMREST.themes.getUrlV1_2() + "?number=500";
+        String url = WPCOMREST.themes.getUrlV1_2() + "?" + WP_THEME_FETCH_NUMBER_PARAM;
         add(WPComGsonRequest.buildGetRequest(url, null, ThemeArrayResponse.class,
                 new Response.Listener<ThemeArrayResponse>() {
                     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
@@ -13,12 +13,6 @@ public class ThemeWPComResponse {
         public List<ThemeWPComResponse> themes;
     }
 
-    public class Price {
-        public int value;
-        public String currency;
-        public String display;
-    }
-
     public String id;
     public String slug;
     public String stylesheet;
@@ -35,7 +29,7 @@ public class ThemeWPComResponse {
     public String date_updated;
     public String language;
     public String download_uri;
-    public Price price;
+    public String price;
     public int rank_popularity;
     public int rank_trending;
 }


### PR DESCRIPTION
Related to #612. This PR uses the newer endpoint (v1.2) which fixes the type mismatch issue and allows us to simply update the type of `price` to a `String`.

cc @kwonye 