### PR TITLE
Jetpack version

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import android.text.TextUtils;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -60,7 +62,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         SiteModel site = mSiteStore.getSites().get(0);
-        assertNotNull(site.getJetpackVersion());
+        assertFalse(TextUtils.isEmpty(site.getJetpackVersion()));
 
         signOutWPCom();
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
@@ -59,6 +59,9 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
         assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
+        SiteModel site = mSiteStore.getSites().get(0);
+        assertNotNull(site.getJetpackVersion());
+
         signOutWPCom();
 
         assertFalse(mSiteStore.hasSite());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -70,6 +70,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     // mIsJetpackConnected is true if Jetpack is installed, activated and connected to a WordPress.com account.
     @Column private boolean mIsJetpackConnected;
     @Column private boolean mIsAutomatedTransfer;
+    @Column private String mJetpackVersion;
 
     // WPCom specifics
     @Column private boolean mIsVisible = true;
@@ -526,6 +527,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setIsAutomatedTransfer(boolean automatedTransfer) {
         mIsAutomatedTransfer = automatedTransfer;
+    }
+
+    public String getJetpackVersion() {
+        return mJetpackVersion;
+    }
+
+    public void setJetpackVersion(String jetpackVersion) {
+        mJetpackVersion = jetpackVersion;
     }
 
     @SiteOrigin

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -510,6 +510,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setTimezone(from.options.gmt_offset);
             site.setFrameNonce(from.options.frame_nonce);
             site.setUnmappedUrl(from.options.unmapped_url);
+            site.setJetpackVersion(from.options.jetpack_version);
 
             try {
                 site.setMaxUploadSize(Long.valueOf(from.options.max_upload_size));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -21,6 +21,7 @@ public class SiteWPComRestResponse implements Response {
         public String max_upload_size;
         public String wp_max_memory_limit;
         public String wp_memory_limit;
+        public String jetpack_version;
     }
 
     public class Plan {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -58,7 +58,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 18;
+        return 19;
     }
 
     @Override
@@ -139,6 +139,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "NAME TEXT,SLUG TEXT,VERSION TEXT,RATING TEXT,ICON TEXT)");
                 oldVersion++;
             case 14:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE MediaUploadModel (_id INTEGER PRIMARY KEY,UPLOAD_STATE INTEGER,"
                         + "PROGRESS REAL,ERROR_TYPE TEXT,ERROR_MESSAGE TEXT,FOREIGN KEY(_id) REFERENCES "
                         + "MediaModel(_id) ON DELETE CASCADE)");
@@ -147,6 +148,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "PostModel(_id) ON DELETE CASCADE)");
                 oldVersion++;
             case 15:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE ThemeModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
                         + "THEME_ID TEXT,NAME TEXT,DESCRIPTION TEXT,SLUG TEXT,VERSION TEXT,AUTHOR_NAME TEXT,"
                         + "AUTHOR_URL TEXT,THEME_URL TEXT,SCREENSHOT_URL TEXT,DEMO_URL TEXT,DOWNLOAD_URL TEXT,"
@@ -154,6 +156,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "AUTO_UPDATE_TRANSLATION INTEGER,IS_WP_COM_THEME INTEGER)");
                 oldVersion++;
             case 16:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table ThemeModel add FREE integer;");
                 db.execSQL("alter table ThemeModel add PRICE_TEXT integer;");
                 oldVersion++;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -162,6 +162,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("alter table SiteModel add EMAIL text;");
                 db.execSQL("alter table SiteModel add DISPLAY_NAME text;");
                 oldVersion++;
+            case 18:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SiteModel add JETPACK_VERSION text;");
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();


### PR DESCRIPTION
This PR adds the `jetpackVersion` property to `SiteModel`. This can be used to check the availability of features on the site such as plugins.

Unforunately, we can not do this by using plugins as there were a lot of API fixes recently and the only way to make sure the feature will work correctly is to make sure we are working with a specific Jetpack version.

/cc @aforcier

P.S: I've also taken the opportunity to add the missing logs for migrations as we had a few cases that didn't have it.