### PR TITLE
issue/688-jetpack-wordpress-version

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -511,6 +511,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setFrameNonce(from.options.frame_nonce);
             site.setUnmappedUrl(from.options.unmapped_url);
             site.setJetpackVersion(from.options.jetpack_version);
+            site.setSoftwareVersion(from.options.software_version);
 
             try {
                 site.setMaxUploadSize(Long.valueOf(from.options.max_upload_size));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -22,6 +22,7 @@ public class SiteWPComRestResponse implements Response {
         public String wp_max_memory_limit;
         public String wp_memory_limit;
         public String jetpack_version;
+        public String software_version;
     }
 
     public class Plan {


### PR DESCRIPTION
Fixes #688 - `software_version` is now stored for Jetpack sites.