### PR TITLE
Theme Store improvements - 2

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.ThemeStore;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -105,7 +105,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         // activate it
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;
-        ActivateThemePayload payload = new ActivateThemePayload(jetpackSite, themeToActivate);
+        SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -195,7 +195,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             mNextEvent = TestEvents.ACTIVATED_THEME;
             ThemeModel themeToActivate = getOtherTheme(themes, themeId);
             assertNotNull(themeToActivate);
-            ActivateThemePayload payload = new ActivateThemePayload(jetpackSite, themeToActivate);
+            SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
             mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
             assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         }
@@ -462,7 +462,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     }
 
     private void installTheme(SiteModel site, ThemeModel theme) throws InterruptedException {
-        ActivateThemePayload install = new ActivateThemePayload(site, theme);
+        SiteThemePayload install = new SiteThemePayload(site, theme);
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.INSTALLED_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newInstallThemeAction(install));
@@ -470,7 +470,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     }
 
     private void deleteTheme(SiteModel site, ThemeModel theme) throws InterruptedException {
-        ActivateThemePayload delete = new ActivateThemePayload(site, theme);
+        SiteThemePayload delete = new SiteThemePayload(site, theme);
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.DELETED_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newDeleteThemeAction(delete));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.ThemeStore;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -61,7 +61,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         assertNotNull(themeToActivate);
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;
-        ActivateThemePayload payload = new ActivateThemePayload(sSite, themeToActivate);
+        SiteThemePayload payload = new SiteThemePayload(sSite, themeToActivate);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertNotNull(mActivatedTheme);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -21,8 +21,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         NONE,
         FETCHED_WPCOM_THEMES,
         FETCHED_CURRENT_THEME,
-        SEARCHED_THEMES,
-        ACTIVATED_THEME,
+        ACTIVATED_THEME
     }
 
     @Inject ThemeStore mThemeStore;
@@ -30,7 +29,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     private TestEvents mNextEvent;
     private ThemeModel mCurrentTheme;
     private ThemeModel mActivatedTheme;
-    private List<ThemeModel> mSearchResults;
 
     @Override
     protected void setUp() throws Exception {
@@ -42,7 +40,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.NONE;
         mCurrentTheme = null;
         mActivatedTheme = null;
-        mSearchResults = null;
     }
 
     public void testActivateTheme() throws InterruptedException {
@@ -93,31 +90,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertNotNull(mCurrentTheme);
-    }
-
-    public void testSearchThemes() throws InterruptedException {
-        // "Twenty *teen" themes
-        final String searchTerm = "twenty";
-
-        ThemeStore.SearchThemesPayload payload = new ThemeStore.SearchThemesPayload(searchTerm);
-        mNextEvent = TestEvents.SEARCHED_THEMES;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(payload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertNotNull(mSearchResults);
-        assertFalse(mSearchResults.isEmpty());
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe
-    public void onThemesSearched(ThemeStore.OnThemesSearched event) {
-        if (event.isError()) {
-            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
-        }
-        assertTrue(mNextEvent == TestEvents.SEARCHED_THEMES);
-        mSearchResults = event.searchResults;
-        mCountDownLatch.countDown();
     }
 
     @SuppressWarnings("unused")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -58,7 +58,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.ActivateThemePayload(site, theme)
+                    val payload = ThemeStore.SiteThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload))
                 }
             }
@@ -76,7 +76,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.ActivateThemePayload(site, theme)
+                    val payload = ThemeStore.SiteThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload))
                 }
             }
@@ -94,7 +94,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.ActivateThemePayload(site, theme)
+                    val payload = ThemeStore.SiteThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newInstallThemeAction(payload))
                 }
             }
@@ -112,7 +112,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.ActivateThemePayload(site, theme)
+                    val payload = ThemeStore.SiteThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newDeleteThemeAction(payload))
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -100,15 +100,6 @@ class ThemeFragment : Fragment() {
             }
         }
 
