### PR TITLE
Adds the ability to update existing terms

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -42,7 +42,6 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     }
 
     private TestEvents mNextEvent;
-    private TermModel mTerm;
 
     @Override
     protected void setUp() throws Exception {
@@ -112,11 +111,11 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     public void testUploadNewCategory() throws InterruptedException {
         // Instantiate new category
-        createNewCategory();
-        setupTermAttributes();
+        TermModel term = createNewCategory();
+        setupTermAttributes(term);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(term);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
@@ -128,11 +127,11 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     public void testUpdateExistingCategory() throws InterruptedException {
         // Instantiate new category
-        createNewCategory();
-        setupTermAttributes();
+        TermModel term = createNewCategory();
+        setupTermAttributes(term);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(term);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
@@ -151,11 +150,11 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     public void testUploadNewTag() throws InterruptedException {
         // Instantiate new tag
-        createNewTag();
-        setupTermAttributes();
+        TermModel term = createNewTag();
+        setupTermAttributes(term);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(term);
 
         TermModel uploadedTerm = mTaxonomyStore.getTagsForSite(sSite).get(0);
 
@@ -170,11 +169,11 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         taxonomyModel.setName(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
 
         // Instantiate new term
-        createNewTerm(taxonomyModel);
-        setupTermAttributes();
+        TermModel term = createNewTerm(taxonomyModel);
+        setupTermAttributes(term);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(term);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
@@ -189,13 +188,13 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         taxonomyModel.setName("roads");
 
         // Instantiate new term
-        createNewTerm(taxonomyModel);
-        setupTermAttributes();
+        TermModel term = createNewTerm(taxonomyModel);
+        setupTermAttributes(term);
 
         mNextEvent = TestEvents.ERROR_INVALID_TAXONOMY;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -206,17 +205,17 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     public void testUploadNewCategoryDuplicate() throws InterruptedException {
         // Instantiate new category
-        createNewCategory();
-        setupTermAttributes();
+        TermModel term = createNewCategory();
+        setupTermAttributes(term);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(term);
 
         // Upload the same term again
         mNextEvent = TestEvents.ERROR_DUPLICATE;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -304,9 +303,9 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch.countDown();
     }
 
-    private void setupTermAttributes() {
-        mTerm.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
-        mTerm.setDescription(TERM_DEFAULT_DESCRIPTION);
+    private void setupTermAttributes(TermModel term) {
+        term.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
+        term.setDescription(TERM_DEFAULT_DESCRIPTION);
     }
 
     private TermModel createNewCategory() {
@@ -316,7 +315,6 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, term.getId());
         assertNotSame(0, term.getLocalSiteId());
 
-        mTerm = term;
         return term;
     }
 
@@ -327,7 +325,6 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, term.getId());
         assertNotSame(0, term.getLocalSiteId());
 
-        mTerm = term;
         return term;
     }
 
@@ -338,7 +335,6 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, term.getId());
         assertNotSame(0, term.getLocalSiteId());
 
-        mTerm = term;
         return term;
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -126,26 +126,8 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     }
 
     public void testUpdateExistingCategory() throws InterruptedException {
-        // Instantiate new category
         TermModel term = createNewCategory();
-        setupTermAttributes(term);
-
-        // Upload new term to site
-        uploadTerm(term);
-
-        TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
-
-        String newDescription = "newDescription";
-        assertFalse(newDescription.equals(uploadedTerm.getDescription()));
-        uploadedTerm.setDescription(newDescription);
-
-        uploadTerm(uploadedTerm);
-        assertEquals(1, WellSqlUtils.getTotalTermsCount()); // make sure we still have only one term
-        TermModel updatedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
-        assertEquals(updatedTerm.getRemoteTermId(), uploadedTerm.getRemoteTermId());
-        assertEquals(updatedTerm.getDescription(), newDescription);
+        testUpdateExistingTerm(term);
     }
 
     public void testUploadNewTag() throws InterruptedException {
@@ -162,6 +144,11 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(1, mTaxonomyStore.getTagsForSite(sSite).size());
 
         assertNotSame(0, uploadedTerm.getRemoteTermId());
+    }
+
+    public void testUpdateExistingTag() throws InterruptedException {
+        TermModel term = createNewTag();
+        testUpdateExistingTerm(term);
     }
 
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
@@ -346,5 +333,26 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void testUpdateExistingTerm(TermModel term) throws InterruptedException {
+        setupTermAttributes(term);
+
+        // Upload new term to site
+        uploadTerm(term);
+
+        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, term.getTaxonomy()).get(0);
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+
+        String newDescription = "newDescription";
+        assertFalse(newDescription.equals(uploadedTerm.getDescription()));
+        uploadedTerm.setDescription(newDescription);
+
+        uploadTerm(uploadedTerm);
+        assertEquals(1, WellSqlUtils.getTotalTermsCount()); // make sure we still have only one term
+        TermModel updatedTerm = mTaxonomyStore.getTermsForSite(sSite, term.getTaxonomy()).get(0);
+        assertEquals(updatedTerm.getRemoteTermId(), uploadedTerm.getRemoteTermId());
+        assertEquals(updatedTerm.getDescription(), newDescription);
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -126,6 +126,29 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    public void testUpdateExistingCategory() throws InterruptedException {
+        // Instantiate new category
+        createNewCategory();
+        setupTermAttributes();
+
+        // Upload new term to site
+        uploadTerm(mTerm);
+
+        TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+
+        String newDescription = "newDescription";
+        assertFalse(newDescription.equals(uploadedTerm.getDescription()));
+        uploadedTerm.setDescription(newDescription);
+
+        uploadTerm(uploadedTerm);
+        assertEquals(1, WellSqlUtils.getTotalTermsCount()); // make sure we still have only one term
+        TermModel updatedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
+        assertEquals(updatedTerm.getRemoteTermId(), uploadedTerm.getRemoteTermId());
+        assertEquals(updatedTerm.getDescription(), newDescription);
+    }
+
     public void testUploadNewTag() throws InterruptedException {
         // Instantiate new tag
         createNewTag();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -44,7 +44,6 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     private TestEvents mNextEvent;
     private TaxonomyError mLastTaxonomyError;
-    private TermModel mTerm;
 
     @Override
     protected void setUp() throws Exception {
@@ -121,11 +120,11 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     public void testUploadNewCategory() throws InterruptedException {
         // Instantiate new category
-        createNewCategory();
-        setupTermAttributes();
+        TermModel term = createNewCategory();
+        setupTermAttributes(term);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(term);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
@@ -136,17 +135,17 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     public void testUpdateExistingCategory() throws InterruptedException {
-        createNewCategory();
-        testUpdateExistingTerm(mTerm);
+        TermModel term = createNewCategory();
+        testUpdateExistingTerm(term);
     }
 
     public void testUploadNewTag() throws InterruptedException {
         // Instantiate new tag
-        createNewTag();
-        setupTermAttributes();
+        TermModel term = createNewTag();
+        setupTermAttributes(term);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(term);
 
         TermModel uploadedTerm = mTaxonomyStore.getTagsForSite(sSite).get(0);
 
@@ -157,8 +156,8 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     public void testUpdateExistingTag() throws InterruptedException {
-        createNewTag();
-        testUpdateExistingTerm(mTerm);
+        TermModel term = createNewTag();
+        testUpdateExistingTerm(term);
     }
 
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
@@ -166,11 +165,11 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         taxonomyModel.setName(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
 
         // Instantiate new term
-        createNewTerm(taxonomyModel);
-        setupTermAttributes();
+        TermModel termModel = createNewTerm(taxonomyModel);
+        setupTermAttributes(termModel);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(termModel);
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
@@ -185,13 +184,13 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         taxonomyModel.setName("roads");
 
         // Instantiate new term
-        createNewTerm(taxonomyModel);
-        setupTermAttributes();
+        TermModel term = createNewTerm(taxonomyModel);
+        setupTermAttributes(term);
 
         mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -206,17 +205,17 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     public void testUploadNewCategoryDuplicate() throws InterruptedException {
         // Instantiate new category
-        createNewCategory();
-        setupTermAttributes();
+        TermModel term = createNewCategory();
+        setupTermAttributes(term);
 
         // Upload new term to site
-        uploadTerm(mTerm);
+        uploadTerm(term);
 
         // Upload the same term again
         mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 
-        RemoteTermPayload pushPayload = new RemoteTermPayload(mTerm, sSite);
+        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -308,9 +307,9 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch.countDown();
     }
 
-    private void setupTermAttributes() {
-        mTerm.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
-        mTerm.setDescription(TERM_DEFAULT_DESCRIPTION);
+    private void setupTermAttributes(TermModel term) {
+        term.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
+        term.setDescription(TERM_DEFAULT_DESCRIPTION);
     }
 
     private TermModel createNewCategory() throws InterruptedException {
@@ -320,7 +319,6 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, term.getId());
         assertNotSame(0, term.getLocalSiteId());
 
-        mTerm = term;
         return term;
     }
 
@@ -331,7 +329,6 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, term.getId());
         assertNotSame(0, term.getLocalSiteId());
 
-        mTerm = term;
         return term;
     }
 
@@ -342,7 +339,6 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, term.getId());
         assertNotSame(0, term.getLocalSiteId());
 
-        mTerm = term;
         return term;
     }
 
@@ -357,7 +353,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     private void testUpdateExistingTerm(TermModel term) throws InterruptedException {
-        setupTermAttributes();
+        setupTermAttributes(term);
 
         // Upload new term to site
         uploadTerm(term);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -135,6 +135,11 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    public void testUpdateExistingCategory() throws InterruptedException {
+        createNewCategory();
+        testUpdateExistingTerm(mTerm);
+    }
+
     public void testUploadNewTag() throws InterruptedException {
         // Instantiate new tag
         createNewTag();
@@ -149,6 +154,11 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(1, mTaxonomyStore.getTagsForSite(sSite).size());
 
         assertNotSame(0, uploadedTerm.getRemoteTermId());
+    }
+
+    public void testUpdateExistingTag() throws InterruptedException {
+        createNewTag();
+        testUpdateExistingTerm(mTerm);
     }
 
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
@@ -344,5 +354,26 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void testUpdateExistingTerm(TermModel term) throws InterruptedException {
+        setupTermAttributes();
+
+        // Upload new term to site
+        uploadTerm(term);
+
+        TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, term.getTaxonomy()).get(0);
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        assertNotSame(0, uploadedTerm.getRemoteTermId());
+
+        String newDescription = "newDescription";
+        assertFalse(newDescription.equals(uploadedTerm.getDescription()));
+        uploadedTerm.setDescription(newDescription);
+
+        uploadTerm(uploadedTerm);
+        assertEquals(1, WellSqlUtils.getTotalTermsCount()); // make sure we still have only one term
+        TermModel updatedTerm = mTaxonomyStore.getTermsForSite(sSite, term.getTaxonomy()).get(0);
+        assertEquals(updatedTerm.getRemoteTermId(), uploadedTerm.getRemoteTermId());
+        assertEquals(updatedTerm.getDescription(), newDescription);
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -211,7 +211,8 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Upload new term to site
         uploadTerm(term);
 
-        // Upload the same term again
+        // Upload the same term again after setting it's remote id to 0 so it doesn't trigger an update
+        term.setRemoteTermId(0);
         mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -10,6 +10,7 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST.SitesEndpoint.SiteEndpoint.TaxonomiesEndpoint;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.model.TermsModel;
@@ -118,7 +119,10 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
 
     public void pushTerm(final TermModel term, final SiteModel site) {
         final String taxonomy = term.getTaxonomy();
-        String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms.new_.getUrlV1_1();
+        TaxonomiesEndpoint endpoint = WPCOMREST.sites.site(site.getSiteId()).taxonomies;
+        String url = term.getRemoteTermId() > 0
+                ? endpoint.taxonomy(taxonomy).terms.slug(term.getSlug()).getUrlV1_1() // update existing term
+                : endpoint.taxonomy(taxonomy).terms.new_.getUrlV1_1(); // upload new term
 
         Map<String, Object> body = termModelToParams(term);
 

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -12,6 +12,7 @@ wp.deletePost
 wp.getTerm
 wp.getTerms
 wp.newTerm
+wp.editTerm
 wp.uploadFile
 wp.newComment
 wp.getComment


### PR DESCRIPTION
This PR adds the ability to update existing terms by checking the remote id on the `TermModel`. If the remote id is set, we'll assume that it's an update and not an upload and act accordingly. It also adds the tests for editing both tags and categories for both xml-rpc and .com sites. Finally, it removes the `mTerm` from both test classes as we don't really need them and it's a pretty bad practice to use global variables when you don't need to. Especially in these tests where there are callbacks happening, unless you go through the whole flow, as a developer you don't know whether the variable is updated or not.

The consumer of this library has to make sure that the remote id's state is correct for what is being tried to achieve (whether upload or update).