### PR TITLE
Add checkstyle rules for @Inject annotation

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -76,6 +76,9 @@
           <option name="XML_ALIGN_ATTRIBUTES" value="false" />
           <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
         </XML>
+        <codeStyleSettings language="JAVA">
+          <option name="FIELD_ANNOTATION_WRAP" value="1" />
+        </codeStyleSettings>
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />
           <indentOptions>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -57,6 +57,11 @@
         <property name="severity" value="error"/>
     </module>
 
+    <module name="RegexpSingleline">
+        <property name="format" value="^(?!.*\bclass\b).*\S.*@Inject"/>
+        <property name="message" value="In-line inject annotation should precede the rest of the declaration"/>
+    </module>
+
     <!-- Specific to FluxC -->
     <module name="RegexpSingleline">
         <property name="format" value="extends Payload[^&lt;]"/>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -58,7 +58,7 @@
     </module>
 
     <module name="RegexpMultiline">
-        <property name="format" value="@Inject\n.*[^{,(]$"/>
+        <property name="format" value="@Inject(\n|\r\n).*[^{,(]$"/>
         <property name="message" value="Inject annotation should be in-line with the annotated field or property"/>
     </module>
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -57,6 +57,11 @@
         <property name="severity" value="error"/>
     </module>
 
+    <module name="RegexpMultiline">
+        <property name="format" value="@Inject\n.*[^{,(]$"/>
+        <property name="message" value="Inject annotation should be in-line with the annotated field or property"/>
+    </module>
+
     <module name="RegexpSingleline">
         <property name="format" value="^(?!.*\bclass\b).*\S.*@Inject"/>
         <property name="message" value="In-line inject annotation should precede the rest of the declaration"/>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -170,8 +170,8 @@ public class CommentStore extends Store {
     // Constructor
 
     @Inject
-    public CommentStore(Dispatcher dispatcher, CommentRestClient commentRestClient, CommentXMLRPCClient
-            commentXMLRPCClient) {
+    public CommentStore(Dispatcher dispatcher, CommentRestClient commentRestClient,
+                        CommentXMLRPCClient commentXMLRPCClient) {
         super(dispatcher);
         mCommentRestClient = commentRestClient;
         mCommentXMLRPCClient = commentXMLRPCClient;


### PR DESCRIPTION
Adds a few new checkstyle rules to standardize some syntax around `@Inject` that have come up several times.

### 1. `@Inject` should be first in in-line declarations, in most cases

#### Allowed:

```java
@Inject AccountStore mAccountStore;
```

```java
@Inject protected AccountStore mAccountStore;
```

```kotlin
@Inject internal lateinit var accountStore: AccountStore
```

(Note: There's a style rule for Kotlin that will flag anything like `internal @Inject var ...` - we could make this an error, but it wouldn't cover java files anyway, and is redundant with the checkstyle rule.)

#### Not allowed:

```java
protected @Inject AccountStore mAccountStore;
```

The checkstyle for this excludes any lines including `class`, since this is valid Kotlin:

```kotlin
class Something @Inject constructor(...) {

}
```

### 2. When annotating fields/properties, `@Inject` should be in-line

#### Allowed:

```java
@Inject AccountStore mAccountStore;
```

#### Not allowed:

```java
@Inject
AccountStore mAccountStore;
```

This one flagged one false positive in `CommentStore` where the type was separated from the name of a constructor field - we should probably not allow this anyway, but since this was the only false positive I just fixed it manually.

I tested these rules in WPAndroid and WCAndroid, and they seem to catch all the problematic cases with no false positives.

cc @maxme (more work for project easter bunny, I guess!)