### PR TITLE
Issue/618 crash google login

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -77,7 +77,11 @@ public class AccountRestClient extends BaseWPComRestClient {
             this.userId = response.user_id;
         }
         public AccountPushSocialResponsePayload(BaseNetworkError error) {
-            this.error = new AccountSocialError(error.volleyError.networkResponse.data);
+            if (error.volleyError.networkResponse == null || error.volleyError.networkResponse.data == null) {
+                this.error = new AccountSocialError("generic_error", "");
+            } else {
+                this.error = new AccountSocialError(error.volleyError.networkResponse.data);
+            }
         }
         public AccountPushSocialResponsePayload() {
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.store.AccountStore.AccountSocialError;
+import org.wordpress.android.fluxc.store.AccountStore.AccountSocialErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.IsAvailableError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
@@ -78,7 +79,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         }
         public AccountPushSocialResponsePayload(BaseNetworkError error) {
             if (error.volleyError.networkResponse == null || error.volleyError.networkResponse.data == null) {
-                this.error = new AccountSocialError("generic_error", "");
+                this.error = new AccountSocialError(AccountSocialErrorType.GENERIC_ERROR, "");
             } else {
                 this.error = new AccountSocialError(error.volleyError.networkResponse.data);
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -6,9 +6,6 @@ import com.android.volley.VolleyError;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.AccountAction;
@@ -35,7 +32,6 @@ import org.wordpress.android.fluxc.persistence.AccountSqlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 
@@ -291,20 +287,6 @@ public class AccountStore extends Store {
         public AccountSocialError(@NonNull AccountSocialErrorType type, @NonNull String message) {
             this.type = type;
             this.message = message;
-        }
-
-        public AccountSocialError(@NonNull byte[] response) {
-            try {
-                String responseBody = new String(response, "UTF-8");
-                JSONObject object = new JSONObject(responseBody);
-                JSONObject data = object.getJSONObject("data");
-                this.nonce = data.optString("two_step_nonce");
-                JSONArray errors = data.getJSONArray("errors");
-                this.type = AccountSocialErrorType.fromString(errors.getJSONObject(0).getString("code"));
-                this.message = errors.getJSONObject(0).getString("message");
-            } catch (UnsupportedEncodingException | JSONException exception) {
-                AppLog.e(T.API, "Unable to parse social error response: " + exception.getMessage());
-            }
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -288,6 +288,11 @@ public class AccountStore extends Store {
             this.message = message;
         }
 
+        public AccountSocialError(@NonNull AccountSocialErrorType type, @NonNull String message) {
+            this.type = type;
+            this.message = message;
+        }
+
         public AccountSocialError(@NonNull byte[] response) {
             try {
                 String responseBody = new String(response, "UTF-8");


### PR DESCRIPTION
### Fix
Add a check for a `null` network response while parsing the social response payload to avoid `NullPointerException` as described in https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/618.