### PR TITLE
UPDATE_SITE_PLUGIN action renamed as CONFIGURE_SITE_PLUGIN

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -93,7 +93,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         UpdateSitePluginPayload payload = new UpdateSitePluginPayload(site, plugin);
-        mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
+        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -154,7 +154,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         UpdateSitePluginPayload payload = new UpdateSitePluginPayload(site, plugin);
-        mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
+        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -371,7 +371,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         plugin.setIsActive(false);
         UpdateSitePluginPayload payload = new UpdateSitePluginPayload(site, plugin);
-        mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
+        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -51,7 +51,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         SITE_CHANGED,
         SITE_REMOVED,
         UNKNOWN_PLUGIN,
-        UPDATED_PLUGIN
+        CONFIGURED_PLUGIN
     }
 
     private TestEvents mNextEvent;
@@ -77,7 +77,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
-    public void testUpdateSitePlugin() throws InterruptedException {
+    public void testConfigureSitePlugin() throws InterruptedException {
         // In order to have a reliable test, let's first fetch the list of plugins, pick the first plugin
         // and change it's active status, so we can make sure when we run the test multiple times, each time
         // an action is actually taken. This wouldn't be the case if we always activate the plugin.
@@ -89,7 +89,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         boolean isActive = !plugin.isActive();
         plugin.setIsActive(isActive);
 
-        mNextEvent = TestEvents.UPDATED_PLUGIN;
+        mNextEvent = TestEvents.CONFIGURED_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
 
         ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin);
@@ -248,7 +248,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
                         + event.error.type);
             }
         } else {
-            assertEquals(mNextEvent, TestEvents.UPDATED_PLUGIN);
+            assertEquals(mNextEvent, TestEvents.CONFIGURED_PLUGIN);
         }
         mCountDownLatch.countDown();
     }
@@ -366,7 +366,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     }
 
     private void deactivatePlugin(SiteModel site, PluginModel plugin) throws InterruptedException {
-        mNextEvent = TestEvents.UPDATED_PLUGIN;
+        mNextEvent = TestEvents.CONFIGURED_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
 
         plugin.setIsActive(false);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginsFetched;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginErrorType;
-import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
@@ -92,7 +92,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.UPDATED_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
 
-        UpdateSitePluginPayload payload = new UpdateSitePluginPayload(site, plugin);
+        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin);
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -153,7 +153,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.UNKNOWN_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
 
-        UpdateSitePluginPayload payload = new UpdateSitePluginPayload(site, plugin);
+        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin);
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -370,7 +370,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
 
         plugin.setIsActive(false);
