### PR TITLE
Update Travis build to only unit test release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 script:
   - ./gradlew assembleDebug assembleRelease
-  - ./gradlew test
+  - ./gradlew testRelease
   - ./gradlew lint || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1)
   - ./gradlew checkstyle
   - ./gradlew ktlint


### PR DESCRIPTION
Builds were very slow earlier. Maybe limiting the unit testing to the release branch will help?

cc @aforcier, @maxme; any benefits of running the tests on variants other than the one we ship with?