-        search_themes.setOnClickListener {
-            val term = getThemeIdFromInput(view)
-            if (TextUtils.isEmpty(term)) {
-                prependToLog("Please enter a search term")
-            } else {
-                dispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(ThemeStore.SearchThemesPayload(term)))
-            }
-        }
-
         delete_theme_jp.setOnClickListener {
             val id = getThemeIdFromInput(view)
             if (TextUtils.isEmpty(id)) {
@@ -197,17 +188,6 @@ class ThemeFragment : Fragment() {
             prependToLog("error: " + event.error.message)
         } else {
             prependToLog("success: theme = " + event.theme.name)
-        }
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onThemesSearched(event: ThemeStore.OnThemesSearched) {
-        prependToLog("onThemesSearched: ")
-        if (event.isError) {
-            prependToLog("error: " + event.error.message)
-        } else {
-            prependToLog("success: result count = " + event.searchResults.size)
         }
     }
 

--- a/example/src/main/res/layout/fragment_themes.xml
+++ b/example/src/main/res/layout/fragment_themes.xml
@@ -30,12 +30,6 @@
         android:layout_height="wrap_content"
         android:text="Fetch current theme WP.com" />
 
-    <Button
-        android:id="@+id/search_themes"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Search Themes" />
-
     <EditText
         android:id="@+id/theme_id"
         android:layout_width="match_parent"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
@@ -21,11 +21,11 @@ public enum ThemeAction implements IAction {
     FETCH_PURCHASED_THEMES,
     @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     ACTIVATE_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     INSTALL_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     DELETE_THEME,
 
     // Remote responses
@@ -37,11 +37,11 @@ public enum ThemeAction implements IAction {
     FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     ACTIVATED_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     INSTALLED_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     DELETED_THEME,
 
     // Local actions

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -18,8 +18,6 @@ public enum ThemeAction implements IAction {
     @Action(payloadType = SiteModel.class)
     FETCH_INSTALLED_THEMES, // Jetpack only
     @Action(payloadType = SiteModel.class)
-    FETCH_PURCHASED_THEMES,
-    @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
     @Action(payloadType = SiteThemePayload.class)
     ACTIVATE_THEME,
@@ -33,8 +31,6 @@ public enum ThemeAction implements IAction {
     FETCHED_WP_COM_THEMES,
     @Action(payloadType = FetchedSiteThemesPayload.class)
     FETCHED_INSTALLED_THEMES,
-    @Action(payloadType = FetchedSiteThemesPayload.class)
-    FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
     @Action(payloadType = SiteThemePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -9,8 +9,6 @@ import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 
 @ActionEnum
 public enum ThemeAction implements IAction {
@@ -23,8 +21,6 @@ public enum ThemeAction implements IAction {
     FETCH_PURCHASED_THEMES,
     @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
-    @Action(payloadType = SearchThemesPayload.class)
-    SEARCH_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATE_THEME,
     @Action(payloadType = ActivateThemePayload.class)
@@ -41,8 +37,6 @@ public enum ThemeAction implements IAction {
     FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
-    @Action(payloadType = SearchedThemesPayload.class)
-    SEARCHED_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATED_THEME,
     @Action(payloadType = ActivateThemePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
@@ -192,30 +191,6 @@ public class ThemeRestClient extends BaseWPComRestClient {
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(site, themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedCurrentThemeAction(payload));
-                    }
-                }));
-    }
-
-    /** [Undocumented!] Endpoint: v1.2/themes?search=$term */
-    public void searchThemes(@NonNull final String searchTerm) {
-        String url = WPCOMREST.themes.getUrlV1_2() + "?search=" + searchTerm;
-        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeListResponse.class,
-                new Response.Listener<WPComThemeListResponse>() {
-                    @Override
-                    public void onResponse(WPComThemeListResponse response) {
-                        AppLog.d(AppLog.T.API, "Received response to search themes request.");
-                        SearchedThemesPayload payload =
-                                new SearchedThemesPayload(searchTerm, createThemeListFromArrayResponse(response));
-                        mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));
-                    }
-                }, new BaseRequest.BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(AppLog.T.API, "Received error response to search themes request.");
-                        ThemesError themeError = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
-                        SearchedThemesPayload payload = new SearchedThemesPayload(themeError);
-                        mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));
                     }
                 }));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeListResponse;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
@@ -56,14 +56,14 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme deletion request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
                         responseTheme.setId(theme.getId());
-                        ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
+                        SiteThemePayload payload = new SiteThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }
                 }, new BaseRequest.BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme deletion request.");
-                        ActivateThemePayload payload = new ActivateThemePayload(site, theme);
+                        SiteThemePayload payload = new SiteThemePayload(site, theme);
                         payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
@@ -81,14 +81,14 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onResponse(JetpackThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme installation request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
-                        ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
+                        SiteThemePayload payload = new SiteThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
                     }
                 }, new BaseRequest.BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme installation request.");
