### PR TITLE
Add support for WP.com V2 endpoints to code generator

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/WPComV2EndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComV2EndpointTest.java
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class WPComV2EndpointTest {
+    @Test
+    public void testAllEndpoints() {
+        // Users
+        assertEquals("/users/username/suggestions/", WPCOMV2.users.username.suggestions.getEndpoint());
+    }
+
+    @Test
+    public void testUrls() {
+        assertEquals("https://public-api.wordpress.com/wpcom/v2/users/username/suggestions/",
+                WPCOMV2.users.username.suggestions.getUrl());
+    }
+}

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPComV2Endpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPComV2Endpoint.java
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.annotations.endpoint;
+
+public class WPComV2Endpoint {
+    private static final String WPCOM_REST_PREFIX = "https://public-api.wordpress.com";
+    private static final String WPCOM_V2_PREFIX = WPCOM_REST_PREFIX + "/wpcom/v2";
+
+    private final String mEndpoint;
+
+    public WPComV2Endpoint(String endpoint) {
+        mEndpoint = endpoint;
+    }
+
+    public WPComV2Endpoint(String endpoint, long id) {
+        this(endpoint + id + "/");
+    }
+
+    public WPComV2Endpoint(String endpoint, String value) {
+        this(endpoint + value + "/");
+    }
+
+    public String getEndpoint() {
+        return mEndpoint;
+    }
+
+    public String getUrl() {
+        return WPCOM_V2_PREFIX + mEndpoint;
+    }
+}

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.annotations.endpoint.EndpointNode;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointTreeGenerator;
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint;
 import org.wordpress.android.fluxc.annotations.endpoint.WPComEndpoint;
+import org.wordpress.android.fluxc.annotations.endpoint.WPComV2Endpoint;
 import org.wordpress.android.fluxc.annotations.endpoint.WPOrgAPIEndpoint;
 
 import java.io.File;
@@ -31,6 +32,7 @@ import javax.lang.model.element.TypeElement;
 @AutoService(Processor.class)
 public class EndpointProcessor extends AbstractProcessor {
     private static final String WPCOMREST_ENDPOINT_FILE = "fluxc/src/main/tools/wp-com-endpoints.txt";
+    private static final String WPCOMV2_ENDPOINT_FILE = "fluxc/src/main/tools/wp-com-v2-endpoints.txt";
     private static final String XMLRPC_ENDPOINT_FILE = "fluxc/src/main/tools/xmlrpc-endpoints.txt";
     private static final String WPAPI_ENDPOINT_FILE = "fluxc/src/main/tools/wp-api-endpoints.txt";
     private static final String WPORG_API_ENDPOINT_FILE = "fluxc/src/main/tools/wporg-api-endpoints.txt";
@@ -63,6 +65,7 @@ public class EndpointProcessor extends AbstractProcessor {
 
         try {
             generateWPCOMRESTEndpointFile();
+            generateWPCOMV2EndpointFile();
             generateXMLRPCEndpointFile();
             generateWPAPIEndpointFile();
             generateWPORGAPIEndpointFile();
@@ -81,6 +84,15 @@ public class EndpointProcessor extends AbstractProcessor {
         EndpointNode rootNode = EndpointTreeGenerator.process(file);
 
         TypeSpec endpointClass = RESTPoet.generate(rootNode, "WPCOMREST", WPComEndpoint.class,
+                WPCOMREST_VARIABLE_ENDPOINT_PATTERN);
+        writeEndpointClassToFile(endpointClass);
+    }
+
+    private void generateWPCOMV2EndpointFile() throws IOException {
+        File file = new File(WPCOMV2_ENDPOINT_FILE);
+        EndpointNode rootNode = EndpointTreeGenerator.process(file);
+
+        TypeSpec endpointClass = RESTPoet.generate(rootNode, "WPCOMV2", WPComV2Endpoint.class,
                 WPCOMREST_VARIABLE_ENDPOINT_PATTERN);
         writeEndpointClassToFile(endpointClass);
     }

--- a/fluxc/src/main/tools/wp-com-v2-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-v2-endpoints.txt
@@ -1,0 +1,1 @@
+/users/username/suggestions/


### PR DESCRIPTION
This adds a new endpoint text file, `wp-com-v2-endpoints.txt`, which is used to generate an endpoint class for WordPress.com V2 endpoints.

These are generally used just like any other WP.com (V1) REST endpoints (as part of a `WPComGsonRequest`, and within a network client that extends `BaseWPComRestClient`). The only difference is to use the generated `WPCOMV2` class instead of `WPCOMREST` to build the endpoint URL.

Note: The V2 endpoints don't seem to currently have a versioning structure, so all FluxC offers is the one kind of URL (https://public-api.wordpress.com/wpcom/v2/...). We can add new URL methods to `WPComV2Endpoint.java` in the future if needed (if `/wpcom/v2.1/` and such are used).

To test, rebuild the project on this branch and run the unit tests (`./gradlew testDebug`).

cc @aerych 