### PR TITLE
Feature/add username suggestions

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -13,10 +13,12 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthEmailErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
+import org.wordpress.android.fluxc.store.AccountStore.FetchUsernameSuggestionsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthEmailSent;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnUsernameChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnUsernameSuggestionsFetched;
 import org.wordpress.android.fluxc.store.AccountStore.PushAccountSettingsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushUsernamePayload;
 import org.wordpress.android.util.AppLog;
@@ -45,7 +47,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AUTH_EMAIL_ERROR_INVALID,
         AUTH_EMAIL_ERROR_NO_SUCH_USER,
         AUTH_EMAIL_ERROR_USER_EXISTS,
-        CHANGE_USERNAME_ERROR_INVALID_INPUT
+        CHANGE_USERNAME_ERROR_INVALID_INPUT,
+        FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME
     }
 
     private TestEvents mNextEvent;
@@ -177,6 +180,16 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
         assertEquals(username, String.valueOf(mAccountStore.getAccount().getUserName()));
         assertEquals(address, String.valueOf(mAccountStore.getAccount().getWebAddress()));
+    }
+
+    public void testFetchWPComUsernameSuggestionsNoNameError() throws InterruptedException {
+        mNextEvent = TestEvents.FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME;
+
+        FetchUsernameSuggestionsPayload payload = new FetchUsernameSuggestionsPayload("");
+        mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
+
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testWPComSignOut() throws InterruptedException {
@@ -359,6 +372,30 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
                     throw new AssertionError("Error should not occur with action type enum: " + event.type);
                 case INVALID_INPUT:
                     assertEquals(mNextEvent, TestEvents.CHANGE_USERNAME_ERROR_INVALID_INPUT);
+                    mCountDownLatch.countDown();
+                    break;
+                default:
+                    throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+            }
+        }
+    }
+
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onUsernameSuggestionsFetched(OnUsernameSuggestionsFetched event) {
+        AppLog.i(AppLog.T.API, "Received OnUsernameSuggestionsFetched");
+
+        if (event.isError()) {
+            AppLog.i(AppLog.T.API, "OnUsernameSuggestionsFetched: " + event.error.type + " - " + event.error.message);
+
+            switch (event.error.type) {
+                case GENERIC_ERROR:
+                    throw new AssertionError("Error should not be tested: " + event.error.type);
+                case REST_MISSING_CALLBACK_PARAM:
+                    throw new AssertionError("Error should not occur with name parameter");
+                case REST_NO_NAME:
+                    assertEquals(mNextEvent, TestEvents.FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME);
                     mCountDownLatch.countDown();
                     break;
                 default:

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -48,7 +48,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AUTH_EMAIL_ERROR_NO_SUCH_USER,
         AUTH_EMAIL_ERROR_USER_EXISTS,
         CHANGE_USERNAME_ERROR_INVALID_INPUT,
-        FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME
+        FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME,
+        FETCH_USERNAME_SUGGESTIONS_SUCCESS
     }
 
     private TestEvents mNextEvent;
@@ -186,6 +187,16 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME;
 
         FetchUsernameSuggestionsPayload payload = new FetchUsernameSuggestionsPayload("");
+        mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
+
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    public void testFetchWPComUsernameSuggestionsSuccess() throws InterruptedException {
+        mNextEvent = TestEvents.FETCH_USERNAME_SUGGESTIONS_SUCCESS;
+
+        FetchUsernameSuggestionsPayload payload = new FetchUsernameSuggestionsPayload("username");
         mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
 
         mCountDownLatch = new CountDownLatch(1);
@@ -401,6 +412,9 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
                 default:
                     throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
+        } else if (event.suggestions.size() != 0) {
+            assertEquals(mNextEvent, TestEvents.FETCH_USERNAME_SUGGESTIONS_SUCCESS);
+            mCountDownLatch.countDown();
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -4,12 +4,14 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.AccountModel;
+import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountFetchUsernameSuggestionsResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountPushSettingsResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountPushSocialResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountPushUsernameResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountRestPayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.IsAvailableResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.NewAccountResponsePayload;
+import org.wordpress.android.fluxc.store.AccountStore.FetchUsernameSuggestionsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.NewAccountPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushAccountSettingsPayload;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialAuthPayload;
@@ -25,6 +27,8 @@ public enum AccountAction implements IAction {
     FETCH_ACCOUNT,          // request fetch of Account information
     @Action
     FETCH_SETTINGS,         // request fetch of Account Settings
+    @Action(payloadType = FetchUsernameSuggestionsPayload.class)
+    FETCH_USERNAME_SUGGESTIONS,  // request fetch of Username Suggestions
     @Action
     SEND_VERIFICATION_EMAIL, // request verification email for unverified accounts
     @Action(payloadType = PushAccountSettingsPayload.class)
@@ -57,6 +61,8 @@ public enum AccountAction implements IAction {
     FETCHED_ACCOUNT,        // response received from Account fetch request
     @Action(payloadType = AccountRestPayload.class)
     FETCHED_SETTINGS,       // response received from Account Settings fetch
+    @Action(payloadType = AccountFetchUsernameSuggestionsResponsePayload.class)
+    FETCHED_USERNAME_SUGGESTIONS,  // response received from Username Suggestions fetch
     @Action(payloadType = NewAccountResponsePayload.class)
     SENT_VERIFICATION_EMAIL,
     @Action(payloadType = AccountPushSettingsResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -139,6 +139,17 @@ public class AccountRestClient extends BaseWPComRestClient {
         }
     }
 
+    public static class AccountFetchUsernameSuggestionsResponsePayload extends Payload<AccountUsernameError> {
+        public List<String> suggestions;
+
+        public AccountFetchUsernameSuggestionsResponsePayload() {
+        }
+
+        public AccountFetchUsernameSuggestionsResponsePayload(List<String> suggestions) {
+            this.suggestions = suggestions;
+        }
+    }
+
     public static class NewAccountResponsePayload extends Payload<NewUserError> {
         public boolean dryRun;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -250,7 +250,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         Map<String, String> params = new HashMap<>();
         params.put("name", name);
 
-        add(WPComGsonRequest.buildGetRequest(url, params, UsernameSuggestionsResponse.class,
+        addUnauthedRequest(WPComGsonRequest.buildGetRequest(url, params, UsernameSuggestionsResponse.class,
                 new Listener<UsernameSuggestionsResponse>() {
                     @Override
                     public void onResponse(UsernameSuggestionsResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
+import org.wordpress.android.fluxc.store.AccountStore.AccountFetchUsernameSuggestionsError;
 import org.wordpress.android.fluxc.store.AccountStore.AccountSocialError;
 import org.wordpress.android.fluxc.store.AccountStore.AccountSocialErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AccountUsernameActionType;
@@ -139,7 +140,8 @@ public class AccountRestClient extends BaseWPComRestClient {
         }
     }
 
-    public static class AccountFetchUsernameSuggestionsResponsePayload extends Payload<AccountUsernameError> {
+    public static class AccountFetchUsernameSuggestionsResponsePayload extends
+            Payload<AccountFetchUsernameSuggestionsError> {
         public List<String> suggestions;
 
         public AccountFetchUsernameSuggestionsResponsePayload() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/UsernameSuggestionsResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/UsernameSuggestionsResponse.java
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.account;
+
+import org.wordpress.android.fluxc.network.Response;
+
+import java.util.List;
+
+public class UsernameSuggestionsResponse implements Response {
+    public List<String> suggestions;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -409,6 +409,36 @@ public class AccountStore extends Store {
         }
     }
 
+    public static class AccountFetchUsernameSuggestionsError implements OnChangedError {
+        public AccountFetchUsernameSuggestionsErrorType type;
+        public String message;
+
+        public AccountFetchUsernameSuggestionsError(@NonNull AccountFetchUsernameSuggestionsErrorType type,
+                                                    @NonNull String message) {
+            this.type = type;
+            this.message = message;
+        }
+    }
+
+    public enum AccountFetchUsernameSuggestionsErrorType {
+        REST_MISSING_CALLBACK_PARAM,
+        REST_NO_NAME,
+        GENERIC_ERROR;
+
+        public static AccountFetchUsernameSuggestionsErrorType fromString(String string) {
+            if (string != null) {
+                for (AccountFetchUsernameSuggestionsErrorType type
+                        : AccountFetchUsernameSuggestionsErrorType.values()) {
+                    if (string.equalsIgnoreCase(type.name())) {
+                        return type;
+                    }
+                }
+            }
+
+            return GENERIC_ERROR;
+        }
+    }
+
     public static class AuthEmailError implements OnChangedError {
         public AuthEmailErrorType type;
         public String message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -76,6 +76,13 @@ public class AccountStore extends Store {
         }
     }
 
+    public static class FetchUsernameSuggestionsPayload extends Payload<BaseNetworkError> {
+        public String name;
+        public FetchUsernameSuggestionsPayload(@NonNull String name) {
+            this.name = name;
+        }
+    }
+
     public static class PushAccountSettingsPayload extends Payload<BaseNetworkError> {
         public Map<String, Object> params;
         public PushAccountSettingsPayload() {


### PR DESCRIPTION
Add a method for fetching username suggestions for a WordPress.com account, `fetchUsernameSuggestions`.  It requires the `name` parameter using the `/wpcom/v2/users/username/suggestions` unauthenticated endpoint.