### PR TITLE
Plugin Directory: Network, DB & Connected Tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -23,7 +23,6 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     }
 
     private TestEvents mNextEvent;
-    private final String mSlug = "akismet";
 
     @Override
     protected void setUp() throws Exception {
@@ -36,12 +35,15 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     }
 
     public void testFetchWPOrgPlugin() throws InterruptedException {
+        String slug = "akismet";
+
         mNextEvent = TestEvents.WPORG_PLUGIN_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
-
-        mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginAction(mSlug));
-
+        mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginAction(slug));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        WPOrgPluginModel wpOrgPlugin = mPluginStore.getWPOrgPluginBySlug(slug);
+        assertNotNull(wpOrgPlugin);
     }
 
     public void testFetchPluginDirectory() throws InterruptedException {
@@ -61,8 +63,6 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         }
 
         assertEquals(TestEvents.WPORG_PLUGIN_FETCHED, mNextEvent);
-        WPOrgPluginModel wpOrgPlugin = mPluginStore.getWPOrgPluginBySlug(mSlug);
-        assertNotNull(wpOrgPlugin);
         mCountDownLatch.countDown();
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -55,6 +55,9 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // TODO: check whether the fetched items are in Store
+        // TODO: either add a check or a new test for pagination
     }
 
     @SuppressWarnings("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -98,11 +98,10 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         String searchTerm = "Writing";
 
         // Initial search
-        mSearchOffset = 0;
-        searchPluginDirectory(searchTerm, mSearchOffset);
+        searchPluginDirectory(searchTerm, 0);
 
         // Search second page: We know that each page will return 50 items and "Writing" has more than 50 items
-        searchPluginDirectory(searchTerm, 50);
+        searchPluginDirectory(searchTerm, FETCH_PLUGIN_DIRECTORY_PAGE_SIZE);
     }
 
     @SuppressWarnings("unused")
@@ -128,12 +127,6 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         assertNotNull(event.searchTerm);
         assertTrue(event.canLoadMore);
         mCountDownLatch.countDown();
-
-        // Test searching a second page
-        if (mSearchOffset == FETCH_PLUGIN_DIRECTORY_PAGE_SIZE) {
-            mSearchOffset = event.plugins.size();
-            searchPluginDirectory(event.searchTerm, mSearchOffset);
-        }
     }
 
     @SuppressWarnings("unused")
