### PR TITLE
Update plugin version

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginSqlUtilsTest.java
@@ -40,7 +40,7 @@ public class PluginSqlUtilsTest {
     @Test
     public void testInsertNullSitePlugin() {
         SiteModel site = getTestSite();
-        Assert.assertEquals(0, PluginSqlUtils.insertOrUpdateSitePlugin(site, null));
+        Assert.assertEquals(0, PluginSqlUtils.insertOrUpdateSitePlugin(null));
         Assert.assertTrue(PluginSqlUtils.getSitePlugins(site).isEmpty());
     }
 
@@ -52,7 +52,7 @@ public class PluginSqlUtilsTest {
         PluginModel plugin = getTestPlugin(name);
 
         // Insert the plugin and assert that it was successful
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin));
         List<PluginModel> sitePlugins = PluginSqlUtils.getSitePlugins(site);
         Assert.assertEquals(1, sitePlugins.size());
 
@@ -72,7 +72,7 @@ public class PluginSqlUtilsTest {
         // First install a plugin and retrieve the DB copy
         PluginModel plugin = getTestPlugin(name);
         plugin.setDisplayName(displayName);
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin));
         List<PluginModel> sitePlugins = PluginSqlUtils.getSitePlugins(site);
         Assert.assertEquals(1, sitePlugins.size());
         PluginModel insertedPlugin = sitePlugins.get(0);
@@ -81,7 +81,7 @@ public class PluginSqlUtilsTest {
         // Then, update the plugin's display name
         String newDisplayName = randomString("newDisplayName");
         insertedPlugin.setDisplayName(newDisplayName);
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, insertedPlugin));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(insertedPlugin));
 
         // Assert that we still have only one plugin in DB and it has the new display name
         List<PluginModel> updatedSitePluginList = PluginSqlUtils.getSitePlugins(site);
@@ -137,7 +137,7 @@ public class PluginSqlUtilsTest {
         PluginModel plugin = getTestPlugin(name);
 
         // Insert the plugin and verify that site plugin size is 1
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin));
         Assert.assertEquals(1, PluginSqlUtils.getSitePlugins(site).size());
 
         // Delete the plugin and verify that site plugin list is empty
@@ -160,8 +160,8 @@ public class PluginSqlUtilsTest {
         plugin2.setDisplayName(displayName2);
 
         // Insert the plugins and verify that site plugin size is 2
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin1));
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin2));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin1));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin2));
         Assert.assertEquals(2, PluginSqlUtils.getSitePlugins(site).size());
 
         // Assert that getSitePluginByName retrieves the correct plugins
