### PR TITLE
Checkstyle/ktlint tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+max_line_length=120

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
     }
 
     dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.12.1'
+        ktlint 'com.github.shyiko:ktlint:0.14.0'
     }
 
     task ktlint(type: JavaExec) {
@@ -55,7 +55,7 @@ subprojects {
 }
 
 ext {
-    kotlinVersion = '1.2.0'
+    kotlinVersion = '1.2.10'
 
     daggerVersion = '2.11'
     supportLibraryVersion = '25.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ allprojects {
         source 'src'
         include '**/*.java'
         include '**/*.kt'
+        include '**/*.xml'
         exclude '**/gen/**'
 
         classpath = files()

--- a/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.kt
@@ -29,8 +29,8 @@ class AccountFragment : Fragment() {
         super.onAttach(context)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?
-            = inflater.inflate(R.layout.fragment_account, container, false)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_account, container, false)
 
     override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -63,8 +63,8 @@ class MainFragment : Fragment() {
         dispatcher.unregister(this)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?
-            = inflater.inflate(R.layout.fragment_main, container, false)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_main, container, false)
 
     override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
@@ -37,8 +37,8 @@ class PostsFragment : Fragment() {
         super.onAttach(context)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?
-            = inflater.inflate(R.layout.fragment_posts, container, false)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_posts, container, false)
 
     override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -40,8 +40,8 @@ class ThemeFragment : Fragment() {
         dispatcher.unregister(this)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?
-            = inflater.inflate(R.layout.fragment_themes, container, false)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_themes, container, false)
 
     override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)


### PR DESCRIPTION
This makes a few small adjustments to our lint rules:

1. The `./gradlew checkstyle` task now also checks `xml` files (the Android Studio plugin was already doing this)
2. I noticed checkstyle wasn't enforcing line length on Kotlin files, so I enabled a `max_line_length` check for ktlint

Also bumped Kotlin and ktlint versions, and fixed some new `ktlint` errors.

cc @maxme