### PR TITLE
Plugin Directory Pagination

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -21,8 +21,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
-    private static final int FETCH_PLUGIN_DIRECTORY_PAGE_SIZE = 50; // from PluginWPOrgClient
-
     @Inject PluginStore mPluginStore;
 
     enum TestEvents {
@@ -33,7 +31,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     }
 
     private TestEvents mNextEvent;
-    private int mSearchOffset;
+    private int mSearchPage;
 
     @Override
     protected void setUp() throws Exception {
@@ -97,11 +95,11 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         // This search term is picked because it has more than 100 results to test pagination
         String searchTerm = "Writing";
 
-        // Initial search
-        searchPluginDirectory(searchTerm, 0);
+        // Search first page
+        searchPluginDirectory(searchTerm, 1);
 
-        // Search second page: We know that each page will return 50 items and "Writing" has more than 50 items
-        searchPluginDirectory(searchTerm, FETCH_PLUGIN_DIRECTORY_PAGE_SIZE);
+        // Search second page
+        searchPluginDirectory(searchTerm, 2);
     }
 
     @SuppressWarnings("unused")
@@ -123,7 +121,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         assertEquals(TestEvents.PLUGIN_DIRECTORY_SEARCHED, mNextEvent);
         // Assert that we got some plugins
         assertTrue(event.plugins != null && event.plugins.size() > 0);
-        assertEquals(mSearchOffset, event.offset);
+        assertEquals(mSearchPage, event.page);
         assertNotNull(event.searchTerm);
         assertTrue(event.canLoadMore);
         mCountDownLatch.countDown();
