### PR TITLE
Fix a possible json parsing crash in WPOrgPluginDeserializer

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
@@ -60,7 +60,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
         response.version = getStringFromJsonIfAvailable(jsonObject, "version");
 
         // Sections
-        if (jsonObject.has("sections")) {
+        if (jsonObject.has("sections") && jsonObject.get("sections").isJsonObject()) {
             JsonObject sections = jsonObject.get("sections").getAsJsonObject();
             response.descriptionAsHtml = getStringFromJsonIfAvailable(sections, "description");
             response.faqAsHtml = getStringFromJsonIfAvailable(sections, "faq");
@@ -70,7 +70,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
 
         // Ratings
         response.numberOfRatings = getIntFromJsonIfAvailable(jsonObject, "num_ratings");
-        if (jsonObject.has("ratings")) {
+        if (jsonObject.has("ratings") && jsonObject.get("ratings").isJsonObject()) {
             JsonObject ratings = jsonObject.get("ratings").getAsJsonObject();
             response.numberOfRatingsOfOne = getIntFromJsonIfAvailable(ratings, "1");
             response.numberOfRatingsOfTwo = getIntFromJsonIfAvailable(ratings, "2");
@@ -97,7 +97,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
     }
 
     private @Nullable String getBannerFromJson(JsonObject jsonObject) throws JsonParseException {
-        if (jsonObject.has("banners")) {
+        if (jsonObject.has("banners") && jsonObject.get("banners").isJsonObject()) {
             JsonObject banners = jsonObject.get("banners").getAsJsonObject();
             if (banners.has("high")) {
                 String bannerUrlHigh = banners.get("high").getAsString();
@@ -115,7 +115,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
     }
 
     private @Nullable String getIconFromJson(JsonObject jsonObject) throws JsonParseException {
-        if (jsonObject.has("icons")) {
+        if (jsonObject.has("icons") && jsonObject.get("icons").isJsonObject()) {
             JsonObject icons = jsonObject.get("icons").getAsJsonObject();
             if (icons.has("2x")) {
                 return icons.get("2x").getAsString();


### PR DESCRIPTION
The ever so amazing plugin info API returns some of the json objects as json array when it's empty, so when we try to parse it as a json object, we get a crash saying it's not a json object. This PR makes sure that it's handled gracefully.

For reference, here are 2 different responses showing different cases for `banners` (shortened for brevity):

```
{"name":"BAC Woocommerce Plugin","slug":"woo-bac","version":"1","banners":[]}
```

```
{"name":"Akismet Anti-Spam","slug":"akismet","version":"4.0.2","banners":{"low":"https:\/\/ps.w.org\/akismet\/assets\/banner-772x250.jpg?rev=479904","high":false}}
```