### PR TITLE
Gradle plugin 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-25.0.3
+    - build-tools-26.0.2
     - android-25
 
 env:

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
     }
 
     dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.9.2'
+        ktlint 'com.github.shyiko:ktlint:0.12.1'
     }
 
     task ktlint(type: JavaExec) {
@@ -54,7 +54,7 @@ subprojects {
 }
 
 ext {
-    kotlinVersion = '1.1.51'
+    kotlinVersion = '1.2.0'
 
     daggerVersion = '2.11'
     supportLibraryVersion = '25.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.0'
+    }
+}
+
 allprojects {
     apply plugin: 'checkstyle'
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,7 +3,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -67,29 +67,35 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
-    compile project(':fluxc');
+    implementation project(':fluxc');
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
 
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile "com.android.support:support-v4:$supportLibraryVersion"
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:support-v4:$supportLibraryVersion"
+
+    // WordPress libs
+    implementation ('org.wordpress:utils:1.16.0') {
+        // Using official volley package
+        exclude group: "com.mcxiaoke.volley";
+    }
 
     // Dagger
-    compile "com.google.dagger:dagger:$daggerVersion"
+    implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
-    provided 'org.glassfish:javax.annotation:10.0-b28'
-    compile "com.google.dagger:dagger-android:$daggerVersion"
+    compileOnly 'org.glassfish:javax.annotation:10.0-b28'
+    implementation "com.google.dagger:dagger-android:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.robolectric:robolectric:3.0'
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.robolectric:robolectric:3.0'
+    androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
+    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestImplementation 'org.mockito:mockito-core:1.10.19'
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
 
     // Debug dependencies
-    debugCompile 'com.facebook.stetho:stetho:1.5.0'
-    debugCompile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
+    debugImplementation 'com.facebook.stetho:stetho:1.5.0'
+    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.example"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestImplementation 'org.mockito:mockito-core:1.10.19'
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
+    androidTestCompileOnly 'org.glassfish:javax.annotation:10.0-b28'
 
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThreeEditTextDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThreeEditTextDialog.kt
@@ -56,8 +56,8 @@ class ThreeEditTextDialog : DialogFragment() {
 
     companion object {
         @JvmStatic
-        fun newInstance(onClickListener: Listener, text1Hint: String, text2Hint: String, text3Hint: String)
-                : ThreeEditTextDialog {
+        fun newInstance(onClickListener: Listener, text1Hint: String, text2Hint: String, text3Hint: String
+        ): ThreeEditTextDialog {
             val fragment = ThreeEditTextDialog()
             fragment.setListener(onClickListener)
             fragment.hint1 = text1Hint

--- a/fluxc-annotations/build.gradle
+++ b/fluxc-annotations/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-    }
-}
-
 apply plugin: 'maven'
 apply plugin: 'java'
 

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -9,7 +9,7 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-    compile project (':fluxc-annotations')
-    compile 'com.google.auto.service:auto-service:1.0-rc2'
-    compile 'com.squareup:javapoet:1.7.0'
+    implementation project (':fluxc-annotations')
+    implementation 'com.google.auto.service:auto-service:1.0-rc2'
+    implementation 'com.squareup:javapoet:1.7.0'
 }

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-    }
-}
-
 apply plugin: 'java'
 apply plugin: 'maven'
 

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -59,36 +59,36 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
 
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
 
     // WordPress libs
-    compile ('org.wordpress:utils:1.16.0') {
+    implementation ('org.wordpress:utils:1.16.0') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley";
     }
 
     // Custom WellSql version
-    compile 'org.wordpress:wellsql:1.2.0'
+    api 'org.wordpress:wellsql:1.2.0'
     kapt 'org.wordpress:wellsql-processor:1.2.0'
 
     // FluxC annotations
-    compile project(':fluxc-annotations')
+    api project(':fluxc-annotations')
     kapt project(':fluxc-processor')
 
     // External libs
-    compile 'org.greenrobot:eventbus:3.0.0'
-    compile 'com.squareup.okhttp3:okhttp:3.8.1'
-    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.8.1'
-    compile 'com.android.volley:volley:1.0.0'
-    compile 'com.google.code.gson:gson:2.7'
-    compile 'org.apache.commons:commons-text:1.1'
+    api 'org.greenrobot:eventbus:3.0.0'
+    api 'com.squareup.okhttp3:okhttp:3.8.1'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.8.1'
+    api 'com.android.volley:volley:1.0.0'
+    implementation 'com.google.code.gson:gson:2.7'
+    implementation 'org.apache.commons:commons-text:1.1'
 
     // Dagger
-    compile "com.google.dagger:dagger:$daggerVersion"
+    implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
-    provided 'org.glassfish:javax.annotation:10.0-b28'
+    compileOnly 'org.glassfish:javax.annotation:10.0-b28'
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -21,7 +21,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         versionCode 4

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -3,7 +3,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 19 08:38:24 CEST 2017
+#Thu Nov 02 13:54:34 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -3,7 +3,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -48,18 +48,24 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
-    compile project(':fluxc');
+    implementation project(':fluxc');
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
 
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile "com.android.support:support-v4:$supportLibraryVersion"
-    compile "com.android.support:recyclerview-v7:$supportLibraryVersion"
+    // WordPress libs
+    implementation ('org.wordpress:utils:1.16.0') {
+        // Using official volley package
+        exclude group: "com.mcxiaoke.volley";
+    }
 
-    compile 'com.squareup.picasso:picasso:2.5.2'
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:support-v4:$supportLibraryVersion"
+    implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
+
+    implementation 'com.squareup.picasso:picasso:2.5.2'
 
     // Dagger
-    compile "com.google.dagger:dagger:$daggerVersion"
+    implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
-    provided 'org.glassfish:javax.annotation:10.0-b28'
+    compileOnly 'org.glassfish:javax.annotation:10.0-b28'
 }

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.instaflux"


### PR DESCRIPTION
Updates FluxC to use [version 3.0.0 of the Gradle Android plugin](https://developer.android.com/studio/build/gradle-plugin-3-0-0.html), along with the [new dependency configurations](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#new_configurations).

Closes #598.

cc @maxme