### PR TITLE
Remove theme search

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -21,8 +21,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         NONE,
         FETCHED_WPCOM_THEMES,
         FETCHED_CURRENT_THEME,
-        SEARCHED_THEMES,
-        ACTIVATED_THEME,
+        ACTIVATED_THEME
     }
 
     @Inject ThemeStore mThemeStore;
@@ -30,7 +29,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     private TestEvents mNextEvent;
     private ThemeModel mCurrentTheme;
     private ThemeModel mActivatedTheme;
-    private List<ThemeModel> mSearchResults;
 
     @Override
     protected void setUp() throws Exception {
@@ -42,7 +40,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.NONE;
         mCurrentTheme = null;
         mActivatedTheme = null;
-        mSearchResults = null;
     }
 
     public void testActivateTheme() throws InterruptedException {
@@ -93,31 +90,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertNotNull(mCurrentTheme);
-    }
-
-    public void testSearchThemes() throws InterruptedException {
-        // "Twenty *teen" themes
-        final String searchTerm = "twenty";
-
-        ThemeStore.SearchThemesPayload payload = new ThemeStore.SearchThemesPayload(searchTerm);
-        mNextEvent = TestEvents.SEARCHED_THEMES;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(payload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertNotNull(mSearchResults);
-        assertFalse(mSearchResults.isEmpty());
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe
-    public void onThemesSearched(ThemeStore.OnThemesSearched event) {
-        if (event.isError()) {
-            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
-        }
-        assertTrue(mNextEvent == TestEvents.SEARCHED_THEMES);
-        mSearchResults = event.searchResults;
-        mCountDownLatch.countDown();
     }
 
     @SuppressWarnings("unused")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -100,15 +100,6 @@ class ThemeFragment : Fragment() {
             }
         }
 
-        search_themes.setOnClickListener {
-            val term = getThemeIdFromInput(view)
-            if (TextUtils.isEmpty(term)) {
-                prependToLog("Please enter a search term")
-            } else {
-                dispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(ThemeStore.SearchThemesPayload(term)))
-            }
-        }
-
         delete_theme_jp.setOnClickListener {
             val id = getThemeIdFromInput(view)
             if (TextUtils.isEmpty(id)) {
@@ -197,17 +188,6 @@ class ThemeFragment : Fragment() {
             prependToLog("error: " + event.error.message)
         } else {
             prependToLog("success: theme = " + event.theme.name)
-        }
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onThemesSearched(event: ThemeStore.OnThemesSearched) {
-        prependToLog("onThemesSearched: ")
-        if (event.isError) {
-            prependToLog("error: " + event.error.message)
-        } else {
-            prependToLog("success: result count = " + event.searchResults.size)
         }
     }
 

--- a/example/src/main/res/layout/fragment_themes.xml
+++ b/example/src/main/res/layout/fragment_themes.xml
@@ -30,12 +30,6 @@
         android:layout_height="wrap_content"
         android:text="Fetch current theme WP.com" />
 
-    <Button
-        android:id="@+id/search_themes"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Search Themes" />
-
     <EditText
         android:id="@+id/theme_id"
         android:layout_width="match_parent"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -9,8 +9,6 @@ import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 
 @ActionEnum
 public enum ThemeAction implements IAction {
@@ -23,8 +21,6 @@ public enum ThemeAction implements IAction {
     FETCH_PURCHASED_THEMES,
     @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
-    @Action(payloadType = SearchThemesPayload.class)
-    SEARCH_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATE_THEME,
     @Action(payloadType = ActivateThemePayload.class)
@@ -41,8 +37,6 @@ public enum ThemeAction implements IAction {
     FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
-    @Action(payloadType = SearchedThemesPayload.class)
-    SEARCHED_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATED_THEME,
     @Action(payloadType = ActivateThemePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
@@ -192,30 +191,6 @@ public class ThemeRestClient extends BaseWPComRestClient {
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(site, themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedCurrentThemeAction(payload));
-                    }
-                }));
-    }
-
-    /** [Undocumented!] Endpoint: v1.2/themes?search=$term */
-    public void searchThemes(@NonNull final String searchTerm) {
-        String url = WPCOMREST.themes.getUrlV1_2() + "?search=" + searchTerm;
-        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeListResponse.class,
-                new Response.Listener<WPComThemeListResponse>() {
-                    @Override
-                    public void onResponse(WPComThemeListResponse response) {
-                        AppLog.d(AppLog.T.API, "Received response to search themes request.");
-                        SearchedThemesPayload payload =
-                                new SearchedThemesPayload(searchTerm, createThemeListFromArrayResponse(response));
-                        mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));
-                    }
-                }, new BaseRequest.BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(AppLog.T.API, "Received error response to search themes request.");
-                        ThemesError themeError = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
-                        SearchedThemesPayload payload = new SearchedThemesPayload(themeError);
-                        mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));
                     }
                 }));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -67,28 +67,6 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class SearchThemesPayload extends Payload<ThemesError> {
-        public String searchTerm;
-
-        public SearchThemesPayload(@NonNull String searchTerm) {
-            this.searchTerm = searchTerm;
-        }
-    }
-
-    public static class SearchedThemesPayload extends Payload<ThemesError> {
-        public String searchTerm;
-        public List<ThemeModel> themes;
-
-        public SearchedThemesPayload(@NonNull String searchTerm, List<ThemeModel> themes) {
-            this.searchTerm = searchTerm;
-            this.themes = themes;
-        }
-
-        public SearchedThemesPayload(ThemesError error) {
-            this.error = error;
-        }
-    }
-
     public static class ActivateThemePayload extends Payload<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -155,14 +133,6 @@ public class ThemeStore extends Store {
         public OnCurrentThemeFetched(SiteModel site, ThemeModel theme) {
             this.site = site;
             this.theme = theme;
-        }
-    }
-
-    public static class OnThemesSearched extends OnChanged<ThemesError> {
-        public List<ThemeModel> searchResults;
-
-        public OnThemesSearched(List<ThemeModel> searchResults) {
-            this.searchResults = searchResults;
         }
     }
 