-                        ActivateThemePayload payload = new ActivateThemePayload(site, theme);
+                        SiteThemePayload payload = new SiteThemePayload(site, theme);
                         payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
@@ -107,7 +107,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(WPComThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to theme activation request.");
-                        ActivateThemePayload payload = new ActivateThemePayload(site, theme);
+                        SiteThemePayload payload = new SiteThemePayload(site, theme);
                         payload.theme.setActive(StringUtils.equals(theme.getThemeId(), response.id));
                         mDispatcher.dispatch(ThemeActionBuilder.newActivatedThemeAction(payload));
                     }
@@ -115,7 +115,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to theme activation request.");
-                        ActivateThemePayload payload = new ActivateThemePayload(site, theme);
+                        SiteThemePayload payload = new SiteThemePayload(site, theme);
                         payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newActivatedThemeAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -124,17 +124,6 @@ public class ThemeSqlUtils {
                 .endWhere().getAsModel();
     }
 
-    /**
-     * Retrieves themes associated with a given site. Installed themes (for Jetpack sites) are the only themes
-     * targeted for now.
-     */
-    public static Cursor getThemesForSiteAsCursor(@NonNull SiteModel site) {
-        return WellSql.select(ThemeModel.class)
-                .where()
-                .equals(ThemeModelTable.LOCAL_SITE_ID, site.getId())
-                .endWhere().getAsCursor();
-    }
-
     public static List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {
         return WellSql.select(ThemeModel.class)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -49,7 +49,7 @@ public class ThemeSqlUtils {
         WellSql.insert(themes).asSingleTransaction(true).execute();
     }
 
-    public static int insertOrReplaceInstalledThemes(@NonNull SiteModel site, @NonNull List<ThemeModel> themes) {
+    public static void insertOrReplaceInstalledThemes(@NonNull SiteModel site, @NonNull List<ThemeModel> themes) {
         // remove existing installed themes
         removeThemes(site);
 
@@ -59,8 +59,6 @@ public class ThemeSqlUtils {
         }
 
         WellSql.insert(themes).asSingleTransaction(true).execute();
-
-        return themes.size();
     }
 
     public static void insertOrReplaceActiveThemeForSite(@NonNull SiteModel site, @NonNull ThemeModel theme) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -37,28 +37,6 @@ public class ThemeSqlUtils {
         }
     }
 
-    public static void insertOrUpdateWpComTheme(@NonNull ThemeModel theme) {
-        List<ThemeModel> existing = WellSql.select(ThemeModel.class)
-                .where().beginGroup()
-                .equals(ThemeModelTable.THEME_ID, theme.getThemeId())
-                .equals(ThemeModelTable.IS_WP_COM_THEME, true)
-                .endGroup().endWhere().getAsModel();
-
-        // Remove local site id if it's set for whatever reason (shouldn't normally happen, so it's a sanity check)
-        theme.setLocalSiteId(0);
-        // Make sure the isWpComTheme flag is set
-        theme.setIsWpComTheme(true);
-
-        if (existing.isEmpty()) {
-            // theme is not in the local DB so we insert it
-            WellSql.insert(theme).asSingleTransaction(true).execute();
-        } else {
-            // theme already exists in the local DB so we update the existing row with the passed theme
-            WellSql.update(ThemeModel.class).whereId(existing.get(0).getId())
-                    .put(theme, new UpdateAllExceptId<>(ThemeModel.class)).execute();
-        }
-    }
-
     public static void insertOrReplaceWpComThemes(@NonNull List<ThemeModel> themes) {
         // remove existing WP.com themes
         removeWpComThemes();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -67,28 +67,6 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class SearchThemesPayload extends Payload<ThemesError> {
-        public String searchTerm;
-
-        public SearchThemesPayload(@NonNull String searchTerm) {
-            this.searchTerm = searchTerm;
-        }
-    }
-
-    public static class SearchedThemesPayload extends Payload<ThemesError> {
-        public String searchTerm;
-        public List<ThemeModel> themes;
-
-        public SearchedThemesPayload(@NonNull String searchTerm, List<ThemeModel> themes) {
-            this.searchTerm = searchTerm;
-            this.themes = themes;
-        }
-
-        public SearchedThemesPayload(ThemesError error) {
-            this.error = error;
-        }
-    }
-
     public static class ActivateThemePayload extends Payload<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -155,14 +133,6 @@ public class ThemeStore extends Store {
         public OnCurrentThemeFetched(SiteModel site, ThemeModel theme) {
             this.site = site;
             this.theme = theme;
-        }
-    }
-
-    public static class OnThemesSearched extends OnChanged<ThemesError> {
-        public List<ThemeModel> searchResults;
-
-        public OnThemesSearched(List<ThemeModel> searchResults) {
-            this.searchResults = searchResults;
         }
     }
 
@@ -241,13 +211,6 @@ public class ThemeStore extends Store {
                 break;
             case FETCHED_CURRENT_THEME:
                 handleCurrentThemeFetched((FetchedCurrentThemePayload) action.getPayload());
-                break;
-            case SEARCH_THEMES:
-                SearchThemesPayload searchPayload = (SearchThemesPayload) action.getPayload();
-                searchThemes(searchPayload.searchTerm);
-                break;
-            case SEARCHED_THEMES:
-                handleSearchedThemes((SearchedThemesPayload) action.getPayload());
                 break;
             case ACTIVATE_THEME:
                 activateTheme((ActivateThemePayload) action.getPayload());
@@ -370,22 +333,6 @@ public class ThemeStore extends Store {
             event.error = payload.error;
         } else {
             ThemeSqlUtils.insertOrReplaceActiveThemeForSite(payload.site, payload.theme);
-        }
-        emitChange(event);
-    }
-
-    private void searchThemes(@NonNull String searchTerm) {
-        mThemeRestClient.searchThemes(searchTerm);
-    }
-
-    private void handleSearchedThemes(@NonNull SearchedThemesPayload payload) {
-        OnThemesSearched event = new OnThemesSearched(payload.themes);
-        if (payload.isError()) {
-            event.error = payload.error;
-        } else {
-            for (ThemeModel theme : payload.themes) {
-                ThemeSqlUtils.insertOrUpdateWpComTheme(theme);
-            }
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -255,10 +255,6 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getWpComThemesCursor();
     }
 
-    public Cursor getThemesCursorForSite(@NonNull SiteModel site) {
-        return ThemeSqlUtils.getThemesForSiteAsCursor(site);
-    }
-
     public List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {
         return ThemeSqlUtils.getThemesForSite(site);
     }
@@ -270,6 +266,7 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getSiteThemeByThemeId(siteModel, themeId);
     }
 
+    @SuppressWarnings("WeakerAccess")
     public ThemeModel getWpComThemeByThemeId(String themeId) {
         if (TextUtils.isEmpty(themeId)) {
             return null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -67,11 +67,11 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class ActivateThemePayload extends Payload<ThemesError> {
+    public static class SiteThemePayload extends Payload<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
 
-        public ActivateThemePayload(SiteModel site, ThemeModel theme) {
+        public SiteThemePayload(@NonNull SiteModel site, @NonNull ThemeModel theme) {
             this.site = site;
             this.theme = theme;
         }
@@ -213,22 +213,22 @@ public class ThemeStore extends Store {
                 handleCurrentThemeFetched((FetchedCurrentThemePayload) action.getPayload());
                 break;
             case ACTIVATE_THEME:
-                activateTheme((ActivateThemePayload) action.getPayload());
+                activateTheme((SiteThemePayload) action.getPayload());
                 break;
             case ACTIVATED_THEME:
-                handleThemeActivated((ActivateThemePayload) action.getPayload());
+                handleThemeActivated((SiteThemePayload) action.getPayload());
                 break;
             case INSTALL_THEME:
-                installTheme((ActivateThemePayload) action.getPayload());
+                installTheme((SiteThemePayload) action.getPayload());
                 break;
             case INSTALLED_THEME:
-                handleThemeInstalled((ActivateThemePayload) action.getPayload());
+                handleThemeInstalled((SiteThemePayload) action.getPayload());
                 break;
             case DELETE_THEME:
-                deleteTheme((ActivateThemePayload) action.getPayload());
+                deleteTheme((SiteThemePayload) action.getPayload());
                 break;
             case DELETED_THEME:
-                handleThemeDeleted((ActivateThemePayload) action.getPayload());
+                handleThemeDeleted((SiteThemePayload) action.getPayload());
                 break;
             case REMOVE_THEME:
                 removeTheme((ThemeModel) action.getPayload());
@@ -337,7 +337,7 @@ public class ThemeStore extends Store {
         emitChange(event);
     }
 
-    private void installTheme(@NonNull ActivateThemePayload payload) {
+    private void installTheme(@NonNull SiteThemePayload payload) {
         if (payload.site.isJetpackConnected() && payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.installTheme(payload.site, payload.theme);
         } else {
@@ -346,7 +346,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    private void handleThemeInstalled(@NonNull ActivateThemePayload payload) {
+    private void handleThemeInstalled(@NonNull SiteThemePayload payload) {
         OnThemeInstalled event = new OnThemeInstalled(payload.site, payload.theme);
         if (payload.isError()) {
             event.error = payload.error;
@@ -356,7 +356,7 @@ public class ThemeStore extends Store {
         emitChange(event);
     }
 
-    private void activateTheme(@NonNull ActivateThemePayload payload) {
+    private void activateTheme(@NonNull SiteThemePayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.activateTheme(payload.site, payload.theme);
         } else {
@@ -365,7 +365,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    private void handleThemeActivated(@NonNull ActivateThemePayload payload) {
+    private void handleThemeActivated(@NonNull SiteThemePayload payload) {
         OnThemeActivated event = new OnThemeActivated(payload.site, payload.theme);
         if (payload.isError()) {
             event.error = payload.error;
@@ -384,7 +384,7 @@ public class ThemeStore extends Store {
         emitChange(event);
     }
 
-    private void deleteTheme(@NonNull ActivateThemePayload payload) {
+    private void deleteTheme(@NonNull SiteThemePayload payload) {
         if (payload.site.isJetpackConnected() && payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.deleteTheme(payload.site, payload.theme);
         } else {
@@ -393,7 +393,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    private void handleThemeDeleted(@NonNull ActivateThemePayload payload) {
+    private void handleThemeDeleted(@NonNull SiteThemePayload payload) {
         OnThemeDeleted event = new OnThemeDeleted(payload.site, payload.theme);
         if (payload.isError()) {
             event.error = payload.error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -209,10 +209,6 @@ public class ThemeStore extends Store {
             case FETCHED_INSTALLED_THEMES:
                 handleInstalledThemesFetched((FetchedSiteThemesPayload) action.getPayload());
                 break;
-            case FETCH_PURCHASED_THEMES:
-                break;
-            case FETCHED_PURCHASED_THEMES:
-                break;
             case FETCH_CURRENT_THEME:
                 fetchCurrentTheme((SiteModel) action.getPayload());
                 break;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -98,6 +98,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class ThemesError implements OnChangedError {
         public ThemeErrorType type;
         public String message;
@@ -113,6 +114,7 @@ public class ThemeStore extends Store {
     }
 
     // OnChanged events
+    @SuppressWarnings("WeakerAccess")
     public static class OnSiteThemesChanged extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeAction origin;
@@ -126,6 +128,7 @@ public class ThemeStore extends Store {
     public static class OnWpComThemesChanged extends OnChanged<ThemesError> {
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnCurrentThemeFetched extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -136,6 +139,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnThemeActivated extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -146,6 +150,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnThemeRemoved extends OnChanged<ThemesError> {
         public ThemeModel theme;
 
@@ -154,6 +159,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnThemeDeleted extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -164,6 +170,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnThemeInstalled extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;


### PR DESCRIPTION
This is continuation of #664 and needs to be reviewed and merged after #668 since the base branch for these changes is `issue/remove-theme-search`. Here is a list of changes made in this PR:

* `ActivateThemePayload` renamed as `SiteThemePayload` because even though the payload was named as `ActivateXX` it was used throughout a lot of actions that had nothing to do with activation of themes. I think `SiteThemePayload` fits it pretty well since it takes a site and a theme.
* A bunch of `WeakerAccess` warnings are suppressed. This is just a quality of life improvement. Since a bunch of our methods/classes are used in WPAndroid we need them to be `public` but AS doesn't know about that, so we have to manually suppress them. We do this elsewhere in the app as well and unless we find a better way, I think we should keep doing it.
* Removed actions for purchased themes. I don't know why these were added, but since they are not implemented yet, there is no reason to keep them
* Removed unused `getThemesForSiteAsCursor`. I've checked this and it doesn't look like we use it WPAndroid either and we shouldn't have methods we don't use until we actually need them.
* Removed `insertOrUpdateWpComTheme`: This was something I recently added as an improvement/fix, but it was only used for searching themes and since we are removing that now, we don't really need it.

There might be some other very minor changes, but these should be an exhaustive list of important ones. Hope it helps with the review!