### PR TITLE
Unescape html entities from plugins response

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
@@ -191,10 +192,10 @@ public class PluginRestClient extends BaseWPComRestClient {
         PluginModel pluginModel = new PluginModel();
         pluginModel.setLocalSiteId(siteModel.getId());
         pluginModel.setName(response.name);
-        pluginModel.setDisplayName(response.display_name);
-        pluginModel.setAuthorName(response.author);
+        pluginModel.setDisplayName(StringEscapeUtils.unescapeHtml4(response.display_name));
+        pluginModel.setAuthorName(StringEscapeUtils.unescapeHtml4(response.author));
         pluginModel.setAuthorUrl(response.author_url);
-        pluginModel.setDescription(response.description);
+        pluginModel.setDescription(StringEscapeUtils.unescapeHtml4(response.description));
         pluginModel.setIsActive(response.active);
         pluginModel.setIsAutoUpdateEnabled(response.autoupdate);
         pluginModel.setPluginUrl(response.plugin_url);


### PR DESCRIPTION
Fixes #643. This PR fixes the issue mentioned here: https://github.com/wordpress-mobile/WordPress-Android/pull/6973#issuecomment-350817529

Please note the difference between the plugin "Widget Importer & Exporter" in the screenshots below.

Before:
![screenshot_1513185334](https://user-images.githubusercontent.com/662023/33952286-5594e422-dfff-11e7-9437-995d99452601.png)

After:
![screenshot_1513185192](https://user-images.githubusercontent.com/662023/33952221-2ef14afe-dfff-11e7-96e9-8b43b583df7f.png)