### PR TITLE
Feature/add social signup

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -9,10 +9,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountRestPayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.IsAvailableResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.NewAccountResponsePayload;
+import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.NewAccountPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushAccountSettingsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialAuthPayload;
-import org.wordpress.android.fluxc.store.AccountStore.PushSocialLoginPayload;
+import org.wordpress.android.fluxc.store.AccountStore.PushSocialPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialSmsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload;
 
@@ -29,9 +30,9 @@ public enum AccountAction implements IAction {
     PUSH_SETTINGS,          // request saving Account Settings remotely
     @Action(payloadType = PushSocialAuthPayload.class)
     PUSH_SOCIAL_AUTH,      // request social auth remotely
-    @Action(payloadType = PushSocialLoginPayload.class)
+    @Action(payloadType = PushSocialPayload.class)
     PUSH_SOCIAL_CONNECT,    // request social connect remotely
-    @Action(payloadType = PushSocialLoginPayload.class)
+    @Action(payloadType = AccountStore.PushSocialPayload.class)
     PUSH_SOCIAL_LOGIN,      // request social login remotely
     @Action(payloadType = PushSocialSmsPayload.class)
     PUSH_SOCIAL_SMS,      // request social sms remotely

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -9,7 +9,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountRestPayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.IsAvailableResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.NewAccountResponsePayload;
-import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.NewAccountPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushAccountSettingsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialAuthPayload;
@@ -32,8 +31,10 @@ public enum AccountAction implements IAction {
     PUSH_SOCIAL_AUTH,      // request social auth remotely
     @Action(payloadType = PushSocialPayload.class)
     PUSH_SOCIAL_CONNECT,    // request social connect remotely
-    @Action(payloadType = AccountStore.PushSocialPayload.class)
+    @Action(payloadType = PushSocialPayload.class)
     PUSH_SOCIAL_LOGIN,      // request social login remotely
+    @Action(payloadType = PushSocialPayload.class)
+    PUSH_SOCIAL_SIGNUP,     // request social signup remotely
     @Action(payloadType = PushSocialSmsPayload.class)
     PUSH_SOCIAL_SMS,      // request social sms remotely
     @Action(payloadType = NewAccountPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -69,6 +69,7 @@ public class AccountRestClient extends BaseWPComRestClient {
     public static class AccountPushSocialResponsePayload extends Payload<AccountSocialError> {
         public AccountPushSocialResponsePayload(AccountSocialResponse response) {
             this.bearerToken = response.bearer_token;
+            this.createdAccount = response.created_account;
             this.phoneNumber = response.phone_number;
             this.twoStepNonce = response.two_step_nonce;
             this.twoStepNonceAuthenticator = response.two_step_nonce_authenticator;
@@ -77,6 +78,7 @@ public class AccountRestClient extends BaseWPComRestClient {
             this.twoStepNotificationSent = response.two_step_notification_sent;
             this.twoStepTypes = convertJsonArrayToStringList(response.two_step_supported_auth_types);
             this.userId = response.user_id;
+            this.userName = response.username;
         }
         public AccountPushSocialResponsePayload() {
         }
@@ -89,6 +91,8 @@ public class AccountRestClient extends BaseWPComRestClient {
         public String twoStepNonceSms;
         public String twoStepNotificationSent;
         public String userId;
+        public String userName;
+        public boolean createdAccount;
 
         private List<String> convertJsonArrayToStringList(JSONArray array) {
             List<String> list = new ArrayList<>();
@@ -116,6 +120,10 @@ public class AccountRestClient extends BaseWPComRestClient {
 
         public boolean hasTwoStepTypes() {
             return this.twoStepTypes != null && this.twoStepTypes.size() > 0;
+        }
+
+        public boolean hasUsername() {
+            return !TextUtils.isEmpty(this.userName);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialRequest.java
@@ -64,6 +64,8 @@ public class AccountSocialRequest extends BaseRequest<AccountSocialResponse> {
             parsed.two_step_nonce_sms = data.optString("two_step_nonce_sms");
             parsed.two_step_notification_sent = data.optString("two_step_notification_sent");
             parsed.user_id = data.optString("user_id");
+            parsed.username = data.optString("username");
+            parsed.created_account = data.optBoolean("created_account");
             return Response.success(parsed, null);
         } catch (JSONException exception) {
             AppLog.e(T.API, "Unable to parse network response: " + exception.getMessage());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
@@ -13,4 +13,6 @@ public class AccountSocialResponse implements Response {
     public String two_step_nonce_sms;
     public String two_step_notification_sent;
     public String user_id;
+    public String username;
+    public boolean created_account;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -608,14 +608,19 @@ public class AccountStore extends Store {
             OnSocialChanged event = new OnSocialChanged();
             event.error = payload.error;
             emitChange(event);
-        // No error and two-factor authentication code sent via SMS; emit only social change.
+        // Two-factor authentication code sent via SMS; emit only social change.
         } else if (payload.hasPhoneNumber()) {
             OnSocialChanged event = new OnSocialChanged(payload);
             emitChange(event);
-        // No error, but either two-factor authentication or social connect is required; emit only social change.
+        // Two-factor authentication or social connect is required; emit only social change.
         } else if (!payload.hasToken()) {
             OnSocialChanged event = new OnSocialChanged(payload);
             event.requiresTwoStepAuth = payload.hasTwoStepTypes();
+            emitChange(event);
+        // Social signup completed; emit only social change.
+        } else if (payload.hasUsername()) {
+            OnSocialChanged event = new OnSocialChanged(payload);
+            event.createdAccount = payload.createdAccount;
             emitChange(event);
         // No error and two-factor authentication is not required; emit only authentication change.
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -142,6 +142,7 @@ public class AccountStore extends Store {
         public String notificationSent;
         public String phoneNumber;
         public String userId;
+        public boolean createdAccount;
         public boolean requiresTwoStepAuth;
 
         public OnSocialChanged() {
@@ -446,6 +447,8 @@ public class AccountStore extends Store {
                 break;
             case PUSH_SOCIAL_LOGIN:
                 createPushSocialLogin((PushSocialPayload) payload);
+                break;
+            case PUSH_SOCIAL_SIGNUP:
                 break;
             case PUSH_SOCIAL_SMS:
                 createPushSocialSms((PushSocialSmsPayload) payload);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -298,6 +298,7 @@ public class AccountStore extends Store {
         NO_PHONE_NUMBER_FOR_ACCOUNT,
         SMS_AUTHENTICATION_UNAVAILABLE,
         SMS_CODE_THROTTLED,
+        TWO_STEP_ENABLED,
         UNABLE_CONNECT,
         UNKNOWN_USER,
         USER_ALREADY_ASSOCIATED,
@@ -306,6 +307,7 @@ public class AccountStore extends Store {
 
         public static AccountSocialErrorType fromString(String string) {
             if (string != null) {
+                string = string.replace("2FA_enabled", "two_step_enabled");
                 for (AccountSocialErrorType type : AccountSocialErrorType.values()) {
                     if (string.equalsIgnoreCase(type.name())) {
                         return type;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -144,7 +144,6 @@ public class AccountStore extends Store {
         public String notificationSent;
         public String phoneNumber;
         public String userId;
-        public boolean createdAccount;
         public boolean requiresTwoStepAuth;
 
         public OnSocialChanged() {
@@ -621,14 +620,14 @@ public class AccountStore extends Store {
             OnSocialChanged event = new OnSocialChanged(payload);
             event.requiresTwoStepAuth = payload.hasTwoStepTypes();
             emitChange(event);
-        // Social signup completed; emit only social change.
-        } else if (payload.hasUsername()) {
-            OnSocialChanged event = new OnSocialChanged(payload);
-            event.createdAccount = payload.createdAccount;
-            emitChange(event);
-        // No error and two-factor authentication is not required; emit only authentication change.
+            // No error and two-factor authentication is not required; emit only authentication change.
         } else {
-            updateToken(new UpdateTokenPayload(payload.bearerToken));
+            // Social login or signup completed; update token and send boolean flag.
+            if (payload.hasUsername()) {
+                updateToken(new UpdateTokenPayload(payload.bearerToken), payload.createdAccount);
+            } else {
+                updateToken(new UpdateTokenPayload(payload.bearerToken));
+            }
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -449,6 +449,7 @@ public class AccountStore extends Store {
                 createPushSocialLogin((PushSocialPayload) payload);
                 break;
             case PUSH_SOCIAL_SIGNUP:
+                createPushSocialSignup((PushSocialPayload) payload);
                 break;
             case PUSH_SOCIAL_SMS:
                 createPushSocialSms((PushSocialSmsPayload) payload);
@@ -660,6 +661,10 @@ public class AccountStore extends Store {
 
     private void createPushSocialLogin(PushSocialPayload payload) {
         mAccountRestClient.pushSocialLogin(payload.idToken, payload.service);
+    }
+
+    private void createPushSocialSignup(PushSocialPayload payload) {
+        mAccountRestClient.pushSocialSignup(payload.idToken, payload.service);
     }
 
     private void createPushSocialSms(PushSocialSmsPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -131,7 +131,9 @@ public class AccountStore extends Store {
         public AccountAction causeOfChange;
     }
 
-    public static class OnAuthenticationChanged extends OnChanged<AuthenticationError> {}
+    public static class OnAuthenticationChanged extends OnChanged<AuthenticationError> {
+        public boolean createdAccount;
+    }
 
     public static class OnSocialChanged extends OnChanged<AccountSocialError> {
         public List<String> twoStepTypes;
@@ -711,6 +713,19 @@ public class AccountStore extends Store {
     private void updateToken(UpdateTokenPayload updateTokenPayload) {
         mAccessToken.set(updateTokenPayload.token);
         emitChange(new OnAuthenticationChanged());
+    }
+
+    /**
+     * Update access token for account store for social login or signup.
+     *
+     * @param updateTokenPayload payload containing token to be updated
+     * @param createdAccount     flag to send in event to determine login or signup
+     */
+    private void updateToken(UpdateTokenPayload updateTokenPayload, boolean createdAccount) {
+        mAccessToken.set(updateTokenPayload.token);
+        OnAuthenticationChanged event = new OnAuthenticationChanged();
+        event.createdAccount = createdAccount;
+        emitChange(event);
     }
 
     private void updateDefaultAccount(AccountModel accountModel, AccountAction cause) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -71,10 +71,10 @@ public class AccountStore extends Store {
         }
     }
 
-    public static class PushSocialLoginPayload extends Payload<BaseNetworkError> {
+    public static class PushSocialPayload extends Payload<BaseNetworkError> {
         public String idToken;
         public String service;
-        public PushSocialLoginPayload(@NonNull String idToken, @NonNull String service) {
+        public PushSocialPayload(@NonNull String idToken, @NonNull String service) {
             this.idToken = idToken;
             this.service = service;
         }
@@ -442,10 +442,10 @@ public class AccountStore extends Store {
                 createPushSocialAuth((PushSocialAuthPayload) payload);
                 break;
             case PUSH_SOCIAL_CONNECT:
-                createPushSocialConnect((PushSocialLoginPayload) payload);
+                createPushSocialConnect((PushSocialPayload) payload);
                 break;
             case PUSH_SOCIAL_LOGIN:
-                createPushSocialLogin((PushSocialLoginPayload) payload);
+                createPushSocialLogin((PushSocialPayload) payload);
                 break;
             case PUSH_SOCIAL_SMS:
                 createPushSocialSms((PushSocialSmsPayload) payload);
@@ -651,11 +651,11 @@ public class AccountStore extends Store {
         mAccountRestClient.pushSocialAuth(payload.userId, payload.type, payload.nonce, payload.code);
     }
 
-    private void createPushSocialConnect(PushSocialLoginPayload payload) {
+    private void createPushSocialConnect(PushSocialPayload payload) {
         mAccountRestClient.pushSocialConnect(payload.idToken, payload.service);
     }
 
-    private void createPushSocialLogin(PushSocialLoginPayload payload) {
+    private void createPushSocialLogin(PushSocialPayload payload) {
         mAccountRestClient.pushSocialLogin(payload.idToken, payload.service);
     }
 


### PR DESCRIPTION
Add a method for social signup, `pushSocialSignup`, to sign up a new user with a WordPress.com account via their social account.  It requires similar parameters to the `pushSocialAuth`, `pushSocialConnect`, `pushSocialLogin`, and `pushSocialSms` methods, but uses the `/users/social/new/` authenticated endpoint.