### PR TITLE
Adds missing plugin properties

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitePluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitePluginModel.java
@@ -19,6 +19,7 @@ public class SitePluginModel implements Identifiable, Serializable {
     @Column private String mDescription;
     @Column private String mAuthorName;
     @Column private String mAuthorUrl;
+    @Column private String mSettingsUrl;
     @Column private boolean mIsActive;
     @Column private boolean mIsAutoUpdateEnabled;
 
@@ -102,6 +103,14 @@ public class SitePluginModel implements Identifiable, Serializable {
 
     public void setAuthorUrl(String authorUrl) {
         mAuthorUrl = authorUrl;
+    }
+
+    public String getSettingsUrl() {
+        return mSettingsUrl;
+    }
+
+    public void setSettingsUrl(String settingsUrl) {
+        mSettingsUrl = settingsUrl;
     }
 
     public boolean isActive() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/WPOrgPluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/WPOrgPluginModel.java
@@ -10,8 +10,7 @@ import java.io.Serializable;
 @Table
 public class WPOrgPluginModel implements Identifiable, Serializable {
     @PrimaryKey @Column private int mId;
-    @Column private String mAuthor;
-    @Column private String mAuthorUrl;
+    @Column private String mAuthorAsHtml;
     @Column private String mBanner;
     @Column private String mDescriptionAsHtml;
     @Column private String mFaqAsHtml;
@@ -43,20 +42,12 @@ public class WPOrgPluginModel implements Identifiable, Serializable {
         return mId;
     }
 
-    public String getAuthor() {
-        return mAuthor;
+    public String getAuthorAsHtml() {
+        return mAuthorAsHtml;
     }
 
-    public void setAuthor(String author) {
-        mAuthor = author;
-    }
-
-    public String getAuthorUrl() {
-        return mAuthorUrl;
-    }
-
-    public void setAuthorUrl(String authorUrl) {
-        mAuthorUrl = authorUrl;
+    public void setAuthorAsHtml(String authorAsHtml) {
+        mAuthorAsHtml = authorAsHtml;
     }
 
     public String getBanner() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/WPOrgPluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/WPOrgPluginModel.java
@@ -10,11 +10,28 @@ import java.io.Serializable;
 @Table
 public class WPOrgPluginModel implements Identifiable, Serializable {
     @PrimaryKey @Column private int mId;
+    @Column private String mAuthor;
+    @Column private String mAuthorUrl;
+    @Column private String mBanner;
+    @Column private String mDescriptionAsHtml;
+    @Column private String mFaqAsHtml;
+    @Column private String mHomepageUrl;
+    @Column private String mIcon;
+    @Column private String mInstallationInstructionsAsHtml;
+    @Column private String mLastUpdated;
     @Column private String mName;
+    @Column private String mRating;
+    @Column private String mRequiredWordPressVersion;
     @Column private String mSlug;
     @Column private String mVersion;
-    @Column private String mRating;
-    @Column private String mIcon;
+    @Column private String mWhatsNewAsHtml;
+    @Column private int mDownloadCount;
+    @Column private int mNumberOfRatings;
+    @Column private int mNumberOfRatingsOfOne;
+    @Column private int mNumberOfRatingsOfTwo;
+    @Column private int mNumberOfRatingsOfThree;
+    @Column private int mNumberOfRatingsOfFour;
+    @Column private int mNumberOfRatingsOfFive;
 
     @Override
     public void setId(int id) {
@@ -26,12 +43,100 @@ public class WPOrgPluginModel implements Identifiable, Serializable {
         return mId;
     }
 
+    public String getAuthor() {
+        return mAuthor;
+    }
+
+    public void setAuthor(String author) {
+        mAuthor = author;
+    }
+
+    public String getAuthorUrl() {
+        return mAuthorUrl;
+    }
+
+    public void setAuthorUrl(String authorUrl) {
+        mAuthorUrl = authorUrl;
+    }
+
+    public String getBanner() {
+        return mBanner;
+    }
+
+    public void setBanner(String banner) {
+        mBanner = banner;
+    }
+
+    public String getDescriptionAsHtml() {
+        return mDescriptionAsHtml;
+    }
+
+    public void setDescriptionAsHtml(String descriptionAsHtml) {
+        mDescriptionAsHtml = descriptionAsHtml;
+    }
+
+    public String getFaqAsHtml() {
+        return mFaqAsHtml;
+    }
+
+    public void setFaqAsHtml(String faqAsHtml) {
+        mFaqAsHtml = faqAsHtml;
+    }
+
+    public String getHomepageUrl() {
+        return mHomepageUrl;
+    }
+
+    public void setHomepageUrl(String homepageUrl) {
+        mHomepageUrl = homepageUrl;
+    }
+
+    public String getIcon() {
+        return mIcon;
+    }
+
+    public void setIcon(String icon) {
+        mIcon = icon;
+    }
+
+    public String getInstallationInstructionsAsHtml() {
+        return mInstallationInstructionsAsHtml;
+    }
+
+    public void setInstallationInstructionsAsHtml(String installationInstructionsAsHtml) {
+        mInstallationInstructionsAsHtml = installationInstructionsAsHtml;
+    }
+
+    public String getLastUpdated() {
+        return mLastUpdated;
+    }
+
+    public void setLastUpdated(String lastUpdated) {
+        mLastUpdated = lastUpdated;
+    }
+
     public String getName() {
         return mName;
     }
 
     public void setName(String name) {
         mName = name;
+    }
+
+    public String getRating() {
+        return mRating;
+    }
+
+    public void setRating(String rating) {
+        mRating = rating;
+    }
+
+    public String getRequiredWordPressVersion() {
+        return mRequiredWordPressVersion;
+    }
+
+    public void setRequiredWordPressVersion(String requiredWordPressVersion) {
+        mRequiredWordPressVersion = requiredWordPressVersion;
     }
 
     public String getSlug() {
@@ -50,19 +155,67 @@ public class WPOrgPluginModel implements Identifiable, Serializable {
         mVersion = version;
     }
 
-    public String getRating() {
-        return mRating;
+    public String getWhatsNewAsHtml() {
+        return mWhatsNewAsHtml;
     }
 
-    public void setRating(String rating) {
-        mRating = rating;
+    public void setWhatsNewAsHtml(String whatsNewAsHtml) {
+        mWhatsNewAsHtml = whatsNewAsHtml;
     }
 
-    public String getIcon() {
-        return mIcon;
+    public int getDownloadCount() {
+        return mDownloadCount;
     }
 
-    public void setIcon(String icon) {
-        mIcon = icon;
+    public void setDownloadCount(int downloadCount) {
+        mDownloadCount = downloadCount;
+    }
+
+    public int getNumberOfRatings() {
+        return mNumberOfRatings;
+    }
+
+    public void setNumberOfRatings(int numberOfRatings) {
+        mNumberOfRatings = numberOfRatings;
+    }
+
+    public int getNumberOfRatingsOfOne() {
+        return mNumberOfRatingsOfOne;
+    }
+
+    public void setNumberOfRatingsOfOne(int numberOfRatingsOfOne) {
+        mNumberOfRatingsOfOne = numberOfRatingsOfOne;
+    }
+
+    public int getNumberOfRatingsOfTwo() {
+        return mNumberOfRatingsOfTwo;
+    }
+
+    public void setNumberOfRatingsOfTwo(int numberOfRatingsOfTwo) {
+        mNumberOfRatingsOfTwo = numberOfRatingsOfTwo;
+    }
+
+    public int getNumberOfRatingsOfThree() {
+        return mNumberOfRatingsOfThree;
+    }
+
+    public void setNumberOfRatingsOfThree(int numberOfRatingsOfThree) {
+        mNumberOfRatingsOfThree = numberOfRatingsOfThree;
+    }
+
+    public int getNumberOfRatingsOfFour() {
+        return mNumberOfRatingsOfFour;
+    }
+
+    public void setNumberOfRatingsOfFour(int numberOfRatingsOfFour) {
+        mNumberOfRatingsOfFour = numberOfRatingsOfFour;
+    }
+
+    public int getNumberOfRatingsOfFive() {
+        return mNumberOfRatingsOfFive;
+    }
+
+    public void setNumberOfRatingsOfFive(int numberOfRatingsOfFive) {
+        mNumberOfRatingsOfFive = numberOfRatingsOfFive;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -202,6 +202,9 @@ public class PluginRestClient extends BaseWPComRestClient {
         sitePluginModel.setPluginUrl(response.plugin_url);
         sitePluginModel.setSlug(response.slug);
         sitePluginModel.setVersion(response.version);
+        if (response.action_links != null) {
+            sitePluginModel.setSettingsUrl(response.action_links.settings);
+        }
         return sitePluginModel;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginWPComRestResponse.java
@@ -1,10 +1,17 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.plugin;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 
 public class PluginWPComRestResponse {
     public class FetchPluginsResponse {
         public List<PluginWPComRestResponse> plugins;
+    }
+
+    public class ActionLinks {
+        @SerializedName("Settings")
+        public String settings;
     }
 
     public boolean active;
@@ -17,4 +24,5 @@ public class PluginWPComRestResponse {
     public String plugin_url;
     public String slug;
     public String version;
+    public ActionLinks action_links;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -72,8 +72,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
 
     private WPOrgPluginModel wpOrgPluginFromResponse(WPOrgPluginResponse response) {
         WPOrgPluginModel wpOrgPluginModel = new WPOrgPluginModel();
-        wpOrgPluginModel.setAuthor(response.author);
-        wpOrgPluginModel.setAuthorUrl(response.authorUrl);
+        wpOrgPluginModel.setAuthorAsHtml(response.authorAsHtml);
         wpOrgPluginModel.setBanner(response.banner);
         wpOrgPluginModel.setDescriptionAsHtml(response.descriptionAsHtml);
         wpOrgPluginModel.setFaqAsHtml(response.faqAsHtml);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -72,11 +72,28 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
 
     private WPOrgPluginModel wpOrgPluginFromResponse(WPOrgPluginResponse response) {
         WPOrgPluginModel wpOrgPluginModel = new WPOrgPluginModel();
+        wpOrgPluginModel.setAuthor(response.author);
+        wpOrgPluginModel.setAuthorUrl(response.authorUrl);
+        wpOrgPluginModel.setBanner(response.banner);
+        wpOrgPluginModel.setDescriptionAsHtml(response.descriptionAsHtml);
+        wpOrgPluginModel.setFaqAsHtml(response.faqAsHtml);
+        wpOrgPluginModel.setHomepageUrl(response.homepageUrl);
+        wpOrgPluginModel.setIcon(response.icon);
+        wpOrgPluginModel.setInstallationInstructionsAsHtml(response.installationInstructionsAsHtml);
+        wpOrgPluginModel.setLastUpdated(response.lastUpdated);
         wpOrgPluginModel.setName(response.name);
         wpOrgPluginModel.setRating(response.rating);
+        wpOrgPluginModel.setRequiredWordPressVersion(response.requiredWordPressVersion);
         wpOrgPluginModel.setSlug(response.slug);
         wpOrgPluginModel.setVersion(response.version);
-        wpOrgPluginModel.setIcon(response.icon);
+        wpOrgPluginModel.setWhatsNewAsHtml(response.whatsNewAsHtml);
+        wpOrgPluginModel.setDownloadCount(response.downloadCount);
+        wpOrgPluginModel.setNumberOfRatings(response.numberOfRatings);
+        wpOrgPluginModel.setNumberOfRatingsOfOne(response.numberOfRatingsOfOne);
+        wpOrgPluginModel.setNumberOfRatingsOfTwo(response.numberOfRatingsOfTwo);
+        wpOrgPluginModel.setNumberOfRatingsOfThree(response.numberOfRatingsOfThree);
+        wpOrgPluginModel.setNumberOfRatingsOfFour(response.numberOfRatingsOfFour);
+        wpOrgPluginModel.setNumberOfRatingsOfFive(response.numberOfRatingsOfFive);
         return wpOrgPluginModel;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -38,7 +38,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     public void fetchWPOrgPlugin(final String pluginSlug) {
         String url = WPORGAPI.plugins.info.version("1.0").slug(pluginSlug).getUrl();
         Map<String, String> params = new HashMap<>();
-        params.put("fields", "icons");
+        params.put("fields", "banners,icons");
         final WPOrgAPIGsonRequest<WPOrgPluginResponse> request =
                 new WPOrgAPIGsonRequest<>(Method.GET, url, params, null, WPOrgPluginResponse.class,
                         new Listener<WPOrgPluginResponse>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
@@ -14,8 +14,7 @@ import java.lang.reflect.Type;
 @SuppressWarnings("WeakerAccess")
 @JsonAdapter(WPOrgPluginDeserializer.class)
 public class WPOrgPluginResponse {
-    public String author;
-    public String authorUrl;
+    public String authorAsHtml;
     public String banner;
     public String homepageUrl;
     public String icon;
@@ -48,12 +47,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
                                            JsonDeserializationContext context) throws JsonParseException {
         JsonObject jsonObject = json.getAsJsonObject();
         WPOrgPluginResponse response = new WPOrgPluginResponse();
-        // Sample string: <a href=\"https://automattic.com/wordpress-plugins/\">Automattic</a>
-        String authorHtml = getStringFromJsonIfAvailable(jsonObject, "author");
-        // Although we could use Regex matching or some other "nicer" way to achieve the same thing, since we'll be
-        // performing these repeatedly and the return format is always the same, we can do it more efficiently
-        response.author = getSubstringBetweenTwoStrings(authorHtml, "\">", "</a>");
-        response.authorUrl = getSubstringBetweenTwoStrings(authorHtml, "href=\"", "\">");
+        response.authorAsHtml = getStringFromJsonIfAvailable(jsonObject, "author");
         response.banner = getBannerFromJson(jsonObject);
         response.downloadCount = getIntFromJsonIfAvailable(jsonObject, "downloaded");
         response.icon = getIconFromJson(jsonObject);
@@ -100,15 +94,6 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
             return jsonObject.get(property).getAsInt();
         }
         return 0;
-    }
-
-    private @Nullable String getSubstringBetweenTwoStrings(String originalStr, String startStr, String endStr) {
-        int beginIndex = originalStr.indexOf(startStr) + startStr.length();
-        int endIndex = originalStr.indexOf(endStr);
-        if (beginIndex != -1 && endIndex != -1 && beginIndex < endIndex && endIndex < originalStr.length()) {
-            return originalStr.substring(beginIndex, endIndex);
-        }
-        return null;
     }
 
     private @Nullable String getBannerFromJson(JsonObject jsonObject) throws JsonParseException {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
@@ -17,12 +17,29 @@ public class WPOrgPluginResponse {
     public String author;
     public String authorUrl;
     public String banner;
-    public String descriptionAsHtml;
+    public String homepageUrl;
     public String icon;
+    public String lastUpdated;
     public String name;
     public String rating;
+    public String requiredWordPressVersion;
     public String slug;
     public String version;
+    public int downloadCount;
+
+    // Sections
+    public String descriptionAsHtml;
+    public String faqAsHtml;
+    public String installationInstructionsAsHtml;
+    public String whatsNewAsHtml;
+
+    // Ratings
+    public int numberOfRatings;
+    public int numberOfRatingsOfOne;
+    public int numberOfRatingsOfTwo;
+    public int numberOfRatingsOfThree;
+    public int numberOfRatingsOfFour;
+    public int numberOfRatingsOfFive;
 }
 
 class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
@@ -38,12 +55,36 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
         response.author = getSubstringBetweenTwoStrings(authorHtml, "\">", "</a>");
         response.authorUrl = getSubstringBetweenTwoStrings(authorHtml, "href=\"", "\">");
         response.banner = getBannerFromJson(jsonObject);
-        response.descriptionAsHtml = getStringFromJsonIfAvailable(jsonObject, "description");
+        response.downloadCount = getIntFromJsonIfAvailable(jsonObject, "downloaded");
+        response.icon = getIconFromJson(jsonObject);
+        response.homepageUrl = getStringFromJsonIfAvailable(jsonObject, "homepage");
+        response.lastUpdated = getStringFromJsonIfAvailable(jsonObject, "last_updated");
         response.name = getStringFromJsonIfAvailable(jsonObject, "name");
+        response.rating = getStringFromJsonIfAvailable(jsonObject, "rating");
+        response.requiredWordPressVersion = getStringFromJsonIfAvailable(jsonObject, "requires");
         response.slug = getStringFromJsonIfAvailable(jsonObject, "slug");
         response.version = getStringFromJsonIfAvailable(jsonObject, "version");
-        response.rating = getStringFromJsonIfAvailable(jsonObject, "rating");
-        response.icon = getIconFromJson(jsonObject);
+
+        // Sections
+        if (jsonObject.has("sections")) {
+            JsonObject sections = jsonObject.get("sections").getAsJsonObject();
+            response.descriptionAsHtml = getStringFromJsonIfAvailable(sections, "description");
+            response.faqAsHtml = getStringFromJsonIfAvailable(sections, "faq");
+            response.installationInstructionsAsHtml = getStringFromJsonIfAvailable(sections, "installation");
+            response.whatsNewAsHtml = getStringFromJsonIfAvailable(sections, "changelog");
+        }
+
+        // Ratings
+        response.numberOfRatings = getIntFromJsonIfAvailable(jsonObject, "num_ratings");
+        if (jsonObject.has("ratings")) {
+            JsonObject ratings = jsonObject.get("ratings").getAsJsonObject();
+            response.numberOfRatingsOfOne = getIntFromJsonIfAvailable(ratings, "1");
+            response.numberOfRatingsOfTwo = getIntFromJsonIfAvailable(ratings, "2");
+            response.numberOfRatingsOfThree = getIntFromJsonIfAvailable(ratings, "3");
+            response.numberOfRatingsOfFour = getIntFromJsonIfAvailable(ratings, "4");
+            response.numberOfRatingsOfFive = getIntFromJsonIfAvailable(ratings, "5");
+        }
+
         return response;
     }
 
@@ -52,6 +93,13 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
             return jsonObject.get(property).getAsString();
         }
         return null;
+    }
+
+    private int getIntFromJsonIfAvailable(JsonObject jsonObject, String property) {
+        if (jsonObject.has(property)) {
+            return jsonObject.get(property).getAsInt();
+        }
+        return 0;
     }
 
     private @Nullable String getSubstringBetweenTwoStrings(String originalStr, String startStr, String endStr) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.wporg.plugin;
 
+import android.support.annotation.Nullable;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -9,13 +11,18 @@ import com.google.gson.annotations.JsonAdapter;
 
 import java.lang.reflect.Type;
 
+@SuppressWarnings("WeakerAccess")
 @JsonAdapter(WPOrgPluginDeserializer.class)
 public class WPOrgPluginResponse {
+    public String author;
+    public String authorUrl;
+    public String banner;
+    public String descriptionAsHtml;
+    public String icon;
     public String name;
+    public String rating;
     public String slug;
     public String version;
-    public String rating;
-    public String icon;
 }
 
 class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
@@ -24,24 +31,64 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
                                            JsonDeserializationContext context) throws JsonParseException {
         JsonObject jsonObject = json.getAsJsonObject();
         WPOrgPluginResponse response = new WPOrgPluginResponse();
+        // Sample string: <a href=\"https://automattic.com/wordpress-plugins/\">Automattic</a>
+        String authorHtml = getStringFromJsonIfAvailable(jsonObject, "author");
+        // Although we could use Regex matching or some other "nicer" way to achieve the same thing, since we'll be
+        // performing these repeatedly and the return format is always the same, we can do it more efficiently
+        response.author = getSubstringBetweenTwoStrings(authorHtml, "\">", "</a>");
+        response.authorUrl = getSubstringBetweenTwoStrings(authorHtml, "href=\"", "\">");
+        response.banner = getBannerFromJson(jsonObject);
+        response.descriptionAsHtml = getStringFromJsonIfAvailable(jsonObject, "description");
         response.name = getStringFromJsonIfAvailable(jsonObject, "name");
         response.slug = getStringFromJsonIfAvailable(jsonObject, "slug");
         response.version = getStringFromJsonIfAvailable(jsonObject, "version");
         response.rating = getStringFromJsonIfAvailable(jsonObject, "rating");
-        if (jsonObject.has("icons")) {
-            JsonObject icons = jsonObject.get("icons").getAsJsonObject();
-            if (icons.has("2x")) {
-                response.icon = icons.get("2x").getAsString();
-            } else if (icons.has("1x")) {
-                response.icon = icons.get("1x").getAsString();
-            }
-        }
+        response.icon = getIconFromJson(jsonObject);
         return response;
     }
 
-    private String getStringFromJsonIfAvailable(JsonObject jsonObject, String property) {
+    private @Nullable String getStringFromJsonIfAvailable(JsonObject jsonObject, String property) {
         if (jsonObject.has(property)) {
             return jsonObject.get(property).getAsString();
+        }
+        return null;
+    }
+
+    private @Nullable String getSubstringBetweenTwoStrings(String originalStr, String startStr, String endStr) {
+        int beginIndex = originalStr.indexOf(startStr) + startStr.length();
+        int endIndex = originalStr.indexOf(endStr);
+        if (beginIndex != -1 && endIndex != -1 && beginIndex < endIndex && endIndex < originalStr.length()) {
+            return originalStr.substring(beginIndex, endIndex);
+        }
+        return null;
+    }
+
+    private @Nullable String getBannerFromJson(JsonObject jsonObject) throws JsonParseException {
+        if (jsonObject.has("banners")) {
+            JsonObject banners = jsonObject.get("banners").getAsJsonObject();
+            if (banners.has("high")) {
+                String bannerUrlHigh = banners.get("high").getAsString();
+                // When high version is not available API returns `false` instead of `null`
+                if (!bannerUrlHigh.equalsIgnoreCase("false")) {
+                    return bannerUrlHigh;
+                }
+            }
+            // High version wasn't available
+            if (banners.has("low")) {
+                return banners.get("low").getAsString();
+            }
+        }
+        return null;
+    }
+
+    private @Nullable String getIconFromJson(JsonObject jsonObject) throws JsonParseException {
+        if (jsonObject.has("icons")) {
+            JsonObject icons = jsonObject.get("icons").getAsJsonObject();
+            if (icons.has("2x")) {
+                return icons.get("2x").getAsString();
+            } else if (icons.has("1x")) {
+                return icons.get("1x").getAsString();
+            }
         }
         return null;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,16 +44,16 @@ public class WellSqlConfig extends DefaultWellConfig {
         add(HTTPAuthModel.class);
         add(MediaModel.class);
         add(MediaUploadModel.class);
-        add(WPOrgPluginModel.class);
-        add(SitePluginModel.class);
         add(PostFormatModel.class);
         add(PostModel.class);
         add(PostUploadModel.class);
         add(RoleModel.class);
         add(SiteModel.class);
+        add(SitePluginModel.class);
         add(TaxonomyModel.class);
         add(TermModel.class);
         add(ThemeModel.class);
+        add(WPOrgPluginModel.class);
     }};
 
     @Override
@@ -181,6 +181,23 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 21:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SitePluginModel add SETTINGS_URL text;");
+                db.execSQL("alter table WPOrgPluginModel add AUTHOR TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add BANNER TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add AUTHOR_URL TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add DESCRIPTION_AS_HTML TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add FAQ_AS_HTML TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add HOMEPAGE_URL TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add INSTALLATION_INSTRUCTIONS_AS_HTML TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add LAST_UPDATED TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add REQUIRED_WORD_PRESS_VERSION TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add WHATS_NEW_AS_HTML TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add DOWNLOAD_COUNT INTEGER;");
+                db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS INTEGER;");
+                db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_ONE INTEGER;");
+                db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_TWO INTEGER;");
+                db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_THREE INTEGER;");
+                db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_FOUR INTEGER;");
+                db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_FIVE INTEGER;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -181,9 +181,8 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 21:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SitePluginModel add SETTINGS_URL text;");
-                db.execSQL("alter table WPOrgPluginModel add AUTHOR TEXT;");
+                db.execSQL("alter table WPOrgPluginModel add AUTHOR_AS_HTML TEXT;");
                 db.execSQL("alter table WPOrgPluginModel add BANNER TEXT;");
-                db.execSQL("alter table WPOrgPluginModel add AUTHOR_URL TEXT;");
                 db.execSQL("alter table WPOrgPluginModel add DESCRIPTION_AS_HTML TEXT;");
                 db.execSQL("alter table WPOrgPluginModel add FAQ_AS_HTML TEXT;");
                 db.execSQL("alter table WPOrgPluginModel add HOMEPAGE_URL TEXT;");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -58,7 +58,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 21;
+        return 22;
     }
 
     @Override
@@ -177,6 +177,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table PluginModel rename to SitePluginModel;");
                 db.execSQL("alter table PluginInfoModel rename to WPOrgPluginModel;");
+                oldVersion++;
+            case 21:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SitePluginModel add SETTINGS_URL text;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
As discussed on Slack with @nbradbury we are adding all the fields we'll need for the plugin directory feature in advance. Since we already have a network call for fetching a single plugin, this change was a natural improvement on that even though the properties are not immediately utilized.

The only thing I am not completely sure about is how we extract the author name and author url fields from the response we get. There are some prettier ways to do this, but I think we need to be efficient there. I felt this was a good middle ground.