### PR TITLE
issue/697-drop-theme-cursor-methods

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -139,26 +139,11 @@ public class ThemeStoreUnitTest {
     }
 
     @Test
-    public void testGetWpThemesAsCursor() {
-        final List<ThemeModel> firstTestThemes = generateThemesTestList(20);
-        final List<ThemeModel> secondTestThemes = generateThemesTestList(30);
-
-        // insert themes and verify count
-        assertEquals(0, mThemeStore.getWpComThemesCursor().getCount());
-        ThemeSqlUtils.insertOrReplaceWpComThemes(firstTestThemes);
-        assertEquals(firstTestThemes.size(), mThemeStore.getWpComThemesCursor().getCount());
-
-        // insert new themes list and verify count
-        ThemeSqlUtils.insertOrReplaceWpComThemes(secondTestThemes);
-        assertEquals(secondTestThemes.size(), mThemeStore.getWpComThemesCursor().getCount());
-    }
-
-    @Test
     public void testRemoveThemesWithNoSite() {
         final List<ThemeModel> testThemes = generateThemesTestList(20);
 
         // insert and verify count
-        assertEquals(0, mThemeStore.getWpComThemesCursor().getCount());
+        assertEquals(0, mThemeStore.getWpComThemes().size());
         ThemeSqlUtils.insertOrReplaceWpComThemes(testThemes);
         assertEquals(testThemes.size(), mThemeStore.getWpComThemes().size());
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.persistence;
 
-import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
@@ -84,13 +83,6 @@ public class ThemeSqlUtils {
                 .equals(ThemeModelTable.LOCAL_SITE_ID, site.getId())
                 .equals(ThemeModelTable.ACTIVE, true)
                 .endGroup().endWhere().getAsModel();
-    }
-
-    public static Cursor getWpComThemesCursor() {
-        return WellSql.select(ThemeModel.class)
-                .where()
-                .equals(ThemeModelTable.IS_WP_COM_THEME, true)
-                .endWhere().getAsCursor();
     }
 
     public static List<ThemeModel> getWpComThemes() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.store;
 
-import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
@@ -256,10 +255,6 @@ public class ThemeStore extends Store {
 
     public List<ThemeModel> getWpComMobileFriendlyThemes(String categorySlug) {
         return ThemeSqlUtils.getWpComMobileFriendlyThemes(categorySlug);
-    }
-
-    public Cursor getWpComThemesCursor() {
-        return ThemeSqlUtils.getWpComThemesCursor();
     }
 
     public List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {


### PR DESCRIPTION
Fixes #697 - drops the theme cursor methods since they're no longer used by WPAndroid.