### PR TITLE
Theme Store connected test improvements

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -100,24 +100,18 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         assertTrue(themes.size() > 1);
 
         // fetch active theme
-        fetchCurrentTheme(jetpackSite);
-        assertNotNull(mCurrentTheme);
+        ThemeModel currentTheme = fetchCurrentTheme(jetpackSite);
+        assertNotNull(currentTheme);
 
         // select a different theme to activate
-        ThemeModel themeToActivate = mCurrentTheme.getThemeId().equals(themes.get(0).getThemeId())
+        ThemeModel themeToActivate = currentTheme.getThemeId().equals(themes.get(0).getThemeId())
                 ? themes.get(1) : themes.get(0);
         assertNotNull(themeToActivate);
 
         // activate it
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.ACTIVATED_THEME;
-        SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
-        mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        // mActivatedTheme is set in onThemeActivated
-        assertNotNull(mActivatedTheme);
-        assertEquals(mActivatedTheme.getThemeId(), themeToActivate.getThemeId());
+        ThemeModel activatedTheme = activateTheme(jetpackSite, themeToActivate);
+        assertNotNull(activatedTheme);
+        assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
 
         signOutWPCom();
     }
@@ -450,6 +444,17 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(jetpackSite));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        return mThemeStore.getActiveThemeForSite(jetpackSite);
+    }
+
+    private ThemeModel activateTheme(@NonNull SiteModel jetpackSite, @NonNull ThemeModel themeToActivate)
+            throws InterruptedException {
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.ACTIVATED_THEME;
+        SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
+        mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         return mThemeStore.getActiveThemeForSite(jetpackSite);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -167,35 +167,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
-    public void testRemoveTheme() throws InterruptedException {
-        // sign in and fetch WP.com themes and installed themes
-        final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
-
-        // verify initial state, no themes in store
-        assertEquals(0, mThemeStore.getWpComThemes().size());
-        assertEquals(0, mThemeStore.getThemesForSite(jetpackSite).size());
-
-        // fetch themes for site and WP.com themes
-        fetchInstalledThemes(jetpackSite);
-        fetchWpComThemes();
-
-        final List<ThemeModel> wpComThemes = mThemeStore.getWpComThemes();
-        final List<ThemeModel> installedThemes = mThemeStore.getThemesForSite(jetpackSite);
-        assertTrue(installedThemes.size() > 0);
-        assertTrue(wpComThemes.size() > 0);
-
-        // remove a theme from each and verify
-        final ThemeModel wpComRemove = wpComThemes.get(0);
-        final ThemeModel installedRemove = installedThemes.get(0);
-        removeTheme(jetpackSite, wpComRemove);
-        assertEquals(wpComThemes.size() - 1, mThemeStore.getWpComThemes().size());
-        removeTheme(jetpackSite, installedRemove);
-        assertEquals(installedThemes.size() - 1, mThemeStore.getThemesForSite(jetpackSite).size());
-
-        // sign out
-        signOutWPCom();
-    }
-
     public void testRemoveSiteThemes() throws InterruptedException {
         // sign in and fetch WP.com themes and installed themes
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
@@ -436,13 +407,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         deleteTheme(jetpackSite, theme);
         // make sure theme is no longer available for site (delete was successful)
         assertNull(mThemeStore.getInstalledThemeByThemeId(jetpackSite, theme.getThemeId()));
-    }
-
-    private void removeTheme(@NonNull SiteModel site, @NonNull ThemeModel theme) throws InterruptedException {
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.REMOVED_THEME;
-        mDispatcher.dispatch(ThemeActionBuilder.newRemoveThemeAction(new SiteThemePayload(site, theme)));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void removeSiteThemes(@NonNull SiteModel site) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -64,6 +64,9 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     public void testFetchInstalledThemes() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
+        // verify that installed themes list is empty first
+        assertTrue(mThemeStore.getThemesForSite(jetpackSite).size() == 0);
+
         // fetch installed themes
         fetchInstalledThemes(jetpackSite);
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -168,27 +168,26 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     }
 
     public void testRemoveSiteThemes() throws InterruptedException {
-        // sign in and fetch WP.com themes and installed themes
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
         // verify initial state, no themes in store
-        assertEquals(0, mThemeStore.getWpComThemes().size());
-        assertEquals(0, mThemeStore.getThemesForSite(jetpackSite).size());
+        assertTrue(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
+        assertTrue(mThemeStore.getWpComThemes().isEmpty());
 
         // fetch themes for site and WP.com themes
         fetchInstalledThemes(jetpackSite);
         fetchWpComThemes();
 
-        final int wpComThemesCount = mThemeStore.getWpComThemes().size();
-        assertTrue(wpComThemesCount > 0);
-        assertTrue(mThemeStore.getThemesForSite(jetpackSite).size() > 0);
+        // Verify fetches were successful
+        assertFalse(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
+        assertFalse(mThemeStore.getWpComThemes().isEmpty());
 
         // remove the site's themes
         removeSiteThemes(jetpackSite);
 
-        // verify they are removed and that WP.com themes are still there
-        assertEquals(wpComThemesCount, mThemeStore.getWpComThemes().size());
-        assertEquals(0, mThemeStore.getThemesForSite(jetpackSite).size());
+        // verify site themes are removed and that WP.com themes are still there
+        assertTrue(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
+        assertFalse(mThemeStore.getWpComThemes().isEmpty());
 
         // sign out
         signOutWPCom();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.ThemeStore;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -105,7 +105,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         // activate it
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;
-        ActivateThemePayload payload = new ActivateThemePayload(jetpackSite, themeToActivate);
+        SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -195,7 +195,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             mNextEvent = TestEvents.ACTIVATED_THEME;
             ThemeModel themeToActivate = getOtherTheme(themes, themeId);
             assertNotNull(themeToActivate);
-            ActivateThemePayload payload = new ActivateThemePayload(jetpackSite, themeToActivate);
+            SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
             mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
             assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         }
@@ -462,7 +462,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     }
 
     private void installTheme(SiteModel site, ThemeModel theme) throws InterruptedException {
-        ActivateThemePayload install = new ActivateThemePayload(site, theme);
+        SiteThemePayload install = new SiteThemePayload(site, theme);
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.INSTALLED_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newInstallThemeAction(install));
@@ -470,7 +470,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     }
 
     private void deleteTheme(SiteModel site, ThemeModel theme) throws InterruptedException {
-        ActivateThemePayload delete = new ActivateThemePayload(site, theme);
+        SiteThemePayload delete = new SiteThemePayload(site, theme);
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.DELETED_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newDeleteThemeAction(delete));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -132,21 +132,11 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // delete edin before attempting to install
         if (listContainsThemeWithId(themes, themeId)) {
-            // find local ThemeModel with matching themeId for delete call
-            ThemeModel listTheme = getThemeFromList(themes, themeId);
-            assertNotNull(listTheme);
-
             // delete existing theme from site
-            themeToInstall.setId(listTheme.getId());
             deleteTheme(jetpackSite, themeToInstall);
-
-            // mDeletedTheme is set in onThemeDeleted
-            assertNotNull(mDeletedTheme);
-            assertEquals(themeId, mDeletedTheme.getThemeId());
 
             // make sure theme is no longer available for site (delete was successful)
             assertFalse(listContainsThemeWithId(mThemeStore.getThemesForSite(jetpackSite), themeId));
-            mActivatedTheme = null;
         }
 
         // install the theme

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -126,8 +126,9 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         // fetch installed themes
         fetchInstalledThemes(jetpackSite);
 
-        // make sure installed themes were successfully fetched
-        assertFalse(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
+        // make sure there are at least 2 themes, one that's active and one that may be activated
+        List<ThemeModel> themes = mThemeStore.getThemesForSite(jetpackSite);
+        assertTrue(themes.size() > 1);
 
         // If the theme is already installed, delete it first
         if (isThemeInstalled(jetpackSite, themeToInstall.getThemeId())) {
@@ -150,8 +151,9 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         // fetch installed themes
         fetchInstalledThemes(jetpackSite);
 
-        // make sure installed themes were successfully fetched
-        assertFalse(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
+        // make sure there are at least 2 themes, one that's active and one that may be activated
+        List<ThemeModel> themes = mThemeStore.getThemesForSite(jetpackSite);
+        assertTrue(themes.size() > 1);
 
         // Install edin if necessary before attempting to delete
         if (!isThemeInstalled(jetpackSite, themeToDelete.getThemeId())) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -79,9 +79,12 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     public void testFetchCurrentTheme() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
+        // Verify there is no active theme for the site at the start
+        assertNull(mThemeStore.getActiveThemeForSite(jetpackSite));
+
         // fetch active theme
-        fetchCurrentThemes(jetpackSite);
-        assertNotNull(mCurrentTheme);
+        ThemeModel currentTheme = fetchCurrentTheme(jetpackSite);
+        assertNotNull(currentTheme);
 
         signOutWPCom();
     }
@@ -97,7 +100,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         assertTrue(themes.size() > 1);
 
         // fetch active theme
-        fetchCurrentThemes(jetpackSite);
+        fetchCurrentTheme(jetpackSite);
         assertNotNull(mCurrentTheme);
 
         // select a different theme to activate
@@ -190,7 +193,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         }
 
         // fetch active theme
-        fetchCurrentThemes(jetpackSite);
+        fetchCurrentTheme(jetpackSite);
 
         // if Edin is active update site's active theme to something else
         if (themeId.equals(mCurrentTheme.getThemeId())) {
@@ -443,11 +446,13 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
-    private void fetchCurrentThemes(@NonNull SiteModel jetpackSite) throws InterruptedException {
+    private ThemeModel fetchCurrentTheme(@NonNull SiteModel jetpackSite) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(jetpackSite));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        return mThemeStore.getActiveThemeForSite(jetpackSite);
     }
 
     private void removeTheme(@NonNull ThemeModel theme) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -49,6 +49,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     private TestEvents mNextEvent;
 
+    private static final String EDIN_THEME_ID = "edin-wpcom";
+
     @Override
     protected void setUp() throws Exception {
         super.setUp();
@@ -118,10 +120,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     public void testInstallTheme() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
-        final String themeId = "edin-wpcom";
         final ThemeModel themeToInstall = new ThemeModel();
-        themeToInstall.setName("Edin");
-        themeToInstall.setThemeId(themeId);
+        themeToInstall.setThemeId(EDIN_THEME_ID);
 
         // fetch installed themes
         fetchInstalledThemes(jetpackSite);
@@ -131,17 +131,17 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         assertFalse(themes.isEmpty());
 
         // delete edin before attempting to install
-        if (listContainsThemeWithId(themes, themeId)) {
+        if (listContainsThemeWithId(themes, EDIN_THEME_ID)) {
             // delete existing theme from site
             deleteTheme(jetpackSite, themeToInstall);
 
             // make sure theme is no longer available for site (delete was successful)
-            assertFalse(listContainsThemeWithId(mThemeStore.getThemesForSite(jetpackSite), themeId));
+            assertFalse(listContainsThemeWithId(mThemeStore.getThemesForSite(jetpackSite), EDIN_THEME_ID));
         }
 
         // install the theme
         installTheme(jetpackSite, themeToInstall);
-        assertTrue(listContainsThemeWithId(mThemeStore.getThemesForSite(jetpackSite), themeId));
+        assertTrue(listContainsThemeWithId(mThemeStore.getThemesForSite(jetpackSite), EDIN_THEME_ID));
 
         signOutWPCom();
     }
@@ -150,17 +150,15 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
         assertTrue(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
 
-        final String themeId = "edin-wpcom";
         final ThemeModel themeToDelete = new ThemeModel();
-        themeToDelete.setName("Edin");
-        themeToDelete.setThemeId(themeId);
+        themeToDelete.setThemeId(EDIN_THEME_ID);
 
         // fetch installed themes
         fetchInstalledThemes(jetpackSite);
 
         List<ThemeModel> themes = mThemeStore.getThemesForSite(jetpackSite);
         assertFalse(themes.isEmpty());
-        ThemeModel listTheme = getThemeFromList(themes, themeId);
+        ThemeModel listTheme = getThemeFromList(themes, EDIN_THEME_ID);
 
         // install edin before attempting to delete
         if (listTheme == null) {
@@ -168,10 +166,10 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
             // mInstalledTheme is set in onThemeInstalled
             assertNotNull(mInstalledTheme);
-            assertEquals(themeId, mInstalledTheme.getThemeId());
+            assertEquals(EDIN_THEME_ID, mInstalledTheme.getThemeId());
 
             // make sure theme is available for site (install was successful)
-            listTheme = getThemeFromList(mThemeStore.getThemesForSite(jetpackSite), themeId);
+            listTheme = getThemeFromList(mThemeStore.getThemesForSite(jetpackSite), EDIN_THEME_ID);
             assertNotNull(listTheme);
         }
 
@@ -179,10 +177,10 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         fetchCurrentTheme(jetpackSite);
 
         // if Edin is active update site's active theme to something else
-        if (themeId.equals(mCurrentTheme.getThemeId())) {
+        if (EDIN_THEME_ID.equals(mCurrentTheme.getThemeId())) {
             mCountDownLatch = new CountDownLatch(1);
             mNextEvent = TestEvents.ACTIVATED_THEME;
-            ThemeModel themeToActivate = getOtherTheme(themes, themeId);
+            ThemeModel themeToActivate = getOtherTheme(themes, EDIN_THEME_ID);
             assertNotNull(themeToActivate);
             SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
             mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
@@ -191,7 +189,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         themeToDelete.setId(listTheme.getId());
         deleteTheme(jetpackSite, themeToDelete);
-        assertFalse(listContainsThemeWithId(mThemeStore.getThemesForSite(jetpackSite), themeId));
+        assertFalse(listContainsThemeWithId(mThemeStore.getThemesForSite(jetpackSite), EDIN_THEME_ID));
 
         signOutWPCom();
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -42,10 +42,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
     @Inject ThemeStore mThemeStore;
-    private ThemeModel mCurrentTheme;
-    private ThemeModel mActivatedTheme;
-    private ThemeModel mInstalledTheme;
-    private ThemeModel mDeletedTheme;
 
     private TestEvents mNextEvent;
 
@@ -59,8 +55,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         init();
         // Reset expected test event
         mNextEvent = TestEvents.NONE;
-        mCurrentTheme = null;
-        mActivatedTheme = null;
     }
 
     public void testFetchInstalledThemes() throws InterruptedException {
@@ -234,7 +228,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         assertTrue(mNextEvent == TestEvents.FETCHED_CURRENT_THEME);
         assertNotNull(event.theme);
-        mCurrentTheme = event.theme;
         mCountDownLatch.countDown();
     }
 
@@ -245,7 +238,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME);
-        mActivatedTheme = event.theme;
         mCountDownLatch.countDown();
     }
 
@@ -256,7 +248,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertTrue(mNextEvent == TestEvents.INSTALLED_THEME);
-        mInstalledTheme = event.theme;
         mCountDownLatch.countDown();
     }
 
@@ -267,7 +258,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertTrue(mNextEvent == TestEvents.DELETED_THEME);
-        mDeletedTheme = event.theme;
         mCountDownLatch.countDown();
     }
 
@@ -399,8 +389,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throws InterruptedException {
         // An active theme can't be deleted, first activate a different theme
         if (theme.getActive()) {
-            ThemeModel otherThemeToActivate = getOtherTheme(mThemeStore.getThemesForSite(jetpackSite)
-                    , EDIN_THEME_ID);
+            ThemeModel otherThemeToActivate = getOtherTheme(mThemeStore.getThemesForSite(jetpackSite),
+                    EDIN_THEME_ID);
             assertNotNull(otherThemeToActivate);
             activateTheme(jetpackSite, otherThemeToActivate);
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -104,8 +104,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         assertNotNull(currentTheme);
 
         // select a different theme to activate
-        ThemeModel themeToActivate = currentTheme.getThemeId().equals(themes.get(0).getThemeId())
-                ? themes.get(1) : themes.get(0);
+        ThemeModel themeToActivate = getOtherTheme(themes, currentTheme.getThemeId());
         assertNotNull(themeToActivate);
 
         // activate it
@@ -499,7 +498,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         return null;
     }
 
-    private ThemeModel getThemeFromList(List<ThemeModel> list, String themeId) {
+    private ThemeModel getThemeFromList(@NonNull List<ThemeModel> list, @NonNull String themeId) {
         for (ThemeModel theme : list) {
             if (themeId.equals(theme.getThemeId())) {
                 return theme;
@@ -508,11 +507,11 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         return null;
     }
 
-    private boolean listContainsThemeWithId(List<ThemeModel> list, String themeId) {
+    private boolean listContainsThemeWithId(@NonNull List<ThemeModel> list, @NonNull String themeId) {
         return getThemeFromList(list, themeId) != null;
     }
 
-    private ThemeModel getOtherTheme(List<ThemeModel> themes, String idToIgnore) {
+    private ThemeModel getOtherTheme(@NonNull List<ThemeModel> themes, @NonNull String idToIgnore) {
         for (ThemeModel theme : themes) {
             if (!idToIgnore.equals(theme.getThemeId())) {
                 return theme;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -216,9 +216,9 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         // remove a theme from each and verify
         final ThemeModel wpComRemove = wpComThemes.get(0);
         final ThemeModel installedRemove = installedThemes.get(0);
-        removeTheme(wpComRemove);
+        removeTheme(jetpackSite, wpComRemove);
         assertEquals(wpComThemes.size() - 1, mThemeStore.getWpComThemes().size());
-        removeTheme(installedRemove);
+        removeTheme(jetpackSite, installedRemove);
         assertEquals(installedThemes.size() - 1, mThemeStore.getThemesForSite(jetpackSite).size());
 
         // sign out
@@ -449,10 +449,10 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         return mThemeStore.getActiveThemeForSite(jetpackSite);
     }
 
-    private void removeTheme(@NonNull ThemeModel theme) throws InterruptedException {
+    private void removeTheme(@NonNull SiteModel site, @NonNull ThemeModel theme) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.REMOVED_THEME;
-        mDispatcher.dispatch(ThemeActionBuilder.newRemoveThemeAction(theme));
+        mDispatcher.dispatch(ThemeActionBuilder.newRemoveThemeAction(new SiteThemePayload(site, theme)));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -65,11 +65,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         // activate a different theme
         ThemeModel themeToActivate = getNewNonPremiumTheme(currentTheme.getThemeId(), mThemeStore.getWpComThemes());
         assertNotNull(themeToActivate);
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.ACTIVATED_THEME;
-        SiteThemePayload payload = new SiteThemePayload(sSite, themeToActivate);
-        mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        activateTheme(themeToActivate);
 
         // Assert that the activation was successful
         ThemeModel activatedTheme = mThemeStore.getActiveThemeForSite(sSite);
@@ -159,6 +155,14 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_WPCOM_THEMES;
         mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void activateTheme(ThemeModel themeToActivate) throws InterruptedException {
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.ACTIVATED_THEME;
+        SiteThemePayload payload = new SiteThemePayload(sSite, themeToActivate);
+        mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -42,17 +42,17 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mActivatedTheme = null;
     }
 
+    public void testFetchCurrentTheme() throws InterruptedException {
+        // Make sure no theme is active at first
+        assertNull(mThemeStore.getActiveThemeForSite(sSite));
+        ThemeModel currentTheme = fetchCurrentTheme();
+        assertNotNull(currentTheme);
+    }
+
     public void testActivateTheme() throws InterruptedException {
         // Make sure no theme is active at first
         assertNull(mThemeStore.getActiveThemeForSite(sSite));
-
-        // get current active theme on a site
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(sSite));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        ThemeModel currentTheme = mThemeStore.getActiveThemeForSite(sSite);
+        ThemeModel currentTheme = fetchCurrentTheme();
         assertNotNull(currentTheme);
 
         // get all themes available
@@ -88,16 +88,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         // verify response received and WP themes list is not empty
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertFalse(mThemeStore.getWpComThemes().isEmpty());
-    }
-
-    public void testFetchCurrentTheme() throws InterruptedException {
-        // fetch current theme
-        mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(sSite));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertNotNull(mCurrentTheme);
     }
 
     @SuppressWarnings("unused")
@@ -169,5 +159,15 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
             }
         }
         return null;
+    }
+
+    private ThemeModel fetchCurrentTheme() throws InterruptedException {
+        // fetch current theme
+        mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(sSite));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        return mThemeStore.getActiveThemeForSite(sSite);
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.ThemeStore;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -61,7 +61,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         assertNotNull(themeToActivate);
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;
-        ActivateThemePayload payload = new ActivateThemePayload(sSite, themeToActivate);
+        SiteThemePayload payload = new SiteThemePayload(sSite, themeToActivate);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertNotNull(mActivatedTheme);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -27,8 +27,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     @Inject ThemeStore mThemeStore;
 
     private TestEvents mNextEvent;
-    private ThemeModel mCurrentTheme;
-    private ThemeModel mActivatedTheme;
 
     @Override
     protected void setUp() throws Exception {
@@ -38,8 +36,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         init();
         // Reset expected test event
         mNextEvent = TestEvents.NONE;
-        mCurrentTheme = null;
-        mActivatedTheme = null;
     }
 
     public void testFetchCurrentTheme() throws InterruptedException {
@@ -97,8 +93,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME);
-        mActivatedTheme = event.theme;
-        mCurrentTheme = event.theme;
         mCountDownLatch.countDown();
     }
 
@@ -120,8 +114,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         }
 
         assertTrue(mNextEvent == TestEvents.FETCHED_CURRENT_THEME);
-        assertNotNull(event.theme);
-        mCurrentTheme = event.theme;
         mCountDownLatch.countDown();
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -21,8 +21,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         NONE,
         FETCHED_WPCOM_THEMES,
         FETCHED_CURRENT_THEME,
-        SEARCHED_THEMES,
-        ACTIVATED_THEME,
+        ACTIVATED_THEME
     }
 
     @Inject ThemeStore mThemeStore;
@@ -30,7 +29,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     private TestEvents mNextEvent;
     private ThemeModel mCurrentTheme;
     private ThemeModel mActivatedTheme;
-    private List<ThemeModel> mSearchResults;
 
     @Override
     protected void setUp() throws Exception {
@@ -42,7 +40,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.NONE;
         mCurrentTheme = null;
         mActivatedTheme = null;
-        mSearchResults = null;
     }
 
     public void testActivateTheme() throws InterruptedException {
@@ -93,31 +90,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertNotNull(mCurrentTheme);
-    }
-
-    public void testSearchThemes() throws InterruptedException {
-        // "Twenty *teen" themes
-        final String searchTerm = "twenty";
-
-        ThemeStore.SearchThemesPayload payload = new ThemeStore.SearchThemesPayload(searchTerm);
-        mNextEvent = TestEvents.SEARCHED_THEMES;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(payload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertNotNull(mSearchResults);
-        assertFalse(mSearchResults.isEmpty());
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe
-    public void onThemesSearched(ThemeStore.OnThemesSearched event) {
-        if (event.isError()) {
-            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
-        }
-        assertTrue(mNextEvent == TestEvents.SEARCHED_THEMES);
-        mSearchResults = event.searchResults;
-        mCountDownLatch.countDown();
     }
 
     @SuppressWarnings("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -45,17 +45,22 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         assertNotNull(currentTheme);
     }
 
+    public void testFetchWPComThemes() throws InterruptedException {
+        // verify themes don't already exist in store
+        assertTrue(mThemeStore.getWpComThemes().isEmpty());
+        fetchWpComThemes();
+        // verify response received and WP themes list is not empty
+        assertFalse(mThemeStore.getWpComThemes().isEmpty());
+    }
+
     public void testActivateTheme() throws InterruptedException {
         // Make sure no theme is active at first
         assertNull(mThemeStore.getActiveThemeForSite(sSite));
         ThemeModel currentTheme = fetchCurrentTheme();
         assertNotNull(currentTheme);
 
-        // get all themes available
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.FETCHED_WPCOM_THEMES;
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // Fetch wp.com themes to activate a different theme
+        fetchWpComThemes();
 
         // activate a different theme
         ThemeModel themeToActivate = getNewNonPremiumTheme(currentTheme.getThemeId(), mThemeStore.getWpComThemes());
@@ -70,20 +75,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         ThemeModel activatedTheme = mThemeStore.getActiveThemeForSite(sSite);
         assertNotNull(activatedTheme);
         assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
-    }
-
-    public void testFetchWPComThemes() throws InterruptedException {
-        // verify themes don't already exist in store
-        assertTrue(mThemeStore.getWpComThemes().isEmpty());
-
-        // no need to sign into account, this is a test for an endpoint that does not require authentication
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.FETCHED_WPCOM_THEMES;
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
-
-        // verify response received and WP themes list is not empty
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertFalse(mThemeStore.getWpComThemes().isEmpty());
     }
 
     @SuppressWarnings("unused")
@@ -161,5 +152,13 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         return mThemeStore.getActiveThemeForSite(sSite);
+    }
+
+    private void fetchWpComThemes() throws InterruptedException {
+        // no need to sign into account, this is a test for an endpoint that does not require authentication
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.FETCHED_WPCOM_THEMES;
+        mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -58,7 +58,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.ActivateThemePayload(site, theme)
+                    val payload = ThemeStore.SiteThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload))
                 }
             }
@@ -76,7 +76,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.ActivateThemePayload(site, theme)
+                    val payload = ThemeStore.SiteThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload))
                 }
             }
