### PR TITLE
Move DebugOkHttpClient to core FluxC

### DIFF
--- a/example/src/debug/java/org/wordpress/android/fluxc/example/di/AppComponentDebug.kt
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/di/AppComponentDebug.kt
@@ -15,6 +15,7 @@ import javax.inject.Singleton
         ApplicationModule::class,
         AppSecretsModule::class,
         DebugOkHttpClientModule::class,
+        InterceptorModule::class,
         ReleaseBaseModule::class,
         ReleaseNetworkModule::class,
         MainActivityModule::class))

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/di/AppComponentDebug.kt
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/di/AppComponentDebug.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
+import org.wordpress.android.fluxc.module.DebugOkHttpClientModule
 import org.wordpress.android.fluxc.module.ReleaseBaseModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
 import javax.inject.Singleton

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/di/DebugOkHttpClientModule.java
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/di/DebugOkHttpClientModule.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.example.di;
 
-import com.facebook.stetho.okhttp3.StethoInterceptor;
-
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.util.AppLog;
@@ -20,19 +18,21 @@ import javax.net.ssl.TrustManager;
 
 import dagger.Module;
 import dagger.Provides;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 
 @Module
 public class DebugOkHttpClientModule {
     @Provides
     @Named("regular")
-    public OkHttpClient.Builder provideOkHttpClientBuilder() {
-        return new OkHttpClient.Builder().addNetworkInterceptor(new StethoInterceptor());
+    public OkHttpClient.Builder provideOkHttpClientBuilder(Interceptor interceptor) {
+        return new OkHttpClient.Builder().addNetworkInterceptor(interceptor);
     }
 
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(MemorizingTrustManager memorizingTrustManager) {
+    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(MemorizingTrustManager memorizingTrustManager,
+                                                                    Interceptor interceptor) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -42,7 +42,7 @@ public class DebugOkHttpClientModule {
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             AppLog.e(T.API, e);
         }
-        builder.addNetworkInterceptor(new StethoInterceptor());
+        builder.addNetworkInterceptor(interceptor);
         return builder;
     }
 

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/di/InterceptorModule.kt
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/di/InterceptorModule.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.fluxc.example.di
+
+import com.facebook.stetho.okhttp3.StethoInterceptor
+
+import dagger.Module
+import dagger.Provides
+import okhttp3.Interceptor
+
+@Module
+class InterceptorModule {
+    @Provides
+    fun provideNetworkInterceptor(): Interceptor = StethoInterceptor()
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.example.di;
+package org.wordpress.android.fluxc.module;
 
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;


### PR DESCRIPTION
Makes `DebugOkHttpClient` more generic and moves it to core FluxC (it was previously part of the example app). This allows other FluxC clients to use debug builds with interceptors without duplicating the code in `DebugOkHttpClient`.