### PR TITLE
Theme improvements final touches

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -158,9 +158,9 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             assertTrue(isThemeInstalled(jetpackSite, themeId));
         }
 
+        // Get the theme from store to make sure the "active" state is correct, so we can deactivate it before deletion
+        ThemeModel themeToDelete = mThemeStore.getInstalledThemeByThemeId(jetpackSite, EDIN_THEME_ID);
         // if Edin is active update site's active theme to something else and delete Edin
-        final ThemeModel themeToDelete = new ThemeModel();
-        themeToDelete.setThemeId(EDIN_THEME_ID);
         deactivateAndDeleteTheme(jetpackSite, themeToDelete);
 
         signOutWPCom();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -38,6 +38,7 @@ import javax.inject.Singleton;
 
 @Singleton
 public class ThemeRestClient extends BaseWPComRestClient {
+    /** Used by {@link #fetchWpComThemes()} request all themes in a single fetch. */
     private static final String WP_THEME_FETCH_NUMBER_PARAM = "number=500";
 
     @Inject
@@ -46,7 +47,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
     }
 
-    /** Endpoint: v1.1/site/$siteId/themes/$themeId/delete */
+    /** [Undocumented!] Endpoint: v1.1/sites/$siteId/themes/$themeId/delete */
     public void deleteTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(theme.getThemeId()).delete.getUrlV1_1();
         add(WPComGsonRequest.buildPostRequest(url, null, JetpackThemeResponse.class,
@@ -71,7 +72,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** Endpoint: v1.1/site/$siteId/themes/$themeId/install */
+    /** [Undocumented!] Endpoint: v1.1/sites/$siteId/themes/$themeId/install */
     public void installTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
         String themeId = getThemeIdWithWpComSuffix(theme);
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(themeId).install.getUrlV1_1();
@@ -96,7 +97,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** Endpoint: v1.1/site/$siteId/themes/mine */
+    /**
+     * Endpoint: v1.1/sites/$siteId/themes/mine
+     * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/themes/mine/">Documentation</a>
+     */
     public void activateTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.mine.getUrlV1_1();
         Map<String, Object> params = new HashMap<>();
@@ -123,7 +127,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** [Undocumented!] Endpoint: v1.2/themes */
+    /**
+     * [Undocumented!] Endpoint: v1.2/themes
+     * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/themes/">Previous version</a>
+     */
     public void fetchWpComThemes() {
         String url = WPCOMREST.themes.getUrlV1_2() + "?" + WP_THEME_FETCH_NUMBER_PARAM;
         add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeListResponse.class,
@@ -147,7 +154,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** Endpoint: v1/site/$siteId/themes */
+    /**
+     * [Undocumented!] Endpoint: v1/sites/$siteId/themes
+     * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/themes/">Similar endpoint</a>
+     */
     public void fetchJetpackInstalledThemes(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.getUrlV1();
         add(WPComGsonRequest.buildGetRequest(url, null, JetpackThemeListResponse.class,
@@ -171,7 +181,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** Endpoint: v1.1/site/$siteId/themes/mine; same endpoint for both Jetpack and WP.com sites */
+    /**
+     * Endpoint: v1.1/sites/$siteId/themes/mine; same endpoint for both Jetpack and WP.com sites!
+     * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/themes/mine/">Documentation</a>
+     */
     public void fetchCurrentTheme(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.mine.getUrlV1_1();
         add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeListResponse;
@@ -65,8 +66,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme deletion request.");
                         SiteThemePayload payload = new SiteThemePayload(site, theme);
-                        payload.error = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new ThemesError(((WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }
                 }));
@@ -90,8 +90,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme installation request.");
                         SiteThemePayload payload = new SiteThemePayload(site, theme);
-                        payload.error = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new ThemesError(((WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
                     }
                 }));
@@ -120,8 +119,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to theme activation request.");
                         SiteThemePayload payload = new SiteThemePayload(site, theme);
-                        payload.error = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new ThemesError(((WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newActivatedThemeAction(payload));
                     }
                 }));
@@ -147,7 +145,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to WP.com themes fetch request.");
                         ThemesError themeError = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
+                                ((WPComGsonNetworkError) error).apiError, error.message);
                         FetchedWpComThemesPayload payload = new FetchedWpComThemesPayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
                     }
@@ -201,7 +199,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to current theme fetch request.");
                         ThemesError themeError = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
+                                ((WPComGsonNetworkError) error).apiError, error.message);
                         FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(site, themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedCurrentThemeAction(payload));
                     }


### PR DESCRIPTION
This PR fixes a small issue with the delete theme test and cherry picks some of the changes in #630 as mentioned in #657. Please note that it was not possible to directly cherry-pick them due to all the changes we made to themes, so I had to make a lot of changes to it. I wanted to preserve @tonyr59h's original commits, that's why it's not done as new commits.

Previous to this change, I've merged `origin/develop` to our `issue/theme-improvements-master` branch and ran all the tests (that's how I found about the issue in the delete theme test). With this PR merged, we'll be ready to merge `issue/theme-improvements-master` to develop. I'll be opening that PR shortly.