### PR TITLE
Preparation for update term changes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -117,7 +117,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         setupTermAttributes();
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadNewTerm(mTerm);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
@@ -133,7 +133,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         setupTermAttributes();
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadNewTerm(mTerm);
 
         TermModel uploadedTerm = mTaxonomyStore.getTagsForSite(sSite).get(0);
 
@@ -152,7 +152,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         setupTermAttributes();
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadNewTerm(mTerm);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
@@ -188,7 +188,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         setupTermAttributes();
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadNewTerm(mTerm);
 
         // Upload the same term again
         mNextEvent = TestEvents.ERROR_DUPLICATE;
@@ -320,7 +320,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         return term;
     }
 
-    private void uploadTerm(TermModel term) throws InterruptedException {
+    private void uploadNewTerm(TermModel term) throws InterruptedException {
         mNextEvent = TestEvents.TERM_UPLOADED;
         mCountDownLatch = new CountDownLatch(1);
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
+import org.wordpress.android.fluxc.store.TaxonomyStore.PushTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
 import org.wordpress.android.fluxc.utils.WellSqlUtils;
@@ -172,7 +173,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.ERROR_INVALID_TAXONOMY;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        PushTermPayload pushPayload = new PushTermPayload(mTerm, sSite, true);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -193,7 +194,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.ERROR_DUPLICATE;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        PushTermPayload pushPayload = new PushTermPayload(mTerm, sSite, true);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -323,7 +324,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.TERM_UPLOADED;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
+        PushTermPayload pushPayload = new PushTermPayload(term, sSite, true);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -126,7 +126,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         setupTermAttributes();
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadNewTerm(mTerm);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
@@ -142,7 +142,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         setupTermAttributes();
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadNewTerm(mTerm);
 
         TermModel uploadedTerm = mTaxonomyStore.getTagsForSite(sSite).get(0);
 
@@ -161,7 +161,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         setupTermAttributes();
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadNewTerm(mTerm);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
@@ -201,7 +201,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         setupTermAttributes();
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadNewTerm(mTerm);
 
         // Upload the same term again
         mNextEvent = TestEvents.ERROR_GENERIC;
@@ -337,7 +337,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         return term;
     }
 
-    private void uploadTerm(TermModel term) throws InterruptedException {
+    private void uploadNewTerm(TermModel term) throws InterruptedException {
         mNextEvent = TestEvents.TERM_UPLOADED;
         mCountDownLatch = new CountDownLatch(1);
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
+import org.wordpress.android.fluxc.store.TaxonomyStore.PushTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
@@ -181,7 +182,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        PushTermPayload pushPayload = new PushTermPayload(mTerm, sSite, true);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -206,7 +207,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        PushTermPayload pushPayload = new PushTermPayload(mTerm, sSite, true);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -340,7 +341,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.TERM_UPLOADED;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
+        PushTermPayload pushPayload = new PushTermPayload(term, sSite, true);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -18,7 +18,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded;
-import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.PushTermPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -95,7 +95,7 @@ public class TaxonomiesFragment extends Fragment {
         newCategory.setName("FluxC-category-" + new Random().nextLong());
         newCategory.setDescription("From FluxC example app");
 
-        RemoteTermPayload payload = new RemoteTermPayload(newCategory, getFirstSite());
+        PushTermPayload payload = new PushTermPayload(newCategory, getFirstSite(), true);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.PushTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 
 @ActionEnum
@@ -21,7 +22,7 @@ public enum TaxonomyAction implements IAction {
     FETCH_TERMS,
     @Action(payloadType = RemoteTermPayload.class)
     FETCH_TERM,
-    @Action(payloadType = RemoteTermPayload.class)
+    @Action(payloadType = PushTermPayload.class)
     PUSH_TERM,
 
     // Remote responses
@@ -29,7 +30,7 @@ public enum TaxonomyAction implements IAction {
     FETCHED_TERMS,
     @Action(payloadType = FetchTermResponsePayload.class)
     FETCHED_TERM,
-    @Action(payloadType = RemoteTermPayload.class)
+    @Action(payloadType = PushTermPayload.class)
     PUSHED_TERM,
 
     // Local actions

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse.TermsResponse;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.PushTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
 import org.wordpress.android.util.StringUtils;
@@ -116,7 +117,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void pushTerm(final TermModel term, final SiteModel site) {
+    public void pushTerm(final TermModel term, final SiteModel site, final boolean isNewTerm) {
         final String taxonomy = term.getTaxonomy();
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms.new_.getUrlV1_1();
 
@@ -133,7 +134,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         uploadedTerm.setLocalSiteId(site.getId());
                         uploadedTerm.setTaxonomy(taxonomy);
 
-                        RemoteTermPayload payload = new RemoteTermPayload(uploadedTerm, site);
+                        PushTermPayload payload = new PushTermPayload(uploadedTerm, site, isNewTerm);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                     }
                 },
@@ -141,7 +142,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
-                        RemoteTermPayload payload = new RemoteTermPayload(term, site);
+                        PushTermPayload payload = new PushTermPayload(term, site, isNewTerm);
                         payload.error = new TaxonomyError(((WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResp
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.PushTermPayload;
-import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
 import org.wordpress.android.util.StringUtils;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.PushTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
@@ -149,7 +150,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void pushTerm(final TermModel term, final SiteModel site) {
+    public void pushTerm(final TermModel term, final SiteModel site, final boolean isNewTerm) {
         Map<String, Object> contentStruct = termModelToContentStruct(term);
 
         List<Object> params = new ArrayList<>(4);
@@ -164,7 +165,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                     public void onResponse(Object response) {
                         term.setRemoteTermId(Long.valueOf((String) response));
 
-                        RemoteTermPayload payload = new RemoteTermPayload(term, site);
+                        PushTermPayload payload = new PushTermPayload(term, site, isNewTerm);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                     }
                 },
@@ -176,7 +177,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                         // 403 - "Parent term does not exist."
                         // 403 - "The term name cannot be empty."
                         // 500 - "A term with the name provided already exists with this parent."
-                        RemoteTermPayload payload = new RemoteTermPayload(term, site);
+                        PushTermPayload payload = new PushTermPayload(term, site, isNewTerm);
                         // TODO: Check the error message and flag this as one of the above specific errors if applicable
                         // Convert GenericErrorType to PostErrorType where applicable
                         TaxonomyError taxonomyError;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -23,7 +23,6 @@ import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.PushTermPayload;
-import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
 import org.wordpress.android.util.MapUtils;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -296,7 +296,7 @@ public class TaxonomyStore extends Store {
                 handleFetchSingleTermCompleted((FetchTermResponsePayload) action.getPayload());
                 break;
             case PUSH_TERM:
-                pushTerm((RemoteTermPayload) action.getPayload());
+                pushTerm((PushTermPayload) action.getPayload());
                 break;
             case PUSHED_TERM:
                 handlePushTermCompleted((RemoteTermPayload) action.getPayload());
@@ -407,12 +407,12 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void pushTerm(RemoteTermPayload payload) {
+    private void pushTerm(PushTermPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
-            mTaxonomyRestClient.pushTerm(payload.term, payload.site);
+            mTaxonomyRestClient.pushTerm(payload.term, payload.site, payload.isNewTerm);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
-            mTaxonomyXMLRPCClient.pushTerm(payload.term, payload.site);
+            mTaxonomyXMLRPCClient.pushTerm(payload.term, payload.site, payload.isNewTerm);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -67,6 +67,17 @@ public class TaxonomyStore extends Store {
         }
     }
 
+    public static class PushTermPayload extends RemoteTermPayload {
+        public TermModel term;
+        public SiteModel site;
+        public boolean isNewTerm;
+
+        public PushTermPayload(TermModel term, SiteModel site, boolean isNewTerm) {
+            super(term, site);
+            this.isNewTerm = isNewTerm;
+        }
+    }
+
     public static class FetchTermResponsePayload extends RemoteTermPayload {
         public TaxonomyAction origin = TaxonomyAction.FETCH_TERM; // Used to track fetching newly uploaded XML-RPC terms
 


### PR DESCRIPTION
I am working on updating an existing term to help @nbradbury with the new tags screen in WPAndroid. As a preparation for those changes, I decided to separate this PR and decided to target a WIP branch.

I am planning to use the `PUSH_TERM` action for both uploading a new term and to update an existing one. This is a pattern we use elsewhere in the app and with the way things are built in `TaxonomyStore` I think this is the best course of action.

As a first step to that, I decided to introduce a new payload called `PushTermPayload` which will be aware of if this is a new term or not. I intend to carry this `boolean` to the event as you'll see in `OnTermUploaded`. The way we (have to) upload a new term to xml-rpc is a bit convoluted and this will mean that there will be a bit more passed information with xml-rpc fetch term action.

This PR by itself doesn't change much but instead makes a proposal for the intended change. I'd love to get your thoughts on this @aforcier as the original author of the `TaxonomyStore`.

Please let me know if you have any questions @nbradbury @aforcier 