### PR TITLE
WooCommerce plugin - WellSql config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ allprojects {
 
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
     }
 
     task checkstyle(type: Checkstyle) {

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ allprojects {
 
     repositories {
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 
     task checkstyle(type: Checkstyle) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
@@ -23,7 +23,8 @@ open class ExampleApp : Application(), HasActivityInjector {
     override fun onCreate() {
         super.onCreate()
         component.inject(this)
-        WellSql.init(WellSqlConfig(applicationContext))
+        val wellSqlConfig = WellSqlConfig(applicationContext, WellSqlConfig.ADDON_WOOCOMMERCE)
+        WellSql.init(wellSqlConfig)
     }
 
     override fun activityInjector(): AndroidInjector<Activity> = activityInjector

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -70,8 +70,8 @@ dependencies {
     }
 
     // Custom WellSql version
-    api 'org.wordpress:wellsql:1.2.0'
-    kapt 'org.wordpress:wellsql-processor:1.2.0'
+    api 'com.github.wordpress-mobile.wellsql:wellsql:07933843555633ef4ea1b5e306a5581e6a34fb46'
+    kapt 'com.github.wordpress-mobile.wellsql:well-processor:07933843555633ef4ea1b5e306a5581e6a34fb46'
 
     // FluxC annotations
     api project(':fluxc-annotations')

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -70,8 +70,8 @@ dependencies {
     }
 
     // Custom WellSql version
-    api 'com.github.wordpress-mobile.wellsql:wellsql:07933843555633ef4ea1b5e306a5581e6a34fb46'
-    kapt 'com.github.wordpress-mobile.wellsql:well-processor:07933843555633ef4ea1b5e306a5581e6a34fb46'
+    api 'org.wordpress:wellsql:1.3.0'
+    kapt 'org.wordpress:wellsql-processor:1.3.0'
 
     // FluxC annotations
     api project(':fluxc-annotations')

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -15,7 +15,9 @@ import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -25,6 +27,7 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 public class WellSqlConfig extends DefaultWellConfig {
     @Retention(SOURCE)
     @StringDef({ADDON_WOOCOMMERCE})
+    @Target(ElementType.PARAMETER)
     public @interface AddOn {}
     public static final String ADDON_WOOCOMMERCE = "WC";
 
@@ -32,7 +35,6 @@ public class WellSqlConfig extends DefaultWellConfig {
         super(context);
     }
 
-    // TODO This can accept a Set<@AddOn String> directly when we enable Java 8
     public WellSqlConfig(Context context, @AddOn String... addOns) {
         super(context, new HashSet<>(Arrays.asList(addOns)));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
+import android.support.annotation.StringDef;
 
 import com.yarolegovich.wellsql.DefaultWellConfig;
 import com.yarolegovich.wellsql.WellSql;
@@ -14,13 +15,26 @@ import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
+import java.lang.annotation.Retention;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 public class WellSqlConfig extends DefaultWellConfig {
+    @Retention(SOURCE)
+    @StringDef({ADDON_WOOCOMMERCE})
+    public @interface AddOn {}
     public static final String ADDON_WOOCOMMERCE = "WC";
 
     public WellSqlConfig(Context context) {
         super(context);
+    }
+
+    // TODO This can accept a Set<@AddOn String> directly when we enable Java 8
+    public WellSqlConfig(Context context, @AddOn String... addOns) {
+        super(context, new HashSet<>(Arrays.asList(addOns)));
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -17,6 +17,8 @@ import org.wordpress.android.util.AppLog.T;
 import java.util.Map;
 
 public class WellSqlConfig extends DefaultWellConfig {
+    public static final String ADDON_WOOCOMMERCE = "WC";
+
     public WellSqlConfig(Context context) {
         super(context);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -218,4 +218,12 @@ public class WellSqlConfig extends DefaultWellConfig {
             db.execSQL(table.createStatement());
         }
     }
+
+    private void migrateAddOn(@AddOn String addOnName, SQLiteDatabase db, int oldDbVersion) {
+        if (mActiveAddOns.contains(addOnName)) {
+            switch (oldDbVersion) {
+                // TODO
+            }
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -11,50 +11,15 @@ import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.TableClass;
 import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 
-import org.wordpress.android.fluxc.model.AccountModel;
-import org.wordpress.android.fluxc.model.CommentModel;
-import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaUploadModel;
-import org.wordpress.android.fluxc.model.WPOrgPluginModel;
-import org.wordpress.android.fluxc.model.SitePluginModel;
-import org.wordpress.android.fluxc.model.PostFormatModel;
-import org.wordpress.android.fluxc.model.PostModel;
-import org.wordpress.android.fluxc.model.PostUploadModel;
-import org.wordpress.android.fluxc.model.RoleModel;
-import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.model.TaxonomyModel;
-import org.wordpress.android.fluxc.model.TermModel;
-import org.wordpress.android.fluxc.model.ThemeModel;
-import org.wordpress.android.fluxc.network.HTTPAuthModel;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class WellSqlConfig extends DefaultWellConfig {
     public WellSqlConfig(Context context) {
         super(context);
     }
-
-    private static final List<Class<? extends Identifiable>> TABLES = new ArrayList<Class<? extends Identifiable>>() {{
-        add(AccountModel.class);
-        add(CommentModel.class);
-        add(HTTPAuthModel.class);
-        add(MediaModel.class);
-        add(MediaUploadModel.class);
-        add(PostFormatModel.class);
-        add(PostModel.class);
-        add(PostUploadModel.class);
-        add(RoleModel.class);
-        add(SiteModel.class);
-        add(SitePluginModel.class);
-        add(TaxonomyModel.class);
-        add(TermModel.class);
-        add(ThemeModel.class);
-        add(WPOrgPluginModel.class);
-    }};
 
     @Override
     public int getDbVersion() {
@@ -68,7 +33,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public void onCreate(SQLiteDatabase db, WellTableManager helper) {
-        for (Class<? extends Identifiable> table : TABLES) {
+        for (Class<? extends Identifiable> table : mTables) {
             helper.createTable(table);
         }
     }
@@ -222,7 +187,7 @@ public class WellSqlConfig extends DefaultWellConfig {
     }
 
     @Override
-    protected Map<Class<?>, SQLiteMapper<?>> registerMappers() {
+    protected Map<Class<? extends Identifiable>, SQLiteMapper<?>> registerMappers() {
         return super.registerMappers();
     }
 
@@ -231,7 +196,7 @@ public class WellSqlConfig extends DefaultWellConfig {
      */
     public void reset() {
         SQLiteDatabase db = WellSql.giveMeWritableDb();
-        for (Class<? extends Identifiable> clazz : TABLES) {
+        for (Class<? extends Identifiable> clazz : mTables) {
             TableClass table = getTable(clazz);
             db.execSQL("DROP TABLE IF EXISTS " + table.getTableName());
             db.execSQL(table.createStatement());

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -50,6 +50,9 @@ dependencies {
         exclude group: "com.mcxiaoke.volley"
     }
 
+    api 'com.github.wordpress-mobile.wellsql:wellsql:07933843555633ef4ea1b5e306a5581e6a34fb46'
+    kapt 'com.github.wordpress-mobile.wellsql:well-processor:07933843555633ef4ea1b5e306a5581e6a34fb46'
+
     // FluxC annotations
     api project(':fluxc-annotations')
     kapt project(':fluxc-processor')

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -50,8 +50,8 @@ dependencies {
         exclude group: "com.mcxiaoke.volley"
     }
 
-    api 'com.github.wordpress-mobile.wellsql:wellsql:07933843555633ef4ea1b5e306a5581e6a34fb46'
-    kapt 'com.github.wordpress-mobile.wellsql:well-processor:07933843555633ef4ea1b5e306a5581e6a34fb46'
+    api 'org.wordpress:wellsql:1.3.0'
+    kapt 'org.wordpress:wellsql-processor:1.3.0'
 
     // FluxC annotations
     api project(':fluxc-annotations')

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId: Int = 0
+    @Column var remoteOrderId: Long? = 0
+
+    override fun getId(): Int = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}


### PR DESCRIPTION
Adds an example model to the WooCommerce plugin, along with configuration necessary to only add the corresponding DB table if the host app is using the WC plugin.

This is a WIP PR - ~for one, https://github.com/wordpress-mobile/wellsql/pull/11 (which is where most of the interesting stuff is happening) needs to be reviewed and merged, and this PR updated back to a release version of wellsql and not a Jitpack hash~ (done in 6e61243).

Note: One thing not implemented yet is the case of enabling the WC plugin after the database has already been set up, or removing the plugin, going through some FluxC upgrades and re-enabling the plugin. The assumption here is that the only client for the WooCommerce plugin module is the WC app, and that will have the plugin module added from the very beginning - I will add some checks/handling for this in the near future just in case though.