### PR TITLE
Plugin error handling changes and more tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -42,14 +42,14 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
     enum TestEvents {
         NONE,
-        PLUGINS_FETCHED,
-        UPDATED_PLUGIN,
+        DELETE_PLUGIN_ERROR,
         DELETED_PLUGIN,
         INSTALLED_PLUGIN,
+        PLUGINS_FETCHED,
         SITE_CHANGED,
         SITE_REMOVED,
         UNKNOWN_PLUGIN,
-        DELETE_PLUGIN_ERROR
+        UPDATED_PLUGIN
     }
 
     private TestEvents mNextEvent;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -72,13 +72,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         FetchSitePluginsError fetchPluginsError
                                 = new FetchSitePluginsError(FetchSitePluginsErrorType.GENERIC_ERROR);
-                        if (networkError instanceof WPComGsonNetworkError) {
-                            switch (((WPComGsonNetworkError) networkError).apiError) {
-                                case "unauthorized":
-                                    fetchPluginsError.type = FetchSitePluginsErrorType.UNAUTHORIZED;
-                                    break;
-                            }
-                        }
+                        fetchPluginsError.type = FetchSitePluginsErrorType.
+                                valueOf(((WPComGsonNetworkError) networkError).apiError.toUpperCase());
                         fetchPluginsError.message = networkError.message;
                         FetchedSitePluginsPayload payload = new FetchedSitePluginsPayload(fetchPluginsError);
                         mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginsAction(payload));
@@ -106,22 +101,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         UpdateSitePluginError updatePluginError
                                 = new UpdateSitePluginError(UpdateSitePluginErrorType.GENERIC_ERROR);
-                        if (networkError instanceof WPComGsonNetworkError) {
-                            switch (((WPComGsonNetworkError) networkError).apiError) {
-                                case "activation_error":
-                                    updatePluginError.type = UpdateSitePluginErrorType.ACTIVATION_ERROR;
-                                    break;
-                                case "deactivation_error":
-                                    updatePluginError.type = UpdateSitePluginErrorType.DEACTIVATION_ERROR;
-                                    break;
-                                case "unauthorized":
-                                    updatePluginError.type = UpdateSitePluginErrorType.UNAUTHORIZED;
-                                    break;
-                                case "unknown_plugin":
-                                    updatePluginError.type = UpdateSitePluginErrorType.UNKNOWN_PLUGIN;
-                                    break;
-                            }
-                        }
+                        updatePluginError.type = UpdateSitePluginErrorType.
+                                valueOf(((WPComGsonNetworkError) networkError).apiError.toUpperCase());
                         updatePluginError.message = networkError.message;
                         UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));
@@ -149,16 +130,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         DeleteSitePluginError deletePluginError
                                 = new DeleteSitePluginError(DeleteSitePluginErrorType.GENERIC_ERROR);
-                        if (networkError instanceof WPComGsonNetworkError) {
-                            switch (((WPComGsonNetworkError) networkError).apiError) {
-                                case "unauthorized":
-                                    deletePluginError.type = DeleteSitePluginErrorType.UNAUTHORIZED;
-                                    break;
-                                case "delete_plugin_error":
-                                    deletePluginError.type = DeleteSitePluginErrorType.DELETE_PLUGIN_ERROR;
-                                    break;
-                            }
-                        }
+                        deletePluginError.type = DeleteSitePluginErrorType.
+                                valueOf(((WPComGsonNetworkError) networkError).apiError.toUpperCase());
                         deletePluginError.message = networkError.message;
                         DeletedSitePluginPayload payload = new DeletedSitePluginPayload(site, deletePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(payload));
@@ -186,25 +159,11 @@ public class PluginRestClient extends BaseWPComRestClient {
                         InstallSitePluginError installPluginError
                                 = new InstallSitePluginError(InstallSitePluginErrorType.GENERIC_ERROR);
                         if (networkError instanceof WPComGsonNetworkError) {
-                            switch (((WPComGsonNetworkError) networkError).apiError) {
-                                case "install_failure":
-                                    installPluginError.type = InstallSitePluginErrorType.INSTALL_FAILURE;
-                                    break;
-                                case "local-file-does-not-exist":
-                                    installPluginError.type = InstallSitePluginErrorType.LOCAL_FILE_DOES_NOT_EXIST;
-                                    break;
-                                case "no_package":
-                                    installPluginError.type = InstallSitePluginErrorType.NO_PACKAGE;
-                                    break;
-                                case "no_plugin_installed":
-                                    installPluginError.type = InstallSitePluginErrorType.NO_PLUGIN_INSTALLED;
-                                    break;
-                                case "plugin_already_installed":
-                                    installPluginError.type = InstallSitePluginErrorType.PLUGIN_ALREADY_INSTALLED;
-                                    break;
-                                case "unauthorized":
-                                    installPluginError.type = InstallSitePluginErrorType.UNAUTHORIZED;
-                                    break;
+                            String apiError = ((WPComGsonNetworkError) networkError).apiError;
+                            if (apiError.equals("local-file-does-not-exist")) {
+                                installPluginError.type = InstallSitePluginErrorType.LOCAL_FILE_DOES_NOT_EXIST;
+                            } else {
+                                installPluginError.type = InstallSitePluginErrorType.valueOf(apiError.toUpperCase());
                             }
                         }
                         installPluginError.message = networkError.message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -37,6 +37,7 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -72,8 +73,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         FetchSitePluginsError fetchPluginsError
                                 = new FetchSitePluginsError(FetchSitePluginsErrorType.GENERIC_ERROR);
-                        fetchPluginsError.type = FetchSitePluginsErrorType.
-                                valueOf(((WPComGsonNetworkError) networkError).apiError.toUpperCase());
+                        fetchPluginsError.type = FetchSitePluginsErrorType.valueOf(((WPComGsonNetworkError)
+                                networkError).apiError.toUpperCase(Locale.ENGLISH));
                         fetchPluginsError.message = networkError.message;
                         FetchedSitePluginsPayload payload = new FetchedSitePluginsPayload(fetchPluginsError);
                         mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginsAction(payload));
@@ -101,8 +102,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         UpdateSitePluginError updatePluginError
                                 = new UpdateSitePluginError(UpdateSitePluginErrorType.GENERIC_ERROR);
-                        updatePluginError.type = UpdateSitePluginErrorType.
-                                valueOf(((WPComGsonNetworkError) networkError).apiError.toUpperCase());
+                        updatePluginError.type = UpdateSitePluginErrorType.valueOf(((WPComGsonNetworkError)
+                                networkError).apiError.toUpperCase(Locale.ENGLISH));
                         updatePluginError.message = networkError.message;
                         UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));
