### PR TITLE
ThemeSqlUtils fixes

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -71,25 +71,28 @@ public class ThemeStoreUnitTest {
     }
 
     @Test
-    public void testInsertOrUpdateTheme() {
+    public void testInsertOrUpdateTheme() throws SiteSqlUtils.DuplicateSiteException {
+        final SiteModel site = SiteUtils.generateJetpackSiteOverRestOnly();
+        SiteSqlUtils.insertOrUpdateSite(site);
+
         final String testThemeId = "fluxc-ftw";
         final String testThemeName = "FluxC FTW";
         final String testUpdatedName = testThemeName + " v2";
-        final ThemeModel insertTheme = generateTestTheme(12345, testThemeId, testThemeName);
+        final ThemeModel insertTheme = generateTestTheme(site.getId(), testThemeId, testThemeName);
 
         // verify theme doesn't already exist
-        assertNull(mThemeStore.getInstalledThemeByThemeId(testThemeId));
+        assertNull(mThemeStore.getInstalledThemeByThemeId(site, testThemeId));
 
         // insert new theme and verify it exists
         ThemeSqlUtils.insertOrUpdateThemeForSite(insertTheme);
-        ThemeModel insertedTheme = mThemeStore.getInstalledThemeByThemeId(testThemeId);
+        ThemeModel insertedTheme = mThemeStore.getInstalledThemeByThemeId(site, testThemeId);
         assertNotNull(insertedTheme);
         assertEquals(testThemeName, insertedTheme.getName());
 
         // update the theme and verify the updated attributes
         insertedTheme.setName(testUpdatedName);
         ThemeSqlUtils.insertOrUpdateThemeForSite(insertedTheme);
-        insertedTheme = mThemeStore.getInstalledThemeByThemeId(testThemeId);
+        insertedTheme = mThemeStore.getInstalledThemeByThemeId(site, testThemeId);
         assertNotNull(insertedTheme);
         assertEquals(testUpdatedName, insertedTheme.getName());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -14,6 +14,10 @@ import java.util.List;
 
 public class ThemeSqlUtils {
     public static void insertOrUpdateThemeForSite(@NonNull ThemeModel theme) {
+        // Always remove WP.com flag while storing as a site associate theme as we might be saving
+        // a copy of a wp.com theme after an activation
+        theme.setIsWpComTheme(false);
+
         List<ThemeModel> existing = WellSql.select(ThemeModel.class)
                 .where().beginGroup()
                 .equals(ThemeModelTable.THEME_ID, theme.getThemeId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.persistence;
 
 import android.database.Cursor;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.wellsql.generated.ThemeModelTable;
 import com.yarolegovich.wellsql.WellSql;
@@ -113,14 +114,33 @@ public class ThemeSqlUtils {
                 .endWhere().getAsModel();
     }
 
-    /**
-     * @return the first theme that matches a given theme ID; null if none found
-     */
-    public static ThemeModel getThemeByThemeId(@NonNull String themeId, boolean isWpComTheme) {
+    public static ThemeModel getWpComThemeByThemeId(String themeId) {
+        if (TextUtils.isEmpty(themeId)) {
+            return null;
+        }
+
         List<ThemeModel> matches = WellSql.select(ThemeModel.class)
                 .where().beginGroup()
                 .equals(ThemeModelTable.THEME_ID, themeId)
-                .equals(ThemeModelTable.IS_WP_COM_THEME, isWpComTheme)
+                .equals(ThemeModelTable.IS_WP_COM_THEME, true)
+                .endGroup().endWhere().getAsModel();
+
+        if (matches == null || matches.isEmpty()) {
+            return null;
+        }
+
+        return matches.get(0);
+    }
+
+    public static ThemeModel getSiteThemeByThemeId(SiteModel siteModel, String themeId) {
+        if (siteModel == null || TextUtils.isEmpty(themeId)) {
+            return null;
+        }
+        List<ThemeModel> matches = WellSql.select(ThemeModel.class)
+                .where().beginGroup()
+                .equals(ThemeModelTable.LOCAL_SITE_ID, siteModel.getId())
+                .equals(ThemeModelTable.THEME_ID, themeId)
+                .equals(ThemeModelTable.IS_WP_COM_THEME, false)
                 .endGroup().endWhere().getAsModel();
 
         if (matches == null || matches.isEmpty()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -413,8 +413,6 @@ public class ThemeStore extends Store {
                 activatedTheme = getInstalledThemeByThemeId(payload.site, payload.theme.getThemeId());
             } else {
                 activatedTheme = getWpComThemeByThemeId(payload.theme.getThemeId());
-                // Remove WP.com flag to store as site-associate theme
-                activatedTheme.setIsWpComTheme(false);
             }
             if (activatedTheme != null) {
                 setActiveThemeForSite(payload.site, activatedTheme);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store;
 
 import android.database.Cursor;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -278,18 +279,18 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getThemesForSite(site);
     }
 
-    public ThemeModel getInstalledThemeByThemeId(String themeId) {
+    public ThemeModel getInstalledThemeByThemeId(SiteModel siteModel, String themeId) {
         if (themeId == null || themeId.isEmpty()) {
             return null;
         }
-        return ThemeSqlUtils.getThemeByThemeId(themeId, false);
+        return ThemeSqlUtils.getSiteThemeByThemeId(siteModel, themeId);
     }
 
     public ThemeModel getWpComThemeByThemeId(String themeId) {
-        if (themeId == null || themeId.isEmpty()) {
+        if (TextUtils.isEmpty(themeId)) {
             return null;
         }
-        return ThemeSqlUtils.getThemeByThemeId(themeId, true);
+        return ThemeSqlUtils.getWpComThemeByThemeId(themeId);
     }
 
     public ThemeModel getActiveThemeForSite(@NonNull SiteModel site) {
@@ -409,7 +410,7 @@ public class ThemeStore extends Store {
             ThemeModel activatedTheme;
             // payload theme doesn't have all the data so we grab a copy of the database theme and update active flag
             if (payload.site.isJetpackConnected()) {
-                activatedTheme = getInstalledThemeByThemeId(payload.theme.getThemeId());
+                activatedTheme = getInstalledThemeByThemeId(payload.site, payload.theme.getThemeId());
             } else {
                 activatedTheme = getWpComThemeByThemeId(payload.theme.getThemeId());
                 // Remove WP.com flag to store as site-associate theme


### PR DESCRIPTION
We have had several issues because `getThemeByThemeId` was not accepting `SiteModel` as a parameter, which meant that if the user had multiple sites it was pretty random which theme model we'd end up querying. I've opted to separate `getWpComThemeByThemeId` and `getInstalledThemeByThemeId` to make it clearer which query does what.

Although this should fix the immediate issue, I don't think it's a good idea to save both wp.com themes and site themes in the same table. It just makes things more complicated to query and one missed flag will end up weird bugs that's very hard to track down. So, I'd suggest us separating `ThemeModel` into `SiteThemeModel` and `WpComThemeModel` to make it easier for us to work with them. If we agree on it, I'll open an issue for it and make the necessary changes when I have a chance.

/cc @kwonye 