@@ -241,13 +211,6 @@ public class ThemeStore extends Store {
                 break;
             case FETCHED_CURRENT_THEME:
                 handleCurrentThemeFetched((FetchedCurrentThemePayload) action.getPayload());
-                break;
-            case SEARCH_THEMES:
-                SearchThemesPayload searchPayload = (SearchThemesPayload) action.getPayload();
-                searchThemes(searchPayload.searchTerm);
-                break;
-            case SEARCHED_THEMES:
-                handleSearchedThemes((SearchedThemesPayload) action.getPayload());
                 break;
             case ACTIVATE_THEME:
                 activateTheme((ActivateThemePayload) action.getPayload());
@@ -370,22 +333,6 @@ public class ThemeStore extends Store {
             event.error = payload.error;
         } else {
             ThemeSqlUtils.insertOrReplaceActiveThemeForSite(payload.site, payload.theme);
-        }
-        emitChange(event);
-    }
-
-    private void searchThemes(@NonNull String searchTerm) {
-        mThemeRestClient.searchThemes(searchTerm);
-    }
-
-    private void handleSearchedThemes(@NonNull SearchedThemesPayload payload) {
-        OnThemesSearched event = new OnThemesSearched(payload.themes);
-        if (payload.isError()) {
-            event.error = payload.error;
-        } else {
-            for (ThemeModel theme : payload.themes) {
-                ThemeSqlUtils.insertOrUpdateWpComTheme(theme);
-            }
         }
         emitChange(event);
     }


### PR DESCRIPTION
Fixes #654. I've been thinking about this and I think the best way to go about search is just to handle it in WPAndroid. We already fetch all available themes at once, so we don't really need the network call. Initially, I thought adding a DB search would be the way to go, but I don't really see the benefit in it. Since all of these themes will be in a `List` in WPAndroid anyway, I don't see why we should depend on FluxC queries to search that same list. I might be missing something though, so I am open to that approach if we have a good reason for it.

If we do it this way and ever decide to add back the theme search network call (which is very unlikely unless we somehow decide to double/triple our available themes or have some additional features in the search request) we could just revert this PR and make the necessary changes.

What do you think @nbradbury?

/cc @kwonye (since you know a lot more about themes than any of us)