@@ -158,6 +151,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     }
 
     private void searchPluginDirectory(String searchTerm, int offset) throws InterruptedException {
+        mSearchOffset = offset;
         mNextEvent = TestEvents.PLUGIN_DIRECTORY_SEARCHED;
         mCountDownLatch = new CountDownLatch(1);
         SearchPluginDirectoryPayload payload = new SearchPluginDirectoryPayload(searchTerm, offset);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -3,8 +3,10 @@ package org.wordpress.android.fluxc.release;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
+import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType;
 import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 import org.wordpress.android.fluxc.store.PluginStore;
+import org.wordpress.android.fluxc.store.PluginStore.FetchPluginDirectoryPayload;
 import org.wordpress.android.fluxc.store.PluginStore.OnPluginDirectoryFetched;
 import org.wordpress.android.fluxc.store.PluginStore.OnWPOrgPluginFetched;
 
@@ -49,8 +51,8 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     public void testFetchPluginDirectory() throws InterruptedException {
         mNextEvent = TestEvents.PLUGIN_DIRECTORY_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
-
-        mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(null));
+        FetchPluginDirectoryPayload payload = new FetchPluginDirectoryPayload(PluginDirectoryType.NEW, false);
+        mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryModel.java
@@ -1,0 +1,39 @@
+package org.wordpress.android.fluxc.model.plugin;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.Table;
+
+@Table
+public class PluginDirectoryModel implements Identifiable {
+    @PrimaryKey @Column private int mId;
+    @Column private String mSlug;
+    @Column private String mDirectoryType;
+
+    @Override
+    public int getId() {
+        return mId;
+    }
+
+    @Override
+    public void setId(int id) {
+        mId = id;
+    }
+
+    public String getSlug() {
+        return mSlug;
+    }
+
+    public void setSlug(String slug) {
+        mSlug = slug;
+    }
+
+    public String getDirectoryType() {
+        return mDirectoryType;
+    }
+
+    public void setDirectoryType(String directoryType) {
+        mDirectoryType = directoryType;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -20,7 +20,9 @@ import java.util.Map;
 
 public abstract class GsonRequest<T> extends BaseRequest<T> {
     private static final String PROTOCOL_CHARSET = "utf-8";
-    private static final String PROTOCOL_CONTENT_TYPE = String.format("application/json; charset=%s", PROTOCOL_CHARSET);
+    private static final String PROTOCOL_CONTENT_TYPE_JSON = String.format("application/json; charset=%s",
+            PROTOCOL_CHARSET);
+    protected static final String PROTOCOL_CONTENT_TYPE_URL_ENCODED = "application/x-www-form-urlencoded";
 
     private final Gson mGson;
     private final Class<T> mClass;
@@ -52,7 +54,7 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
 
     @Override
     public String getBodyContentType() {
-        return PROTOCOL_CONTENT_TYPE;
+        return PROTOCOL_CONTENT_TYPE_JSON;
     }
 
     @Override
@@ -62,7 +64,7 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
 
     @Override
     public byte[] getBody() throws AuthFailureError {
-        if (mBody == null) {
+        if (mBody == null || getBodyContentType().equals(PROTOCOL_CONTENT_TYPE_URL_ENCODED)) {
             return super.getBody();
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/WPOrgAPIGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/WPOrgAPIGsonRequest.java
@@ -22,4 +22,9 @@ public class WPOrgAPIGsonRequest<T> extends GsonRequest<T> {
     public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
         return error;
     }
+
+    @Override
+    public String getBodyContentType() {
+        return PROTOCOL_CONTENT_TYPE_URL_ENCODED;
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/FetchPluginDirectoryResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/FetchPluginDirectoryResponse.java
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.network.wporg.plugin;
+
+import java.util.List;
+
+public class FetchPluginDirectoryResponse {
+    public class FetchPluginDirectoryResponseInfo {
+        public int page;
+        public int pages;
+        public int results;
+    }
+
+    public FetchPluginDirectoryResponseInfo info;
+    public List<WPOrgPluginResponse> plugins;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/FetchPluginDirectoryResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/FetchPluginDirectoryResponse.java
@@ -1,14 +1,59 @@
 package org.wordpress.android.fluxc.network.wporg.plugin;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
 import java.util.List;
 
+@JsonAdapter(FetchPluginDirectoryResponseDeserializer.class)
 public class FetchPluginDirectoryResponse {
     public class FetchPluginDirectoryResponseInfo {
         public int page;
         public int pages;
-        public int results;
     }
 
     public FetchPluginDirectoryResponseInfo info;
     public List<WPOrgPluginResponse> plugins;
+
+    FetchPluginDirectoryResponse() {
+        info = new FetchPluginDirectoryResponseInfo();
+    }
+}
+
+class FetchPluginDirectoryResponseDeserializer implements JsonDeserializer<FetchPluginDirectoryResponse> {
+    @Override
+    public FetchPluginDirectoryResponse deserialize(JsonElement json, Type typeOfT,
+                                                    JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        FetchPluginDirectoryResponse response = new FetchPluginDirectoryResponse();
+
+        if (jsonObject.has("plugins")) {
+            JsonElement pluginsEl = jsonObject.get("plugins");
+            if (pluginsEl.isJsonArray()) {
+                JsonArray pluginsJsonArray = pluginsEl.getAsJsonArray();
+                Type collectionType = new TypeToken<List<WPOrgPluginResponse>>(){}.getType();
+                response.plugins = context.deserialize(pluginsJsonArray, collectionType);
+            }
+        }
+        if (jsonObject.has("info")) {
+            JsonElement infoEl = jsonObject.get("info");
+            if (infoEl.isJsonObject()) {
+                JsonObject info = jsonObject.get("info").getAsJsonObject();
+                if (info.has("page")) {
+                    response.info.page = info.get("page").getAsInt();
+                }
+                if (info.has("pages")) {
+                    response.info.pages = info.get("pages").getAsInt();
+                }
+            }
+        }
+        return response;
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginDirectoryPaylo
 import org.wordpress.android.fluxc.store.PluginStore.FetchedWPOrgPluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryError;
 import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryErrorType;
+import org.wordpress.android.fluxc.store.PluginStore.SearchedPluginDirectoryPayload;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -100,6 +101,36 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                                         FetchWPOrgPluginErrorType.GENERIC_ERROR);
                                 mDispatcher.dispatch(PluginActionBuilder.newFetchedWporgPluginAction(
                                         new FetchedWPOrgPluginPayload(pluginSlug, error)));
+                            }
+                        }
+                );
+        add(request);
+    }
+
+    public void searchPluginDirectory(final String searchTerm) {
+        String url = WPORGAPI.plugins.info.version("1.1").getUrl() + "?action=query_plugins";
+        final Map<String, String> params = getCommonPluginDirectoryParams();
+        params.put("request[search]", searchTerm);
+        final WPOrgAPIGsonRequest<FetchPluginDirectoryResponse> request =
+                new WPOrgAPIGsonRequest<>(Method.POST, url, params, null, FetchPluginDirectoryResponse.class,
+                        new Listener<FetchPluginDirectoryResponse>() {
+                            @Override
+                            public void onResponse(FetchPluginDirectoryResponse response) {
+                                // TODO: handle pagination and return correct value for offset
+                                SearchedPluginDirectoryPayload payload =
+                                        new SearchedPluginDirectoryPayload(searchTerm, 0);
+                                mDispatcher.dispatch(PluginActionBuilder.newSearchedPluginDirectoryAction(payload));
+                            }
+                        },
+                        new BaseErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull BaseNetworkError networkError) {
+                                // TODO: handle pagination and return correct value for offset
+                                SearchedPluginDirectoryPayload payload =
+                                        new SearchedPluginDirectoryPayload(searchTerm, 0);
+                                payload.error = new PluginDirectoryError(
+                                        PluginDirectoryErrorType.GENERIC_ERROR, networkError.message);
+                                mDispatcher.dispatch(PluginActionBuilder.newSearchedPluginDirectoryAction(payload));
                             }
                         }
                 );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -24,7 +24,9 @@ import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryError;
 import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.SearchedPluginDirectoryPayload;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -119,6 +121,10 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                                 // TODO: handle pagination and return correct value for offset
                                 SearchedPluginDirectoryPayload payload =
                                         new SearchedPluginDirectoryPayload(searchTerm, 0);
+                                if (response != null) {
+                                    payload.plugins = wpOrgPluginListFromResponse(response);
+                                }
+                                // TODO: throw an error if the response is null
                                 mDispatcher.dispatch(PluginActionBuilder.newSearchedPluginDirectoryAction(payload));
                             }
                         },
@@ -149,6 +155,16 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         params.put("request[fields][sections]", String.valueOf(1));
         params.put("request[fields][tested]", String.valueOf(0));
         return params;
+    }
+
+    private List<WPOrgPluginModel> wpOrgPluginListFromResponse(@NonNull FetchPluginDirectoryResponse response) {
+        List<WPOrgPluginModel> pluginList = new ArrayList<>();
+        if (response.plugins != null) {
+            for (WPOrgPluginResponse wpOrgPluginResponse : response.plugins) {
+                pluginList.add(wpOrgPluginFromResponse(wpOrgPluginResponse));
+            }
+        }
+        return pluginList;
     }
 
     private WPOrgPluginModel wpOrgPluginFromResponse(WPOrgPluginResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -53,9 +53,15 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                         new Listener<FetchPluginDirectoryResponse>() {
                             @Override
                             public void onResponse(FetchPluginDirectoryResponse response) {
-                                // TODO: return correct value for canLoadMore
                                 FetchedPluginDirectoryPayload payload =
                                         new FetchedPluginDirectoryPayload(directoryType, loadMore);
+                                if (response != null) {
+                                    payload.canLoadMore = response.info.page < response.info.pages;
+                                    payload.plugins = wpOrgPluginListFromResponse(response);
+                                } else {
+                                    payload.error = new PluginDirectoryError(
+                                            PluginDirectoryErrorType.EMPTY_RESPONSE, null);
+                                }
                                 mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginDirectoryAction(payload));
                             }
                         },
@@ -118,13 +124,15 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                         new Listener<FetchPluginDirectoryResponse>() {
                             @Override
                             public void onResponse(FetchPluginDirectoryResponse response) {
-                                // TODO: return correct value for canLoadMore
                                 SearchedPluginDirectoryPayload payload =
                                         new SearchedPluginDirectoryPayload(searchTerm, offset);
                                 if (response != null) {
+                                    payload.canLoadMore = response.info.page < response.info.pages;
                                     payload.plugins = wpOrgPluginListFromResponse(response);
+                                } else {
+                                    payload.error = new PluginDirectoryError(
+                                            PluginDirectoryErrorType.EMPTY_RESPONSE, null);
                                 }
-                                // TODO: throw an error if the response is null
                                 mDispatcher.dispatch(PluginActionBuilder.newSearchedPluginDirectoryAction(payload));
                             }
                         },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -82,7 +82,6 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     public void fetchWPOrgPlugin(final String pluginSlug) {
         String url = WPORGAPI.plugins.info.version("1.0").slug(pluginSlug).getUrl();
         Map<String, String> params = new HashMap<>();
-        // TODO: check if we need more fields similar to the ones in getPluginDirectoryParams
         params.put("fields", "banners,icons");
         final WPOrgAPIGsonRequest<WPOrgPluginResponse> request =
                 new WPOrgAPIGsonRequest<>(Method.GET, url, params, null, WPOrgPluginResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -116,7 +116,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
 
     public void searchPluginDirectory(final String searchTerm, final int offset) {
         String url = WPORGAPI.plugins.info.version("1.1").getUrl() + "?action=query_plugins";
-        final Map<String, String> params = getCommonPluginDirectoryParams(0);
+        final Map<String, String> params = getCommonPluginDirectoryParams(offset);
         params.put("request[search]", searchTerm);
         final WPOrgAPIGsonRequest<FetchPluginDirectoryResponse> request =
                 new WPOrgAPIGsonRequest<>(Method.POST, url, params, null, FetchPluginDirectoryResponse.class,
@@ -151,7 +151,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
 
     private Map<String, String> getCommonPluginDirectoryParams(int offset) {
         Map<String, String> params = new HashMap<>();
-        int page = (int) Math.floor(((double) offset) / FETCH_PLUGIN_DIRECTORY_PAGE_SIZE);
+        int page = getPageNumberFromOffset(offset);
         params.put("request[page]", String.valueOf(page));
         params.put("request[per_page]", String.valueOf(FETCH_PLUGIN_DIRECTORY_PAGE_SIZE));
         params.put("request[fields][banners]", String.valueOf(1));
@@ -197,5 +197,14 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         wpOrgPluginModel.setNumberOfRatingsOfFour(response.numberOfRatingsOfFour);
         wpOrgPluginModel.setNumberOfRatingsOfFive(response.numberOfRatingsOfFive);
         return wpOrgPluginModel;
+    }
+
+    private int getPageNumberFromOffset(int offset) {
+        // Offset = 0, page = 1
+        // Offset = 20, page = 1
+        // Offset = 50, page = 2
+        // Offset = 80, page = 2
+        // Offset = 100, page = 3
+        return (int) Math.floor(((double) offset) / FETCH_PLUGIN_DIRECTORY_PAGE_SIZE) + 1;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
@@ -60,7 +60,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
         response.version = getStringFromJsonIfAvailable(jsonObject, "version");
 
         // Sections
-        if (jsonObject.has("sections")) {
+        if (jsonObject.has("sections") && jsonObject.get("sections").isJsonObject()) {
             JsonObject sections = jsonObject.get("sections").getAsJsonObject();
             response.descriptionAsHtml = getStringFromJsonIfAvailable(sections, "description");
             response.faqAsHtml = getStringFromJsonIfAvailable(sections, "faq");
@@ -70,7 +70,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
 
         // Ratings
         response.numberOfRatings = getIntFromJsonIfAvailable(jsonObject, "num_ratings");
-        if (jsonObject.has("ratings")) {
+        if (jsonObject.has("ratings") && jsonObject.get("ratings").isJsonObject()) {
             JsonObject ratings = jsonObject.get("ratings").getAsJsonObject();
             response.numberOfRatingsOfOne = getIntFromJsonIfAvailable(ratings, "1");
             response.numberOfRatingsOfTwo = getIntFromJsonIfAvailable(ratings, "2");
@@ -97,7 +97,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
     }
 
     private @Nullable String getBannerFromJson(JsonObject jsonObject) throws JsonParseException {
-        if (jsonObject.has("banners")) {
+        if (jsonObject.has("banners") && jsonObject.get("banners").isJsonObject()) {
             JsonObject banners = jsonObject.get("banners").getAsJsonObject();
             if (banners.has("high")) {
                 String bannerUrlHigh = banners.get("high").getAsString();
@@ -115,7 +115,7 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
     }
 
     private @Nullable String getIconFromJson(JsonObject jsonObject) throws JsonParseException {
-        if (jsonObject.has("icons")) {
+        if (jsonObject.has("icons") && jsonObject.get("icons").isJsonObject()) {
             JsonObject icons = jsonObject.get("icons").getAsJsonObject();
             if (icons.has("2x")) {
                 return icons.get("2x").getAsString();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -147,6 +147,11 @@ public class PluginSqlUtils {
         }
     }
 
+    public static int getNumberOfPluginsForDirectory(PluginDirectoryType directoryType) {
+        List<PluginDirectoryModel> pluginDirectoryList = getPluginDirectoriesForType(directoryType);
+        return pluginDirectoryList != null ? pluginDirectoryList.size() : 0;
+    }
+
     private static List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType) {
         return WellSql.select(PluginDirectoryModel.class)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType;
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
 import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.yarolegovich.wellsql.SelectQuery.ORDER_ASCENDING;
@@ -91,6 +92,15 @@ public class PluginSqlUtils {
         return result.isEmpty() ? null : result.get(0);
     }
 
+    public static List<WPOrgPluginModel> getWPOrgPluginsForDirectory(PluginDirectoryType directoryType) {
+        List<PluginDirectoryModel> directoryModels = getPluginDirectoriesForType(directoryType);
+        List<WPOrgPluginModel> wpOrgPluginModels = new ArrayList<>(directoryModels.size());
+        for (PluginDirectoryModel pluginDirectoryModel : directoryModels) {
+            wpOrgPluginModels.add(getWPOrgPluginBySlug(pluginDirectoryModel.getSlug()));
+        }
+        return wpOrgPluginModels;
+    }
+
     public static void insertOrUpdateWPOrgPlugin(WPOrgPluginModel wpOrgPluginModel) {
         if (wpOrgPluginModel == null) {
             return;
@@ -135,6 +145,14 @@ public class PluginSqlUtils {
         for (PluginDirectoryModel pluginDirectory : pluginDirectories) {
             insertOrUpdatePluginDirectoryModel(pluginDirectory);
         }
+    }
+
+    private static List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType) {
+        return WellSql.select(PluginDirectoryModel.class)
+                .where()
+                .equals(PluginDirectoryModelTable.DIRECTORY_TYPE, directoryType)
+                .endWhere()
+                .getAsModel();
     }
 
     private static PluginDirectoryModel getPluginDirectoryModel(String directoryType, String slug) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -2,10 +2,13 @@ package org.wordpress.android.fluxc.persistence;
 
 import android.support.annotation.NonNull;
 
+import com.wellsql.generated.PluginDirectoryModelTable;
 import com.wellsql.generated.WPOrgPluginModelTable;
 import com.wellsql.generated.SitePluginModelTable;
 import com.yarolegovich.wellsql.WellSql;
 
+import org.wordpress.android.fluxc.model.plugin.PluginDirectoryModel;
+import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType;
 import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -73,6 +76,21 @@ public class PluginSqlUtils {
                 .endWhere().execute();
     }
 
+    public static SitePluginModel getSitePluginByName(SiteModel site, String name) {
+        List<SitePluginModel> result = WellSql.select(SitePluginModel.class)
+                .where().equals(SitePluginModelTable.NAME, name)
+                .equals(SitePluginModelTable.LOCAL_SITE_ID, site.getId())
+                .endWhere().getAsModel();
+        return result.isEmpty() ? null : result.get(0);
+    }
+
+    public static WPOrgPluginModel getWPOrgPluginBySlug(String slug) {
+        List<WPOrgPluginModel> result = WellSql.select(WPOrgPluginModel.class)
+                .where().equals(WPOrgPluginModelTable.SLUG, slug)
+                .endWhere().getAsModel();
+        return result.isEmpty() ? null : result.get(0);
+    }
+
     public static int insertOrUpdateWPOrgPlugin(WPOrgPluginModel wpOrgPluginModel) {
         if (wpOrgPluginModel == null) {
             return 0;
@@ -91,18 +109,10 @@ public class PluginSqlUtils {
         }
     }
 
-    public static SitePluginModel getSitePluginByName(SiteModel site, String name) {
-        List<SitePluginModel> result = WellSql.select(SitePluginModel.class)
-                .where().equals(SitePluginModelTable.NAME, name)
-                .equals(SitePluginModelTable.LOCAL_SITE_ID, site.getId())
-                .endWhere().getAsModel();
-        return result.isEmpty() ? null : result.get(0);
-    }
-
-    public static WPOrgPluginModel getWPOrgPluginBySlug(String slug) {
-        List<WPOrgPluginModel> result = WellSql.select(WPOrgPluginModel.class)
-                .where().equals(WPOrgPluginModelTable.SLUG, slug)
-                .endWhere().getAsModel();
-        return result.isEmpty() ? null : result.get(0);
+    public static void deletePluginDirectoryForType(PluginDirectoryType directoryType) {
+        WellSql.delete(PluginDirectoryModel.class)
+                .where()
+                .equals(PluginDirectoryModelTable.DIRECTORY_TYPE, directoryType.toString())
+                .endWhere().execute();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.persistence;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.wellsql.generated.PluginDirectoryModelTable;
 import com.wellsql.generated.SitePluginModelTable;
@@ -92,7 +93,7 @@ public class PluginSqlUtils {
         return result.isEmpty() ? null : result.get(0);
     }
 
-    public static List<WPOrgPluginModel> getWPOrgPluginsForDirectory(PluginDirectoryType directoryType) {
+    public static @NonNull List<WPOrgPluginModel> getWPOrgPluginsForDirectory(PluginDirectoryType directoryType) {
         List<PluginDirectoryModel> directoryModels = getPluginDirectoriesForType(directoryType);
         List<WPOrgPluginModel> wpOrgPluginModels = new ArrayList<>(directoryModels.size());
         for (PluginDirectoryModel pluginDirectoryModel : directoryModels) {
@@ -152,7 +153,7 @@ public class PluginSqlUtils {
         return pluginDirectoryList != null ? pluginDirectoryList.size() : 0;
     }
 
-    private static List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType) {
+    private static @Nullable List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType) {
         return WellSql.select(PluginDirectoryModel.class)
                 .where()
                 .equals(PluginDirectoryModelTable.DIRECTORY_TYPE, directoryType)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -91,9 +91,9 @@ public class PluginSqlUtils {
         return result.isEmpty() ? null : result.get(0);
     }
 
-    public static int insertOrUpdateWPOrgPlugin(WPOrgPluginModel wpOrgPluginModel) {
+    public static void insertOrUpdateWPOrgPlugin(WPOrgPluginModel wpOrgPluginModel) {
         if (wpOrgPluginModel == null) {
-            return 0;
+            return;
         }
 
         // Slug is the primary key in remote, so we should use that to identify WPOrgPluginModels
@@ -101,11 +101,20 @@ public class PluginSqlUtils {
 
         if (oldPlugin == null) {
             WellSql.insert(wpOrgPluginModel).execute();
-            return 1;
         } else {
             int oldId = oldPlugin.getId();
-            return WellSql.update(WPOrgPluginModel.class).whereId(oldId)
+            WellSql.update(WPOrgPluginModel.class).whereId(oldId)
                     .put(wpOrgPluginModel, new UpdateAllExceptId<>(WPOrgPluginModel.class)).execute();
+        }
+    }
+
+    public static void insertOrUpdateWPOrgPluginList(List<WPOrgPluginModel> wpOrgPluginModels) {
+        if (wpOrgPluginModels == null) {
+            return;
+        }
+
+        for (WPOrgPluginModel pluginModel : wpOrgPluginModels) {
+            insertOrUpdateWPOrgPlugin(pluginModel);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -97,7 +97,10 @@ public class PluginSqlUtils {
         List<PluginDirectoryModel> directoryModels = getPluginDirectoriesForType(directoryType);
         List<WPOrgPluginModel> wpOrgPluginModels = new ArrayList<>(directoryModels.size());
         for (PluginDirectoryModel pluginDirectoryModel : directoryModels) {
-            wpOrgPluginModels.add(getWPOrgPluginBySlug(pluginDirectoryModel.getSlug()));
+            WPOrgPluginModel wpOrgPluginModel = getWPOrgPluginBySlug(pluginDirectoryModel.getSlug());
+            if (wpOrgPluginModel != null) {
+                wpOrgPluginModels.add(wpOrgPluginModel);
+            }
         }
         return wpOrgPluginModels;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static com.yarolegovich.wellsql.SelectQuery.ORDER_ASCENDING;
 
 public class PluginSqlUtils {
-    public static List<SitePluginModel> getSitePlugins(@NonNull SiteModel site) {
+    public static @NonNull List<SitePluginModel> getSitePlugins(@NonNull SiteModel site) {
         return WellSql.select(SitePluginModel.class)
                 .where()
                 .equals(SitePluginModelTable.LOCAL_SITE_ID, site.getId())
@@ -78,7 +78,7 @@ public class PluginSqlUtils {
                 .endWhere().execute();
     }
 
-    public static SitePluginModel getSitePluginByName(SiteModel site, String name) {
+    public static @Nullable SitePluginModel getSitePluginByName(SiteModel site, String name) {
         List<SitePluginModel> result = WellSql.select(SitePluginModel.class)
                 .where().equals(SitePluginModelTable.NAME, name)
                 .equals(SitePluginModelTable.LOCAL_SITE_ID, site.getId())
@@ -86,7 +86,7 @@ public class PluginSqlUtils {
         return result.isEmpty() ? null : result.get(0);
     }
 
-    public static WPOrgPluginModel getWPOrgPluginBySlug(String slug) {
+    public static @Nullable WPOrgPluginModel getWPOrgPluginBySlug(String slug) {
         List<WPOrgPluginModel> result = WellSql.select(WPOrgPluginModel.class)
                 .where().equals(WPOrgPluginModelTable.SLUG, slug)
                 .endWhere().getAsModel();
@@ -152,11 +152,10 @@ public class PluginSqlUtils {
     }
 
     public static int getNumberOfPluginsForDirectory(PluginDirectoryType directoryType) {
-        List<PluginDirectoryModel> pluginDirectoryList = getPluginDirectoriesForType(directoryType);
-        return pluginDirectoryList != null ? pluginDirectoryList.size() : 0;
+        return getPluginDirectoriesForType(directoryType).size();
     }
 
-    private static @Nullable List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType) {
+    private static @NonNull List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType) {
         return WellSql.select(PluginDirectoryModel.class)
                 .where()
                 .equals(PluginDirectoryModelTable.DIRECTORY_TYPE, directoryType)
@@ -164,7 +163,7 @@ public class PluginSqlUtils {
                 .getAsModel();
     }
 
-    private static PluginDirectoryModel getPluginDirectoryModel(String directoryType, String slug) {
+    private static @Nullable PluginDirectoryModel getPluginDirectoryModel(String directoryType, String slug) {
         List<PluginDirectoryModel> result = WellSql.select(PluginDirectoryModel.class)
                 .where()
                 .equals(PluginDirectoryModelTable.SLUG, slug)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -15,8 +15,6 @@ import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaUploadModel;
-import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
-import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.PostUploadModel;
@@ -25,6 +23,9 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
+import org.wordpress.android.fluxc.model.plugin.PluginDirectoryModel;
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
+import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 import org.wordpress.android.fluxc.network.HTTPAuthModel;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -44,6 +45,7 @@ public class WellSqlConfig extends DefaultWellConfig {
         add(HTTPAuthModel.class);
         add(MediaModel.class);
         add(MediaUploadModel.class);
+        add(PluginDirectoryModel.class);
         add(PostFormatModel.class);
         add(PostModel.class);
         add(PostUploadModel.class);
@@ -58,7 +60,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 22;
+        return 23;
     }
 
     @Override
@@ -197,6 +199,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_THREE INTEGER;");
                 db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_FOUR INTEGER;");
                 db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_FIVE INTEGER;");
+                oldVersion++;
+            case 22:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("CREATE TABLE PluginDirectoryModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                        + "SLUG TEXT,DIRECTORY_TYPE TEXT)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -606,7 +606,7 @@ public class PluginStore extends Store {
     }
 
     private void fetchPluginDirectory(FetchPluginDirectoryPayload payload) {
-        // TODO: call PluginWPOrgClient's fetchPluginDirectory method (yet to be implemented)
+        mPluginWPOrgClient.fetchPluginDirectory(payload.type);
     }
 
     private void fetchSitePlugins(SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -568,7 +568,7 @@ public class PluginStore extends Store {
         }
     }
 
-    public @Nullable List<WPOrgPluginModel> getPluginDirectory(PluginDirectoryType type) {
+    public @NonNull List<WPOrgPluginModel> getPluginDirectory(PluginDirectoryType type) {
         return PluginSqlUtils.getWPOrgPluginsForDirectory(type);
     }
 
@@ -767,6 +767,7 @@ public class PluginStore extends Store {
             PluginDirectoryModel pluginDirectoryModel = new PluginDirectoryModel();
             pluginDirectoryModel.setSlug(wpOrgPluginModel.getSlug());
             pluginDirectoryModel.setDirectoryType(directoryType.toString());
+            directoryList.add(pluginDirectoryModel);
         }
         return directoryList;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -572,15 +572,15 @@ public class PluginStore extends Store {
         return PluginSqlUtils.getWPOrgPluginsForDirectory(type);
     }
 
-    public SitePluginModel getSitePluginByName(SiteModel site, String name) {
+    public @Nullable SitePluginModel getSitePluginByName(SiteModel site, String name) {
         return PluginSqlUtils.getSitePluginByName(site, name);
     }
 
-    public List<SitePluginModel> getSitePlugins(SiteModel site) {
+    public @NonNull List<SitePluginModel> getSitePlugins(SiteModel site) {
         return PluginSqlUtils.getSitePlugins(site);
     }
 
-    public WPOrgPluginModel getWPOrgPluginBySlug(String slug) {
+    public @Nullable WPOrgPluginModel getWPOrgPluginBySlug(String slug) {
         return PluginSqlUtils.getWPOrgPluginBySlug(slug);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -634,7 +634,7 @@ public class PluginStore extends Store {
     }
 
     private void searchPluginDirectory(SearchPluginDirectoryPayload payload) {
-        // TODO: call PluginWPOrgClient's fetchPluginDirectory method (yet to be implemented)
+        mPluginWPOrgClient.searchPluginDirectory(payload.searchTerm);
     }
 
     private void updateSitePlugin(UpdateSitePluginPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -344,6 +344,7 @@ public class PluginStore extends Store {
     }
 
     public enum PluginDirectoryErrorType {
+        EMPTY_RESPONSE,
         GENERIC_ERROR
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -606,7 +606,11 @@ public class PluginStore extends Store {
     }
 
     private void fetchPluginDirectory(FetchPluginDirectoryPayload payload) {
-        mPluginWPOrgClient.fetchPluginDirectory(payload.type);
+        int offset = 0;
+        if (payload.loadMore) {
+            offset = PluginSqlUtils.getNumberOfPluginsForDirectory(payload.type);
+        }
+        mPluginWPOrgClient.fetchPluginDirectory(payload.type, offset);
     }
 
     private void fetchSitePlugins(SiteModel site) {
@@ -634,7 +638,7 @@ public class PluginStore extends Store {
     }
 
     private void searchPluginDirectory(SearchPluginDirectoryPayload payload) {
-        mPluginWPOrgClient.searchPluginDirectory(payload.searchTerm);
+        mPluginWPOrgClient.searchPluginDirectory(payload.searchTerm, payload.offset);
     }
 
     private void updateSitePlugin(UpdateSitePluginPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -684,6 +684,10 @@ public class PluginStore extends Store {
         } else {
             event.canLoadMore = payload.canLoadMore;
             // TODO: Save the payload.plugins to DB
+            if (!payload.loadMore) {
+                // This is a fresh list, we need to remove the directory records for the fetched type
+                PluginSqlUtils.deletePluginDirectoryForType(payload.type);
+            }
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -567,9 +567,8 @@ public class PluginStore extends Store {
         }
     }
 
-    public List<WPOrgPluginModel> getPluginDirectory(PluginDirectoryType type) {
-        // TODO: query the plugin directory from PluginSqlUtils
-        return new ArrayList<>();
+    public @Nullable List<WPOrgPluginModel> getPluginDirectory(PluginDirectoryType type) {
+        return PluginSqlUtils.getWPOrgPluginsForDirectory(type);
     }
 
     public SitePluginModel getSitePluginByName(SiteModel site, String name) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -684,7 +684,6 @@ public class PluginStore extends Store {
             event.error = payload.error;
         } else {
             event.canLoadMore = payload.canLoadMore;
-            // TODO: Save the payload.plugins to DB
             if (!payload.loadMore) {
                 // This is a fresh list, we need to remove the directory records for the fetched type
                 PluginSqlUtils.deletePluginDirectoryForType(payload.type);
@@ -696,6 +695,7 @@ public class PluginStore extends Store {
                 // do standalone fetches for plugins with `FETCH_WPORG_PLUGIN` action.
                 PluginSqlUtils.insertOrUpdatePluginDirectoryList(pluginDirectoryListFromWPOrgPlugins(payload.plugins,
                         payload.type));
+                PluginSqlUtils.insertOrUpdateWPOrgPluginList(payload.plugins);
             }
         }
         emitChange(event);


### PR DESCRIPTION
A few things to note about this PR:

* Plugin directory endpoint is expecting the data to be url encoded, so I added a new body type `PROTOCOL_CONTENT_TYPE_URL_ENCODED` to GsonRequest. I am not sure that's the correct way to do this (whether I should have used another type of request) so if @aforcier or @maxme can weigh in on that specific part, that'd be great!
* As discussed before, the pagination logic lives inside the Plugin Store and the client doesn't know about it. All the client needs to do, to fetch plugin directory, is to request a refresh or to load more items.
* `PluginDirectoryModel` is just a smaller version of `WPOrgPluginModel` with the type of directory information attached to it. There could be multiple `PluginDirectoryModel` records of "Akismet" plugin for different plugin directories, but there can only be one `WPOrgPluginModel` record of it. This way, we can separate which items to load when the client asks for a specific directory type. Also, our offset will not be affected by different directory types, standalone requests or search.
* It'd have been easy to implement search the same way plugin directory works, but due to the temporary nature of this feature, I don't think it makes sense to keep the information in the DB. The client will have all the information it needs to search or load new pages of an existing search.
* Connected tests are added for both fetch and search plugin directory features which also makes sure the pagination works as expected. Again, due to how search works, it's test is a little worse than ideal, but it gets the job done!

Related issues that might come up during the review of this PR:
* The DB queries are not optimized. I opened a new issue for this #682 as it's not a priority right now.
* Better error handling is required. I don't know what type of errors can occur for these requests and will need to do trial and error to figure out. I've found an important one which I opened a separate issue for #683. We also need tests to make sure these errors are handled correctly.

Edit: I really don't like the name `PluginDirectoryModel` and I am open to other ideas!