@@ -191,7 +191,7 @@ public class PluginSqlUtilsTest {
             String name = randomString("name");
             pluginNames.add(name);
             PluginModel plugin = getTestPlugin(name);
-            Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin));
+            Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin));
         }
         return pluginNames;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -11,7 +11,9 @@ import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginVersionPayload;
 
 @ActionEnum
 public enum PluginAction implements IAction {
@@ -26,6 +28,8 @@ public enum PluginAction implements IAction {
     INSTALL_SITE_PLUGIN,
     @Action(payloadType = UpdateSitePluginPayload.class)
     UPDATE_SITE_PLUGIN,
+    @Action(payloadType = UpdateSitePluginVersionPayload.class)
+    UPDATE_SITE_PLUGIN_VERSION,
 
     // Remote responses
     @Action(payloadType = DeletedSitePluginPayload.class)
@@ -37,5 +41,7 @@ public enum PluginAction implements IAction {
     @Action(payloadType = InstalledSitePluginPayload.class)
     INSTALLED_SITE_PLUGIN,
     @Action(payloadType = UpdatedSitePluginPayload.class)
-    UPDATED_SITE_PLUGIN
+    UPDATED_SITE_PLUGIN,
+    @Action(payloadType = UpdatedSitePluginVersionPayload.class)
+    UPDATED_SITE_PLUGIN_VERSION
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -95,9 +95,10 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
-                        PluginModel pluginModel = pluginModelFromResponse(site, response);
+                        PluginModel pluginFromResponse = pluginModelFromResponse(site, response);
+                        pluginFromResponse.setId(plugin.getId());
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(
-                                new UpdatedSitePluginPayload(site, pluginModel)));
+                                new UpdatedSitePluginPayload(site, pluginFromResponse)));
                     }
                 },
                 new BaseErrorListener() {
@@ -124,9 +125,10 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
-                        PluginModel pluginModel = pluginModelFromResponse(site, response);
+                        PluginModel pluginFromResponse = pluginModelFromResponse(site, response);
+                        pluginFromResponse.setId(plugin.getId());
                         mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(
-                                new DeletedSitePluginPayload(site, pluginModel)));
+                                new DeletedSitePluginPayload(site, pluginFromResponse)));
                     }
                 },
                 new BaseErrorListener() {
@@ -152,9 +154,9 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
-                        PluginModel pluginModel = pluginModelFromResponse(site, response);
+                        PluginModel pluginFromResponse = pluginModelFromResponse(site, response);
                         mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(
-                                new InstalledSitePluginPayload(site, pluginModel)));
+                                new InstalledSitePluginPayload(site, pluginFromResponse)));
                     }
                 },
                 new BaseErrorListener() {
@@ -188,9 +190,10 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
-                        PluginModel pluginModel = pluginModelFromResponse(site, response);
+                        PluginModel pluginFromResponse = pluginModelFromResponse(site, response);
+                        pluginFromResponse.setId(plugin.getId());
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginVersionAction(
-                                new UpdatedSitePluginVersionPayload(site, pluginModel)));
+                                new UpdatedSitePluginVersionPayload(site, pluginFromResponse)));
                     }
                 },
                 new BaseErrorListener() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -30,7 +30,10 @@ import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginErrorType;
+import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionError;
+import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginVersionPayload;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -185,13 +188,22 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
-                        // TODO
+                        PluginModel pluginModel = pluginModelFromResponse(site, response);
+                        mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginVersionAction(
+                                new UpdatedSitePluginVersionPayload(site, pluginModel)));
                     }
                 },
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        // TODO
+                        UpdateSitePluginVersionError updatePluginVersionError
+                                = new UpdateSitePluginVersionError(UpdateSitePluginVersionErrorType.GENERIC_ERROR);
+                        updatePluginVersionError.type = UpdateSitePluginVersionErrorType
+                                .valueOf(((WPComGsonNetworkError) networkError).apiError.toUpperCase(Locale.ENGLISH));
+                        updatePluginVersionError.message = networkError.message;
+                        UpdatedSitePluginVersionPayload payload = new UpdatedSitePluginVersionPayload(site,
+                                updatePluginVersionError);
+                        mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginVersionAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -20,18 +20,13 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginWPComRestResponse.FetchPluginsResponse;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginError;
-import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginsError;
-import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginsErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError;
-import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginError;
-import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionError;
-import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginVersionPayload;
 
@@ -73,11 +68,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        FetchSitePluginsError fetchPluginsError
-                                = new FetchSitePluginsError(FetchSitePluginsErrorType.GENERIC_ERROR);
-                        fetchPluginsError.type = FetchSitePluginsErrorType.fromString(((WPComGsonNetworkError)
-                                networkError).apiError);
-                        fetchPluginsError.message = networkError.message;
+                        FetchSitePluginsError fetchPluginsError = new FetchSitePluginsError(((WPComGsonNetworkError)
+                                networkError).apiError, networkError.message);
                         FetchedSitePluginsPayload payload = new FetchedSitePluginsPayload(fetchPluginsError);
                         mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginsAction(payload));
                     }
