### PR TITLE
Add Stetho to Instaflux

### DIFF
--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -71,4 +71,5 @@ dependencies {
 
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'
+    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
 }

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -68,4 +68,7 @@ dependencies {
     implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     compileOnly 'org.glassfish:javax.annotation:10.0-b28'
+
+    // Debug dependencies
+    debugImplementation 'com.facebook.stetho:stetho:1.5.0'
 }

--- a/instaflux/src/debug/AndroidManifest.xml
+++ b/instaflux/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest package="org.wordpress.android.fluxc.instaflux"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:name=".InstafluxDebugApp"
+        tools:replace="android:name" />
+
+</manifest>

--- a/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/AppComponentDebug.java
+++ b/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/AppComponentDebug.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.fluxc.instaflux;
 
 import org.wordpress.android.fluxc.module.AppContextModule;
+import org.wordpress.android.fluxc.module.DebugOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
-import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 
 import javax.inject.Singleton;
 
@@ -13,7 +13,8 @@ import dagger.Component;
 @Component(modules = {
         AppContextModule.class,
         AppSecretsModule.class,
-        ReleaseOkHttpClientModule.class,
+        DebugOkHttpClientModule.class,
+        InterceptorModule.class,
         ReleaseBaseModule.class,
         ReleaseNetworkModule.class
 })

--- a/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/AppComponentDebug.java
+++ b/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/AppComponentDebug.java
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.instaflux;
+
+import org.wordpress.android.fluxc.module.AppContextModule;
+import org.wordpress.android.fluxc.module.ReleaseBaseModule;
+import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
+import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+
+@Singleton
+@Component(modules = {
+        AppContextModule.class,
+        AppSecretsModule.class,
+        ReleaseOkHttpClientModule.class,
+        ReleaseBaseModule.class,
+        ReleaseNetworkModule.class
+})
+public interface AppComponentDebug extends AppComponent {}

--- a/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/InstafluxDebugApp.java
+++ b/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/InstafluxDebugApp.java
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.instaflux;
+
+import org.wordpress.android.fluxc.module.AppContextModule;
+
+public class InstafluxDebugApp extends InstafluxApp {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        initDaggerComponent();
+    }
+
+    protected void initDaggerComponent() {
+        mComponent = DaggerAppComponentDebug.builder()
+                .appContextModule(new AppContextModule(getApplicationContext()))
+                .build();
+    }
+}

--- a/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/InstafluxDebugApp.java
+++ b/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/InstafluxDebugApp.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.instaflux;
 
+import com.facebook.stetho.Stetho;
+
 import org.wordpress.android.fluxc.module.AppContextModule;
 
 public class InstafluxDebugApp extends InstafluxApp {
@@ -7,6 +9,7 @@ public class InstafluxDebugApp extends InstafluxApp {
     public void onCreate() {
         super.onCreate();
         initDaggerComponent();
+        Stetho.initializeWithDefaults(this);
     }
 
     protected void initDaggerComponent() {

--- a/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/InterceptorModule.java
+++ b/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/InterceptorModule.java
@@ -1,0 +1,15 @@
+package org.wordpress.android.fluxc.instaflux;
+
+import com.facebook.stetho.okhttp3.StethoInterceptor;
+
+import dagger.Module;
+import dagger.Provides;
+import okhttp3.Interceptor;
+
+@Module
+public class InterceptorModule {
+    @Provides
+    public Interceptor provideNetworkInterceptor() {
+        return new StethoInterceptor();
+    }
+}

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/InstafluxApp.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/InstafluxApp.java
@@ -8,19 +8,23 @@ import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 
 public class InstafluxApp extends Application {
-    private AppComponent mComponent;
+    protected AppComponent mComponent;
 
     @Override
     public void onCreate() {
         super.onCreate();
-        mComponent = DaggerAppComponent.builder()
-                .appContextModule(new AppContextModule(getApplicationContext()))
-                .build();
+        initDaggerComponent();
         component().inject(this);
         WellSql.init(new WellSqlConfig(getApplicationContext()));
     }
 
     public AppComponent component() {
         return mComponent;
+    }
+
+    protected void initDaggerComponent() {
+        mComponent = DaggerAppComponent.builder()
+                .appContextModule(new AppContextModule(getApplicationContext()))
+                .build();
     }
 }


### PR DESCRIPTION
Adds Stetho to Instaflux for inspecting the database and network requests through Chrome inspection. I've found this useful while working on the WooCommerce plugin, since Instaflux is not importing that and I can test database config differences and so on without leaving the FluxC repo.

Relies on #628, which moves `DebugOkHttpClient` to core FluxC so it can be reused.