### PR TITLE
ThemeStore: Cleanup response models

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/JetpackThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/JetpackThemeResponse.java
@@ -3,9 +3,9 @@ package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
-public class ThemeJetpackResponse {
-    public class MultipleJetpackThemesResponse {
-        public List<ThemeJetpackResponse> themes;
+public class JetpackThemeResponse {
+    public class JetpackThemeListResponse {
+        public List<JetpackThemeResponse> themes;
         public int count;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeJetpackResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeJetpackResponse.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 
 import java.util.List;
 
+@SuppressWarnings("WeakerAccess")
 public class ThemeJetpackResponse {
     public class MultipleJetpackThemesResponse {
         public List<ThemeJetpackResponse> themes;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -18,7 +18,7 @@ import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
-import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.ThemeListResponse;
+import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeListResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeMapResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
@@ -129,10 +129,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** [Undocumented!] Endpoint: v1.2/themes */
     public void fetchWpComThemes() {
         String url = WPCOMREST.themes.getUrlV1_2() + "?" + WP_THEME_FETCH_NUMBER_PARAM;
-        add(WPComGsonRequest.buildGetRequest(url, null, ThemeListResponse.class,
-                new Response.Listener<ThemeListResponse>() {
+        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeListResponse.class,
+                new Response.Listener<WPComThemeListResponse>() {
                     @Override
-                    public void onResponse(ThemeListResponse response) {
+                    public void onResponse(WPComThemeListResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to WP.com themes fetch request.");
                         FetchedThemesPayload payload = new FetchedThemesPayload(null);
                         payload.themes = createThemeListFromArrayResponse(response);
@@ -225,10 +225,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** [Undocumented!] Endpoint: v1.2/themes?search=$term */
     public void searchThemes(@NonNull final String searchTerm) {
         String url = WPCOMREST.themes.getUrlV1_2() + "?search=" + searchTerm;
-        add(WPComGsonRequest.buildGetRequest(url, null, ThemeListResponse.class,
-                new Response.Listener<ThemeListResponse>() {
+        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeListResponse.class,
+                new Response.Listener<WPComThemeListResponse>() {
                     @Override
-                    public void onResponse(ThemeListResponse response) {
+                    public void onResponse(WPComThemeListResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to search themes request.");
                         SearchedThemesPayload payload =
                                 new SearchedThemesPayload(searchTerm, createThemeListFromArrayResponse(response));
@@ -299,7 +299,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
         return themeList;
     }
 
-    private static List<ThemeModel> createThemeListFromArrayResponse(ThemeListResponse response) {
+    private static List<ThemeModel> createThemeListFromArrayResponse(WPComThemeListResponse response) {
         final List<ThemeModel> themeList = new ArrayList<>();
         for (WPComThemeResponse item : response.themes) {
             themeList.add(createThemeFromWPComResponse(item));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -18,9 +18,9 @@ import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
-import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeWPComResponse.ThemeArrayResponse;
-import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeWPComResponse.MultipleWPComThemesResponse;
-import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeJetpackResponse.MultipleJetpackThemesResponse;
+import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.ThemeListResponse;
+import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeMapResponse;
+import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
 import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedThemesPayload;
@@ -50,10 +50,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** Endpoint: v1.1/site/$siteId/themes/$themeId/delete */
     public void deleteTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(theme.getThemeId()).delete.getUrlV1_1();
-        add(WPComGsonRequest.buildPostRequest(url, null, ThemeJetpackResponse.class,
-                new Response.Listener<ThemeJetpackResponse>() {
+        add(WPComGsonRequest.buildPostRequest(url, null, JetpackThemeResponse.class,
+                new Response.Listener<JetpackThemeResponse>() {
                     @Override
-                    public void onResponse(ThemeJetpackResponse response) {
+                    public void onResponse(JetpackThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme deletion request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
                         responseTheme.setId(theme.getId());
@@ -77,10 +77,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     public void installTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
         String themeId = getThemeIdWithWpComSuffix(theme);
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(themeId).install.getUrlV1_1();
-        add(WPComGsonRequest.buildPostRequest(url, null, ThemeJetpackResponse.class,
-                new Response.Listener<ThemeJetpackResponse>() {
+        add(WPComGsonRequest.buildPostRequest(url, null, JetpackThemeResponse.class,
+                new Response.Listener<JetpackThemeResponse>() {
                     @Override
-                    public void onResponse(ThemeJetpackResponse response) {
+                    public void onResponse(JetpackThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme installation request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
                         responseTheme.setLocalSiteId(site.getId());
@@ -105,10 +105,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
         Map<String, Object> params = new HashMap<>();
         params.put("theme", theme.getThemeId());
 
-        add(WPComGsonRequest.buildPostRequest(url, params, ThemeWPComResponse.class,
-                new Response.Listener<ThemeWPComResponse>() {
+        add(WPComGsonRequest.buildPostRequest(url, params, WPComThemeResponse.class,
+                new Response.Listener<WPComThemeResponse>() {
                     @Override
-                    public void onResponse(ThemeWPComResponse response) {
+                    public void onResponse(WPComThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to theme activation request.");
                         ActivateThemePayload payload = new ActivateThemePayload(site, theme);
                         payload.theme.setActive(StringUtils.equals(theme.getThemeId(), response.id));
@@ -129,10 +129,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** [Undocumented!] Endpoint: v1.2/themes */
     public void fetchWpComThemes() {
         String url = WPCOMREST.themes.getUrlV1_2() + "?" + WP_THEME_FETCH_NUMBER_PARAM;
-        add(WPComGsonRequest.buildGetRequest(url, null, ThemeArrayResponse.class,
-                new Response.Listener<ThemeArrayResponse>() {
+        add(WPComGsonRequest.buildGetRequest(url, null, ThemeListResponse.class,
+                new Response.Listener<ThemeListResponse>() {
                     @Override
-                    public void onResponse(ThemeArrayResponse response) {
+                    public void onResponse(ThemeListResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to WP.com themes fetch request.");
                         FetchedThemesPayload payload = new FetchedThemesPayload(null);
                         payload.themes = createThemeListFromArrayResponse(response);
@@ -153,10 +153,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** Endpoint: v1/site/$siteId/themes */
     public void fetchJetpackInstalledThemes(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.getUrlV1();
-        add(WPComGsonRequest.buildGetRequest(url, null, MultipleJetpackThemesResponse.class,
-                new Response.Listener<MultipleJetpackThemesResponse>() {
+        add(WPComGsonRequest.buildGetRequest(url, null, JetpackThemeListResponse.class,
+                new Response.Listener<JetpackThemeListResponse>() {
                     @Override
-                    public void onResponse(MultipleJetpackThemesResponse response) {
+                    public void onResponse(JetpackThemeListResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack installed themes fetch request.");
                         List<ThemeModel> themes = createThemeListFromJetpackResponse(response);
                         FetchedThemesPayload payload = new FetchedThemesPayload(site, themes);
@@ -177,10 +177,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** Endpoint: v1.2/site/$siteId/themes */
     public void fetchWpComSiteThemes(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.getUrlV1_2();
-        add(WPComGsonRequest.buildGetRequest(url, null, MultipleWPComThemesResponse.class,
-                new Response.Listener<MultipleWPComThemesResponse>() {
+        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeMapResponse.class,
+                new Response.Listener<WPComThemeMapResponse>() {
                     @Override
-                    public void onResponse(MultipleWPComThemesResponse response) {
+                    public void onResponse(WPComThemeMapResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to themes fetch request for WP.com site.");
                         FetchedThemesPayload payload =
                                 new FetchedThemesPayload(site, createThemeListFromWPComResponse(response));
@@ -201,10 +201,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** Endpoint: v1.1/site/$siteId/themes/mine; same endpoint for both Jetpack and WP.com sites */
     public void fetchCurrentTheme(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.mine.getUrlV1_1();
-        add(WPComGsonRequest.buildGetRequest(url, null, ThemeWPComResponse.class,
-                new Response.Listener<ThemeWPComResponse>() {
+        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeResponse.class,
+                new Response.Listener<WPComThemeResponse>() {
                     @Override
-                    public void onResponse(ThemeWPComResponse response) {
+                    public void onResponse(WPComThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to current theme fetch request.");
                         ThemeModel responseTheme = createThemeFromWPComResponse(response);
                         FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(site, responseTheme);
@@ -225,10 +225,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** [Undocumented!] Endpoint: v1.2/themes?search=$term */
     public void searchThemes(@NonNull final String searchTerm) {
         String url = WPCOMREST.themes.getUrlV1_2() + "?search=" + searchTerm;
-        add(WPComGsonRequest.buildGetRequest(url, null, ThemeArrayResponse.class,
-                new Response.Listener<ThemeArrayResponse>() {
+        add(WPComGsonRequest.buildGetRequest(url, null, ThemeListResponse.class,
+                new Response.Listener<ThemeListResponse>() {
                     @Override
-                    public void onResponse(ThemeArrayResponse response) {
+                    public void onResponse(ThemeListResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to search themes request.");
                         SearchedThemesPayload payload =
                                 new SearchedThemesPayload(searchTerm, createThemeListFromArrayResponse(response));
@@ -246,7 +246,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    private static ThemeModel createThemeFromWPComResponse(ThemeWPComResponse response) {
+    private static ThemeModel createThemeFromWPComResponse(WPComThemeResponse response) {
         ThemeModel theme = new ThemeModel();
         theme.setThemeId(response.id);
         theme.setSlug(response.slug);
@@ -267,7 +267,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
         return theme;
     }
 
-    private static ThemeModel createThemeFromJetpackResponse(ThemeJetpackResponse response) {
+    private static ThemeModel createThemeFromJetpackResponse(JetpackThemeResponse response) {
         ThemeModel theme = new ThemeModel();
         theme.setThemeId(response.id);
         theme.setName(response.name);
@@ -291,26 +291,26 @@ public class ThemeRestClient extends BaseWPComRestClient {
     }
 
     /** Creates a list of ThemeModels from the WP.com /v1.1/themes REST response. */
-    private static List<ThemeModel> createThemeListFromWPComResponse(MultipleWPComThemesResponse response) {
-        List<ThemeModel> themeList = new ArrayList<>();
-        for (ThemeWPComResponse item : response.themes.values()) {
+    private static List<ThemeModel> createThemeListFromWPComResponse(WPComThemeMapResponse response) {
+        final List<ThemeModel> themeList = new ArrayList<>();
+        for (WPComThemeResponse item : response.themes.values()) {
             themeList.add(createThemeFromWPComResponse(item));
         }
         return themeList;
     }
 
-    private static List<ThemeModel> createThemeListFromArrayResponse(ThemeArrayResponse response) {
-        List<ThemeModel> themeList = new ArrayList<>();
-        for (ThemeWPComResponse item : response.themes) {
+    private static List<ThemeModel> createThemeListFromArrayResponse(ThemeListResponse response) {
+        final List<ThemeModel> themeList = new ArrayList<>();
+        for (WPComThemeResponse item : response.themes) {
             themeList.add(createThemeFromWPComResponse(item));
         }
         return themeList;
     }
 
     /** Creates a list of ThemeModels from the Jetpack /v1/sites/$siteId/themes REST response. */
-    private static List<ThemeModel> createThemeListFromJetpackResponse(MultipleJetpackThemesResponse response) {
-        List<ThemeModel> themeList = new ArrayList<>();
-        for (ThemeJetpackResponse item : response.themes) {
+    private static List<ThemeModel> createThemeListFromJetpackResponse(JetpackThemeListResponse response) {
+        final List<ThemeModel> themeList = new ArrayList<>();
+        for (JetpackThemeResponse item : response.themes) {
             themeList.add(createThemeFromJetpackResponse(item));
         }
         return themeList;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeListResponse;
-import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeMapResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
 import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
@@ -174,30 +173,6 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** Endpoint: v1.2/site/$siteId/themes */
-    public void fetchWpComSiteThemes(@NonNull final SiteModel site) {
-        String url = WPCOMREST.sites.site(site.getSiteId()).themes.getUrlV1_2();
-        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeMapResponse.class,
-                new Response.Listener<WPComThemeMapResponse>() {
-                    @Override
-                    public void onResponse(WPComThemeMapResponse response) {
-                        AppLog.d(AppLog.T.API, "Received response to themes fetch request for WP.com site.");
-                        FetchedThemesPayload payload =
-                                new FetchedThemesPayload(site, createThemeListFromWPComResponse(response));
-                        mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
-                    }
-                }, new BaseRequest.BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(AppLog.T.API, "Received error response to themes fetch request for WP.com site.");
-                        ThemesError themeError = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
-                        FetchedThemesPayload payload = new FetchedThemesPayload(themeError);
-                        mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
-                    }
-                }));
-    }
-
     /** Endpoint: v1.1/site/$siteId/themes/mine; same endpoint for both Jetpack and WP.com sites */
     public void fetchCurrentTheme(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.mine.getUrlV1_1();
@@ -288,15 +263,6 @@ public class ThemeRestClient extends BaseWPComRestClient {
         theme.setScreenshotUrl(screenshotUrl);
 
         return theme;
-    }
-
-    /** Creates a list of ThemeModels from the WP.com /v1.1/themes REST response. */
-    private static List<ThemeModel> createThemeListFromWPComResponse(WPComThemeMapResponse response) {
-        final List<ThemeModel> themeList = new ArrayList<>();
-        for (WPComThemeResponse item : response.themes.values()) {
-            themeList.add(createThemeFromWPComResponse(item));
-        }
-        return themeList;
     }
 
     private static List<ThemeModel> createThemeListFromArrayResponse(WPComThemeListResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeWPComResponse.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 import java.util.List;
 import java.util.Map;
 
+@SuppressWarnings("WeakerAccess")
 public class ThemeWPComResponse {
     public class MultipleWPComThemesResponse {
         public Map<String, ThemeWPComResponse> themes;
@@ -22,14 +23,8 @@ public class ThemeWPComResponse {
     public String theme_uri;
     public String demo_uri;
     public String version;
-    public String template;
     public String screenshot;
     public String description;
-    public String date_launched;
-    public String date_updated;
-    public String language;
     public String download_uri;
     public String price;
-    public int rank_popularity;
-    public int rank_trending;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -10,7 +10,7 @@ public class WPComThemeResponse {
         public int count;
     }
 
-    public class ThemeListResponse {
+    public class WPComThemeListResponse {
         public List<WPComThemeResponse> themes;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -4,14 +4,14 @@ import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("WeakerAccess")
-public class ThemeWPComResponse {
-    public class MultipleWPComThemesResponse {
-        public Map<String, ThemeWPComResponse> themes;
+public class WPComThemeResponse {
+    public class WPComThemeMapResponse {
+        public Map<String, WPComThemeResponse> themes;
         public int count;
     }
 
-    public class ThemeArrayResponse {
-        public List<ThemeWPComResponse> themes;
+    public class ThemeListResponse {
+        public List<WPComThemeResponse> themes;
     }
 
     public String id;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -1,15 +1,9 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 
 import java.util.List;
-import java.util.Map;
 
 @SuppressWarnings("WeakerAccess")
 public class WPComThemeResponse {
-    public class WPComThemeMapResponse {
-        public Map<String, WPComThemeResponse> themes;
-        public int count;
-    }
-
     public class WPComThemeListResponse {
         public List<WPComThemeResponse> themes;
     }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -53,7 +53,6 @@
 /sites/$site/taxonomies/$taxonomy#String/terms/slug:$slug#String/
 
 /themes
-/sites/$site/themes
 /sites/$site/themes/mine
 /sites/$site/themes/$theme_ID#String/delete
 /sites/$site/themes/$theme_ID#String/install


### PR DESCRIPTION
Not-so-small-but-definitely-minor PR that removes unused REST response fields, fixes class warnings (via suppression), and renames the response classes for readability.

cc @oguzkocer 