### PR TITLE
Issue/665 delete term

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -359,7 +359,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
 
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
-        mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(pushPayload));
+        mDispatcher.dispatch(TaxonomyActionBuilder.newDeleteTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -159,6 +159,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         uploadTerm(term);
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
 
+        term = mTaxonomyStore.getTagsForSite(sSite).get(0);
         deleteTerm(term);
         assertEquals(0, WellSqlUtils.getTotalTermsCount());
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -35,6 +35,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         TERMS_FETCHED,
         TERM_UPDATED,
         TERM_UPLOADED,
+        TERM_DELETED,
         ERROR_INVALID_TAXONOMY,
         ERROR_DUPLICATE,
         ERROR_UNAUTHORIZED,
@@ -149,6 +150,17 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     public void testUpdateExistingTag() throws InterruptedException {
         TermModel term = createNewTag();
         testUpdateExistingTerm(term);
+    }
+
+    public void testDeleteTag() throws InterruptedException {
+        TermModel term = createNewTag();
+        setupTermAttributes(term);
+
+        uploadTerm(term);
+        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+
+        deleteTerm(term);
+        assertEquals(0, WellSqlUtils.getTotalTermsCount());
     }
 
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
@@ -331,6 +343,16 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void deleteTerm(TermModel term) throws InterruptedException {
+        mNextEvent = TestEvents.TERM_DELETED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
+        mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(pushPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -268,6 +268,12 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
                     mCountDownLatch.countDown();
                 }
                 break;
+            case REMOVE_TERM:
+                if (mNextEvent.equals(TestEvents.TERM_DELETED)) {
+                    AppLog.i(T.API, "Deleted " + event.rowsAffected + " term");
+                    mCountDownLatch.countDown();
+                }
+                break;
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -285,6 +285,12 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
                     mCountDownLatch.countDown();
                 }
                 break;
+            case REMOVE_TERM:
+                if (mNextEvent.equals(TestEvents.TERM_DELETED)) {
+                    AppLog.i(T.API, "Deleted " + event.rowsAffected + " term");
+                    mCountDownLatch.countDown();
+                }
+                break;
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -234,6 +234,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadTerm(term);
         assertEquals(1, WellSqlUtils.getTotalTermsCount());
 
+        term = mTaxonomyStore.getTagsForSite(sSite).get(0);
         deleteTerm(term);
         assertEquals(0, WellSqlUtils.getTotalTermsCount());
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -151,6 +151,16 @@ public class TaxonomyStoreUnitTest {
     }
 
     @Test
+    public void testRemoveTag() {
+        TermModel tag = TaxonomyTestUtils.generateSampleTag();
+        TaxonomySqlUtils.insertOrUpdateTerm(tag);
+        assertEquals(1, TaxonomyTestUtils.getTermsCount());
+
+        TaxonomySqlUtils.removeTerm(tag);
+        assertEquals(0, TaxonomyTestUtils.getTermsCount());
+    }
+
+    @Test
     public void testClearTaxonomy() {
         SiteModel site = new SiteModel();
         site.setId(6);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -23,6 +23,8 @@ public enum TaxonomyAction implements IAction {
     FETCH_TERM,
     @Action(payloadType = RemoteTermPayload.class)
     PUSH_TERM,
+    @Action(payloadType = RemoteTermPayload.class)
+    REMOVE_TERM,
 
     // Remote responses
     @Action(payloadType = FetchTermsResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -24,9 +24,9 @@ public enum TaxonomyAction implements IAction {
     @Action(payloadType = RemoteTermPayload.class)
     PUSH_TERM,
     @Action(payloadType = RemoteTermPayload.class)
-    REMOVE_TERM,
+    DELETE_TERM,
     @Action(payloadType = RemoteTermPayload.class)
-    REMOVED_TERM,
+    DELETED_TERM,
 
     // Remote responses
     @Action(payloadType = FetchTermsResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -25,8 +25,6 @@ public enum TaxonomyAction implements IAction {
     PUSH_TERM,
     @Action(payloadType = RemoteTermPayload.class)
     DELETE_TERM,
-    @Action(payloadType = RemoteTermPayload.class)
-    DELETED_TERM,
 
     // Remote responses
     @Action(payloadType = FetchTermsResponsePayload.class)
@@ -35,10 +33,14 @@ public enum TaxonomyAction implements IAction {
     FETCHED_TERM,
     @Action(payloadType = RemoteTermPayload.class)
     PUSHED_TERM,
+    @Action(payloadType = RemoteTermPayload.class)
+    DELETED_TERM,
 
     // Local actions
     @Action(payloadType = TermModel.class)
     UPDATE_TERM,
+    @Action(payloadType = TermModel.class)
+    REMOVE_TERM,
     @Action
     REMOVE_ALL_TERMS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TaxonomyAction.java
@@ -25,6 +25,8 @@ public enum TaxonomyAction implements IAction {
     PUSH_TERM,
     @Action(payloadType = RemoteTermPayload.class)
     REMOVE_TERM,
+    @Action(payloadType = RemoteTermPayload.class)
+    REMOVED_TERM,
 
     // Remote responses
     @Action(payloadType = FetchTermsResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -154,7 +154,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void removeTerm(final TermModel term, final SiteModel site) {
+    public void deleteTerm(final TermModel term, final SiteModel site) {
         final String taxonomy = term.getTaxonomy();
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms.new_.getUrlV1_1();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -156,9 +156,8 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
 
     public void deleteTerm(final TermModel term, final SiteModel site) {
         final String taxonomy = term.getTaxonomy();
-        // TODO: "delete" rather than "new_"
-        String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms.new_.getUrlV1_1();
-
+        String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms
+                .slug(term.getSlug()).delete.getUrlV1_1();
         Map<String, Object> body = termModelToParams(term);
 
         final WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, body,
@@ -166,7 +165,8 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                 new Listener<TermWPComRestResponse>() {
                     @Override
                     public void onResponse(TermWPComRestResponse response) {
-                        // TODO: mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(term));
+                        RemoteTermPayload payload = new RemoteTermPayload(term, site);
+                        mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                     }
                 },
                 new BaseErrorListener() {
@@ -175,7 +175,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
                         RemoteTermPayload payload = new RemoteTermPayload(term, site);
                         payload.error = new TaxonomyError(((WPComGsonNetworkError) error).apiError, error.message);
-                        // TODO: mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
+                        mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -156,6 +156,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
 
     public void deleteTerm(final TermModel term, final SiteModel site) {
         final String taxonomy = term.getTaxonomy();
+        // TODO: "delete" rather than "new_"
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms.new_.getUrlV1_1();
 
         Map<String, Object> body = termModelToParams(term);
@@ -165,14 +166,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                 new Listener<TermWPComRestResponse>() {
                     @Override
                     public void onResponse(TermWPComRestResponse response) {
-                        TermModel uploadedTerm = termResponseToTermModel(response);
-
-                        uploadedTerm.setId(term.getId());
-                        uploadedTerm.setLocalSiteId(site.getId());
-                        uploadedTerm.setTaxonomy(taxonomy);
-
-                        RemoteTermPayload payload = new RemoteTermPayload(uploadedTerm, site);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
+                        // TODO: mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(term));
                     }
                 },
                 new BaseErrorListener() {
@@ -181,7 +175,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
                         RemoteTermPayload payload = new RemoteTermPayload(term, site);
                         payload.error = new TaxonomyError(((WPComGsonNetworkError) error).apiError, error.message);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
+                        // TODO: mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                     }
                 }
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -162,9 +162,8 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         final String taxonomy = term.getTaxonomy();
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms
                 .slug(term.getSlug()).delete.getUrlV1_1();
-        Map<String, Object> body = termModelToParams(term);
 
-        final WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, body,
+        final WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, null,
                 TermWPComRestResponse.class,
                 new Listener<TermWPComRestResponse>() {
                     @Override
@@ -183,8 +182,6 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                     }
                 }
         );
-
-        request.addQueryParameter("context", "edit");
 
         request.disableRetries();
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -211,7 +211,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         params.add(site.getUsername());
         params.add(site.getPassword());
         params.add(term.getTaxonomy());
-        params.add(term.getId());
+        params.add(term.getRemoteTermId());
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.DELETE_TERM, params,
                 new Listener<Object>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -212,7 +212,8 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());
         params.add(site.getPassword());
-        params.add(contentStruct);
+        params.add(term.getTaxonomy());
+        params.add(term.getId());
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.DELETE_TERM, params,
                 new Listener<Object>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -206,8 +206,6 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
     }
 
     public void deleteTerm(final TermModel term, final SiteModel site) {
-        Map<String, Object> contentStruct = termModelToContentStruct(term);
-
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -242,6 +242,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         request.disableRetries();
         add(request);
     }
+
     private TermsModel termsResponseToTermsModel(Object[] response, SiteModel site) {
         List<Map<?, ?>> termsList = new ArrayList<>();
         for (Object responseObject : response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -197,6 +197,8 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
+    // TODO: deleteTerm
+
     private TermsModel termsResponseToTermsModel(Object[] response, SiteModel site) {
         List<Map<?, ?>> termsList = new ArrayList<>();
         for (Object responseObject : response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -136,6 +136,20 @@ public class TaxonomySqlUtils {
                 .execute();
     }
 
+    public static int deleteTerm(TermModel term) {
+        if (term == null) {
+            return 0;
+        }
+
+        return WellSql.delete(TermModel.class)
+                .where().beginGroup()
+                .equals(TermModelTable.TAXONOMY, term.getTaxonomy())
+                .equals(TermModelTable.REMOTE_TERM_ID, term.getRemoteTermId())
+                .equals(TermModelTable.LOCAL_SITE_ID, term.getLocalSiteId())
+                .endGroup().endWhere()
+                .execute();
+    }
+
     public static int deleteAllTerms() {
         return WellSql.delete(TermModel.class).execute();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -136,7 +136,7 @@ public class TaxonomySqlUtils {
                 .execute();
     }
 
-    public static int deleteTerm(TermModel term) {
+    public static int removeTerm(TermModel term) {
         if (term == null) {
             return 0;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -298,11 +298,11 @@ public class TaxonomyStore extends Store {
             case PUSHED_TERM:
                 handlePushTermCompleted((RemoteTermPayload) action.getPayload());
                 break;
-            case REMOVE_TERM:
+            case DELETE_TERM:
                 removeTerm((TermModel) action.getPayload());
                 break;
-            case REMOVED_TERM:
-                handleRemoveTermCompleted((RemoteTermPayload) action.getPayload());
+            case DELETED_TERM:
+                handleDeleteTermCompleted((RemoteTermPayload) action.getPayload());
                 break;
             case REMOVE_ALL_TERMS:
                 removeAllTerms();
@@ -390,7 +390,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void handleRemoveTermCompleted(RemoteTermPayload payload) {
+    private void handleDeleteTermCompleted(RemoteTermPayload payload) {
         if (payload.isError()) {
             OnTermRemoved onTermRemoved = new OnTermRemoved(payload.term);
             onTermRemoved.error = payload.error;
@@ -442,7 +442,7 @@ public class TaxonomyStore extends Store {
         int rowsAffected = TaxonomySqlUtils.deleteTerm(term);
 
         OnTaxonomyChanged onTaxonomyChanged = new OnTaxonomyChanged(rowsAffected, term.getTaxonomy());
-        onTaxonomyChanged.causeOfChange = TaxonomyAction.REMOVE_TERM;
+        onTaxonomyChanged.causeOfChange = TaxonomyAction.DELETE_TERM;
         emitChange(onTaxonomyChanged);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -299,6 +299,9 @@ public class TaxonomyStore extends Store {
                 handlePushTermCompleted((RemoteTermPayload) action.getPayload());
                 break;
             case REMOVE_TERM:
+                removeTerm((TermModel) action.getPayload());
+                break;
+            case REMOVED_TERM:
                 handleRemoveTermCompleted((RemoteTermPayload) action.getPayload());
                 break;
             case REMOVE_ALL_TERMS:

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -99,14 +99,6 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    public static class OnTermRemoved extends OnChanged<TaxonomyError> {
-        public TermModel term;
-
-        public OnTermRemoved(TermModel term) {
-            this.term = term;
-        }
-    }
-
     public static class TaxonomyError implements OnChangedError {
         public TaxonomyErrorType type;
         public String message;
@@ -392,9 +384,10 @@ public class TaxonomyStore extends Store {
 
     private void handleDeleteTermCompleted(RemoteTermPayload payload) {
         if (payload.isError()) {
-            OnTermRemoved onTermRemoved = new OnTermRemoved(payload.term);
-            onTermRemoved.error = payload.error;
-            emitChange(onTermRemoved);
+            OnTaxonomyChanged event = new OnTaxonomyChanged(0, payload.term.getTaxonomy());
+            event.error = payload.error;
+            event.causeOfChange = TaxonomyAction.DELETE_TERM;
+            emitChange(event);
         } else {
             removeTerm(payload.term);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -446,7 +446,7 @@ public class TaxonomyStore extends Store {
     }
 
     private void removeTerm(TermModel term) {
-        int rowsAffected = TaxonomySqlUtils.deleteTerm(term);
+        int rowsAffected = TaxonomySqlUtils.removeTerm(term);
 
         OnTaxonomyChanged onTaxonomyChanged = new OnTaxonomyChanged(rowsAffected, term.getTaxonomy());
         onTaxonomyChanged.causeOfChange = TaxonomyAction.REMOVE_TERM;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -396,7 +396,6 @@ public class TaxonomyStore extends Store {
             onTermRemoved.error = payload.error;
             emitChange(onTermRemoved);
         } else {
-            removeTerm(payload.term);
             emitChange(new OnTermRemoved(payload.term));
         }
     }
@@ -442,7 +441,7 @@ public class TaxonomyStore extends Store {
         int rowsAffected = TaxonomySqlUtils.deleteTerm(term);
 
         OnTaxonomyChanged onTaxonomyChanged = new OnTaxonomyChanged(rowsAffected, term.getTaxonomy());
-        onTaxonomyChanged.causeOfChange = TaxonomyAction.DELETE_TERM;
+        onTaxonomyChanged.causeOfChange = TaxonomyAction.REMOVE_TERM;
         emitChange(onTaxonomyChanged);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -299,7 +299,7 @@ public class TaxonomyStore extends Store {
                 handlePushTermCompleted((RemoteTermPayload) action.getPayload());
                 break;
             case DELETE_TERM:
-                removeTerm((TermModel) action.getPayload());
+                deleteTerm((RemoteTermPayload) action.getPayload());
                 break;
             case DELETED_TERM:
                 handleDeleteTermCompleted((RemoteTermPayload) action.getPayload());
@@ -396,7 +396,7 @@ public class TaxonomyStore extends Store {
             onTermRemoved.error = payload.error;
             emitChange(onTermRemoved);
         } else {
-            emitChange(new OnTermRemoved(payload.term));
+            removeTerm(payload.term);
         }
     }
 
@@ -426,6 +426,14 @@ public class TaxonomyStore extends Store {
         } else {
             // TODO: check for WP-REST-API plugin and use it here
             mTaxonomyXMLRPCClient.pushTerm(payload.term, payload.site);
+        }
+    }
+
+    private void deleteTerm(RemoteTermPayload payload) {
+        if (payload.site.isUsingWpComRestApi()) {
+            mTaxonomyRestClient.deleteTerm(payload.term, payload.site);
+        } else {
+            mTaxonomyXMLRPCClient.deleteTerm(payload.term, payload.site);
         }
     }
 

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -53,6 +53,7 @@
 /sites/$site/taxonomies/$taxonomy#String/terms/
 /sites/$site/taxonomies/$taxonomy#String/terms/new/
 /sites/$site/taxonomies/$taxonomy#String/terms/slug:$slug#String/
+/sites/$site/taxonomies/$taxonomy/terms/slug:$slug/delete/
 
 /themes
 /sites/$site/themes/mine

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -53,7 +53,7 @@
 /sites/$site/taxonomies/$taxonomy#String/terms/
 /sites/$site/taxonomies/$taxonomy#String/terms/new/
 /sites/$site/taxonomies/$taxonomy#String/terms/slug:$slug#String/
-/sites/$site/taxonomies/$taxonomy/terms/slug:$slug/delete/
+/sites/$site/taxonomies/$taxonomy#String/terms/slug:$slug#String/delete/
 
 /themes
 /sites/$site/themes/mine

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -12,6 +12,7 @@ wp.deletePost
 wp.getTerm
 wp.getTerms
 wp.newTerm
+wp.deleteTerm
 wp.uploadFile
 wp.newComment
 wp.getComment

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -12,6 +12,7 @@ wp.deletePost
 wp.getTerm
 wp.getTerms
 wp.newTerm
+wp.deleteTerm
 wp.editTerm
 wp.uploadFile
 wp.newComment


### PR DESCRIPTION
Fixes #665 - adds the ability to delete a term, for use in the upcoming WPAndroid tag list redesign. This is my first substantial FluxC PR, so please be merciless in the review.

cc @oguzkocer 