### PR TITLE
Fixes themes search action

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -84,14 +84,14 @@ public class ThemeStoreUnitTest {
         assertNull(mThemeStore.getInstalledThemeByThemeId(site, testThemeId));
 
         // insert new theme and verify it exists
-        ThemeSqlUtils.insertOrUpdateThemeForSite(insertTheme);
+        ThemeSqlUtils.insertOrUpdateSiteTheme(site, insertTheme);
         ThemeModel insertedTheme = mThemeStore.getInstalledThemeByThemeId(site, testThemeId);
         assertNotNull(insertedTheme);
         assertEquals(testThemeName, insertedTheme.getName());
 
         // update the theme and verify the updated attributes
         insertedTheme.setName(testUpdatedName);
-        ThemeSqlUtils.insertOrUpdateThemeForSite(insertedTheme);
+        ThemeSqlUtils.insertOrUpdateSiteTheme(site, insertedTheme);
         insertedTheme = mThemeStore.getInstalledThemeByThemeId(site, testThemeId);
         assertNotNull(insertedTheme);
         assertEquals(testUpdatedName, insertedTheme.getName());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -56,7 +56,6 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme deletion request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
                         responseTheme.setId(theme.getId());
-                        responseTheme.setLocalSiteId(site.getId());
                         ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }
@@ -82,7 +81,6 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onResponse(JetpackThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme installation request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
-                        responseTheme.setLocalSiteId(site.getId());
                         ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -13,14 +13,16 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import java.util.List;
 
 public class ThemeSqlUtils {
-    public static void insertOrUpdateThemeForSite(@NonNull ThemeModel theme) {
+    public static void insertOrUpdateSiteTheme(@NonNull SiteModel site, @NonNull ThemeModel theme) {
         List<ThemeModel> existing = WellSql.select(ThemeModel.class)
                 .where().beginGroup()
                 .equals(ThemeModelTable.THEME_ID, theme.getThemeId())
-                .equals(ThemeModelTable.LOCAL_SITE_ID, theme.getLocalSiteId())
+                .equals(ThemeModelTable.LOCAL_SITE_ID, site.getId())
                 .equals(ThemeModelTable.IS_WP_COM_THEME, false)
                 .endGroup().endWhere().getAsModel();
 
+        // Make sure the local id of the theme is set correctly
+        theme.setLocalSiteId(site.getId());
         // Always remove WP.com flag while storing as a site associate theme as we might be saving
         // a copy of a wp.com theme after an activation
         theme.setIsWpComTheme(false);
@@ -42,6 +44,8 @@ public class ThemeSqlUtils {
                 .equals(ThemeModelTable.IS_WP_COM_THEME, true)
                 .endGroup().endWhere().getAsModel();
 
+        // Remove local site id if it's set for whatever reason (shouldn't normally happen, so it's a sanity check)
+        theme.setLocalSiteId(0);
         // Make sure the isWpComTheme flag is set
         theme.setIsWpComTheme(true);
 
@@ -93,10 +97,9 @@ public class ThemeSqlUtils {
             }
         }
 
-        // make sure active flag and local site ID are set then add to db
+        // make sure active flag is set
         theme.setActive(true);
-        theme.setLocalSiteId(site.getId());
-        insertOrUpdateThemeForSite(theme);
+        insertOrUpdateSiteTheme(site, theme);
     }
 
     public static List<ThemeModel> getActiveThemeForSite(@NonNull SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -388,7 +388,7 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.insertOrUpdateThemeForSite(payload.theme);
+            ThemeSqlUtils.insertOrUpdateSiteTheme(payload.site, payload.theme);
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -368,7 +368,7 @@ public class ThemeStore extends Store {
             event.error = payload.error;
         } else {
             for (ThemeModel theme : payload.themes) {
-                ThemeSqlUtils.insertOrUpdateThemeForSite(theme);
+                ThemeSqlUtils.insertOrUpdateWpComTheme(theme);
             }
         }
         emitChange(event);


### PR DESCRIPTION
This PR fixes this issue: https://github.com/wordpress-mobile/WordPress-Android/issues/6995. The problem was that we were using `insertOrUpdateThemeForSite` to insert a theme from search action. Previous to #649, this was working because we were not setting the `isWpComTheme` inside the `ThemeSqlUtils` method. We had to make that change to fix another issue which led to this one.

The reason I didn't fully catch the issue while working on #649 on FluxC side was the naming of `insertOrUpdateThemeForSite`. I expected only site specific themes to be saved by that method. I've decided to separate that method into 2 distinct ones and made sure that each theme saved using those methods are setup properly (their `isWpComTheme` flag and their local site id).

I've tried this fix in `WPAndroid` and it seems to be working now.

Although this PR fixes the issue, I am still quite confused about why we have a network search action. It looks like we fetch every wp.com theme in the first place**, so why not do a local search instead? Unless we have a reason for this, I'd suggest dropping the network call altogether to have a more responsive UI. (This should happen in a separate PR)

** When we fetch the wp.com themes, we pass 500 parameter as the number of themes to fetch and I think we only have around ~300 of them, so basically it's fetching all the themes.

/cc @kwonye