-        UpdateSitePluginPayload payload = new UpdateSitePluginPayload(site, plugin);
+        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin);
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -22,7 +22,7 @@ import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginConfigured;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginsFetched;
-import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginErrorType;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
@@ -241,7 +241,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     public void onSitePluginConfigured(OnSitePluginConfigured event) {
         AppLog.i(T.API, "Received onSitePluginConfigured");
         if (event.isError()) {
-            if (event.error.type.equals(UpdateSitePluginErrorType.UNKNOWN_PLUGIN)) {
+            if (event.error.type.equals(ConfigureSitePluginErrorType.UNKNOWN_PLUGIN)) {
                 assertEquals(mNextEvent, TestEvents.UNKNOWN_PLUGIN);
             } else {
                 throw new AssertionError("Unexpected error occurred in onSitePluginConfigured with type: "

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -18,7 +18,7 @@ import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
-import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginUpdated;
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginConfigured;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginsFetched;
@@ -238,13 +238,13 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onSitePluginUpdated(OnSitePluginUpdated event) {
-        AppLog.i(T.API, "Received onSitePluginUpdated");
+    public void onSitePluginConfigured(OnSitePluginConfigured event) {
+        AppLog.i(T.API, "Received onSitePluginConfigured");
         if (event.isError()) {
             if (event.error.type.equals(UpdateSitePluginErrorType.UNKNOWN_PLUGIN)) {
                 assertEquals(mNextEvent, TestEvents.UNKNOWN_PLUGIN);
             } else {
-                throw new AssertionError("Unexpected error occurred in onSitePluginUpdated with type: "
+                throw new AssertionError("Unexpected error occurred in onSitePluginConfigured with type: "
                         + event.error.type);
             }
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -4,21 +4,21 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginInfoPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
-import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionPayload;
-import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginVersionPayload;
 
 @ActionEnum
 public enum PluginAction implements IAction {
     // Remote actions
-    @Action(payloadType = UpdateSitePluginPayload.class)
+    @Action(payloadType = ConfigureSitePluginPayload.class)
     CONFIGURE_SITE_PLUGIN,
     @Action(payloadType = DeleteSitePluginPayload.class)
     DELETE_SITE_PLUGIN,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionPayload;
-import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginVersionPayload;
 
 @ActionEnum
@@ -32,7 +32,7 @@ public enum PluginAction implements IAction {
     UPDATE_SITE_PLUGIN_VERSION,
 
     // Remote responses
-    @Action(payloadType = UpdatedSitePluginPayload.class)
+    @Action(payloadType = ConfiguredSitePluginPayload.class)
     CONFIGURED_SITE_PLUGIN,
     @Action(payloadType = DeletedSitePluginPayload.class)
     DELETED_SITE_PLUGIN,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -18,6 +18,8 @@ import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginVersionPay
 @ActionEnum
 public enum PluginAction implements IAction {
     // Remote actions
+    @Action(payloadType = UpdateSitePluginPayload.class)
+    CONFIGURE_SITE_PLUGIN,
     @Action(payloadType = DeleteSitePluginPayload.class)
     DELETE_SITE_PLUGIN,
     @Action(payloadType = String.class)
@@ -26,12 +28,12 @@ public enum PluginAction implements IAction {
     FETCH_SITE_PLUGINS,
     @Action(payloadType = InstallSitePluginPayload.class)
     INSTALL_SITE_PLUGIN,
-    @Action(payloadType = UpdateSitePluginPayload.class)
-    UPDATE_SITE_PLUGIN,
     @Action(payloadType = UpdateSitePluginVersionPayload.class)
     UPDATE_SITE_PLUGIN_VERSION,
 
     // Remote responses
+    @Action(payloadType = UpdatedSitePluginPayload.class)
+    CONFIGURED_SITE_PLUGIN,
     @Action(payloadType = DeletedSitePluginPayload.class)
     DELETED_SITE_PLUGIN,
     @Action(payloadType = FetchedPluginInfoPayload.class)
@@ -40,8 +42,6 @@ public enum PluginAction implements IAction {
     FETCHED_SITE_PLUGINS,
     @Action(payloadType = InstalledSitePluginPayload.class)
     INSTALLED_SITE_PLUGIN,
-    @Action(payloadType = UpdatedSitePluginPayload.class)
-    UPDATED_SITE_PLUGIN,
     @Action(payloadType = UpdatedSitePluginVersionPayload.class)
     UPDATED_SITE_PLUGIN_VERSION
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -88,7 +88,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onResponse(PluginWPComRestResponse response) {
                         PluginModel pluginFromResponse = pluginModelFromResponse(site, response);
                         pluginFromResponse.setId(plugin.getId());
-                        mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(
+                        mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(
                                 new UpdatedSitePluginPayload(site, pluginFromResponse)));
                     }
                 },
@@ -98,7 +98,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         UpdateSitePluginError updatePluginError = new UpdateSitePluginError(((WPComGsonNetworkError)
                                 networkError).apiError, networkError.message);
                         UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, updatePluginError);
-                        mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));
+                        mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginWPComRestResponse.FetchPluginsResponse;
-import org.wordpress.android.fluxc.store.PluginStore;
 import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
@@ -27,7 +26,7 @@ import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginsError;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
-import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginError;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionError;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginVersionPayload;
 
@@ -96,8 +95,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        UpdateSitePluginError updatePluginError = new UpdateSitePluginError(((WPComGsonNetworkError)
-                                networkError).apiError, networkError.message);
+                        ConfigureSitePluginError updatePluginError = new ConfigureSitePluginError(((
+                                WPComGsonNetworkError) networkError).apiError, networkError.message);
                         ConfiguredSitePluginPayload payload = new ConfiguredSitePluginPayload(site, updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -78,7 +78,7 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void updateSitePlugin(@NonNull final SiteModel site, @NonNull final PluginModel plugin) {
+    public void configureSitePlugin(@NonNull final SiteModel site, @NonNull final PluginModel plugin) {
         String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(getEncodedPluginName(plugin)).getUrlV1_2();
         Map<String, Object> params = paramsFromPluginModel(plugin);
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, params,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -95,9 +95,10 @@ public class PluginRestClient extends BaseWPComRestClient {
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        ConfigureSitePluginError updatePluginError = new ConfigureSitePluginError(((
+                        ConfigureSitePluginError configurePluginError = new ConfigureSitePluginError(((
                                 WPComGsonNetworkError) networkError).apiError, networkError.message);
-                        ConfiguredSitePluginPayload payload = new ConfiguredSitePluginPayload(site, updatePluginError);
+                        ConfiguredSitePluginPayload payload =
+                                new ConfiguredSitePluginPayload(site, configurePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -19,6 +19,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginWPComRestResponse.FetchPluginsResponse;
+import org.wordpress.android.fluxc.store.PluginStore;
+import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginsError;
@@ -27,7 +29,6 @@ import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionError;
-import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginVersionPayload;
 
 import java.io.UnsupportedEncodingException;
@@ -89,7 +90,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         PluginModel pluginFromResponse = pluginModelFromResponse(site, response);
                         pluginFromResponse.setId(plugin.getId());
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(
-                                new UpdatedSitePluginPayload(site, pluginFromResponse)));
+                                new ConfiguredSitePluginPayload(site, pluginFromResponse)));
                     }
                 },
                 new BaseErrorListener() {
@@ -97,7 +98,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         UpdateSitePluginError updatePluginError = new UpdateSitePluginError(((WPComGsonNetworkError)
                                 networkError).apiError, networkError.message);
-                        UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, updatePluginError);
+                        ConfiguredSitePluginPayload payload = new ConfiguredSitePluginPayload(site, updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -127,16 +127,16 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class UpdatedSitePluginPayload extends Payload<UpdateSitePluginError> {
+    public static class ConfiguredSitePluginPayload extends Payload<UpdateSitePluginError> {
         public SiteModel site;
         public PluginModel plugin;
 
-        public UpdatedSitePluginPayload(SiteModel site, PluginModel plugin) {
+        public ConfiguredSitePluginPayload(SiteModel site, PluginModel plugin) {
             this.site = site;
             this.plugin = plugin;
         }
 
-        public UpdatedSitePluginPayload(SiteModel site, UpdateSitePluginError error) {
+        public ConfiguredSitePluginPayload(SiteModel site, UpdateSitePluginError error) {
             this.site = site;
             this.error = error;
         }
@@ -437,7 +437,7 @@ public class PluginStore extends Store {
                 break;
             // Network callbacks
             case CONFIGURED_SITE_PLUGIN:
-                updatedSitePlugin((UpdatedSitePluginPayload) action.getPayload());
+                configuredSitePlugin((ConfiguredSitePluginPayload) action.getPayload());
                 break;
             case FETCHED_SITE_PLUGINS:
                 fetchedSitePlugins((FetchedSitePluginsPayload) action.getPayload());
@@ -488,8 +488,8 @@ public class PluginStore extends Store {
             mPluginRestClient.updateSitePlugin(payload.site, payload.plugin);
         } else {
             UpdateSitePluginError error = new UpdateSitePluginError(UpdateSitePluginErrorType.NOT_AVAILABLE);
-            UpdatedSitePluginPayload errorPayload = new UpdatedSitePluginPayload(payload.site, error);
-            updatedSitePlugin(errorPayload);
+            ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site, error);
+            configuredSitePlugin(errorPayload);
         }
     }
 
@@ -545,7 +545,7 @@ public class PluginStore extends Store {
         emitChange(event);
     }
 
-    private void updatedSitePlugin(UpdatedSitePluginPayload payload) {
+    private void configuredSitePlugin(ConfiguredSitePluginPayload payload) {
         OnSitePluginConfigured event = new OnSitePluginConfigured(payload.site);
         if (payload.isError()) {
             event.error = payload.error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -359,10 +359,10 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class OnSitePluginUpdated extends OnChanged<UpdateSitePluginError> {
+    public static class OnSitePluginConfigured extends OnChanged<UpdateSitePluginError> {
         public SiteModel site;
         public PluginModel plugin;
-        public OnSitePluginUpdated(SiteModel site) {
+        public OnSitePluginConfigured(SiteModel site) {
             this.site = site;
         }
     }
@@ -546,7 +546,7 @@ public class PluginStore extends Store {
     }
 
     private void updatedSitePlugin(UpdatedSitePluginPayload payload) {
-        OnSitePluginUpdated event = new OnSitePluginUpdated(payload.site);
+        OnSitePluginConfigured event = new OnSitePluginConfigured(payload.site);
         if (payload.isError()) {
             event.error = payload.error;
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -485,7 +485,7 @@ public class PluginStore extends Store {
 
     private void configureSitePlugin(ConfigureSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.updateSitePlugin(payload.site, payload.plugin);
+            mPluginRestClient.configureSitePlugin(payload.site, payload.plugin);
         } else {
             ConfigureSitePluginError error = new ConfigureSitePluginError(ConfigureSitePluginErrorType.NOT_AVAILABLE);
             ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site, error);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -127,7 +127,7 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class ConfiguredSitePluginPayload extends Payload<UpdateSitePluginError> {
+    public static class ConfiguredSitePluginPayload extends Payload<ConfigureSitePluginError> {
         public SiteModel site;
         public PluginModel plugin;
 
@@ -136,7 +136,7 @@ public class PluginStore extends Store {
             this.plugin = plugin;
         }
 
-        public ConfiguredSitePluginPayload(SiteModel site, UpdateSitePluginError error) {
+        public ConfiguredSitePluginPayload(SiteModel site, ConfigureSitePluginError error) {
             this.site = site;
             this.error = error;
         }
@@ -209,16 +209,16 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class UpdateSitePluginError implements OnChangedError {
-        public UpdateSitePluginErrorType type;
+    public static class ConfigureSitePluginError implements OnChangedError {
+        public ConfigureSitePluginErrorType type;
         @Nullable public String message;
 
-        UpdateSitePluginError(UpdateSitePluginErrorType type) {
+        ConfigureSitePluginError(ConfigureSitePluginErrorType type) {
             this.type = type;
         }
 
-        public UpdateSitePluginError(String type, @Nullable String message) {
-            this.type = UpdateSitePluginErrorType.fromString(type);
+        public ConfigureSitePluginError(String type, @Nullable String message) {
+            this.type = ConfigureSitePluginErrorType.fromString(type);
             this.message = message;
         }
     }
@@ -305,7 +305,7 @@ public class PluginStore extends Store {
         }
     }
 
-    public enum UpdateSitePluginErrorType {
+    public enum ConfigureSitePluginErrorType {
         GENERIC_ERROR,
         ACTIVATION_ERROR,
         DEACTIVATION_ERROR,
@@ -313,9 +313,9 @@ public class PluginStore extends Store {
         UNAUTHORIZED,
         UNKNOWN_PLUGIN;
 
-        public static UpdateSitePluginErrorType fromString(String string) {
+        public static ConfigureSitePluginErrorType fromString(String string) {
             if (string != null) {
-                for (UpdateSitePluginErrorType v : UpdateSitePluginErrorType.values()) {
+                for (ConfigureSitePluginErrorType v : ConfigureSitePluginErrorType.values()) {
                     if (string.equalsIgnoreCase(v.name())) {
                         return v;
                     }
@@ -359,7 +359,7 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class OnSitePluginConfigured extends OnChanged<UpdateSitePluginError> {
+    public static class OnSitePluginConfigured extends OnChanged<ConfigureSitePluginError> {
         public SiteModel site;
         public PluginModel plugin;
         public OnSitePluginConfigured(SiteModel site) {
@@ -487,7 +487,7 @@ public class PluginStore extends Store {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
             mPluginRestClient.updateSitePlugin(payload.site, payload.plugin);
         } else {
-            UpdateSitePluginError error = new UpdateSitePluginError(UpdateSitePluginErrorType.NOT_AVAILABLE);
+            ConfigureSitePluginError error = new ConfigureSitePluginError(ConfigureSitePluginErrorType.NOT_AVAILABLE);
             ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site, error);
             configuredSitePlugin(errorPayload);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -416,14 +416,15 @@ public class PluginStore extends Store {
             return;
         }
         switch ((PluginAction) actionType) {
+            // Remote actions
+            case CONFIGURE_SITE_PLUGIN:
+                updateSitePlugin((UpdateSitePluginPayload) action.getPayload());
+                break;
             case FETCH_SITE_PLUGINS:
                 fetchSitePlugins((SiteModel) action.getPayload());
                 break;
             case FETCH_PLUGIN_INFO:
                 fetchPluginInfo((String) action.getPayload());
-                break;
-            case UPDATE_SITE_PLUGIN:
-                updateSitePlugin((UpdateSitePluginPayload) action.getPayload());
                 break;
             case UPDATE_SITE_PLUGIN_VERSION:
                 updateSitePluginVersion((UpdateSitePluginVersionPayload) action.getPayload());
@@ -434,14 +435,15 @@ public class PluginStore extends Store {
             case INSTALL_SITE_PLUGIN:
                 installSitePlugin((InstallSitePluginPayload) action.getPayload());
                 break;
+            // Network callbacks
+            case CONFIGURED_SITE_PLUGIN:
+                updatedSitePlugin((UpdatedSitePluginPayload) action.getPayload());
+                break;
             case FETCHED_SITE_PLUGINS:
                 fetchedSitePlugins((FetchedSitePluginsPayload) action.getPayload());
                 break;
             case FETCHED_PLUGIN_INFO:
                 fetchedPluginInfo((FetchedPluginInfoPayload) action.getPayload());
-                break;
-            case UPDATED_SITE_PLUGIN:
-                updatedSitePlugin((UpdatedSitePluginPayload) action.getPayload());
                 break;
             case UPDATED_SITE_PLUGIN_VERSION:
                 updatedSitePluginVersion((UpdatedSitePluginVersionPayload) action.getPayload());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -48,11 +48,11 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class UpdateSitePluginPayload extends Payload<BaseNetworkError> {
+    public static class ConfigureSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public PluginModel plugin;
 
-        public UpdateSitePluginPayload(SiteModel site, PluginModel plugin) {
+        public ConfigureSitePluginPayload(SiteModel site, PluginModel plugin) {
             this.site = site;
             this.plugin = plugin;
         }
@@ -418,7 +418,7 @@ public class PluginStore extends Store {
         switch ((PluginAction) actionType) {
             // Remote actions
             case CONFIGURE_SITE_PLUGIN:
-                updateSitePlugin((UpdateSitePluginPayload) action.getPayload());
+                configureSitePlugin((ConfigureSitePluginPayload) action.getPayload());
                 break;
             case FETCH_SITE_PLUGINS:
                 fetchSitePlugins((SiteModel) action.getPayload());
@@ -483,7 +483,7 @@ public class PluginStore extends Store {
         mPluginWPOrgClient.fetchPluginInfo(plugin);
     }
 
-    private void updateSitePlugin(UpdateSitePluginPayload payload) {
+    private void configureSitePlugin(ConfigureSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
             mPluginRestClient.updateSitePlugin(payload.site, payload.plugin);
         } else {


### PR DESCRIPTION
`UPDATE_SITE_PLUGIN` and `UPDATE_SITE_PLUGIN_VERSION` was a little too confusing. This PR changes the `UPDATE_SITE_PLUGIN` action's name to `CONFIGURE_SITE_PLUGIN` and another PR will be coming to change `UPDATE_SITE_PLUGIN_VERSION` to `UPDATE_SITE_PLUGIN` since we don't need that `VERSION` part anymore with this change.

No implementation change has been made, but feel free to run the tests in `ReleaseStack_PluginTestJetpack` and `PluginSqlUtilsTest` which I've already done but just in case :)

/cc @aforcier 