### PR TITLE
Unescape WPOrgPluginModel name before assigning it

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -6,6 +6,7 @@ import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPORGAPI;
@@ -184,7 +185,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         wpOrgPluginModel.setIcon(response.icon);
         wpOrgPluginModel.setInstallationInstructionsAsHtml(response.installationInstructionsAsHtml);
         wpOrgPluginModel.setLastUpdated(response.lastUpdated);
-        wpOrgPluginModel.setName(response.name);
+        wpOrgPluginModel.setName(StringEscapeUtils.unescapeHtml4(response.name));
         wpOrgPluginModel.setRating(response.rating);
         wpOrgPluginModel.setRequiredWordPressVersion(response.requiredWordPressVersion);
         wpOrgPluginModel.setSlug(response.slug);


### PR DESCRIPTION
Fixes #694 - Unescapes the WPOrgPluginModel name before assigning it. Tested with WPAndroid, here's the before shot:

![before](https://user-images.githubusercontent.com/3903757/35240874-cfb98346-ff82-11e7-8fde-5ffbefaeeadf.png)

And the after shot:

![after](https://user-images.githubusercontent.com/3903757/35240888-d4a3ec3e-ff82-11e7-8cc0-8c86aaf17f08.png)