@@ -130,8 +131,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         DeleteSitePluginError deletePluginError
                                 = new DeleteSitePluginError(DeleteSitePluginErrorType.GENERIC_ERROR);
-                        deletePluginError.type = DeleteSitePluginErrorType.
-                                valueOf(((WPComGsonNetworkError) networkError).apiError.toUpperCase());
+                        deletePluginError.type = DeleteSitePluginErrorType.valueOf(((WPComGsonNetworkError)
+                                networkError).apiError.toUpperCase(Locale.ENGLISH));
                         deletePluginError.message = networkError.message;
                         DeletedSitePluginPayload payload = new DeletedSitePluginPayload(site, deletePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(payload));
@@ -163,7 +164,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                             if (apiError.equals("local-file-does-not-exist")) {
                                 installPluginError.type = InstallSitePluginErrorType.LOCAL_FILE_DOES_NOT_EXIST;
                             } else {
-                                installPluginError.type = InstallSitePluginErrorType.valueOf(apiError.toUpperCase());
+                                installPluginError.type = InstallSitePluginErrorType
+                                        .valueOf(apiError.toUpperCase(Locale.ENGLISH));
                             }
                         }
                         installPluginError.message = networkError.message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -117,6 +117,9 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 case "unauthorized":
                                     updatePluginError.type = UpdateSitePluginErrorType.UNAUTHORIZED;
                                     break;
+                                case "unknown_plugin":
+                                    updatePluginError.type = UpdateSitePluginErrorType.UNKNOWN_PLUGIN;
+                                    break;
                             }
                         }
                         updatePluginError.message = networkError.message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -190,7 +190,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 case "install_failure":
                                     installPluginError.type = InstallSitePluginErrorType.INSTALL_FAILURE;
                                     break;
-                                case "local_file_does_not_exist":
+                                case "local-file-does-not-exist":
                                     installPluginError.type = InstallSitePluginErrorType.LOCAL_FILE_DOES_NOT_EXIST;
                                     break;
                                 case "no_package":

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -186,7 +186,8 @@ public class PluginStore extends Store {
         GENERIC_ERROR,
         UNAUTHORIZED,
         DELETE_PLUGIN_ERROR,
-        NOT_AVAILABLE // Return for non-jetpack sites
+        NOT_AVAILABLE, // Return for non-jetpack sites
+        UNKNOWN_PLUGIN
     }
 
     public enum FetchPluginInfoErrorType {
@@ -212,11 +213,11 @@ public class PluginStore extends Store {
 
     public enum UpdateSitePluginErrorType {
         GENERIC_ERROR,
-        UNAUTHORIZED,
         ACTIVATION_ERROR,
         DEACTIVATION_ERROR,
-        UNKNOWN_PLUGIN,
-        NOT_AVAILABLE // Return for non-jetpack sites
+        NOT_AVAILABLE, // Return for non-jetpack sites
+        UNAUTHORIZED,
+        UNKNOWN_PLUGIN
     }
 
     // OnChanged Events

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -215,6 +215,7 @@ public class PluginStore extends Store {
         UNAUTHORIZED,
         ACTIVATION_ERROR,
         DEACTIVATION_ERROR,
+        UNKNOWN_PLUGIN,
         NOT_AVAILABLE // Return for non-jetpack sites
     }
 


### PR DESCRIPTION
This PR should be the last one for the install & delete plugin improvements WIP branch. This PR adds a few more tests for error paths, improves the error type handling in `PluginRestClient` and fixes a couple small issues (like using dashes instead of underscores for an error type 🤦‍♂️ )

I've a few last things in mind for Plugins to polish things up, but we are almost there!

P.S: I've finally updated the test to use the jetpack site, because I was getting tired of not commiting that.

/cc @tonyr59h 