@@ -94,7 +94,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.ActivateThemePayload(site, theme)
+                    val payload = ThemeStore.SiteThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newInstallThemeAction(payload))
                 }
             }
@@ -112,7 +112,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.ActivateThemePayload(site, theme)
+                    val payload = ThemeStore.SiteThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newDeleteThemeAction(payload))
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -100,15 +100,6 @@ class ThemeFragment : Fragment() {
             }
         }
 
-        search_themes.setOnClickListener {
-            val term = getThemeIdFromInput(view)
-            if (TextUtils.isEmpty(term)) {
-                prependToLog("Please enter a search term")
-            } else {
-                dispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(ThemeStore.SearchThemesPayload(term)))
-            }
-        }
-
         delete_theme_jp.setOnClickListener {
             val id = getThemeIdFromInput(view)
             if (TextUtils.isEmpty(id)) {
@@ -197,17 +188,6 @@ class ThemeFragment : Fragment() {
             prependToLog("error: " + event.error.message)
         } else {
             prependToLog("success: theme = " + event.theme.name)
-        }
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onThemesSearched(event: ThemeStore.OnThemesSearched) {
-        prependToLog("onThemesSearched: ")
-        if (event.isError) {
-            prependToLog("error: " + event.error.message)
-        } else {
-            prependToLog("success: result count = " + event.searchResults.size)
         }
     }
 

--- a/example/src/main/res/layout/fragment_themes.xml
+++ b/example/src/main/res/layout/fragment_themes.xml
@@ -30,12 +30,6 @@
         android:layout_height="wrap_content"
         android:text="Fetch current theme WP.com" />
 
-    <Button
-        android:id="@+id/search_themes"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Search Themes" />
-
     <EditText
         android:id="@+id/theme_id"
         android:layout_width="match_parent"

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -179,7 +179,7 @@ public class ThemeStoreUnitTest {
         assertEquals(testThemes.size(), mThemeStore.getThemesForSite(site).size());
 
         // remove and verify count
-        ThemeSqlUtils.removeThemes(site);
+        ThemeSqlUtils.removeSiteThemes(site);
         assertEquals(0, mThemeStore.getThemesForSite(site).size());
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
@@ -21,11 +21,11 @@ public enum ThemeAction implements IAction {
     FETCH_PURCHASED_THEMES,
     @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     ACTIVATE_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     INSTALL_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     DELETE_THEME,
 
     // Remote responses
@@ -37,11 +37,11 @@ public enum ThemeAction implements IAction {
     FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     ACTIVATED_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     INSTALLED_THEME,
-    @Action(payloadType = ActivateThemePayload.class)
+    @Action(payloadType = SiteThemePayload.class)
     DELETED_THEME,
 
     // Local actions

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -18,8 +18,6 @@ public enum ThemeAction implements IAction {
     @Action(payloadType = SiteModel.class)
     FETCH_INSTALLED_THEMES, // Jetpack only
     @Action(payloadType = SiteModel.class)
-    FETCH_PURCHASED_THEMES,
-    @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
     @Action(payloadType = SiteThemePayload.class)
     ACTIVATE_THEME,
@@ -33,8 +31,6 @@ public enum ThemeAction implements IAction {
     FETCHED_WP_COM_THEMES,
     @Action(payloadType = FetchedSiteThemesPayload.class)
     FETCHED_INSTALLED_THEMES,
-    @Action(payloadType = FetchedSiteThemesPayload.class)
-    FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
     @Action(payloadType = SiteThemePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -9,8 +9,6 @@ import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 
 @ActionEnum
 public enum ThemeAction implements IAction {
@@ -23,8 +21,6 @@ public enum ThemeAction implements IAction {
     FETCH_PURCHASED_THEMES,
     @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
-    @Action(payloadType = SearchThemesPayload.class)
-    SEARCH_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATE_THEME,
     @Action(payloadType = ActivateThemePayload.class)
@@ -41,8 +37,6 @@ public enum ThemeAction implements IAction {
     FETCHED_PURCHASED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
-    @Action(payloadType = SearchedThemesPayload.class)
-    SEARCHED_THEMES,
     @Action(payloadType = ActivateThemePayload.class)
     ACTIVATED_THEME,
     @Action(payloadType = ActivateThemePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -40,8 +40,6 @@ public enum ThemeAction implements IAction {
     DELETED_THEME,
 
     // Local actions
-    @Action(payloadType = SiteThemePayload.class)
-    REMOVE_THEME,
     @Action(payloadType = SiteModel.class)
     REMOVE_SITE_THEMES
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -4,11 +4,10 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.model.ThemeModel;
-import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
 @ActionEnum
 public enum ThemeAction implements IAction {
@@ -41,7 +40,7 @@ public enum ThemeAction implements IAction {
     DELETED_THEME,
 
     // Local actions
-    @Action(payloadType = ThemeModel.class)
+    @Action(payloadType = SiteThemePayload.class)
     REMOVE_THEME,
     @Action(payloadType = SiteModel.class)
     REMOVE_SITE_THEMES

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchedThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
@@ -192,30 +191,6 @@ public class ThemeRestClient extends BaseWPComRestClient {
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(site, themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedCurrentThemeAction(payload));
-                    }
-                }));
-    }
-
-    /** [Undocumented!] Endpoint: v1.2/themes?search=$term */
-    public void searchThemes(@NonNull final String searchTerm) {
-        String url = WPCOMREST.themes.getUrlV1_2() + "?search=" + searchTerm;
-        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeListResponse.class,
-                new Response.Listener<WPComThemeListResponse>() {
-                    @Override
-                    public void onResponse(WPComThemeListResponse response) {
-                        AppLog.d(AppLog.T.API, "Received response to search themes request.");
-                        SearchedThemesPayload payload =
-                                new SearchedThemesPayload(searchTerm, createThemeListFromArrayResponse(response));
-                        mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));
-                    }
-                }, new BaseRequest.BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        AppLog.e(AppLog.T.API, "Received error response to search themes request.");
-                        ThemesError themeError = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
-                        SearchedThemesPayload payload = new SearchedThemesPayload(themeError);
-                        mDispatcher.dispatch(ThemeActionBuilder.newSearchedThemesAction(payload));
                     }
                 }));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeListResponse;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
@@ -56,14 +56,14 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme deletion request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
                         responseTheme.setId(theme.getId());
-                        ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
+                        SiteThemePayload payload = new SiteThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }
                 }, new BaseRequest.BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme deletion request.");
-                        ActivateThemePayload payload = new ActivateThemePayload(site, theme);
+                        SiteThemePayload payload = new SiteThemePayload(site, theme);
                         payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
@@ -81,14 +81,14 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onResponse(JetpackThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to Jetpack theme installation request.");
                         ThemeModel responseTheme = createThemeFromJetpackResponse(response);
-                        ActivateThemePayload payload = new ActivateThemePayload(site, responseTheme);
+                        SiteThemePayload payload = new SiteThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
                     }
                 }, new BaseRequest.BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme installation request.");
-                        ActivateThemePayload payload = new ActivateThemePayload(site, theme);
+                        SiteThemePayload payload = new SiteThemePayload(site, theme);
                         payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
@@ -107,7 +107,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(WPComThemeResponse response) {
                         AppLog.d(AppLog.T.API, "Received response to theme activation request.");
-                        ActivateThemePayload payload = new ActivateThemePayload(site, theme);
+                        SiteThemePayload payload = new SiteThemePayload(site, theme);
                         payload.theme.setActive(StringUtils.equals(theme.getThemeId(), response.id));
                         mDispatcher.dispatch(ThemeActionBuilder.newActivatedThemeAction(payload));
                     }
@@ -115,7 +115,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to theme activation request.");
-                        ActivateThemePayload payload = new ActivateThemePayload(site, theme);
+                        SiteThemePayload payload = new SiteThemePayload(site, theme);
                         payload.error = new ThemesError(
                                 ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newActivatedThemeAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -51,7 +51,7 @@ public class ThemeSqlUtils {
 
     public static void insertOrReplaceInstalledThemes(@NonNull SiteModel site, @NonNull List<ThemeModel> themes) {
         // remove existing installed themes
-        removeThemes(site);
+        removeSiteThemes(site);
 
         // ensure site ID is set before inserting
         for (ThemeModel theme : themes) {
@@ -155,17 +155,15 @@ public class ThemeSqlUtils {
                 .where()
                 .equals(ThemeModelTable.LOCAL_SITE_ID, site.getId())
                 .equals(ThemeModelTable.THEME_ID, theme.getThemeId())
+                .equals(ThemeModelTable.IS_WP_COM_THEME, false)
                 .endWhere().execute();
     }
 
-    public static void removeThemes(@NonNull SiteModel site) {
-        removeThemes(site.getId());
-    }
-
-    private static void removeThemes(int localSiteId) {
+    public static void removeSiteThemes(@NonNull SiteModel site) {
         WellSql.delete(ThemeModel.class)
                 .where()
-                .equals(ThemeModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(ThemeModelTable.LOCAL_SITE_ID, site.getId())
+                .equals(ThemeModelTable.IS_WP_COM_THEME, false)
                 .endWhere().execute();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -150,10 +150,11 @@ public class ThemeSqlUtils {
                 .endWhere().execute();
     }
 
-    public static void removeTheme(@NonNull ThemeModel theme) {
+    public static void removeSiteTheme(@NonNull SiteModel site, @NonNull ThemeModel theme) {
         WellSql.delete(ThemeModel.class)
                 .where()
-                .equals(ThemeModelTable.ID, theme.getId())
+                .equals(ThemeModelTable.LOCAL_SITE_ID, site.getId())
+                .equals(ThemeModelTable.THEME_ID, theme.getThemeId())
                 .endWhere().execute();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -124,17 +124,6 @@ public class ThemeSqlUtils {
                 .endWhere().getAsModel();
     }
 
-    /**
-     * Retrieves themes associated with a given site. Installed themes (for Jetpack sites) are the only themes
-     * targeted for now.
-     */
-    public static Cursor getThemesForSiteAsCursor(@NonNull SiteModel site) {
-        return WellSql.select(ThemeModel.class)
-                .where()
-                .equals(ThemeModelTable.LOCAL_SITE_ID, site.getId())
-                .endWhere().getAsCursor();
-    }
-
     public static List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {
         return WellSql.select(ThemeModel.class)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -49,7 +49,7 @@ public class ThemeSqlUtils {
         WellSql.insert(themes).asSingleTransaction(true).execute();
     }
 
-    public static int insertOrReplaceInstalledThemes(@NonNull SiteModel site, @NonNull List<ThemeModel> themes) {
+    public static void insertOrReplaceInstalledThemes(@NonNull SiteModel site, @NonNull List<ThemeModel> themes) {
         // remove existing installed themes
         removeThemes(site);
 
@@ -59,8 +59,6 @@ public class ThemeSqlUtils {
         }
 
         WellSql.insert(themes).asSingleTransaction(true).execute();
-
-        return themes.size();
     }
 
     public static void insertOrReplaceActiveThemeForSite(@NonNull SiteModel site, @NonNull ThemeModel theme) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -37,28 +37,6 @@ public class ThemeSqlUtils {
         }
     }
 
-    public static void insertOrUpdateWpComTheme(@NonNull ThemeModel theme) {
-        List<ThemeModel> existing = WellSql.select(ThemeModel.class)
-                .where().beginGroup()
-                .equals(ThemeModelTable.THEME_ID, theme.getThemeId())
-                .equals(ThemeModelTable.IS_WP_COM_THEME, true)
-                .endGroup().endWhere().getAsModel();
-
-        // Remove local site id if it's set for whatever reason (shouldn't normally happen, so it's a sanity check)
-        theme.setLocalSiteId(0);
-        // Make sure the isWpComTheme flag is set
-        theme.setIsWpComTheme(true);
-
-        if (existing.isEmpty()) {
-            // theme is not in the local DB so we insert it
-            WellSql.insert(theme).asSingleTransaction(true).execute();
-        } else {
-            // theme already exists in the local DB so we update the existing row with the passed theme
-            WellSql.update(ThemeModel.class).whereId(existing.get(0).getId())
-                    .put(theme, new UpdateAllExceptId<>(ThemeModel.class)).execute();
-        }
-    }
-
     public static void insertOrReplaceWpComThemes(@NonNull List<ThemeModel> themes) {
         // remove existing WP.com themes
         removeWpComThemes();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -67,28 +67,6 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class SearchThemesPayload extends Payload<ThemesError> {
-        public String searchTerm;
-
-        public SearchThemesPayload(@NonNull String searchTerm) {
-            this.searchTerm = searchTerm;
-        }
-    }
-
-    public static class SearchedThemesPayload extends Payload<ThemesError> {
-        public String searchTerm;
-        public List<ThemeModel> themes;
-
-        public SearchedThemesPayload(@NonNull String searchTerm, List<ThemeModel> themes) {
-            this.searchTerm = searchTerm;
-            this.themes = themes;
-        }
-
-        public SearchedThemesPayload(ThemesError error) {
-            this.error = error;
-        }
-    }
-
     public static class ActivateThemePayload extends Payload<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -155,14 +133,6 @@ public class ThemeStore extends Store {
         public OnCurrentThemeFetched(SiteModel site, ThemeModel theme) {
             this.site = site;
             this.theme = theme;
-        }
-    }
-
-    public static class OnThemesSearched extends OnChanged<ThemesError> {
-        public List<ThemeModel> searchResults;
-
-        public OnThemesSearched(List<ThemeModel> searchResults) {
-            this.searchResults = searchResults;
         }
     }
 
@@ -241,13 +211,6 @@ public class ThemeStore extends Store {
                 break;
             case FETCHED_CURRENT_THEME:
                 handleCurrentThemeFetched((FetchedCurrentThemePayload) action.getPayload());
-                break;
-            case SEARCH_THEMES:
-                SearchThemesPayload searchPayload = (SearchThemesPayload) action.getPayload();
-                searchThemes(searchPayload.searchTerm);
-                break;
-            case SEARCHED_THEMES:
-                handleSearchedThemes((SearchedThemesPayload) action.getPayload());
                 break;
             case ACTIVATE_THEME:
                 activateTheme((ActivateThemePayload) action.getPayload());
@@ -370,22 +333,6 @@ public class ThemeStore extends Store {
             event.error = payload.error;
         } else {
             ThemeSqlUtils.insertOrReplaceActiveThemeForSite(payload.site, payload.theme);
-        }
-        emitChange(event);
-    }
-
-    private void searchThemes(@NonNull String searchTerm) {
-        mThemeRestClient.searchThemes(searchTerm);
-    }
-
-    private void handleSearchedThemes(@NonNull SearchedThemesPayload payload) {
-        OnThemesSearched event = new OnThemesSearched(payload.themes);
-        if (payload.isError()) {
-            event.error = payload.error;
-        } else {
-            for (ThemeModel theme : payload.themes) {
-                ThemeSqlUtils.insertOrUpdateWpComTheme(theme);
-            }
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -403,13 +403,8 @@ public class ThemeStore extends Store {
         emitChange(event);
     }
 
-    private void removeSiteThemes(SiteModel site) {
-        final List<ThemeModel> themes = getThemesForSite(site);
-        if (!themes.isEmpty()) {
-            for (ThemeModel theme : themes) {
-                ThemeSqlUtils.removeSiteTheme(site, theme);
-            }
-        }
+    private void removeSiteThemes(@NonNull SiteModel site) {
+        ThemeSqlUtils.removeSiteThemes(site);
         emitChange(new OnSiteThemesChanged(site, ThemeAction.REMOVE_SITE_THEMES));
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -255,10 +255,6 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getWpComThemesCursor();
     }
 
-    public Cursor getThemesCursorForSite(@NonNull SiteModel site) {
-        return ThemeSqlUtils.getThemesForSiteAsCursor(site);
-    }
-
     public List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {
         return ThemeSqlUtils.getThemesForSite(site);
     }
@@ -270,6 +266,7 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getSiteThemeByThemeId(siteModel, themeId);
     }
 
+    @SuppressWarnings("WeakerAccess")
     public ThemeModel getWpComThemeByThemeId(String themeId) {
         if (TextUtils.isEmpty(themeId)) {
             return null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.store;
 
-import android.content.res.Resources;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -67,11 +67,11 @@ public class ThemeStore extends Store {
         }
     }
 
-    public static class ActivateThemePayload extends Payload<ThemesError> {
+    public static class SiteThemePayload extends Payload<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
 
-        public ActivateThemePayload(SiteModel site, ThemeModel theme) {
+        public SiteThemePayload(@NonNull SiteModel site, @NonNull ThemeModel theme) {
             this.site = site;
             this.theme = theme;
         }
@@ -213,22 +213,22 @@ public class ThemeStore extends Store {
                 handleCurrentThemeFetched((FetchedCurrentThemePayload) action.getPayload());
                 break;
             case ACTIVATE_THEME:
-                activateTheme((ActivateThemePayload) action.getPayload());
+                activateTheme((SiteThemePayload) action.getPayload());
                 break;
             case ACTIVATED_THEME:
-                handleThemeActivated((ActivateThemePayload) action.getPayload());
+                handleThemeActivated((SiteThemePayload) action.getPayload());
                 break;
             case INSTALL_THEME:
-                installTheme((ActivateThemePayload) action.getPayload());
+                installTheme((SiteThemePayload) action.getPayload());
                 break;
             case INSTALLED_THEME:
-                handleThemeInstalled((ActivateThemePayload) action.getPayload());
+                handleThemeInstalled((SiteThemePayload) action.getPayload());
                 break;
             case DELETE_THEME:
-                deleteTheme((ActivateThemePayload) action.getPayload());
+                deleteTheme((SiteThemePayload) action.getPayload());
                 break;
             case DELETED_THEME:
-                handleThemeDeleted((ActivateThemePayload) action.getPayload());
+                handleThemeDeleted((SiteThemePayload) action.getPayload());
                 break;
             case REMOVE_THEME:
                 removeTheme((ThemeModel) action.getPayload());
@@ -337,7 +337,7 @@ public class ThemeStore extends Store {
         emitChange(event);
     }
 
-    private void installTheme(@NonNull ActivateThemePayload payload) {
+    private void installTheme(@NonNull SiteThemePayload payload) {
         if (payload.site.isJetpackConnected() && payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.installTheme(payload.site, payload.theme);
         } else {
@@ -346,7 +346,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    private void handleThemeInstalled(@NonNull ActivateThemePayload payload) {
+    private void handleThemeInstalled(@NonNull SiteThemePayload payload) {
         OnThemeInstalled event = new OnThemeInstalled(payload.site, payload.theme);
         if (payload.isError()) {
             event.error = payload.error;
@@ -356,7 +356,7 @@ public class ThemeStore extends Store {
         emitChange(event);
     }
 
-    private void activateTheme(@NonNull ActivateThemePayload payload) {
+    private void activateTheme(@NonNull SiteThemePayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.activateTheme(payload.site, payload.theme);
         } else {
@@ -365,7 +365,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    private void handleThemeActivated(@NonNull ActivateThemePayload payload) {
+    private void handleThemeActivated(@NonNull SiteThemePayload payload) {
         OnThemeActivated event = new OnThemeActivated(payload.site, payload.theme);
         if (payload.isError()) {
             event.error = payload.error;
@@ -384,7 +384,7 @@ public class ThemeStore extends Store {
         emitChange(event);
     }
 
-    private void deleteTheme(@NonNull ActivateThemePayload payload) {
+    private void deleteTheme(@NonNull SiteThemePayload payload) {
         if (payload.site.isJetpackConnected() && payload.site.isUsingWpComRestApi()) {
             mThemeRestClient.deleteTheme(payload.site, payload.theme);
         } else {
@@ -393,7 +393,7 @@ public class ThemeStore extends Store {
         }
     }
 
-    private void handleThemeDeleted(@NonNull ActivateThemePayload payload) {
+    private void handleThemeDeleted(@NonNull SiteThemePayload payload) {
         OnThemeDeleted event = new OnThemeDeleted(payload.site, payload.theme);
         if (payload.isError()) {
             event.error = payload.error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store;
 
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
@@ -152,9 +153,11 @@ public class ThemeStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class OnThemeRemoved extends OnChanged<ThemesError> {
+        public SiteModel site;
         public ThemeModel theme;
 
-        public OnThemeRemoved(ThemeModel theme) {
+        public OnThemeRemoved(@NonNull SiteModel site, @NonNull ThemeModel theme) {
+            this.site = site;
             this.theme = theme;
         }
     }
@@ -234,7 +237,7 @@ public class ThemeStore extends Store {
                 handleThemeDeleted((SiteThemePayload) action.getPayload());
                 break;
             case REMOVE_THEME:
-                removeTheme((ThemeModel) action.getPayload());
+                removeSiteTheme((SiteThemePayload) action.getPayload());
                 break;
             case REMOVE_SITE_THEMES:
                 removeSiteThemes((SiteModel) action.getPayload());
@@ -403,11 +406,9 @@ public class ThemeStore extends Store {
         emitChange(event);
     }
 
-    private void removeTheme(ThemeModel theme) {
-        if (theme != null) {
-            ThemeSqlUtils.removeSiteTheme(null, theme);
-        }
-        emitChange(new OnThemeRemoved(theme));
+    private void removeSiteTheme(@NonNull SiteThemePayload payload) {
+        ThemeSqlUtils.removeSiteTheme(payload.site, payload.theme);
+        emitChange(new OnThemeRemoved(payload.site, payload.theme));
     }
 
     private void removeSiteThemes(SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -209,10 +209,6 @@ public class ThemeStore extends Store {
             case FETCHED_INSTALLED_THEMES:
                 handleInstalledThemesFetched((FetchedSiteThemesPayload) action.getPayload());
                 break;
-            case FETCH_PURCHASED_THEMES:
-                break;
-            case FETCHED_PURCHASED_THEMES:
-                break;
             case FETCH_CURRENT_THEME:
                 fetchCurrentTheme((SiteModel) action.getPayload());
                 break;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -98,6 +98,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class ThemesError implements OnChangedError {
         public ThemeErrorType type;
         public String message;
@@ -113,6 +114,7 @@ public class ThemeStore extends Store {
     }
 
     // OnChanged events
+    @SuppressWarnings("WeakerAccess")
     public static class OnSiteThemesChanged extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeAction origin;
@@ -126,6 +128,7 @@ public class ThemeStore extends Store {
     public static class OnWpComThemesChanged extends OnChanged<ThemesError> {
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnCurrentThemeFetched extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -136,6 +139,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnThemeActivated extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -146,6 +150,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnThemeRemoved extends OnChanged<ThemesError> {
         public ThemeModel theme;
 
@@ -154,6 +159,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnThemeDeleted extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;
@@ -164,6 +170,7 @@ public class ThemeStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class OnThemeInstalled extends OnChanged<ThemesError> {
         public SiteModel site;
         public ThemeModel theme;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -398,14 +398,14 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.removeTheme(payload.theme);
+            ThemeSqlUtils.removeSiteTheme(payload.site, payload.theme);
         }
         emitChange(event);
     }
 
     private void removeTheme(ThemeModel theme) {
         if (theme != null) {
-            ThemeSqlUtils.removeTheme(theme);
+            ThemeSqlUtils.removeSiteTheme(null, theme);
         }
         emitChange(new OnThemeRemoved(theme));
     }
@@ -414,7 +414,7 @@ public class ThemeStore extends Store {
         final List<ThemeModel> themes = getThemesForSite(site);
         if (!themes.isEmpty()) {
             for (ThemeModel theme : themes) {
-                ThemeSqlUtils.removeTheme(theme);
+                ThemeSqlUtils.removeSiteTheme(site, theme);
             }
         }
         emitChange(new OnSiteThemesChanged(site, ThemeAction.REMOVE_SITE_THEMES));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -236,9 +236,6 @@ public class ThemeStore extends Store {
             case DELETED_THEME:
                 handleThemeDeleted((SiteThemePayload) action.getPayload());
                 break;
-            case REMOVE_THEME:
-                removeSiteTheme((SiteThemePayload) action.getPayload());
-                break;
             case REMOVE_SITE_THEMES:
                 removeSiteThemes((SiteModel) action.getPayload());
                 break;
@@ -404,11 +401,6 @@ public class ThemeStore extends Store {
             ThemeSqlUtils.removeSiteTheme(payload.site, payload.theme);
         }
         emitChange(event);
-    }
-
-    private void removeSiteTheme(@NonNull SiteThemePayload payload) {
-        ThemeSqlUtils.removeSiteTheme(payload.site, payload.theme);
-        emitChange(new OnThemeRemoved(payload.site, payload.theme));
     }
 
     private void removeSiteThemes(SiteModel site) {


### PR DESCRIPTION
This PR needs to be reviewed after #669. It's a part of the continued effort for improving `ThemeStore` in general. I've reviewed all the connected tests and made some improvements to most of them. Some of these changes are minor and it aims to make the test more readable and easy to track. Some of them are pretty much written from scratch with a goal of making the test more robust. As a result of some changes to the tests, some small improvements are also made for the actual `ThemeStore` as well.

Aside from all these, I've decided to remove the `REMOVE_THEME` local action as we weren't actually using it yet and it required some changes which I didn't want to go through yet. If we ever need it, which I think is unlikely, we can add the improved version and it's test.

Adding justifications for each change would probably make this a big wall of text, so instead, please let me know if there is anything not clear or if something or some change doesn't make sense.