@@ -103,11 +95,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        UpdateSitePluginError updatePluginError
-                                = new UpdateSitePluginError(UpdateSitePluginErrorType.GENERIC_ERROR);
-                        updatePluginError.type = UpdateSitePluginErrorType.fromString(((WPComGsonNetworkError)
-                                networkError).apiError);
-                        updatePluginError.message = networkError.message;
+                        UpdateSitePluginError updatePluginError = new UpdateSitePluginError(((WPComGsonNetworkError)
+                                networkError).apiError, networkError.message);
                         UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));
                     }
@@ -133,11 +122,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        DeleteSitePluginError deletePluginError
-                                = new DeleteSitePluginError(DeleteSitePluginErrorType.GENERIC_ERROR);
-                        deletePluginError.type = DeleteSitePluginErrorType.fromString(((WPComGsonNetworkError)
-                                networkError).apiError);
-                        deletePluginError.message = networkError.message;
+                        DeleteSitePluginError deletePluginError = new DeleteSitePluginError(((WPComGsonNetworkError)
+                                networkError).apiError, networkError.message);
                         DeletedSitePluginPayload payload = new DeletedSitePluginPayload(site, deletePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(payload));
                     }
@@ -161,11 +147,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        InstallSitePluginError installPluginError
-                                = new InstallSitePluginError(InstallSitePluginErrorType.GENERIC_ERROR);
-                        installPluginError.type = InstallSitePluginErrorType.fromString(((WPComGsonNetworkError)
-                                networkError).apiError);
-                        installPluginError.message = networkError.message;
+                        InstallSitePluginError installPluginError = new InstallSitePluginError(((WPComGsonNetworkError)
+                                networkError).apiError, networkError.message);
                         InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, installPluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(payload));
                     }
@@ -192,10 +175,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         UpdateSitePluginVersionError updatePluginVersionError
-                                = new UpdateSitePluginVersionError(UpdateSitePluginVersionErrorType.GENERIC_ERROR);
-                        updatePluginVersionError.type = UpdateSitePluginVersionErrorType
-                                .fromString(((WPComGsonNetworkError) networkError).apiError);
-                        updatePluginVersionError.message = networkError.message;
+                                = new UpdateSitePluginVersionError(((WPComGsonNetworkError) networkError).apiError,
+                                networkError.message);
                         UpdatedSitePluginVersionPayload payload = new UpdatedSitePluginVersionPayload(site,
                                 updatePluginVersionError);
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginVersionAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -40,7 +40,6 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import javax.inject.Inject;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -76,8 +76,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         FetchSitePluginsError fetchPluginsError
                                 = new FetchSitePluginsError(FetchSitePluginsErrorType.GENERIC_ERROR);
-                        fetchPluginsError.type = FetchSitePluginsErrorType.valueOf(((WPComGsonNetworkError)
-                                networkError).apiError.toUpperCase(Locale.ENGLISH));
+                        fetchPluginsError.type = FetchSitePluginsErrorType.fromString(((WPComGsonNetworkError)
+                                networkError).apiError);
                         fetchPluginsError.message = networkError.message;
                         FetchedSitePluginsPayload payload = new FetchedSitePluginsPayload(fetchPluginsError);
                         mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginsAction(payload));
@@ -106,8 +106,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         UpdateSitePluginError updatePluginError
                                 = new UpdateSitePluginError(UpdateSitePluginErrorType.GENERIC_ERROR);
-                        updatePluginError.type = UpdateSitePluginErrorType.valueOf(((WPComGsonNetworkError)
-                                networkError).apiError.toUpperCase(Locale.ENGLISH));
+                        updatePluginError.type = UpdateSitePluginErrorType.fromString(((WPComGsonNetworkError)
+                                networkError).apiError);
                         updatePluginError.message = networkError.message;
                         UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));
@@ -136,8 +136,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         DeleteSitePluginError deletePluginError
                                 = new DeleteSitePluginError(DeleteSitePluginErrorType.GENERIC_ERROR);
