### PR TITLE
Fix a possible NPE in handleThemeActivated

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -412,8 +412,10 @@ public class ThemeStore extends Store {
                 activatedTheme = getInstalledThemeByThemeId(payload.theme.getThemeId());
             } else {
                 activatedTheme = getWpComThemeByThemeId(payload.theme.getThemeId());
-                // Remove WP.com flag to store as site-associate theme
-                activatedTheme.setIsWpComTheme(false);
+                if (activatedTheme != null) {
+                    // Remove WP.com flag to store as site-associate theme
+                    activatedTheme.setIsWpComTheme(false);
+                }
             }
             if (activatedTheme != null) {
                 setActiveThemeForSite(payload.site, activatedTheme);


### PR DESCRIPTION
This PR should fix the crash reported here https://github.com/wordpress-mobile/WordPress-Android/issues/6976. However, I think we should look into why `activatedTheme` is `null` in the first place. I've spent a fair bit of time and I don't see any reason for it. Assuming there is a good reason for it, we should try to get the theme instead of ignoring the issue or at least return an error. I am opening a new issue for this.

@tonyr59h Do you have any thought on why this might be happening?

/cc @maxme 