### PR TITLE
WooCommerce plugin - Initial setup

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -67,7 +67,8 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
-    implementation project(':fluxc');
+    implementation project(':fluxc')
+    implementation project(':plugins:woocommerce')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
@@ -23,7 +23,8 @@ open class ExampleApp : Application(), HasActivityInjector {
     override fun onCreate() {
         super.onCreate()
         component.inject(this)
-        WellSql.init(WellSqlConfig(applicationContext))
+        val wellSqlConfig = WellSqlConfig(applicationContext, WellSqlConfig.ADDON_WOOCOMMERCE)
+        WellSql.init(wellSqlConfig)
     }
 
     override fun activityInjector(): AndroidInjector<Activity> = activityInjector

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -88,6 +88,7 @@ class MainFragment : Fragment() {
         taxonomies.setOnClickListener(getOnClickListener(TaxonomiesFragment()))
         uploads.setOnClickListener(getOnClickListener(UploadsFragment()))
         themes.setOnClickListener(getOnClickListener(ThemeFragment()))
+        woo.setOnClickListener(getOnClickListener(WooCommerceFragment()))
     }
 
     // Private methods

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.fluxc.example
+
+import android.app.Fragment
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import dagger.android.AndroidInjection
+import kotlinx.android.synthetic.main.fragment_woocommerce.*
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import javax.inject.Inject
+
+class WooCommerceFragment : Fragment() {
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    override fun onAttach(context: Context?) {
+        AndroidInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_woocommerce, container, false)
+
+    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        log_sites.setOnClickListener {
+            for (site in wooCommerceStore.getWooCommerceSites()) {
+                prependToLog(site.name + ": " + if (site.isWpComStore) "WP.com store" else "Self-hosted store")
+                AppLog.i(T.API, LogUtils.toString(site))
+            }
+        }
+    }
+
+    private fun prependToLog(s: String) = (activity as MainExampleActivity).prependToLog(s)
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.example.SitesFragment
 import org.wordpress.android.fluxc.example.TaxonomiesFragment
 import org.wordpress.android.fluxc.example.ThemeFragment
 import org.wordpress.android.fluxc.example.UploadsFragment
+import org.wordpress.android.fluxc.example.WooCommerceFragment
 
 @Module
 internal abstract class FragmentsModule {
@@ -44,4 +45,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideUploadsFragmentInjector(): UploadsFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooCommerceFragmentInjector(): WooCommerceFragment
 }

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -41,59 +41,82 @@
         android:layout_height="2dp"
         android:background="@color/material_grey_600" />
 
-    <Button
-        android:id="@+id/account"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Account" />
+        android:orientation="horizontal">
 
-    <Button
-        android:id="@+id/sites"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Sites" />
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_gravity="left"
+            android:layout_weight="1">
 
-    <Button
-        android:id="@+id/posts"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Posts" />
+            <Button
+                android:id="@+id/account"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Account" />
 
-    <Button
-        android:id="@+id/comments"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Comments" />
+            <Button
+                android:id="@+id/sites"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Sites" />
 
-    <Button
-        android:id="@+id/media"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Media" />
+            <Button
+                android:id="@+id/posts"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Posts" />
 
-    <Button
-        android:id="@+id/taxonomies"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Taxonomies" />
+            <Button
+                android:id="@+id/comments"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Comments" />
 
-    <Button
-        android:id="@+id/uploads"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Uploads" />
+            <Button
+                android:id="@+id/media"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Media" />
 
-    <Button
-        android:id="@+id/themes"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Themes" />
+            <Button
+                android:id="@+id/taxonomies"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Taxonomies" />
 
-    <Button
-        android:id="@+id/woo"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="right"
-        android:text="Woo" />
+            <Button
+                android:id="@+id/uploads"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Uploads" />
 
+            <Button
+                android:id="@+id/themes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Themes" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_gravity="right"
+            android:layout_weight="1">
+
+            <Button
+                android:id="@+id/woo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="right"
+                android:text="Woo" />
+
+        </LinearLayout>
+    </LinearLayout>
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -89,4 +89,11 @@
         android:layout_height="wrap_content"
         android:text="Themes" />
 
+    <Button
+        android:id="@+id/woo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="right"
+        android:text="Woo" />
+
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -1,0 +1,15 @@
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="org.wordpress.android.fluxc.example.WooCommerceFragment">
+
+    <Button
+        android:id="@+id/log_sites"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Log Sites" />
+
+</LinearLayout>

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -27,6 +27,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.TypeElement;
+import javax.tools.StandardLocation;
 
 @SuppressWarnings("unused")
 @AutoService(Processor.class)
@@ -64,11 +65,14 @@ public class EndpointProcessor extends AbstractProcessor {
         mFiler = processingEnv.getFiler();
 
         try {
-            generateWPCOMRESTEndpointFile();
-            generateWPCOMV2EndpointFile();
-            generateXMLRPCEndpointFile();
-            generateWPAPIEndpointFile();
-            generateWPORGAPIEndpointFile();
+            String outputPath = mFiler.getResource(StandardLocation.CLASS_OUTPUT, "", "tmp").getName();
+            if (outputPath.contains("/fluxc/build/")) {
+                generateWPCOMRESTEndpointFile();
+                generateWPCOMV2EndpointFile();
+                generateXMLRPCEndpointFile();
+                generateWPAPIEndpointFile();
+                generateWPORGAPIEndpointFile();
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -70,8 +70,8 @@ dependencies {
     }
 
     // Custom WellSql version
-    api 'org.wordpress:wellsql:1.2.0'
-    kapt 'org.wordpress:wellsql-processor:1.2.0'
+    api 'org.wordpress:wellsql:1.3.0'
+    kapt 'org.wordpress:wellsql-processor:1.3.0'
 
     // FluxC annotations
     api project(':fluxc-annotations')

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -69,8 +69,10 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private boolean mIsJetpackInstalled;
     // mIsJetpackConnected is true if Jetpack is installed, activated and connected to a WordPress.com account.
     @Column private boolean mIsJetpackConnected;
-    @Column private boolean mIsAutomatedTransfer;
     @Column private String mJetpackVersion;
+    @Column private boolean mIsAutomatedTransfer;
+    @Column private boolean mIsWpComStore;
+    @Column private boolean mHasWooCommerce;
 
     // WPCom specifics
     @Column private boolean mIsVisible = true;
@@ -521,6 +523,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mIsJetpackConnected = jetpackConnected;
     }
 
+    public String getJetpackVersion() {
+        return mJetpackVersion;
+    }
+
+    public void setJetpackVersion(String jetpackVersion) {
+        mJetpackVersion = jetpackVersion;
+    }
+
     public boolean isAutomatedTransfer() {
         return mIsAutomatedTransfer;
     }
@@ -529,12 +539,20 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mIsAutomatedTransfer = automatedTransfer;
     }
 
-    public String getJetpackVersion() {
-        return mJetpackVersion;
+    public boolean isWpComStore() {
+        return mIsWpComStore;
     }
 
-    public void setJetpackVersion(String jetpackVersion) {
-        mJetpackVersion = jetpackVersion;
+    public void setIsWpComStore(boolean isWpComStore) {
+        mIsWpComStore = isWpComStore;
+    }
+
+    public boolean getHasWooCommerce() {
+        return mHasWooCommerce;
+    }
+
+    public void setHasWooCommerce(boolean hasWooCommerce) {
+        mHasWooCommerce = hasWooCommerce;
     }
 
     @SiteOrigin

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -505,6 +505,8 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setIsFeaturedImageSupported(from.options.featured_images_enabled);
             site.setIsVideoPressSupported(from.options.videopress_enabled);
             site.setIsAutomatedTransfer(from.options.is_automated_transfer);
+            site.setIsWpComStore(from.options.is_wpcom_store);
+            site.setHasWooCommerce(from.options.woocommerce_is_active);
             site.setAdminUrl(from.options.admin_url);
             site.setLoginUrl(from.options.login_url);
             site.setTimezone(from.options.gmt_offset);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -13,6 +13,8 @@ public class SiteWPComRestResponse implements Response {
         public boolean videopress_enabled;
         public boolean featured_images_enabled;
         public boolean is_automated_transfer;
+        public boolean is_wpcom_store;
+        public boolean woocommerce_is_active;
         public String admin_url;
         public String login_url;
         public String gmt_offset;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -58,7 +58,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 23;
+        return 24;
     }
 
     @Override
@@ -201,6 +201,11 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 22:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table ThemeModel add MOBILE_FRIENDLY_CATEGORY_SLUG text;");
+                oldVersion++;
+            case 23:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("ALTER TABLE SiteModel ADD IS_WP_COM_STORE INTEGER");
+                db.execSQL("ALTER TABLE SiteModel ADD HAS_WOO_COMMERCE INTEGER");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
+import android.support.annotation.StringDef;
 
 import com.yarolegovich.wellsql.DefaultWellConfig;
 import com.yarolegovich.wellsql.WellSql;
@@ -11,50 +12,32 @@ import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.TableClass;
 import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 
-import org.wordpress.android.fluxc.model.AccountModel;
-import org.wordpress.android.fluxc.model.CommentModel;
-import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaUploadModel;
-import org.wordpress.android.fluxc.model.WPOrgPluginModel;
-import org.wordpress.android.fluxc.model.SitePluginModel;
-import org.wordpress.android.fluxc.model.PostFormatModel;
-import org.wordpress.android.fluxc.model.PostModel;
-import org.wordpress.android.fluxc.model.PostUploadModel;
-import org.wordpress.android.fluxc.model.RoleModel;
-import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.model.TaxonomyModel;
-import org.wordpress.android.fluxc.model.TermModel;
-import org.wordpress.android.fluxc.model.ThemeModel;
-import org.wordpress.android.fluxc.network.HTTPAuthModel;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 public class WellSqlConfig extends DefaultWellConfig {
+    @Retention(SOURCE)
+    @StringDef({ADDON_WOOCOMMERCE})
+    @Target(ElementType.PARAMETER)
+    public @interface AddOn {}
+    public static final String ADDON_WOOCOMMERCE = "WC";
+
     public WellSqlConfig(Context context) {
         super(context);
     }
 
-    private static final List<Class<? extends Identifiable>> TABLES = new ArrayList<Class<? extends Identifiable>>() {{
-        add(AccountModel.class);
-        add(CommentModel.class);
-        add(HTTPAuthModel.class);
-        add(MediaModel.class);
-        add(MediaUploadModel.class);
-        add(PostFormatModel.class);
-        add(PostModel.class);
-        add(PostUploadModel.class);
-        add(RoleModel.class);
-        add(SiteModel.class);
-        add(SitePluginModel.class);
-        add(TaxonomyModel.class);
-        add(TermModel.class);
-        add(ThemeModel.class);
-        add(WPOrgPluginModel.class);
-    }};
+    public WellSqlConfig(Context context, @AddOn String... addOns) {
+        super(context, new HashSet<>(Arrays.asList(addOns)));
+    }
 
     @Override
     public int getDbVersion() {
@@ -68,7 +51,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public void onCreate(SQLiteDatabase db, WellTableManager helper) {
-        for (Class<? extends Identifiable> table : TABLES) {
+        for (Class<? extends Identifiable> table : mTables) {
             helper.createTable(table);
         }
     }
@@ -222,7 +205,7 @@ public class WellSqlConfig extends DefaultWellConfig {
     }
 
     @Override
-    protected Map<Class<?>, SQLiteMapper<?>> registerMappers() {
+    protected Map<Class<? extends Identifiable>, SQLiteMapper<?>> registerMappers() {
         return super.registerMappers();
     }
 
@@ -231,10 +214,18 @@ public class WellSqlConfig extends DefaultWellConfig {
      */
     public void reset() {
         SQLiteDatabase db = WellSql.giveMeWritableDb();
-        for (Class<? extends Identifiable> clazz : TABLES) {
+        for (Class<? extends Identifiable> clazz : mTables) {
             TableClass table = getTable(clazz);
             db.execSQL("DROP TABLE IF EXISTS " + table.getTableName());
             db.execSQL(table.createStatement());
+        }
+    }
+
+    private void migrateAddOn(@AddOn String addOnName, SQLiteDatabase db, int oldDbVersion) {
+        if (mActiveAddOns.contains(addOnName)) {
+            switch (oldDbVersion) {
+                // TODO
+            }
         }
     }
 }

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+repositories {
+    jcenter()
+}
+
+android {
+    compileSdkVersion 25
+    buildToolsVersion '26.0.2'
+
+    defaultConfig {
+        versionCode 1
+        versionName "0.1"
+        minSdkVersion 14
+        targetSdkVersion 25
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+}
+
+dependencies {
+    implementation project(':fluxc')
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+}

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -42,4 +42,19 @@ dependencies {
     implementation project(':fluxc')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+
+    // WordPress libs
+    implementation ('org.wordpress:utils:1.16.0') {
+        // Using official volley package
+        exclude group: "com.mcxiaoke.volley"
+    }
+
+    // FluxC annotations
+    api project(':fluxc-annotations')
+    kapt project(':fluxc-processor')
+
+    // Dagger
+    implementation "com.google.dagger:dagger:$daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$daggerVersion"
+    compileOnly 'org.glassfish:javax.annotation:10.0-b28'
 }

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -4,11 +4,13 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.github.dcendents.android-maven'
 
 repositories {
     jcenter()

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.dcendents.android-maven'
 
 repositories {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -50,6 +50,9 @@ dependencies {
         exclude group: "com.mcxiaoke.volley"
     }
 
+    api 'org.wordpress:wellsql:1.3.0'
+    kapt 'org.wordpress:wellsql-processor:1.3.0'
+
     // FluxC annotations
     api project(':fluxc-annotations')
     kapt project(':fluxc-processor')

--- a/plugins/woocommerce/src/main/AndroidManifest.xml
+++ b/plugins/woocommerce/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    package="org.wordpress.android.fluxc.plugins.woocommerce" >
+</manifest>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/action/WooCommerceAction.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/action/WooCommerceAction.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.action
+
+import org.wordpress.android.fluxc.annotations.ActionEnum
+import org.wordpress.android.fluxc.annotations.action.IAction
+
+@ActionEnum
+enum class WooCommerceAction : IAction {
+    // Remote actions
+    // Remote responses
+    // Local actions
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId: Int = 0
+    @Column var remoteOrderId: Long? = 0
+
+    override fun getId(): Int = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.fluxc.store
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WooCommerceAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooCommerceStore @Inject constructor(dispatcher: Dispatcher) : Store(dispatcher) {
+    override fun onRegister() {
+        AppLog.d(T.API, "WooCommerceStore onRegister")
+    }
+
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? WooCommerceAction ?: return
+        // TODO
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -1,10 +1,13 @@
 package org.wordpress.android.fluxc.store
 
+import com.wellsql.generated.SiteModelTable
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WooCommerceAction
 import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
@@ -21,4 +24,7 @@ class WooCommerceStore @Inject constructor(dispatcher: Dispatcher) : Store(dispa
         val actionType = action.type as? WooCommerceAction ?: return
         // TODO
     }
+
+    fun getWooCommerceSites(): MutableList<SiteModel> =
+            SiteSqlUtils.getSitesWith(SiteModelTable.HAS_WOO_COMMERCE, true).asModel
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
-include ':fluxc', ':fluxc-processor', ':fluxc-annotations'
+include ':fluxc', ':fluxc-processor', ':fluxc-annotations', ':plugins:woocommerce'
 include ':example'
 include ':instaflux'


### PR DESCRIPTION
Sets up the basics for a new WooCommerce store. This is added in a separate module from core `fluxc`, allowing FluxC clients to choose to use the `WooCommerce` plugin or not.

This is targeting the`woocommerce-store` feature branch as there are several more pieces needed to complete the core setup for the plugin (see https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/615).

This PR adds:

* A new module, `:plugin:woocommerce`
* Two new fields from the WP.com API, `is_wpcom_store`, `woocommerce_is_active`, stored in the `SiteModel`, to allow us to identify Jetpack sites with WooCommerce installed
* A tweak to the endpoint class generator to support multiple modules calling `fluxc-processor`
* A demo on use of the plugin in the example app

A few things are missing to complete core setup of the plugin and will be added in subsequent PRs:
* A WooCommerce network client and a Dagger module that provides it
* Support for database table generation from models inside the plugin module ~(this will require some changes to wellsql, which are a WIP)~ changes complete, see #642 (which has been merged into this PR's branch)

To use the plugin in an eternal project, import it using Jitpack along with core FluxC:

```
compile('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:[hash or snapshot]')
compile 'com.github.wordpress-mobile.WordPress-FluxC-Android:woocommerce:[hash or snapshot]'
```