-                        deletePluginError.type = DeleteSitePluginErrorType.valueOf(((WPComGsonNetworkError)
-                                networkError).apiError.toUpperCase(Locale.ENGLISH));
+                        deletePluginError.type = DeleteSitePluginErrorType.fromString(((WPComGsonNetworkError)
+                                networkError).apiError);
                         deletePluginError.message = networkError.message;
                         DeletedSitePluginPayload payload = new DeletedSitePluginPayload(site, deletePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(payload));
@@ -164,15 +164,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         InstallSitePluginError installPluginError
                                 = new InstallSitePluginError(InstallSitePluginErrorType.GENERIC_ERROR);
-                        if (networkError instanceof WPComGsonNetworkError) {
-                            String apiError = ((WPComGsonNetworkError) networkError).apiError;
-                            if (apiError.equals("local-file-does-not-exist")) {
-                                installPluginError.type = InstallSitePluginErrorType.LOCAL_FILE_DOES_NOT_EXIST;
-                            } else {
-                                installPluginError.type = InstallSitePluginErrorType
-                                        .valueOf(apiError.toUpperCase(Locale.ENGLISH));
-                            }
-                        }
+                        installPluginError.type = InstallSitePluginErrorType.fromString(((WPComGsonNetworkError)
+                                networkError).apiError);
                         installPluginError.message = networkError.message;
                         InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, installPluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(payload));
@@ -202,7 +195,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         UpdateSitePluginVersionError updatePluginVersionError
                                 = new UpdateSitePluginVersionError(UpdateSitePluginVersionErrorType.GENERIC_ERROR);
                         updatePluginVersionError.type = UpdateSitePluginVersionErrorType