@@ -150,11 +148,11 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
-    private void searchPluginDirectory(String searchTerm, int offset) throws InterruptedException {
-        mSearchOffset = offset;
+    private void searchPluginDirectory(String searchTerm, int page) throws InterruptedException {
+        mSearchPage = page;
         mNextEvent = TestEvents.PLUGIN_DIRECTORY_SEARCHED;
         mCountDownLatch = new CountDownLatch(1);
-        SearchPluginDirectoryPayload payload = new SearchPluginDirectoryPayload(searchTerm, offset);
+        SearchPluginDirectoryPayload payload = new SearchPluginDirectoryPayload(searchTerm, page);
         mDispatcher.dispatch(PluginActionBuilder.newSearchPluginDirectoryAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryModel.java
@@ -10,6 +10,7 @@ public class PluginDirectoryModel implements Identifiable {
     @PrimaryKey @Column private int mId;
     @Column private String mSlug;
     @Column private String mDirectoryType;
+    @Column private int mPage;
 
     @Override
     public int getId() {
@@ -35,5 +36,13 @@ public class PluginDirectoryModel implements Identifiable {
 
     public void setDirectoryType(String directoryType) {
         mDirectoryType = directoryType;
+    }
+
+    public int getPage() {
+        return mPage;
+    }
+
+    public void setPage(int page) {
+        mPage = page;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryType.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryType.java
@@ -6,6 +6,7 @@ public enum PluginDirectoryType {
     NEW,
     POPULAR;
 
+    @Override
     public String toString() {
         return this.name().toLowerCase(Locale.US);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryType.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryType.java
@@ -1,11 +1,13 @@
 package org.wordpress.android.fluxc.model.plugin;
 
+import java.util.Locale;
+
 public enum PluginDirectoryType {
     NEW,
     POPULAR;
 
     public String toString() {
-        return this.name().toLowerCase();
+        return this.name().toLowerCase(Locale.US);
     }
 
     public static PluginDirectoryType fromString(String string) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryType.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryType.java
@@ -5,7 +5,7 @@ public enum PluginDirectoryType {
     POPULAR;
 
     public String toString() {
-        return this.name();
+        return this.name().toLowerCase();
     }
 
     public static PluginDirectoryType fromString(String string) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -20,9 +20,7 @@ import java.util.Map;
 
 public abstract class GsonRequest<T> extends BaseRequest<T> {
     private static final String PROTOCOL_CHARSET = "utf-8";
-    private static final String PROTOCOL_CONTENT_TYPE_JSON = String.format("application/json; charset=%s",
-            PROTOCOL_CHARSET);
-    protected static final String PROTOCOL_CONTENT_TYPE_URL_ENCODED = "application/x-www-form-urlencoded";
+    private static final String PROTOCOL_CONTENT_TYPE = String.format("application/json; charset=%s", PROTOCOL_CHARSET);
 
     private final Gson mGson;
     private final Class<T> mClass;
@@ -54,7 +52,7 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
 
     @Override
     public String getBodyContentType() {
-        return PROTOCOL_CONTENT_TYPE_JSON;
+        return PROTOCOL_CONTENT_TYPE;
     }
 
     @Override
@@ -64,7 +62,7 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
 
     @Override
     public byte[] getBody() throws AuthFailureError {
-        if (mBody == null || getBodyContentType().equals(PROTOCOL_CONTENT_TYPE_URL_ENCODED)) {
+        if (mBody == null) {
             return super.getBody();
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/WPOrgAPIGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/WPOrgAPIGsonRequest.java
@@ -22,9 +22,4 @@ public class WPOrgAPIGsonRequest<T> extends GsonRequest<T> {
     public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
         return error;
     }
-
-    @Override
-    public String getBodyContentType() {
-        return PROTOCOL_CONTENT_TYPE_URL_ENCODED;
-    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -44,12 +44,12 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     }
 
     public void fetchPluginDirectory(final PluginDirectoryType directoryType, int offset) {
-        String url = WPORGAPI.plugins.info.version("1.1").getUrl() + "?action=query_plugins";
+        String url = WPORGAPI.plugins.info.version("1.1").getUrl();
         final boolean loadMore = offset > 0;
         final Map<String, String> params = getCommonPluginDirectoryParams(offset);
         params.put("request[browse]", directoryType.toString());
         final WPOrgAPIGsonRequest<FetchPluginDirectoryResponse> request =
-                new WPOrgAPIGsonRequest<>(Method.POST, url, params, null, FetchPluginDirectoryResponse.class,
+                new WPOrgAPIGsonRequest<>(Method.GET, url, params, null, FetchPluginDirectoryResponse.class,
                         new Listener<FetchPluginDirectoryResponse>() {
                             @Override
                             public void onResponse(FetchPluginDirectoryResponse response) {
@@ -115,11 +115,11 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     }
 
     public void searchPluginDirectory(final String searchTerm, final int offset) {
-        String url = WPORGAPI.plugins.info.version("1.1").getUrl() + "?action=query_plugins";
+        String url = WPORGAPI.plugins.info.version("1.1").getUrl();
         final Map<String, String> params = getCommonPluginDirectoryParams(offset);
         params.put("request[search]", searchTerm);
         final WPOrgAPIGsonRequest<FetchPluginDirectoryResponse> request =
-                new WPOrgAPIGsonRequest<>(Method.POST, url, params, null, FetchPluginDirectoryResponse.class,
+                new WPOrgAPIGsonRequest<>(Method.GET, url, params, null, FetchPluginDirectoryResponse.class,
                         new Listener<FetchPluginDirectoryResponse>() {
                             @Override
                             public void onResponse(FetchPluginDirectoryResponse response) {
@@ -152,6 +152,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     private Map<String, String> getCommonPluginDirectoryParams(int offset) {
         Map<String, String> params = new HashMap<>();
         int page = getPageNumberFromOffset(offset);
+        params.put("action", "query_plugins");
         params.put("request[page]", String.valueOf(page));
         params.put("request[per_page]", String.valueOf(FETCH_PLUGIN_DIRECTORY_PAGE_SIZE));
         params.put("request[fields][banners]", String.valueOf(1));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -57,6 +57,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                                         new FetchedPluginDirectoryPayload(directoryType, loadMore);
                                 if (response != null) {
                                     payload.canLoadMore = response.info.page < response.info.pages;
+                                    payload.page = response.info.page;
                                     payload.plugins = wpOrgPluginListFromResponse(response);
                                 } else {
                                     payload.error = new PluginDirectoryError(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -159,7 +159,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         params.put("request[fields][compatibility]", String.valueOf(1));
         params.put("request[fields][icons]", String.valueOf(1));
         params.put("request[fields][requires]", String.valueOf(1));
-        params.put("request[fields][sections]", String.valueOf(1));
+        params.put("request[fields][sections]", String.valueOf(0));
         params.put("request[fields][tested]", String.valueOf(0));
         return params;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -115,9 +115,9 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         add(request);
     }
 
-    public void searchPluginDirectory(final String searchTerm, final int offset) {
+    public void searchPluginDirectory(final String searchTerm, final int page) {
         String url = WPORGAPI.plugins.info.version("1.1").getUrl();
-        final Map<String, String> params = getCommonPluginDirectoryParams(offset);
+        final Map<String, String> params = getCommonPluginDirectoryParams(page);
         params.put("request[search]", searchTerm);
         final WPOrgAPIGsonRequest<FetchPluginDirectoryResponse> request =
                 new WPOrgAPIGsonRequest<>(Method.GET, url, params, null, FetchPluginDirectoryResponse.class,
@@ -125,7 +125,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                             @Override
                             public void onResponse(FetchPluginDirectoryResponse response) {
                                 SearchedPluginDirectoryPayload payload =
-                                        new SearchedPluginDirectoryPayload(searchTerm, offset);
+                                        new SearchedPluginDirectoryPayload(searchTerm, page);
                                 if (response != null) {
                                     payload.canLoadMore = response.info.page < response.info.pages;
                                     payload.plugins = wpOrgPluginListFromResponse(response);
@@ -140,7 +140,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                             @Override
                             public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                                 SearchedPluginDirectoryPayload payload =
-                                        new SearchedPluginDirectoryPayload(searchTerm, offset);
+                                        new SearchedPluginDirectoryPayload(searchTerm, page);
                                 payload.error = new PluginDirectoryError(
                                         PluginDirectoryErrorType.GENERIC_ERROR, networkError.message);
                                 mDispatcher.dispatch(PluginActionBuilder.newSearchedPluginDirectoryAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -43,10 +43,10 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         mDispatcher = dispatcher;
     }
 
-    public void fetchPluginDirectory(final PluginDirectoryType directoryType, int offset) {
+    public void fetchPluginDirectory(final PluginDirectoryType directoryType, int page) {
         String url = WPORGAPI.plugins.info.version("1.1").getUrl();
-        final boolean loadMore = offset > 0;
-        final Map<String, String> params = getCommonPluginDirectoryParams(offset);
+        final boolean loadMore = page > 1;
+        final Map<String, String> params = getCommonPluginDirectoryParams(page);
         params.put("request[browse]", directoryType.toString());
         final WPOrgAPIGsonRequest<FetchPluginDirectoryResponse> request =
                 new WPOrgAPIGsonRequest<>(Method.GET, url, params, null, FetchPluginDirectoryResponse.class,
@@ -150,9 +150,8 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         add(request);
     }
 
-    private Map<String, String> getCommonPluginDirectoryParams(int offset) {
+    private Map<String, String> getCommonPluginDirectoryParams(int page) {
         Map<String, String> params = new HashMap<>();
-        int page = getPageNumberFromOffset(offset);
         params.put("action", "query_plugins");
         params.put("request[page]", String.valueOf(page));
         params.put("request[per_page]", String.valueOf(FETCH_PLUGIN_DIRECTORY_PAGE_SIZE));
@@ -199,14 +198,5 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         wpOrgPluginModel.setNumberOfRatingsOfFour(response.numberOfRatingsOfFour);
         wpOrgPluginModel.setNumberOfRatingsOfFive(response.numberOfRatingsOfFive);
         return wpOrgPluginModel;
-    }
-
-    private int getPageNumberFromOffset(int offset) {
-        // Offset = 0, page = 1
-        // Offset = 20, page = 1
-        // Offset = 50, page = 2
-        // Offset = 80, page = 2
-        // Offset = 100, page = 3
-        return (int) Math.floor(((double) offset) / FETCH_PLUGIN_DIRECTORY_PAGE_SIZE) + 1;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -151,8 +151,13 @@ public class PluginSqlUtils {
         }
     }
 
-    public static int getNumberOfPluginsForDirectory(PluginDirectoryType directoryType) {
-        return getPluginDirectoriesForType(directoryType).size();
+    public static int getLastRequestedPageForDirectoryType(PluginDirectoryType directoryType) {
+        List<PluginDirectoryModel> list = getPluginDirectoriesForType(directoryType);
+        int page = 0;
+        for (PluginDirectoryModel pluginDirectoryModel : list) {
+            page = Math.max(pluginDirectoryModel.getPage(), page);
+        }
+        return page;
     }
 
     private static @NonNull List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -207,7 +207,7 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 23:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE PluginDirectoryModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                        + "SLUG TEXT,DIRECTORY_TYPE TEXT)");
+                        + "SLUG TEXT,DIRECTORY_TYPE TEXT,PAGE INTEGER)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -75,11 +75,11 @@ public class PluginStore extends Store {
     @SuppressWarnings("WeakerAccess")
     public static class SearchPluginDirectoryPayload extends Payload<BaseNetworkError> {
         public String searchTerm;
-        public int offset;
+        public int page;
 
-        public SearchPluginDirectoryPayload(String searchTerm, int offset) {
+        public SearchPluginDirectoryPayload(String searchTerm, int page) {
             this.searchTerm = searchTerm;
-            this.offset = offset;
+            this.page = page;
         }
     }
 
@@ -188,13 +188,13 @@ public class PluginStore extends Store {
     @SuppressWarnings("WeakerAccess")
     public static class SearchedPluginDirectoryPayload extends Payload<PluginDirectoryError> {
         public String searchTerm;
-        public int offset;
+        public int page;
         public boolean canLoadMore;
         public List<WPOrgPluginModel> plugins;
 
-        public SearchedPluginDirectoryPayload(String searchTerm, int offset) {
+        public SearchedPluginDirectoryPayload(String searchTerm, int page) {
             this.searchTerm = searchTerm;
-            this.offset = offset;
+            this.page = page;
         }
     }
 
@@ -430,13 +430,13 @@ public class PluginStore extends Store {
     @SuppressWarnings("WeakerAccess")
     public static class OnPluginDirectorySearched extends OnChanged<PluginDirectoryError> {
         public String searchTerm;
-        public int offset;
+        public int page;
         public boolean canLoadMore;
         public List<WPOrgPluginModel> plugins;
 
-        public OnPluginDirectorySearched(String searchTerm, int offset) {
+        public OnPluginDirectorySearched(String searchTerm, int page) {
             this.searchTerm = searchTerm;
-            this.offset = offset;
+            this.page = page;
         }
     }
 
@@ -640,7 +640,7 @@ public class PluginStore extends Store {
     }
 
     private void searchPluginDirectory(SearchPluginDirectoryPayload payload) {
-        mPluginWPOrgClient.searchPluginDirectory(payload.searchTerm, payload.offset);
+        mPluginWPOrgClient.searchPluginDirectory(payload.searchTerm, payload.page);
     }
 
     private void updateSitePlugin(UpdateSitePluginPayload payload) {
@@ -739,7 +739,7 @@ public class PluginStore extends Store {
     }
 
     private void searchedPluginDirectory(SearchedPluginDirectoryPayload payload) {
-        OnPluginDirectorySearched event = new OnPluginDirectorySearched(payload.searchTerm, payload.offset);
+        OnPluginDirectorySearched event = new OnPluginDirectorySearched(payload.searchTerm, payload.page);
         if (payload.isError()) {
             event.error = payload.error;
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -131,6 +131,7 @@ public class PluginStore extends Store {
         public PluginDirectoryType type;
         public boolean loadMore;
         public boolean canLoadMore;
+        public int page;
         public List<WPOrgPluginModel> plugins;
 
         public FetchedPluginDirectoryPayload(PluginDirectoryType type, boolean loadMore) {
@@ -696,9 +697,10 @@ public class PluginStore extends Store {
                 // For pagination to work correctly, we need to separate the actual plugin data from the list of plugins
                 // for each directory type. This is important because the same data will be fetched from multiple
                 // sources. We fetch different directory types (same plugin can be in both new and popular) as well as
-                // do standalone fetches for plugins with `FETCH_WPORG_PLUGIN` action.
+                // do standalone fetches for plugins with `FETCH_WPORG_PLUGIN` action. We also need to keep track of the
+                // page the plugin belongs to, because the `per_page` parameter is unreliable.
                 PluginSqlUtils.insertOrUpdatePluginDirectoryList(pluginDirectoryListFromWPOrgPlugins(payload.plugins,
-                        payload.type));
+                        payload.type, payload.page));
                 PluginSqlUtils.insertOrUpdateWPOrgPluginList(payload.plugins);
             }
         }
@@ -761,12 +763,14 @@ public class PluginStore extends Store {
     // Helpers
 
     private List<PluginDirectoryModel> pluginDirectoryListFromWPOrgPlugins(@NonNull List<WPOrgPluginModel> wpOrgPlugins,
-                                                                           PluginDirectoryType directoryType) {
+                                                                           PluginDirectoryType directoryType,
+                                                                           int page) {
         List<PluginDirectoryModel> directoryList = new ArrayList<>(wpOrgPlugins.size());
         for (WPOrgPluginModel wpOrgPluginModel : wpOrgPlugins) {
             PluginDirectoryModel pluginDirectoryModel = new PluginDirectoryModel();
             pluginDirectoryModel.setSlug(wpOrgPluginModel.getSlug());
             pluginDirectoryModel.setDirectoryType(directoryType.toString());
+            pluginDirectoryModel.setPage(page);
             directoryList.add(pluginDirectoryModel);
         }
         return directoryList;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -608,11 +608,11 @@ public class PluginStore extends Store {
     }
 
     private void fetchPluginDirectory(FetchPluginDirectoryPayload payload) {
-        int offset = 0;
+        int page = 1;
         if (payload.loadMore) {
-            offset = PluginSqlUtils.getNumberOfPluginsForDirectory(payload.type);
+            page = PluginSqlUtils.getLastRequestedPageForDirectoryType(payload.type) + 1;
         }
-        mPluginWPOrgClient.fetchPluginDirectory(payload.type, offset);
+        mPluginWPOrgClient.fetchPluginDirectory(payload.type, page);
     }
 
     private void fetchSitePlugins(SiteModel site) {


### PR DESCRIPTION
Fixes #686. I am keeping a checklist for the necessary changes/improvements in #690. I am aware that some things in this PR are not optimized, but that's by design as I am trying to focus on more urgent issues. Since we are merging this to a WIP branch and we are keeping a checklist of what's necessary, this should be fine.

This PR changes how the pagination is handled. Here is a little story to explain how it works and why it's done this way:

> The endpoint we are using for the plugin directory has `per_page` and `page` parameters. Unfortunately, there is no "give me plugins after this one" or "give me plugins before this one" parameters. It doesn't even have an `offset` parameter.
> 
> There are different type of directories ("new", "popular" etc) and a plugin can be in both directories. We also do single plugin fetches when we need more details for a particular plugin that's coming from a different endpoint. When you combine all these, it means we can't rely on a single table to be able to calculate the offset from. Also, if we were to use a single table, we would have ended up with multiple records for the same objects and having multiple sources of truth can be dangerous.
> 
> To get around this limitation, we separated the the information in 2 tables. `PluginDirectoryModelTable` and `WPOrgPluginModelTable`. The `WPOrgPluginModelTable` contains the actual data and `PluginDirectoryModelTable` contains the information about which data needs to be shown for each directory type.
> 
> The initial implementation was using the number of items in the `PluginDirectoryModelTable` for the directory type we are interested in to find out the offset and then calculate the page number. However, it turns out that `per_page` is only a suggestion for this endpoint. You might be asking for 50 items, but it'll only return 50 items on a good day. Otherwise, it might return 45, 48 etc. Sooo.. that approach doesn't really work.
> 
> I've then tried several fetch requests and tried to understand the pagination. I thought maybe we keep doubling the number of items we have to make sure we don't miss anything. Maybe we ask for the first 100 items, if we get 85 items, we ask for the next 85. I probably wouldn't use that approach, but I wanted to see how the api behaved. So, it turns out that the items have kind of like indexes and the next item actually is the 101th one, not the 86th one. I speculated that this is because the DB query probably gets everything then there is a filter (like give me the ones that are not deleted).
> 
> So, for this beatiful API, the best we can do is keep asking for the next page. This is easy to do if we want to involve WPAndroid in it, but we don't want to do that, so we need to save this information in our DB. We either save which page each item belongs to (`PluginDirectoryModelTable` page field) or we save in which page we are for each directory (separate table, one record for each directory type). I couldn't find any other way to do this, but I'd love to hear if there are any better ideas, because I hate this one :(