-                                .valueOf(((WPComGsonNetworkError) networkError).apiError.toUpperCase(Locale.ENGLISH));
+                                .fromString(((WPComGsonNetworkError) networkError).apiError);
                         updatePluginVersionError.message = networkError.message;
                         UpdatedSitePluginVersionPayload payload = new UpdatedSitePluginVersionPayload(site,
                                 updatePluginVersionError);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -177,6 +177,27 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void updateSitePluginVersion(@NonNull final SiteModel site, @NonNull final PluginModel plugin) {
+        String url = WPCOMREST.sites.site(site.getSiteId()).
+                plugins.name(getEncodedPluginName(plugin)).update.getUrlV1_2();
+        final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
+                PluginWPComRestResponse.class,
+                new Listener<PluginWPComRestResponse>() {
+                    @Override
+                    public void onResponse(PluginWPComRestResponse response) {
+                        // TODO
+                    }
+                },
+                new BaseErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull BaseNetworkError networkError) {
+                        // TODO
+                    }
+                }
+        );
+        add(request);
+    }
+
     private PluginModel pluginModelFromResponse(SiteModel siteModel, PluginWPComRestResponse response) {
         PluginModel pluginModel = new PluginModel();
         pluginModel.setLocalSiteId(siteModel.getId());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -37,17 +37,20 @@ public class PluginSqlUtils {
                 .endWhere().execute();
     }
 
-    public static int insertOrUpdateSitePlugin(SiteModel site, PluginModel plugin) {
+    public static int insertOrUpdateSitePlugin(PluginModel plugin) {
         if (plugin == null) {
             return 0;
         }
 
-        PluginModel oldPlugin = getSitePluginByName(site, plugin.getName());
-        if (oldPlugin == null) {
+        List<PluginModel> pluginResult = WellSql.select(PluginModel.class)
+                .where()
+                .equals(PluginModelTable.ID, plugin.getId())
+                .endWhere().getAsModel();
+        if (pluginResult.isEmpty()) {
             WellSql.insert(plugin).execute();
             return 1;
         } else {
-            int oldId = oldPlugin.getId();
+            int oldId = plugin.getId();
             return WellSql.update(PluginModel.class).whereId(oldId)
                     .put(plugin, new UpdateAllExceptId<>(PluginModel.class)).execute();
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -223,18 +223,51 @@ public class PluginStore extends Store {
         UNAUTHORIZED,
         DELETE_PLUGIN_ERROR,
         NOT_AVAILABLE, // Return for non-jetpack sites
-        UNKNOWN_PLUGIN
+        UNKNOWN_PLUGIN;
+
+        public static DeleteSitePluginErrorType fromString(String string) {
+            if (string != null) {
+                for (DeleteSitePluginErrorType v : DeleteSitePluginErrorType.values()) {
+                    if (string.equalsIgnoreCase(v.name())) {
+                        return v;
+                    }
+                }
+            }
+            return GENERIC_ERROR;
+        }
     }
 
     public enum FetchPluginInfoErrorType {
         EMPTY_RESPONSE,
-        GENERIC_ERROR
+        GENERIC_ERROR;
+
+        public static FetchPluginInfoErrorType fromString(String string) {
+            if (string != null) {
+                for (FetchPluginInfoErrorType v : FetchPluginInfoErrorType.values()) {
+                    if (string.equalsIgnoreCase(v.name())) {
+                        return v;
+                    }
+                }
+            }
+            return GENERIC_ERROR;
+        }
     }
 
     public enum FetchSitePluginsErrorType {
         GENERIC_ERROR,
         UNAUTHORIZED,
-        NOT_AVAILABLE // Return for non-jetpack sites
+        NOT_AVAILABLE; // Return for non-jetpack sites
+
+        public static FetchSitePluginsErrorType fromString(String string) {
+            if (string != null) {
+                for (FetchSitePluginsErrorType v : FetchSitePluginsErrorType.values()) {
+                    if (string.equalsIgnoreCase(v.name())) {
+                        return v;
+                    }
+                }
+            }
+            return GENERIC_ERROR;
+        }
     }
 
     public enum InstallSitePluginErrorType {
@@ -245,7 +278,21 @@ public class PluginStore extends Store {
         NO_PLUGIN_INSTALLED,
         NOT_AVAILABLE, // Return for non-jetpack sites
         PLUGIN_ALREADY_INSTALLED,
-        UNAUTHORIZED
+        UNAUTHORIZED;
+
+        public static InstallSitePluginErrorType fromString(String string) {
+            if (string != null) {
+                if (string.equalsIgnoreCase("local-file-does-not-exist")) {
+                    return LOCAL_FILE_DOES_NOT_EXIST;
+                }
+                for (InstallSitePluginErrorType v : InstallSitePluginErrorType.values()) {
+                    if (string.equalsIgnoreCase(v.name())) {
+                        return v;
+                    }
+                }
+            }
+            return GENERIC_ERROR;
+        }
     }
 
     public enum UpdateSitePluginErrorType {
@@ -254,13 +301,35 @@ public class PluginStore extends Store {
         DEACTIVATION_ERROR,
         NOT_AVAILABLE, // Return for non-jetpack sites
         UNAUTHORIZED,
-        UNKNOWN_PLUGIN
+        UNKNOWN_PLUGIN;
+
+        public static UpdateSitePluginErrorType fromString(String string) {
+            if (string != null) {
+                for (UpdateSitePluginErrorType v : UpdateSitePluginErrorType.values()) {
+                    if (string.equalsIgnoreCase(v.name())) {
+                        return v;
+                    }
+                }
+            }
+            return GENERIC_ERROR;
+        }
     }
 
     public enum UpdateSitePluginVersionErrorType {
         GENERIC_ERROR,
         NOT_AVAILABLE, // Return for non-jetpack sites
-        UPDATE_FAIL
+        UPDATE_FAIL;
+
+        public static UpdateSitePluginVersionErrorType fromString(String string) {
+            if (string != null) {
+                for (UpdateSitePluginVersionErrorType v : UpdateSitePluginVersionErrorType.values()) {
+                    if (string.equalsIgnoreCase(v.name())) {
+                        return v;
+                    }
+                }
+            }
+            return GENERIC_ERROR;
+        }
     }
 
     // OnChanged Events

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -239,18 +239,7 @@ public class PluginStore extends Store {
 
     public enum FetchPluginInfoErrorType {
         EMPTY_RESPONSE,
-        GENERIC_ERROR;
-
-        public static FetchPluginInfoErrorType fromString(String string) {
-            if (string != null) {
-                for (FetchPluginInfoErrorType v : FetchPluginInfoErrorType.values()) {
-                    if (string.equalsIgnoreCase(v.name())) {
-                        return v;
-                    }
-                }
-            }
-            return GENERIC_ERROR;
-        }
+        GENERIC_ERROR
     }
 
     public enum FetchSitePluginsErrorType {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -480,7 +480,6 @@ public class PluginStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            payload.plugin.setLocalSiteId(payload.site.getId());
             event.plugin = payload.plugin;
             PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
         }
@@ -492,7 +491,6 @@ public class PluginStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            payload.plugin.setLocalSiteId(payload.site.getId());
             event.plugin = payload.plugin;
             PluginSqlUtils.deleteSitePlugin(payload.site, payload.plugin);
         }
@@ -504,7 +502,6 @@ public class PluginStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            payload.plugin.setLocalSiteId(payload.site.getId());
             event.plugin = payload.plugin;
             PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -57,6 +57,16 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class UpdateSitePluginVersionPayload extends Payload<BaseNetworkError> {
+        public SiteModel site;
+        public PluginModel plugin;
+
+        public UpdateSitePluginVersionPayload(SiteModel site, PluginModel plugin) {
+            this.site = site;
+            this.plugin = plugin;
+        }
+    }
+
     // Response payloads
 
     public static class DeletedSitePluginPayload extends Payload<DeleteSitePluginError> {
@@ -131,6 +141,21 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class UpdatedSitePluginVersionPayload extends Payload<UpdateSitePluginVersionError> {
+        public SiteModel site;
+        public PluginModel plugin;
+
+        public UpdatedSitePluginVersionPayload(SiteModel site, PluginModel plugin) {
+            this.site = site;
+            this.plugin = plugin;
+        }
+
+        public UpdatedSitePluginVersionPayload(SiteModel site, UpdateSitePluginVersionError error) {
+            this.site = site;
+            this.error = error;
+        }
+    }
+
     // Errors
 
     public static class DeleteSitePluginError implements OnChangedError {
@@ -182,6 +207,15 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class UpdateSitePluginVersionError implements OnChangedError {
+        public UpdateSitePluginVersionErrorType type;
+        public String message;
+
+        public UpdateSitePluginVersionError(UpdateSitePluginVersionErrorType type) {
+            this.type = type;
+        }
+    }
+
     // Error types
 
     public enum DeleteSitePluginErrorType {
@@ -221,6 +255,12 @@ public class PluginStore extends Store {
         NOT_AVAILABLE, // Return for non-jetpack sites
         UNAUTHORIZED,
         UNKNOWN_PLUGIN
+    }
+
+    public enum UpdateSitePluginVersionErrorType {
+        GENERIC_ERROR,
+        NOT_AVAILABLE, // Return for non-jetpack sites
+        UPDATE_FAILED
     }
 
     // OnChanged Events

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -470,7 +470,7 @@ public class PluginStore extends Store {
         } else {
             payload.plugin.setLocalSiteId(payload.site.getId());
             event.plugin = payload.plugin;
-            PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
+            PluginSqlUtils.insertOrUpdateSitePlugin(payload.plugin);
         }
         emitChange(event);
     }
@@ -481,7 +481,7 @@ public class PluginStore extends Store {
             event.error = payload.error;
         } else {
             event.plugin = payload.plugin;
-            PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
+            PluginSqlUtils.insertOrUpdateSitePlugin(payload.plugin);
         }
         emitChange(event);
     }
@@ -503,7 +503,7 @@ public class PluginStore extends Store {
             event.error = payload.error;
         } else {
             event.plugin = payload.plugin;
-            PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
+            PluginSqlUtils.insertOrUpdateSitePlugin(payload.plugin);
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -162,8 +162,13 @@ public class PluginStore extends Store {
         public DeleteSitePluginErrorType type;
         public String message;
 
-        public DeleteSitePluginError(DeleteSitePluginErrorType type) {
+        DeleteSitePluginError(DeleteSitePluginErrorType type) {
             this.type = type;
+        }
+
+        public DeleteSitePluginError(String type, String message) {
+            this.type = DeleteSitePluginErrorType.fromString(type);
+            this.message = message == null ? "" : message;
         }
     }
 
@@ -179,13 +184,13 @@ public class PluginStore extends Store {
         public FetchSitePluginsErrorType type;
         public String message;
 
-        public FetchSitePluginsError(FetchSitePluginsErrorType type) {
-            this(type, "");
+        FetchSitePluginsError(FetchSitePluginsErrorType type) {
+            this.type = type;
         }
 
-        FetchSitePluginsError(FetchSitePluginsErrorType type, String message) {
-            this.type = type;
-            this.message = message;
+        public FetchSitePluginsError(String type, String message) {
+            this.type = FetchSitePluginsErrorType.fromString(type);
+            this.message = message == null ? "" : message;
         }
     }
 
@@ -193,8 +198,13 @@ public class PluginStore extends Store {
         public InstallSitePluginErrorType type;
         public String message;
 
-        public InstallSitePluginError(InstallSitePluginErrorType type) {
+        InstallSitePluginError(InstallSitePluginErrorType type) {
             this.type = type;
+        }
+
+        public InstallSitePluginError(String type, String message) {
+            this.type = InstallSitePluginErrorType.fromString(type);
+            this.message = message == null ? "" : message;
         }
     }
 
@@ -202,8 +212,13 @@ public class PluginStore extends Store {
         public UpdateSitePluginErrorType type;
         public String message;
 
-        public UpdateSitePluginError(UpdateSitePluginErrorType type) {
+        UpdateSitePluginError(UpdateSitePluginErrorType type) {
             this.type = type;
+        }
+
+        public UpdateSitePluginError(String type, String message) {
+            this.type = UpdateSitePluginErrorType.fromString(type);
+            this.message = message == null ? "" : message;
         }
     }
 
@@ -211,8 +226,13 @@ public class PluginStore extends Store {
         public UpdateSitePluginVersionErrorType type;
         public String message;
 
-        public UpdateSitePluginVersionError(UpdateSitePluginVersionErrorType type) {
+        UpdateSitePluginVersionError(UpdateSitePluginVersionErrorType type) {
             this.type = type;
+        }
+
+        public UpdateSitePluginVersionError(String type, String message) {
+            this.type = UpdateSitePluginVersionErrorType.fromString(type);
+            this.message = message == null ? "" : message;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -260,7 +260,7 @@ public class PluginStore extends Store {
     public enum UpdateSitePluginVersionErrorType {
         GENERIC_ERROR,
         NOT_AVAILABLE, // Return for non-jetpack sites
-        UPDATE_FAILED
+        UPDATE_FAIL
     }
 
     // OnChanged Events

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -413,7 +413,7 @@ public class PluginStore extends Store {
 
     private void updateSitePluginVersion(UpdateSitePluginVersionPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.updateSitePlugin(payload.site, payload.plugin);
+            mPluginRestClient.updateSitePluginVersion(payload.site, payload.plugin);
         } else {
             UpdateSitePluginVersionError error = new UpdateSitePluginVersionError(
                     UpdateSitePluginVersionErrorType.NOT_AVAILABLE);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.store;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -160,7 +161,7 @@ public class PluginStore extends Store {
 
     public static class DeleteSitePluginError implements OnChangedError {
         public DeleteSitePluginErrorType type;
-        public String message;
+        @Nullable public String message;
 
         DeleteSitePluginError(DeleteSitePluginErrorType type) {
             this.type = type;
@@ -182,57 +183,57 @@ public class PluginStore extends Store {
 
     public static class FetchSitePluginsError implements OnChangedError {
         public FetchSitePluginsErrorType type;
-        public String message;
+        @Nullable public String message;
 
         FetchSitePluginsError(FetchSitePluginsErrorType type) {
             this.type = type;
         }
 
-        public FetchSitePluginsError(String type, String message) {
+        public FetchSitePluginsError(String type, @Nullable String message) {
             this.type = FetchSitePluginsErrorType.fromString(type);
-            this.message = message == null ? "" : message;
+            this.message = message;
         }
     }
 
     public static class InstallSitePluginError implements OnChangedError {
         public InstallSitePluginErrorType type;
-        public String message;
+        @Nullable public String message;
 
         InstallSitePluginError(InstallSitePluginErrorType type) {
             this.type = type;
         }
 
-        public InstallSitePluginError(String type, String message) {
+        public InstallSitePluginError(String type, @Nullable String message) {
             this.type = InstallSitePluginErrorType.fromString(type);
-            this.message = message == null ? "" : message;
+            this.message = message;
         }
     }
 
     public static class UpdateSitePluginError implements OnChangedError {
         public UpdateSitePluginErrorType type;
-        public String message;
+        @Nullable public String message;
 
         UpdateSitePluginError(UpdateSitePluginErrorType type) {
             this.type = type;
         }
 
-        public UpdateSitePluginError(String type, String message) {
+        public UpdateSitePluginError(String type, @Nullable String message) {
             this.type = UpdateSitePluginErrorType.fromString(type);
-            this.message = message == null ? "" : message;
+            this.message = message;
         }
     }
 
     public static class UpdateSitePluginVersionError implements OnChangedError {
         public UpdateSitePluginVersionErrorType type;
-        public String message;
+        @Nullable public String message;
 
         UpdateSitePluginVersionError(UpdateSitePluginVersionErrorType type) {
             this.type = type;
         }
 
-        public UpdateSitePluginVersionError(String type, String message) {
+        public UpdateSitePluginVersionError(String type, @Nullable String message) {
             this.type = UpdateSitePluginVersionErrorType.fromString(type);
-            this.message = message == null ? "" : message;
+            this.message = message;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -167,9 +167,9 @@ public class PluginStore extends Store {
             this.type = type;
         }
 
-        public DeleteSitePluginError(String type, String message) {
+        public DeleteSitePluginError(String type, @Nullable String message) {
             this.type = DeleteSitePluginErrorType.fromString(type);
-            this.message = message == null ? "" : message;
+            this.message = message;
         }
     }
 
@@ -367,6 +367,7 @@ public class PluginStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnSitePluginVersionUpdated extends OnChanged<UpdateSitePluginVersionError> {
         public SiteModel site;
         public PluginModel plugin;

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -40,6 +40,7 @@
 /sites/$site/plugins/$name#String
 /sites/$site/plugins/$name#String/delete
 /sites/$site/plugins/$name#String/install
+/sites/$site/plugins/$name#String/update
 
 /sites/$site/posts/
 /sites/$site/posts/$post_ID/


### PR DESCRIPTION
This PR adds the ability to update plugin versions. It follows the same pattern as all the other actions for `PluginStore`. I have two main worries about these changes:

1. `UPDATE_SITE_PLUGIN` and `UPDATE_SITE_PLUGIN_VERSION` are a bit too close to each other in terms of their meaning. Especially update plugin might be mistaken as updating it's version. Also, due to the name similarity of the actions there is a lot of methods/classes that has similar names now and using autocomplete is pretty hard for them within the library. I'd really like to change the `UPDATE_SITE_PLUGIN` name to something else, but I am not sure what would be a good name for it.
2. I don't see a good way to add a test for this feature. The problem is, there is no easy way to make sure an outdated plugin is installed on a site. I am not really comfortable leaving this feature untested, but an exploration for how to add this test could take some time, so I am suggesting adding a new issue for it and taking care of it when we have some extra time.

/cc @tonyr59h 