### PR TITLE
Replace InstrumentationTestCase by JUnit tests and use the test orchestrator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ allprojects {
 
     repositories {
         jcenter()
+        google()
     }
 
     task checkstyle(type: Checkstyle) {
@@ -58,5 +59,5 @@ ext {
     kotlinVersion = '1.2.20'
 
     daggerVersion = '2.11'
-    supportLibraryVersion = '25.3.1'
+    supportLibraryVersion = '25.4.0'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     implementation ('org.wordpress:utils:1.16.0') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley";
+        exclude group: "com.android.support";
     }
 
     // Dagger

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,10 +7,6 @@ buildscript {
     }
 }
 
-repositories {
-    jcenter()
-}
-
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -29,6 +25,8 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -37,8 +35,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
     lintOptions {
         warning 'InvalidPackage'
+    }
+
+    testOptions {
+        execution 'ANDROID_TEST_ORCHESTRATOR'
     }
 }
 
@@ -99,4 +102,8 @@ dependencies {
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'
     debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
+
+    // Test orchestrator
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestUtil 'com.android.support.test:orchestrator:1.0.1'
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
@@ -1,6 +1,13 @@
 package org.wordpress.android.fluxc.mocked;
 
+import android.support.test.runner.AndroidJUnit4;
+
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -12,6 +19,7 @@ import javax.inject.Inject;
 /**
  * Tests using a Mocked Network app component. Test the Store itself and not the underlying network component(s).
  */
+@RunWith(AndroidJUnit4.class)
 public class MockedStack_AccountTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
@@ -19,7 +27,8 @@ public class MockedStack_AccountTest extends MockedStack_Base {
     public boolean mIsError;
 
     @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         super.setUp();
         // Inject
         mMockedNetworkAppComponent.inject(this);
@@ -27,6 +36,7 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         mDispatcher.register(this);
     }
 
+    @Test
     public void testAuthenticationOK() {
         AuthenticatePayload payload = new AuthenticatePayload("test", "test");
         mIsError = false;
@@ -34,6 +44,7 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
     }
 
+    @Test
     public void testAuthenticationKO() {
         AuthenticatePayload payload = new AuthenticatePayload("error", "error");
         mIsError = true;
@@ -43,6 +54,6 @@ public class MockedStack_AccountTest extends MockedStack_Base {
 
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
-        assertEquals(mIsError, event.isError());
+        Assert.assertEquals(mIsError, event.isError());
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
@@ -1,21 +1,22 @@
 package org.wordpress.android.fluxc.mocked;
 
 import android.content.Context;
-import android.test.InstrumentationTestCase;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import org.junit.Before;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 
-public class MockedStack_Base extends InstrumentationTestCase {
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+
+public class MockedStack_Base {
     Context mAppContext;
     MockedNetworkAppComponent mMockedNetworkAppComponent;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         // Needed for Mockito
         System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
         mAppContext = getInstrumentation().getTargetContext().getApplicationContext();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
@@ -8,7 +8,7 @@ public class MockedStack_SiteTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         // Inject
         mMockedNetworkAppComponent.inject(this);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.mocked;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
@@ -40,7 +42,7 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
     private CountDownLatch mCountDownLatch;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         // Inject
         mMockedNetworkAppComponent.inject(this);
@@ -52,12 +54,12 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
     public void testUploadMedia() throws InterruptedException {
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
         startSuccessfulMediaUpload(testMedia, getTestSite());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Confirm that the corresponding MediaUploadModel's state has been updated automatically
         // (confirming that the UploadStore was spun up once we set up the MediaStore)
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
+        Assert.assertNotNull(mediaUploadModel);
     }
 
     @SuppressWarnings("unused")
@@ -70,13 +72,13 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
         }
 
         if (event.isError()) {
-            assertEquals(TestEvents.MEDIA_ERROR, mNextEvent);
+            Assert.assertEquals(TestEvents.MEDIA_ERROR, mNextEvent);
             mCountDownLatch.countDown();
             return;
         }
 
         if (event.completed) {
-            assertEquals(TestEvents.UPLOADED_MEDIA, mNextEvent);
+            Assert.assertEquals(TestEvents.UPLOADED_MEDIA, mNextEvent);
             mCountDownLatch.countDown();
         }
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.mocked;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
@@ -64,7 +66,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
     private CountDownLatch mCountDownLatch;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         // Inject
         mMockedNetworkAppComponent.inject(this);
@@ -76,28 +78,28 @@ public class MockedStack_UploadTest extends MockedStack_Base {
     public void testUploadMedia() throws InterruptedException {
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
         startSuccessfulMediaUpload(testMedia, getTestSite());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Confirm that the corresponding MediaUploadModel's state has been updated automatically
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(1F, mUploadStore.getUploadProgressForMedia(testMedia));
-        assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(1F, mUploadStore.getUploadProgressForMedia(testMedia));
+        Assert.assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
     }
 
     public void testUploadMediaError() throws InterruptedException {
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
         startFailingMediaUpload(testMedia, getTestSite());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Wait for the event to be processed by the UploadStore
         TestUtils.waitFor(50);
 
         // Confirm that the corresponding MediaUploadModel's state has been updated automatically
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(0F, mUploadStore.getUploadProgressForMedia(testMedia));
-        assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(0F, mUploadStore.getUploadProgressForMedia(testMedia));
+        Assert.assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
     }
 
     public void testRegisterPostAndUploadMediaWithError() throws InterruptedException {
@@ -116,83 +118,83 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         TestUtils.waitFor(50);
 
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
         // Register the post with the UploadStore and verify that it exists and has the right state
         List<MediaModel> mediaModelList = new ArrayList<>();
         mediaModelList.add(testMedia);
         mUploadStore.registerPostModel(mPost, mediaModelList);
-        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
+        Assert.assertTrue(mUploadStore.isRegisteredPostModel(mPost));
 
         // PostUploadModel exists and has correct state and associated media
-        assertEquals(1, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(1, mUploadStore.getPendingPosts().size());
         PostUploadModel postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertNotNull(postUploadModel);
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isPendingPost(mPost));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isPendingPost(mPost));
         Set<Integer> associatedMedia = postUploadModel.getAssociatedMediaIdSet();
-        assertEquals(1, associatedMedia.size());
-        assertTrue(associatedMedia.contains(testMedia.getId()));
+        Assert.assertEquals(1, associatedMedia.size());
+        Assert.assertTrue(associatedMedia.contains(testMedia.getId()));
 
         // MediaUploadModel exists and has correct state
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
         // UploadStore returns the correct sets of media for the post by type
-        assertEquals(1, mUploadStore.getUploadingMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
+        Assert.assertEquals(1, mUploadStore.getUploadingMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Media upload completed
         // PostUploadModel still exists and has correct state and associated media
-        assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(1, mUploadStore.getCancelledPosts().size());
+        Assert.assertEquals(0, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(1, mUploadStore.getCancelledPosts().size());
         postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertNotNull(postUploadModel);
-        assertEquals(PostUploadModel.CANCELLED, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isCancelledPost(mPost));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(PostUploadModel.CANCELLED, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isCancelledPost(mPost));
         associatedMedia = postUploadModel.getAssociatedMediaIdSet();
-        assertEquals(1, associatedMedia.size());
-        assertTrue(associatedMedia.contains(testMedia.getId()));
+        Assert.assertEquals(1, associatedMedia.size());
+        Assert.assertTrue(associatedMedia.contains(testMedia.getId()));
 
         // MediaUploadModel still exists and has correct state
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
+        Assert.assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
 
         // UploadStore returns the correct sets of media for the post by type
-        assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
-        assertEquals(1, mUploadStore.getFailedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
+        Assert.assertEquals(1, mUploadStore.getFailedMediaForPost(mPost).size());
 
         // Clean up failed media manually
         clearMedia(mPost, mUploadStore.getFailedMediaForPost(mPost));
 
         // UploadStore returns the correct sets of media for the post by type
-        assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
 
         // Upload post to site (pretend we've removed the failed media from the post content)
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.UPLOADED_POST;
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(new RemotePostPayload(mPost, site)));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(site));
 
         // Since the post upload completed successfully, the PostUploadModel should have been deleted
-        assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(0, mUploadStore.getFailedPosts().size());
-        assertEquals(0, mUploadStore.getCancelledPosts().size());
-        assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
-        assertNull(getPostUploadModelForPostModel(uploadedPost));
-        assertFalse(mUploadStore.isPendingPost(mPost));
+        Assert.assertEquals(0, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(0, mUploadStore.getFailedPosts().size());
+        Assert.assertEquals(0, mUploadStore.getCancelledPosts().size());
+        Assert.assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
+        Assert.assertNull(getPostUploadModelForPostModel(uploadedPost));
+        Assert.assertFalse(mUploadStore.isPendingPost(mPost));
     }
 
     public void testRegisterPostAndUploadMediaWithPostCancellation() throws InterruptedException {
@@ -211,57 +213,57 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         TestUtils.waitFor(50);
 
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
         // Register the post with the UploadStore and verify that it exists and has the right state
         List<MediaModel> mediaModelList = new ArrayList<>();
         mediaModelList.add(testMedia);
         mUploadStore.registerPostModel(mPost, mediaModelList);
-        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
+        Assert.assertTrue(mUploadStore.isRegisteredPostModel(mPost));
 
         mNextEvent = TestEvents.CANCELLED_POST;
         mDispatcher.dispatch(UploadActionBuilder.newCancelPostAction(mPost));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // The media upload action we already started will be next, reset the CountDownLatch and mNextEvent
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.UPLOADED_MEDIA;
 
         // The Post should be cancelled (the media upload should continue unaffected)
-        assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(0, mUploadStore.getFailedPosts().size());
-        assertEquals(1, mUploadStore.getCancelledPosts().size());
-        assertEquals(1, mUploadStore.getAllRegisteredPosts().size());
+        Assert.assertEquals(0, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(0, mUploadStore.getFailedPosts().size());
+        Assert.assertEquals(1, mUploadStore.getCancelledPosts().size());
+        Assert.assertEquals(1, mUploadStore.getAllRegisteredPosts().size());
 
         // The media upload should be unaffected
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Media upload completed
         // PostUploadModel still exists and has correct state and associated media
-        assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(1, mUploadStore.getCancelledPosts().size());
-        assertEquals(1, mUploadStore.getAllRegisteredPosts().size());
+        Assert.assertEquals(0, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(1, mUploadStore.getCancelledPosts().size());
+        Assert.assertEquals(1, mUploadStore.getAllRegisteredPosts().size());
         PostUploadModel postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertNotNull(postUploadModel);
-        assertEquals(PostUploadModel.CANCELLED, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isCancelledPost(mPost));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(PostUploadModel.CANCELLED, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isCancelledPost(mPost));
         Set<Integer> associatedMedia = postUploadModel.getAssociatedMediaIdSet();
-        assertEquals(1, associatedMedia.size());
-        assertTrue(associatedMedia.contains(testMedia.getId()));
+        Assert.assertEquals(1, associatedMedia.size());
+        Assert.assertTrue(associatedMedia.contains(testMedia.getId()));
 
         // MediaUploadModel still exists and has correct state
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
+        Assert.assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
 
         // UploadStore returns the correct sets of media for the post by type
-        assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
-        assertEquals(1, mUploadStore.getCompletedMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
+        Assert.assertEquals(1, mUploadStore.getCompletedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
     }
 
     public void testUploadMediaInCancelledPost() throws InterruptedException {
@@ -283,21 +285,21 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         List<MediaModel> mediaModelList = new ArrayList<>();
         mediaModelList.add(testMedia);
         mUploadStore.registerPostModel(mPost, mediaModelList);
-        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
+        Assert.assertTrue(mUploadStore.isRegisteredPostModel(mPost));
 
         // MediaUploadModel exists and has correct state
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Media upload completed
         // PostUploadModel still exists and has correct state and associated media
-        assertTrue(mUploadStore.isCancelledPost(mPost));
+        Assert.assertTrue(mUploadStore.isCancelledPost(mPost));
 
         // MediaUploadModel still exists and has correct state
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
+        Assert.assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
 
         // Clean up failed media manually
         clearMedia(mPost, mUploadStore.getFailedMediaForPost(mPost));
@@ -312,12 +314,12 @@ public class MockedStack_UploadTest extends MockedStack_Base {
 
         // The cancelled post should be cleared since we've now modified it
         // There's no pending post either, because we haven't re-registered one yet
-        assertEquals(0, mUploadStore.getCancelledPosts().size());
-        assertEquals(0, mUploadStore.getFailedPosts().size());
-        assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
+        Assert.assertEquals(0, mUploadStore.getCancelledPosts().size());
+        Assert.assertEquals(0, mUploadStore.getFailedPosts().size());
+        Assert.assertEquals(0, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
 
-        assertNull(getPostUploadModelForPostModel(mPost));
+        Assert.assertNull(getPostUploadModelForPostModel(mPost));
     }
 
     public void testUpdateMediaModelState() throws InterruptedException {
@@ -339,11 +341,11 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         List<MediaModel> mediaModelList = new ArrayList<>();
         mediaModelList.add(testMedia);
         mUploadStore.registerPostModel(mPost, mediaModelList);
-        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
+        Assert.assertTrue(mUploadStore.isRegisteredPostModel(mPost));
 
         // MediaUploadModel exists and has correct state
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
         // Manually set the MediaModel to FAILED
         // This might happen, e.g., if the app using FluxC was terminated, and any 'UPLOADING' MediaModels are set
@@ -352,26 +354,26 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         mNextEvent = TestEvents.MEDIA_CHANGED;
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(testMedia));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Wait for the event to be processed by the UploadStore
         TestUtils.waitFor(50);
 
         // The MediaUploadModel should have been set to FAILED automatically via the UPDATE_MEDIA action
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
-        assertNotNull(mediaUploadModel.getMediaError());
-        assertEquals(0F, mUploadStore.getUploadProgressForMedia(testMedia));
+        Assert.assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel.getMediaError());
+        Assert.assertEquals(0F, mUploadStore.getUploadProgressForMedia(testMedia));
 
         // The PostUploadModel should have been set to CANCELLED automatically via the UPDATE_MEDIA action
         PostUploadModel postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertEquals(PostUploadModel.CANCELLED, postUploadModel.getUploadState());
+        Assert.assertEquals(PostUploadModel.CANCELLED, postUploadModel.getUploadState());
 
         // Reset expected event back to the UPLOADED_MEDIA we were expecting at the start,
         // and finish off the events for this test
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.UPLOADED_MEDIA;
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")
@@ -387,7 +389,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
             throw new AssertionError("Unexpected error: " + event.error.type + " - " + event.error.message);
         }
 
-        assertEquals(TestEvents.UPLOADED_POST, mNextEvent);
+        Assert.assertEquals(TestEvents.UPLOADED_POST, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -401,13 +403,13 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         }
 
         if (event.isError()) {
-            assertEquals(TestEvents.MEDIA_ERROR, mNextEvent);
+            Assert.assertEquals(TestEvents.MEDIA_ERROR, mNextEvent);
             mCountDownLatch.countDown();
             return;
         }
 
         if (event.completed) {
-            assertEquals(TestEvents.UPLOADED_MEDIA, mNextEvent);
+            Assert.assertEquals(TestEvents.UPLOADED_MEDIA, mNextEvent);
             mCountDownLatch.countDown();
         }
     }
@@ -417,7 +419,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
     public void onMediaChanged(OnMediaChanged event) {
         AppLog.i(T.API, "Received OnMediaChanged");
 
-        assertEquals(TestEvents.MEDIA_CHANGED, mNextEvent);
+        Assert.assertEquals(TestEvents.MEDIA_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -427,10 +429,10 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         AppLog.i(T.API, "Received OnUploadChanged");
 
         if (mNextEvent.equals(TestEvents.CANCELLED_POST)) {
-            assertEquals(UploadAction.CANCEL_POST, event.cause);
+            Assert.assertEquals(UploadAction.CANCEL_POST, event.cause);
             mCountDownLatch.countDown();
         } else if (mNextEvent.equals(TestEvents.CLEARED_MEDIA)) {
-            assertEquals(UploadAction.CLEAR_MEDIA_FOR_POST, event.cause);
+            Assert.assertEquals(UploadAction.CLEAR_MEDIA_FOR_POST, event.cause);
             mCountDownLatch.countDown();
         } else {
             throw new AssertionError("Unexpected OnUploadChanged event with cause: " + event.cause);
@@ -497,7 +499,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.CLEARED_MEDIA;
         mDispatcher.dispatch(UploadActionBuilder.newClearMediaForPostAction(clearMediaPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private static MediaUploadModel getMediaUploadModelForMediaModel(MediaModel mediaModel) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
@@ -48,20 +50,20 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableBlogAction("wordpress"));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("wordpress", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
+        Assert.assertEquals("wordpress", mLastEvent.value);
+        Assert.assertFalse(mLastEvent.isAvailable);
 
         String unavailableBlog = "docbrown" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
         mNextEvent = TestEvents.IS_AVAILABLE_BLOG;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableBlogAction(unavailableBlog));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(unavailableBlog, mLastEvent.value);
-        assertTrue(mLastEvent.isAvailable);
+        Assert.assertEquals(unavailableBlog, mLastEvent.value);
+        Assert.assertTrue(mLastEvent.isAvailable);
     }
 
     public void testIsAvailableBlogInvalid() throws InterruptedException {
@@ -69,10 +71,10 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableBlogAction("notavalidname#"));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("notavalidname#", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
+        Assert.assertEquals("notavalidname#", mLastEvent.value);
+        Assert.assertFalse(mLastEvent.isAvailable);
     }
 
     public void testIsAvailableDomain() throws InterruptedException {
@@ -80,21 +82,21 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableDomainAction("docbrown.com"));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("docbrown.com", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
-        assertTrue(mLastEvent.suggestions.size() > 0);
+        Assert.assertEquals("docbrown.com", mLastEvent.value);
+        Assert.assertFalse(mLastEvent.isAvailable);
+        Assert.assertTrue(mLastEvent.suggestions.size() > 0);
 
         String unavailableDomain = "docbrown" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + ".com";
         mNextEvent = TestEvents.IS_AVAILABLE_DOMAIN;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableDomainAction(unavailableDomain));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(unavailableDomain, mLastEvent.value);
-        assertTrue(mLastEvent.isAvailable);
+        Assert.assertEquals(unavailableDomain, mLastEvent.value);
+        Assert.assertTrue(mLastEvent.isAvailable);
         assertNull(mLastEvent.suggestions);
     }
 
@@ -103,10 +105,10 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableDomainAction("notavaliddomain#"));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("notavaliddomain#", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
+        Assert.assertEquals("notavaliddomain#", mLastEvent.value);
+        Assert.assertFalse(mLastEvent.isAvailable);
     }
 
     public void testIsAvailableEmail() throws InterruptedException {
@@ -114,20 +116,20 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableEmailAction("mobile@automattic.com"));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("mobile@automattic.com", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
+        Assert.assertEquals("mobile@automattic.com", mLastEvent.value);
+        Assert.assertFalse(mLastEvent.isAvailable);
 
         String unavailableEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
         mNextEvent = TestEvents.IS_AVAILABLE_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableEmailAction(unavailableEmail));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(unavailableEmail, mLastEvent.value);
-        assertTrue(mLastEvent.isAvailable);
+        Assert.assertEquals(unavailableEmail, mLastEvent.value);
+        Assert.assertTrue(mLastEvent.isAvailable);
     }
 
     public void testIsAvailableEmailInvalid() throws InterruptedException {
@@ -135,10 +137,10 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableEmailAction("notanemail"));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("notanemail", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
+        Assert.assertEquals("notanemail", mLastEvent.value);
+        Assert.assertFalse(mLastEvent.isAvailable);
     }
 
     public void testIsAvailableUsername() throws InterruptedException {
@@ -146,20 +148,20 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableUsernameAction("mobile"));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("mobile", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
+        Assert.assertEquals("mobile", mLastEvent.value);
+        Assert.assertFalse(mLastEvent.isAvailable);
 
         String unavailableUsername = "fluxc" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
         mNextEvent = TestEvents.IS_AVAILABLE_USERNAME;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableUsernameAction(unavailableUsername));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(unavailableUsername, mLastEvent.value);
-        assertTrue(mLastEvent.isAvailable);
+        Assert.assertEquals(unavailableUsername, mLastEvent.value);
+        Assert.assertTrue(mLastEvent.isAvailable);
     }
 
     public void testIsAvailableUsernameInvalid() throws InterruptedException {
@@ -167,10 +169,10 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newIsAvailableUsernameAction("invalidusername#"));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("invalidusername#", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
+        Assert.assertEquals("invalidusername#", mLastEvent.value);
+        Assert.assertFalse(mLastEvent.isAvailable);
     }
 
     @SuppressWarnings("unused")
@@ -181,26 +183,26 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         if (event.isError()) {
             AppLog.d(T.API, "OnAvailabilityChecked has error: " + event.error.type + " - " + event.error.message);
             if (mNextEvent.equals(TestEvents.ERROR_INVALID)) {
-                assertEquals(IsAvailableErrorType.INVALID, event.error.type);
+                Assert.assertEquals(IsAvailableErrorType.INVALID, event.error.type);
                 mCountDownLatch.countDown();
             }
             return;
         }
         switch (event.type) {
             case BLOG:
-                assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_BLOG);
+                Assert.assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_BLOG);
                 mCountDownLatch.countDown();
                 break;
             case DOMAIN:
-                assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_DOMAIN);
+                Assert.assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_DOMAIN);
                 mCountDownLatch.countDown();
                 break;
             case EMAIL:
-                assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_EMAIL);
+                Assert.assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_EMAIL);
                 mCountDownLatch.countDown();
                 break;
             case USERNAME:
-                assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_USERNAME);
+                Assert.assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_USERNAME);
                 mCountDownLatch.countDown();
                 break;
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
@@ -89,7 +91,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
         mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         mCountDownLatch = new CountDownLatch(2);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testWPComPost() throws InterruptedException {
@@ -105,9 +107,9 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         payload.params.put("description", newValue);
         mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
+        Assert.assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
     }
 
     public void testWPComPostNoChange() throws InterruptedException {
@@ -121,7 +123,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
         mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         mCountDownLatch = new CountDownLatch(2);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         mNextEvent = TestEvents.POSTED;
         PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
@@ -131,9 +133,9 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         payload.params.put("description", newValue);
         mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
+        Assert.assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
     }
 
     public void testWPComPostPrimarySiteIdNoChange() throws InterruptedException {
@@ -147,7 +149,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
         mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         mCountDownLatch = new CountDownLatch(2);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         mNextEvent = TestEvents.POSTED;
         PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
@@ -157,9 +159,9 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         payload.params.put("primary_site_ID", newValue);
         mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(newValue, String.valueOf(mAccountStore.getAccount().getPrimarySiteId()));
+        Assert.assertEquals(newValue, String.valueOf(mAccountStore.getAccount().getPrimarySiteId()));
     }
 
     public void testChangeWPComUsernameInvalidInputError() throws InterruptedException {
@@ -177,10 +179,10 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AccountActionBuilder.newPushUsernameAction(payload));
 
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(username, String.valueOf(mAccountStore.getAccount().getUserName()));
-        assertEquals(address, String.valueOf(mAccountStore.getAccount().getWebAddress()));
+        Assert.assertEquals(username, String.valueOf(mAccountStore.getAccount().getUserName()));
+        Assert.assertEquals(address, String.valueOf(mAccountStore.getAccount().getWebAddress()));
     }
 
     public void testFetchWPComUsernameSuggestionsNoNameError() throws InterruptedException {
@@ -190,7 +192,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
 
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testFetchWPComUsernameSuggestionsSuccess() throws InterruptedException {
@@ -200,7 +202,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
 
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testWPComSignOut() throws InterruptedException {
@@ -210,10 +212,10 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(2); // Wait for OnAuthenticationChanged and OnAccountChanged
         mNextEvent = TestEvents.AUTHENTICATE;
         mDispatcher.dispatch(AccountActionBuilder.newSignOutAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertFalse(mAccountStore.hasAccessToken());
-        assertEquals(0, mAccountStore.getAccount().getUserId());
+        Assert.assertFalse(mAccountStore.hasAccessToken());
+        Assert.assertEquals(0, mAccountStore.getAccount().getUserId());
     }
 
     public void testWPComSignOutCollision() throws InterruptedException {
@@ -225,14 +227,14 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
         Thread.sleep(100);
         mDispatcher.dispatch(AccountActionBuilder.newSignOutAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         mCountDownLatch = new CountDownLatch(1); // Wait for FETCH_ACCOUNT result
         mNextEvent = TestEvents.FETCH_ERROR;
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertFalse(mAccountStore.hasAccessToken());
-        assertEquals(0, mAccountStore.getAccount().getUserId());
+        Assert.assertFalse(mAccountStore.hasAccessToken());
+        Assert.assertEquals(0, mAccountStore.getAccount().getUserId());
     }
 
     public void testSendAuthEmail() throws InterruptedException {
@@ -240,7 +242,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailViaUsername() throws InterruptedException {
@@ -248,7 +250,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailInvalid() throws InterruptedException {
@@ -257,7 +259,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthEmailPayload payload = new AuthEmailPayload("email@domain", false);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailNoSuchUser() throws InterruptedException {
@@ -266,7 +268,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailSignup() throws InterruptedException {
@@ -275,7 +277,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailSignupInvalid() throws InterruptedException {
@@ -283,7 +285,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthEmailPayload payload = new AuthEmailPayload("email@domain", true);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailSignupUserExists() throws InterruptedException {
@@ -291,7 +293,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")
@@ -301,16 +303,16 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         if (event.isError()) {
             switch (mNextEvent) {
                 case AUTHENTICATE_2FA_ERROR:
-                    assertEquals(event.error.type, AuthenticationErrorType.NEEDS_2FA);
+                    Assert.assertEquals(event.error.type, AuthenticationErrorType.NEEDS_2FA);
                     break;
                 case INCORRECT_USERNAME_OR_PASSWORD_ERROR:
-                    assertEquals(event.error.type, AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD);
+                    Assert.assertEquals(event.error.type, AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD);
                     break;
                 default:
                     throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
         } else {
-            assertEquals(mNextEvent, TestEvents.AUTHENTICATE);
+            Assert.assertEquals(mNextEvent, TestEvents.AUTHENTICATE);
         }
         mCountDownLatch.countDown();
     }
@@ -322,7 +324,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         if (event.isError()) {
             switch (event.error.type) {
                 case ACCOUNT_FETCH_ERROR:
-                    assertEquals(mNextEvent, TestEvents.FETCH_ERROR);
+                    Assert.assertEquals(mNextEvent, TestEvents.FETCH_ERROR);
                     mCountDownLatch.countDown();
                     break;
                 default:
@@ -331,14 +333,14 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
             return;
         }
         if (event.causeOfChange == AccountAction.FETCH_ACCOUNT) {
-            assertEquals(mNextEvent, TestEvents.FETCHED);
-            assertEquals(BuildConfig.TEST_WPCOM_USERNAME_TEST1, mAccountStore.getAccount().getUserName());
+            Assert.assertEquals(mNextEvent, TestEvents.FETCHED);
+            Assert.assertEquals(BuildConfig.TEST_WPCOM_USERNAME_TEST1, mAccountStore.getAccount().getUserName());
         } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
-            assertEquals(mNextEvent, TestEvents.FETCHED);
-            assertEquals(BuildConfig.TEST_WPCOM_USERNAME_TEST1, mAccountStore.getAccount().getUserName());
+            Assert.assertEquals(mNextEvent, TestEvents.FETCHED);
+            Assert.assertEquals(BuildConfig.TEST_WPCOM_USERNAME_TEST1, mAccountStore.getAccount().getUserName());
         } else if (event.causeOfChange == AccountAction.PUSH_SETTINGS) {
-            assertEquals(mNextEvent, TestEvents.POSTED);
-            assertEquals(mExpectAccountInfosChanged, event.accountInfosChanged);
+            Assert.assertEquals(mNextEvent, TestEvents.POSTED);
+            Assert.assertEquals(mExpectAccountInfosChanged, event.accountInfosChanged);
         }
         mCountDownLatch.countDown();
     }
@@ -351,19 +353,19 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
             AppLog.i(AppLog.T.API, "OnAuthEmailSent has error: " + event.error.type + " - " + event.error.message);
             if (event.error.type == AuthEmailErrorType.INVALID_EMAIL) {
                 if (event.isSignup) {
-                    assertTrue(mNextEvent == TestEvents.AUTH_EMAIL_ERROR_INVALID);
+                    Assert.assertTrue(mNextEvent == TestEvents.AUTH_EMAIL_ERROR_INVALID);
                 } else {
-                    assertTrue(mNextEvent == TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER);
+                    Assert.assertTrue(mNextEvent == TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER);
                 }
                 mCountDownLatch.countDown();
             } else if (event.error.type == AuthEmailErrorType.USER_EXISTS) {
-                assertEquals(mNextEvent, TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS);
+                Assert.assertEquals(mNextEvent, TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS);
                 mCountDownLatch.countDown();
             } else {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
         } else {
-            assertEquals(mNextEvent, TestEvents.SENT_AUTH_EMAIL);
+            Assert.assertEquals(mNextEvent, TestEvents.SENT_AUTH_EMAIL);
             mCountDownLatch.countDown();
         }
     }
@@ -382,7 +384,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
                 case INVALID_ACTION:
                     throw new AssertionError("Error should not occur with action type enum: " + event.type);
                 case INVALID_INPUT:
-                    assertEquals(mNextEvent, TestEvents.CHANGE_USERNAME_ERROR_INVALID_INPUT);
+                    Assert.assertEquals(mNextEvent, TestEvents.CHANGE_USERNAME_ERROR_INVALID_INPUT);
                     mCountDownLatch.countDown();
                     break;
                 default:
@@ -406,14 +408,14 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
                 case REST_MISSING_CALLBACK_PARAM:
                     throw new AssertionError("Error should not occur with name parameter");
                 case REST_NO_NAME:
-                    assertEquals(mNextEvent, TestEvents.FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME);
+                    Assert.assertEquals(mNextEvent, TestEvents.FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME);
                     mCountDownLatch.countDown();
                     break;
                 default:
                     throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
         } else if (event.suggestions.size() != 0) {
-            assertEquals(mNextEvent, TestEvents.FETCH_USERNAME_SUGGESTIONS_SUCCESS);
+            Assert.assertEquals(mNextEvent, TestEvents.FETCH_USERNAME_SUGGESTIONS_SUCCESS);
             mCountDownLatch.countDown();
         }
     }
@@ -422,6 +424,6 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthenticatePayload payload = new AuthenticatePayload(username, password);
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.release;
 
 import com.yarolegovich.wellsql.SelectQuery;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.CommentActionBuilder;
@@ -71,7 +73,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         // Verify it was inserted in the DB
         List<CommentModel> comments = CommentSqlUtils.getCommentsForSite(sSite, SelectQuery.ORDER_ASCENDING,
                 CommentStatus.ALL);
-        assertEquals(mNewComment.getId(), comments.get(0).getId());
+        Assert.assertEquals(mNewComment.getId(), comments.get(0).getId());
     }
 
     // Note: This test is not specific to WPCOM (local changes only)
@@ -86,22 +88,22 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.COMMENT_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newUpdateCommentAction(mNewComment));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check the last comment we get from the DB is the same
         List<CommentModel> comments = CommentSqlUtils.getCommentsForSite(sSite, SelectQuery.ORDER_ASCENDING,
                 CommentStatus.ALL);
-        assertEquals(mNewComment.getContent(), comments.get(0).getContent());
+        Assert.assertEquals(mNewComment.getContent(), comments.get(0).getContent());
 
         // Remove that comment
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newRemoveCommentAction(mNewComment));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check the last comment we get from the DB is different
         comments = CommentSqlUtils.getCommentsForSite(sSite, SelectQuery.ORDER_ASCENDING, CommentStatus.ALL);
         if (comments.size() != 0) {
-            assertNotSame(mNewComment.getId(), comments.get(0).getId());
+            Assert.assertNotSame(mNewComment.getId(), comments.get(0).getId());
         }
     }
 
@@ -109,15 +111,15 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         fetchFirstComments();
 
         int count = mCommentStore.getNumberOfCommentsForSite(sSite, CommentStatus.ALL);
-        assertNotSame(0, count); // Only work if the site has at least one comment.
+        Assert.assertNotSame(0, count); // Only work if the site has at least one comment.
 
         // Remove all comments for this site
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newRemoveCommentsAction(sSite));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         count = mCommentStore.getNumberOfCommentsForSite(sSite, CommentStatus.ALL);
-        assertEquals(0, count);
+        Assert.assertEquals(0, count);
     }
 
     public void testInstantiateAndCreateNewComment() throws InterruptedException {
@@ -132,11 +134,11 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, mFirstPost, mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertTrue(comment.getContent().contains(mNewComment.getContent()));
+        Assert.assertTrue(comment.getContent().contains(mNewComment.getContent()));
     }
 
     public void testLikeAndUnlikeComment() throws InterruptedException {
@@ -149,22 +151,22 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newLikeCommentAction(new RemoteLikeCommentPayload(sSite,
                 firstComment, true)));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(firstComment.getId());
-        assertTrue(comment.getILike());
+        Assert.assertTrue(comment.getILike());
 
         // Unlike comment
         mNextEvent = TestEvents.COMMENT_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newLikeCommentAction(new RemoteLikeCommentPayload(sSite,
                 firstComment, false)));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         comment = mCommentStore.getCommentByLocalId(firstComment.getId());
-        assertFalse(comment.getILike());
+        Assert.assertFalse(comment.getILike());
     }
 
     public void testDeleteCommentOnce() throws InterruptedException {
@@ -179,22 +181,22 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCreateCommentPayload payload1 = new RemoteCreateCommentPayload(sSite, mFirstPost, mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertTrue(comment.getContent().contains(mNewComment.getContent()));
+        Assert.assertTrue(comment.getContent().contains(mNewComment.getContent()));
 
         // Delete
         mNextEvent = TestEvents.COMMENT_CHANGED;
         RemoteCommentPayload payload2 = new RemoteCommentPayload(sSite, comment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Make sure the comment is still here but state changed
         comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertEquals(CommentStatus.TRASH.toString(), comment.getStatus());
+        Assert.assertEquals(CommentStatus.TRASH.toString(), comment.getStatus());
     }
 
     public void testDeleteCommentTwice() throws InterruptedException {
@@ -209,27 +211,27 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCreateCommentPayload payload1 = new RemoteCreateCommentPayload(sSite, mFirstPost, mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertTrue(comment.getContent().contains(mNewComment.getContent()));
+        Assert.assertTrue(comment.getContent().contains(mNewComment.getContent()));
 
         // Delete once (ie. move to trash)
         mNextEvent = TestEvents.COMMENT_CHANGED;
         RemoteCommentPayload payload2 = new RemoteCommentPayload(sSite, comment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Delete twice (ie. real delete)
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Make sure the comment was deleted (local test only, but should mean it was deleted correctly on the server)
         comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertEquals(comment, null);
+        Assert.assertEquals(comment, null);
     }
 
     public void testErrorDuplicatedComment() throws InterruptedException {
@@ -244,13 +246,13 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCreateCommentPayload payload1 = new RemoteCreateCommentPayload(sSite, mFirstPost, mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Dispatch the same payload (with the same comment), we should get a 409 error "comment_duplicate"
         mNextEvent = TestEvents.COMMENT_CHANGED_DUPLICATE_COMMENT;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testNewCommentToAnUnknownPost() throws InterruptedException {
@@ -263,7 +265,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, fakePost, newComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testReplyToAnUnknownComment() throws InterruptedException {
@@ -274,7 +276,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, fakeComment, newComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testInstantiateAndCreateReplyComment() throws InterruptedException {
@@ -293,15 +295,15 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, firstComment, mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
 
         // Using .contains() in the assert below because server might wrap the response in <p>
-        assertTrue(comment.getContent().contains(mNewComment.getContent()));
-        assertNotSame(mNewComment.getRemoteCommentId(), comment.getRemoteCommentId());
-        assertNotSame(mNewComment.getRemoteSiteId(), comment.getRemoteSiteId());
+        Assert.assertTrue(comment.getContent().contains(mNewComment.getContent()));
+        Assert.assertNotSame(mNewComment.getRemoteCommentId(), comment.getRemoteCommentId());
+        Assert.assertNotSame(mNewComment.getRemoteSiteId(), comment.getRemoteSiteId());
     }
 
     public void testFetchComments() throws InterruptedException {
@@ -310,7 +312,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testFetchComment() throws InterruptedException {
@@ -322,7 +324,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testEditValidComment() throws InterruptedException {
@@ -339,7 +341,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCommentPayload pushCommentPayload = new RemoteCommentPayload(sSite, firstComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newPushCommentAction(pushCommentPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Make sure it was edited
         RemoteCommentPayload payload = new RemoteCommentPayload(sSite, firstComment);
@@ -347,11 +349,11 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         CommentModel updatedComment = CommentSqlUtils.getCommentByLocalCommentId(firstComment.getId());
-        assertNotNull(updatedComment);
-        assertTrue(updatedComment.getContent().contains(firstComment.getContent()));
+        Assert.assertNotNull(updatedComment);
+        Assert.assertTrue(updatedComment.getContent().contains(firstComment.getContent()));
     }
 
     public void testEditInvalidComment() throws InterruptedException {
@@ -364,7 +366,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         RemoteCommentPayload pushCommentPayload = new RemoteCommentPayload(sSite, comment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newPushCommentAction(pushCommentPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")
@@ -374,13 +376,13 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             AppLog.i(T.TESTS, "event error type: " + event.error.type);
             if (mNextEvent == TestEvents.COMMENT_CHANGED_UNKNOWN_COMMENT) {
-                assertEquals(event.error.type, CommentErrorType.UNKNOWN_COMMENT);
+                Assert.assertEquals(event.error.type, CommentErrorType.UNKNOWN_COMMENT);
             } else if (mNextEvent == TestEvents.COMMENT_CHANGED_UNKNOWN_POST) {
-                assertEquals(event.error.type, CommentErrorType.UNKNOWN_POST);
+                Assert.assertEquals(event.error.type, CommentErrorType.UNKNOWN_POST);
             } else if (mNextEvent == TestEvents.COMMENT_CHANGED_DUPLICATE_COMMENT) {
-                assertEquals(event.error.type, CommentErrorType.DUPLICATE_COMMENT);
+                Assert.assertEquals(event.error.type, CommentErrorType.DUPLICATE_COMMENT);
             } else if (mNextEvent == TestEvents.COMMENT_CHANGED_ERROR) {
-                assertEquals(event.error.type, CommentErrorType.UNKNOWN_COMMENT);
+                Assert.assertEquals(event.error.type, CommentErrorType.UNKNOWN_COMMENT);
             } else {
                 throw new AssertionError("Error occurred for event: " + mNextEvent + " with type: " + event.error.type);
             }
@@ -388,7 +390,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
             return;
         }
         AppLog.i(T.TESTS, "comments count " + comments.size());
-        assertEquals(TestEvents.COMMENT_CHANGED, mNextEvent);
+        Assert.assertEquals(TestEvents.COMMENT_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -397,7 +399,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     public void onPostChanged(OnPostChanged event) {
         List<PostModel> posts = mPostStore.getPostsForSite(sSite);
         mFirstPost = getFirstPublishedPost(posts);
-        assertEquals(mNextEvent, TestEvents.POSTS_FETCHED);
+        Assert.assertEquals(mNextEvent, TestEvents.POSTS_FETCHED);
         mCountDownLatch.countDown();
     }
 
@@ -415,8 +417,8 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     private CommentModel createNewComment() {
         CommentModel comment = mCommentStore.instantiateCommentModel(sSite);
 
-        assertNotNull(comment);
-        assertTrue(comment.getId() != 0);
+        Assert.assertNotNull(comment);
+        Assert.assertTrue(comment.getId() != 0);
 
         mNewComment = comment;
         return comment;
@@ -430,7 +432,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.COMMENT_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         mComments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
     }
 
@@ -438,6 +440,6 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(sSite, false)));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.CommentActionBuilder;
@@ -61,7 +63,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testFetchComment() throws InterruptedException {
@@ -72,7 +74,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteCommentPayload fetchCommentPayload = new RemoteCommentPayload(sSite, firstComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentAction(fetchCommentPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testInstantiateAndCreateNewComment() throws InterruptedException {
@@ -87,11 +89,11 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertTrue(comment.getContent().contains(mNewComment.getContent()));
+        Assert.assertTrue(comment.getContent().contains(mNewComment.getContent()));
     }
 
     public void testInstantiateAndCreateNewCommentDuplicate() throws InterruptedException {
@@ -106,13 +108,13 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Same comment again
         mNextEvent = TestEvents.COMMENT_CHANGED_ERROR;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testReplyToAnUnknownComment() throws InterruptedException {
@@ -128,7 +130,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, fakeComment, newComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testInstantiateAndCreateReplyComment() throws InterruptedException {
@@ -147,12 +149,12 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, firstComment, mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertEquals(comment.getContent(), mNewComment.getContent());
-        assertEquals(comment.getRemoteParentCommentId(), firstComment.getRemoteCommentId());
+        Assert.assertEquals(comment.getContent(), mNewComment.getContent());
+        Assert.assertEquals(comment.getRemoteParentCommentId(), firstComment.getRemoteCommentId());
     }
 
     public void testEditValidComment() throws InterruptedException {
@@ -170,10 +172,10 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.COMMENT_CHANGED;
         mDispatcher.dispatch(CommentActionBuilder.newPushCommentAction(pushCommentPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         CommentModel comment = mCommentStore.getCommentByLocalId(firstComment.getId());
-        assertEquals(comment.getContent(), firstComment.getContent());
+        Assert.assertEquals(comment.getContent(), firstComment.getContent());
     }
 
     public void testEditInvalidComment() throws InterruptedException {
@@ -191,7 +193,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.COMMENT_CHANGED_ERROR;
         mDispatcher.dispatch(CommentActionBuilder.newPushCommentAction(pushCommentPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testDeleteCommentOnce() throws InterruptedException {
@@ -206,22 +208,22 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteCreateCommentPayload payload1 = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertTrue(comment.getContent().contains(mNewComment.getContent()));
+        Assert.assertTrue(comment.getContent().contains(mNewComment.getContent()));
 
         // Delete
         mNextEvent = TestEvents.COMMENT_CHANGED;
         RemoteCommentPayload payload2 = new RemoteCommentPayload(sSite, comment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Make sure the comment is still here but state changed
         comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertEquals(CommentStatus.TRASH.toString(), comment.getStatus());
+        Assert.assertEquals(CommentStatus.TRASH.toString(), comment.getStatus());
     }
 
     public void testDeleteCommentTwice() throws InterruptedException {
@@ -236,27 +238,27 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteCreateCommentPayload payload1 = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload1));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertTrue(comment.getContent().contains(mNewComment.getContent()));
+        Assert.assertTrue(comment.getContent().contains(mNewComment.getContent()));
 
         // Delete once (ie. move to trash)
         mNextEvent = TestEvents.COMMENT_CHANGED;
         RemoteCommentPayload payload2 = new RemoteCommentPayload(sSite, comment);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Delete twice (ie. real delete)
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newDeleteCommentAction(payload2));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Make sure the comment was deleted (local test only, but should mean it was deleted correctly on the server)
         comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertEquals(null, comment);
+        Assert.assertEquals(null, comment);
     }
 
     // OnChanged Events
@@ -268,9 +270,9 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         if (event.isError()) {
             AppLog.i(T.TESTS, "event error type: " + event.error.type);
             if (mNextEvent == TestEvents.COMMENT_CHANGED_UNKNOWN_COMMENT) {
-                assertEquals(event.error.type, CommentErrorType.GENERIC_ERROR);
+                Assert.assertEquals(event.error.type, CommentErrorType.GENERIC_ERROR);
             } else if (mNextEvent == TestEvents.COMMENT_CHANGED_ERROR) {
-                assertEquals(event.error.type, CommentErrorType.GENERIC_ERROR);
+                Assert.assertEquals(event.error.type, CommentErrorType.GENERIC_ERROR);
             } else {
                 throw new AssertionError("Error occurred for event: " + mNextEvent + " with type: " + event.error.type);
             }
@@ -278,7 +280,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
             return;
         }
         AppLog.i(T.TESTS, "comments count " + comments.size());
-        assertEquals(TestEvents.COMMENT_CHANGED, mNextEvent);
+        Assert.assertEquals(TestEvents.COMMENT_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -286,7 +288,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Subscribe
     public void onPostChanged(OnPostChanged event) {
         mPosts = mPostStore.getPostsForSite(sSite);
-        assertEquals(mNextEvent, TestEvents.POSTS_FETCHED);
+        Assert.assertEquals(mNextEvent, TestEvents.POSTS_FETCHED);
         mCountDownLatch.countDown();
     }
 
@@ -295,8 +297,8 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private CommentModel createNewComment() {
         CommentModel comment = mCommentStore.instantiateCommentModel(sSite);
 
-        assertNotNull(comment);
-        assertTrue(comment.getId() != 0);
+        Assert.assertNotNull(comment);
+        Assert.assertTrue(comment.getId() != 0);
 
         mNewComment = comment;
         return comment;
@@ -311,7 +313,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         mComments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
     }
 
@@ -319,6 +321,6 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(sSite, false)));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -76,7 +78,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testInvalidUrlFetchSites() throws InterruptedException {
@@ -90,7 +92,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testNonWordPressFetchSites() throws InterruptedException {
@@ -104,7 +106,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testWPComUrlFetchSites() throws InterruptedException {
@@ -118,7 +120,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testXMLRPCSimpleFetchSites() throws InterruptedException {
@@ -374,7 +376,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testXMLRPCForbiddenDiscovery() throws InterruptedException {
@@ -388,7 +390,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testXMLRPCMissingMethodDiscovery() throws InterruptedException {
@@ -402,7 +404,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testWPAPISimpleFetchSites() throws InterruptedException {
@@ -417,7 +419,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
             mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
             // Wait for a network response / onChanged event
-            assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            Assert.assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
             // TODO: Fetch site (and migrate this test to use checkSelfHostedSimpleFetchForSite)
         }
@@ -446,7 +448,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         fetchSites();
     }
@@ -465,7 +467,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onAuthenticationChanged error event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Add an exception for the last certificate
         mMemorizingTrustManager.storeLastFailure();
@@ -477,7 +479,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onAuthenticationChanged error event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         fetchSites();
 
@@ -497,7 +499,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onAuthenticationChanged error event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Set known HTTP Auth credentials
         mHTTPAuthManager.addHTTPAuthCredentials(authUsername, authPassword, mUrl, null);
@@ -509,7 +511,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         fetchSites();
     }
@@ -525,7 +527,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
 
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private static String addBadProtocolToUrl(String url) {
@@ -539,9 +541,9 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type " + event.error.type);
         }
-        assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
-        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -552,9 +554,9 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type " + event.error.type);
         }
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
-        assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -571,21 +573,21 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
             // ERROR :(
             AppLog.i(T.API, "Discovery error: " + event.error);
             if (event.error == DiscoveryError.INVALID_URL) {
-                assertEquals(TestEvents.INVALID_URL_ERROR, mNextEvent);
+                Assert.assertEquals(TestEvents.INVALID_URL_ERROR, mNextEvent);
             } else if (event.error == DiscoveryError.NO_SITE_ERROR) {
-                assertEquals(TestEvents.NO_SITE_ERROR, mNextEvent);
+                Assert.assertEquals(TestEvents.NO_SITE_ERROR, mNextEvent);
             } else if (event.error == DiscoveryError.WORDPRESS_COM_SITE) {
-                assertEquals(TestEvents.WORDPRESS_COM_SITE, mNextEvent);
+                Assert.assertEquals(TestEvents.WORDPRESS_COM_SITE, mNextEvent);
             } else if (event.error == DiscoveryError.HTTP_AUTH_REQUIRED) {
-                assertEquals(TestEvents.HTTP_AUTH_REQUIRED, mNextEvent);
+                Assert.assertEquals(TestEvents.HTTP_AUTH_REQUIRED, mNextEvent);
             } else if (event.error == DiscoveryError.ERRONEOUS_SSL_CERTIFICATE) {
-                assertEquals(TestEvents.ERRONEOUS_SSL_CERTIFICATE, mNextEvent);
+                Assert.assertEquals(TestEvents.ERRONEOUS_SSL_CERTIFICATE, mNextEvent);
             } else if (event.error == DiscoveryError.XMLRPC_BLOCKED) {
-                assertEquals(TestEvents.XMLRPC_BLOCKED, mNextEvent);
+                Assert.assertEquals(TestEvents.XMLRPC_BLOCKED, mNextEvent);
             } else if (event.error == DiscoveryError.XMLRPC_FORBIDDEN) {
-                assertEquals(TestEvents.XMLRPC_FORBIDDEN, mNextEvent);
+                Assert.assertEquals(TestEvents.XMLRPC_FORBIDDEN, mNextEvent);
             } else if (event.error == DiscoveryError.MISSING_XMLRPC_METHOD) {
-                assertEquals(TestEvents.MISSING_XMLRPC_METHOD, mNextEvent);
+                Assert.assertEquals(TestEvents.MISSING_XMLRPC_METHOD, mNextEvent);
             } else {
                 throw new AssertionError("Didn't get the correct error, expected: " + mNextEvent + ", and got: "
                         + event.error);
@@ -597,16 +599,16 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
             AppLog.i(T.API, "Discovery succeeded, XML-RPC endpoint: " + event.xmlRpcEndpoint + ", WP-API endpoint: "
                     + event.wpRestEndpoint);
             if (mNextEvent.equals(TestEvents.DISCOVERY_SUCCEEDED_WPAPI)) {
-                assertTrue(event.wpRestEndpoint != null && !event.wpRestEndpoint.isEmpty());
+                Assert.assertTrue(event.wpRestEndpoint != null && !event.wpRestEndpoint.isEmpty());
                 mUrl = event.wpRestEndpoint;
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.DISCOVERY_SUCCEEDED_XMLRPC)) {
-                assertTrue(event.xmlRpcEndpoint != null && !event.xmlRpcEndpoint.isEmpty());
+                Assert.assertTrue(event.xmlRpcEndpoint != null && !event.xmlRpcEndpoint.isEmpty());
                 mUrl = event.xmlRpcEndpoint;
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.DISCOVERY_SUCCEEDED_XMLRPC_ONLY)) {
-                assertTrue(event.xmlRpcEndpoint != null && !event.xmlRpcEndpoint.isEmpty());
-                assertTrue(event.wpRestEndpoint == null || event.wpRestEndpoint.isEmpty());
+                Assert.assertTrue(event.xmlRpcEndpoint != null && !event.xmlRpcEndpoint.isEmpty());
+                Assert.assertTrue(event.wpRestEndpoint == null || event.wpRestEndpoint.isEmpty());
                 mUrl = event.xmlRpcEndpoint;
                 mCountDownLatch.countDown();
             }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
@@ -3,6 +3,8 @@ package org.wordpress.android.fluxc.release;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -71,7 +73,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
                                     // Network request hasn't happened yet, keep waiting
                                     return;
                                 }
-                                assertNotNull(response.getBitmap());
+                                Assert.assertNotNull(response.getBitmap());
                                 mCountDownLatch.countDown();
                             }
 
@@ -87,7 +89,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
 
         runTestOnUiThread(loadImageTask);
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")
@@ -97,8 +99,8 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mSiteStore.hasSite());
-        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -108,7 +110,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
+        Assert.assertEquals(TestEvents.FETCHED_MEDIA_LIST, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -127,7 +129,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
         // Retry to fetch sites,we expect a site refresh
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
         // Wait for a network response
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchSiteMedia(SiteModel site) throws InterruptedException {
@@ -138,8 +140,8 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
                 site, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertFalse(mMediaStore.getAllSiteMedia(site).isEmpty());
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertFalse(mMediaStore.getAllSiteMedia(site).isEmpty());
     }
 }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -97,18 +99,18 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
     public void onMediaUploaded(OnMediaUploaded event) {
         if (event.isError()) {
             if (event.error.type == MediaErrorType.EXCEEDS_FILESIZE_LIMIT) {
-                assertEquals(TestEvents.ERROR_EXCEEDS_FILESIZE_LIMIT, mNextEvent);
+                Assert.assertEquals(TestEvents.ERROR_EXCEEDS_FILESIZE_LIMIT, mNextEvent);
                 mCountDownLatch.countDown();
                 return;
             } else if (event.error.type == MediaErrorType.EXCEEDS_MEMORY_LIMIT) {
-                assertEquals(TestEvents.ERROR_EXCEEDS_MEMORY_LIMIT, mNextEvent);
+                Assert.assertEquals(TestEvents.ERROR_EXCEEDS_MEMORY_LIMIT, mNextEvent);
                 mCountDownLatch.countDown();
                 return;
             }
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         if (event.completed) {
-            assertEquals(TestEvents.MEDIA_UPLOADED, mNextEvent);
+            Assert.assertEquals(TestEvents.MEDIA_UPLOADED, mNextEvent);
             mCountDownLatch.countDown();
         }
     }
@@ -137,7 +139,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         MediaPayload payload = new MediaPayload(site, media);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")
@@ -166,8 +168,8 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mSiteStore.hasSite());
-        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -178,7 +180,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
+        Assert.assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -190,19 +192,19 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         // Correct user we should get an OnAuthenticationChanged message
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch account from REST API, and wait for OnAccountChanged event
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch sites from REST API, and wait for onSiteChanged event
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchSite(SiteModel site) throws InterruptedException {
@@ -211,7 +213,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
 
         mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void signOutWPCom() throws InterruptedException {
@@ -220,6 +222,6 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.SITE_REMOVED;
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.release;
 
 import android.annotation.SuppressLint;
 
+import junit.framework.Assert;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
@@ -71,9 +73,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // delete media and verify it's not in the store
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -88,31 +90,31 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // remove all local media and verify store is empty
         mNextEvent = TestEvents.REMOVED_MEDIA;
         removeAllSiteMedia();
-        assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+        Assert.assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // fetch media list and verify store is not empty
         mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
         fetchMediaList();
-        assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+        Assert.assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // remove all media again
         mNextEvent = TestEvents.REMOVED_MEDIA;
         removeAllSiteMedia();
-        assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+        Assert.assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // fetch only images, verify store is not empty and contains only images
         mNextEvent = TestEvents.FETCHED_MEDIA_IMAGE_LIST;
         fetchMediaImageList();
         List<MediaModel> mediaList = mMediaStore.getSiteImages(sSite);
-        assertFalse(mediaList.isEmpty());
-        assertTrue(mMediaStore.getSiteMediaCount(sSite) == mediaList.size());
+        Assert.assertFalse(mediaList.isEmpty());
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(sSite) == mediaList.size());
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -126,9 +128,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // remove local media and verify it's not in the store
         mNextEvent = TestEvents.REMOVED_MEDIA;
@@ -138,7 +140,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         // fetch test media from remote and verify it's in the store
         mNextEvent = TestEvents.FETCHED_KNOWN_IMAGES;
         fetchMedia(testMedia);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -152,9 +154,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // create a random title and push changes
         testMedia.setTitle(RandomStringUtils.randomAlphabetic(8));
@@ -163,8 +165,8 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
         // verify store media has been updated
         MediaModel storeMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
-        assertNotNull(storeMedia);
-        assertEquals(testMedia.getTitle(), storeMedia.getTitle());
+        Assert.assertNotNull(storeMedia);
+        Assert.assertEquals(testMedia.getTitle(), storeMedia.getTitle());
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -189,9 +191,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -208,9 +210,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
         testMedia.setMediaId(mLastUploadedId);
         MediaModel uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
-        assertNotNull(uploadedMedia);
-        assertEquals(1, uploadedMedia.getPostId());
-        assertEquals(5, uploadedMedia.getLocalPostId());
+        Assert.assertNotNull(uploadedMedia);
+        Assert.assertEquals(1, uploadedMedia.getPostId());
+        Assert.assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;
         deleteMedia(testMedia);
@@ -223,9 +225,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
         testMedia.setMediaId(mLastUploadedId);
         uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
-        assertNotNull(uploadedMedia);
-        assertEquals(0, uploadedMedia.getPostId());
-        assertEquals(5, uploadedMedia.getLocalPostId());
+        Assert.assertNotNull(uploadedMedia);
+        Assert.assertEquals(0, uploadedMedia.getPostId());
+        Assert.assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;
         deleteMedia(testMedia);
@@ -245,9 +247,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         CancelMediaPayload cancelPayload = new CancelMediaPayload(sSite, testMedia);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(0, mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(0, mMediaStore.getSiteMediaCount(sSite));
 
         // Now, try canceling with delete=false (canceled image should be marked as failed and kept in the store)
         testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -262,11 +264,11 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         cancelPayload = new CancelMediaPayload(sSite, testMedia, false);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
         MediaModel canceledMedia = mMediaStore.getMediaWithLocalId(testMedia.getId());
-        assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
+        Assert.assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
     }
 
     public void testUploadMultipleImages() throws InterruptedException {
@@ -286,15 +288,15 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()));
 
         // verify all have been uploaded
-        assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
-        assertEquals(mUploadedMediaModels.size(),
+        Assert.assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
+        Assert.assertEquals(mUploadedMediaModels.size(),
                 mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
 
         // verify they exist in the MediaStore
         Iterator<MediaModel> iterator = mUploadedMediaModels.values().iterator();
         while (iterator.hasNext()) {
             MediaModel media = iterator.next();
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, media.getMediaId()));
+            Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, media.getMediaId()));
         }
 
         // delete test images (bear in mind this is done sequentially)
@@ -327,17 +329,17 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()), amountToCancel, true);
 
         // verify how many have been uploaded
-        assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
+        Assert.assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
 
         // verify each one of the remaining, non-cancelled uploads exist in the MediaStore
         for (long mediaId : mUploadedIds) {
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
+            Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
         }
 
         // Only completed uploads should exist in the store
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaCount(sSite));
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
+        Assert.assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
 
         // delete test images (bear in mind this is done sequentially)
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -370,19 +372,19 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()), amountToCancel, false);
 
         // verify how many have been uploaded
-        assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
+        Assert.assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
 
         // verify each one of the remaining, non-cancelled uploads exist in the MediaStore
         for (long mediaId : mUploadedIds) {
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
+            Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
         }
 
         // All the original uploads should exist in the store, whether cancelled or not
-        assertEquals(mUploadedMediaModels.size(), mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(mUploadedMediaModels.size(), mMediaStore.getSiteMediaCount(sSite));
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
+        Assert.assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
         // All cancelled media should have a FAILED state
-        assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.FAILED).size());
+        Assert.assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.FAILED).size());
 
         // delete test images (bear in mind this is done sequentially)
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -401,9 +403,9 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -433,7 +435,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
                 } else {
                     AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
                 }
-                assertNotNull(media);
+                Assert.assertNotNull(media);
             } else if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA) {
                 mUploadedIds.add(event.media.getMediaId());
                 // now update our own map object with the new media id
@@ -443,7 +445,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
                 } else {
                     AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
                 }
-                assertNotNull(media);
+                Assert.assertNotNull(media);
             } else if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
                 mLastUploadedId = event.media.getMediaId();
             } else {
@@ -458,7 +460,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     public void onMediaChanged(OnMediaChanged event) {
         if (event.isError()) {
             if (event.cause == MediaAction.PUSH_MEDIA) {
-                assertEquals(TestEvents.PUSH_ERROR, mNextEvent);
+                Assert.assertEquals(TestEvents.PUSH_ERROR, mNextEvent);
             } else {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
@@ -467,14 +469,14 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         }
         if (event.cause == MediaAction.FETCH_MEDIA) {
             if (eventHasKnownImages(event)) {
-                assertEquals(TestEvents.FETCHED_KNOWN_IMAGES, mNextEvent);
+                Assert.assertEquals(TestEvents.FETCHED_KNOWN_IMAGES, mNextEvent);
             }
         } else if (event.cause == MediaAction.PUSH_MEDIA) {
-            assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
+            Assert.assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
         } else if (event.cause == MediaAction.DELETE_MEDIA) {
-            assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
+            Assert.assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
         } else if (event.cause == MediaAction.REMOVE_MEDIA) {
-            assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
+            Assert.assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
         } else {
             throw new AssertionError("Unexpected event: " + event.cause);
         }
@@ -489,7 +491,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         }
         boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
                 || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
-        assertTrue(isMediaListEvent);
+        Assert.assertTrue(isMediaListEvent);
         mCountDownLatch.countDown();
     }
 
@@ -535,7 +537,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         MediaPayload payload = new MediaPayload(sSite, media);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchMediaList() throws InterruptedException {
@@ -543,7 +545,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
                 sSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchMediaImageList() throws InterruptedException {
@@ -551,21 +553,21 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
                 sSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false, MediaUtils.MIME_TYPE_IMAGE);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchMedia(MediaModel media) throws InterruptedException {
         MediaPayload fetchPayload = new MediaPayload(sSite, media, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaAction(fetchPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void uploadMedia(MediaModel media) throws InterruptedException {
         MediaPayload payload = new MediaPayload(sSite, media);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void uploadMultipleMedia(List<MediaModel> mediaList) throws InterruptedException {
@@ -592,20 +594,20 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
             }
         }
 
-        assertTrue(mCountDownLatch.await(TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void deleteMedia(MediaModel media) throws InterruptedException {
         MediaPayload deletePayload = new MediaPayload(sSite, media);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newDeleteMediaAction(deletePayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void removeMedia(MediaModel media) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(media));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void removeAllSiteMedia() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.release;
 
 import android.annotation.SuppressLint;
 
+import junit.framework.Assert;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
@@ -85,9 +87,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // delete media and verify it's not in the store
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -109,31 +111,31 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // remove all local media and verify store is empty
         mNextEvent = TestEvents.REMOVED_MEDIA;
         removeAllSiteMedia();
-        assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+        Assert.assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // fetch media list and verify store is not empty
         mNextEvent = TestEvents.FETCHED_MEDIA_LIST;
         fetchMediaList();
-        assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+        Assert.assertFalse(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // remove all media again
         mNextEvent = TestEvents.REMOVED_MEDIA;
         removeAllSiteMedia();
-        assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
+        Assert.assertTrue(mMediaStore.getAllSiteMedia(sSite).isEmpty());
 
         // fetch only images, verify store is not empty and contains only images
         mNextEvent = TestEvents.FETCHED_MEDIA_IMAGE_LIST;
         fetchMediaImageList();
         List<MediaModel> mediaList = mMediaStore.getSiteImages(sSite);
-        assertFalse(mediaList.isEmpty());
-        assertTrue(mMediaStore.getSiteMediaCount(sSite) == mediaList.size());
+        Assert.assertFalse(mediaList.isEmpty());
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(sSite) == mediaList.size());
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -159,9 +161,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // remove local media and verify it's not in the store
         mNextEvent = TestEvents.REMOVED_MEDIA;
@@ -171,7 +173,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // fetch test media from remote and verify it's in the store
         mNextEvent = TestEvents.FETCHED_MEDIA;
         fetchMedia(testMedia);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -185,9 +187,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // create a random title and push changes
         testMedia.setTitle(RandomStringUtils.randomAlphabetic(8));
@@ -196,8 +198,8 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // verify store media has been updated
         MediaModel storeMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
-        assertNotNull(storeMedia);
-        assertEquals(testMedia.getTitle(), storeMedia.getTitle());
+        Assert.assertNotNull(storeMedia);
+        Assert.assertEquals(testMedia.getTitle(), storeMedia.getTitle());
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -211,9 +213,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -230,9 +232,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         testMedia.setMediaId(mLastUploadedId);
         MediaModel uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
-        assertNotNull(uploadedMedia);
-        assertEquals(1, uploadedMedia.getPostId());
-        assertEquals(5, uploadedMedia.getLocalPostId());
+        Assert.assertNotNull(uploadedMedia);
+        Assert.assertEquals(1, uploadedMedia.getPostId());
+        Assert.assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;
         deleteMedia(testMedia);
@@ -245,9 +247,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         testMedia.setMediaId(mLastUploadedId);
         uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
-        assertNotNull(uploadedMedia);
-        assertEquals(0, uploadedMedia.getPostId());
-        assertEquals(5, uploadedMedia.getLocalPostId());
+        Assert.assertNotNull(uploadedMedia);
+        Assert.assertEquals(0, uploadedMedia.getPostId());
+        Assert.assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;
         deleteMedia(testMedia);
@@ -267,9 +269,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         CancelMediaPayload cancelPayload = new CancelMediaPayload(sSite, testMedia);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(0, mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(0, mMediaStore.getSiteMediaCount(sSite));
 
         // Now, try canceling with delete=false (canceled image should be marked as failed and kept in the store)
         testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -284,11 +286,11 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         cancelPayload = new CancelMediaPayload(sSite, testMedia, false);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
         MediaModel canceledMedia = mMediaStore.getMediaWithLocalId(testMedia.getId());
-        assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
+        Assert.assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
     }
 
     public void testUploadMultipleImages() throws InterruptedException {
@@ -308,15 +310,15 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()));
 
         // verify all have been uploaded
-        assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
-        assertEquals(mUploadedMediaModels.size(),
+        Assert.assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
+        Assert.assertEquals(mUploadedMediaModels.size(),
                 mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
 
         // verify they exist in the MediaStore
         Iterator<MediaModel> iterator = mUploadedMediaModels.values().iterator();
         while (iterator.hasNext()) {
             MediaModel media = iterator.next();
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, media.getMediaId()));
+            Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, media.getMediaId()));
         }
 
         // delete test images (bear in mind this is done sequentially)
@@ -349,17 +351,17 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()), amountToCancel, true);
 
         // verify how many have been uploaded
-        assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
+        Assert.assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
 
         // verify each one of the remaining, non-cancelled uploads exist in the MediaStore
         for (long mediaId : mUploadedIds) {
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
+            Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
         }
 
         // Only completed uploads should exist in the store
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteImageCount(sSite));
+        Assert.assertEquals(mUploadedIds.size(), mMediaStore.getSiteImageCount(sSite));
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
+        Assert.assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
 
         // delete test images (bear in mind this is done sequentially)
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -392,19 +394,19 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()), amountToCancel, false);
 
         // verify how many have been uploaded
-        assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
+        Assert.assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
 
         // verify each one of the remaining, non-cancelled uploads exist in the MediaStore
         for (long mediaId : mUploadedIds) {
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
+            Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
         }
 
         // All the original uploads should exist in the store, whether cancelled or not
-        assertEquals(mUploadedMediaModels.size(), mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(mUploadedMediaModels.size(), mMediaStore.getSiteMediaCount(sSite));
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
+        Assert.assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
         // All cancelled media should have a FAILED state
-        assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.FAILED).size());
+        Assert.assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.FAILED).size());
 
         // delete test images (bear in mind this is done sequentially)
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -423,9 +425,9 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadMedia(testMedia);
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -450,19 +452,19 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         MediaPayload payload = new MediaPayload(site, testMedia);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(site, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(site, testMedia.getMediaId()));
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
         MediaPayload deletePayload = new MediaPayload(site, testMedia);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newDeleteMediaAction(deletePayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testUploadVideoOlderWordPress() throws InterruptedException {
@@ -483,19 +485,19 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         MediaPayload payload = new MediaPayload(site, testMedia);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(site, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(site, testMedia.getMediaId()));
 
         // delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
         MediaPayload deletePayload = new MediaPayload(site, testMedia);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newDeleteMediaAction(deletePayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")
@@ -521,7 +523,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 } else {
                     AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
                 }
-                assertNotNull(media);
+                Assert.assertNotNull(media);
             } else if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA) {
                 mUploadedIds.add(event.media.getMediaId());
                 // now update our own map object with the new media id
@@ -531,7 +533,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 } else {
                     AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
                 }
-                assertNotNull(media);
+                Assert.assertNotNull(media);
             } else if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
                 mLastUploadedId = event.media.getMediaId();
             } else {
@@ -548,23 +550,23 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         if (event.isError()) {
             if (event.error.type == MediaErrorType.NULL_MEDIA_ARG) {
-                assertEquals(TestEvents.NULL_ERROR, mNextEvent);
+                Assert.assertEquals(TestEvents.NULL_ERROR, mNextEvent);
             } else if (event.error.type == MediaErrorType.MALFORMED_MEDIA_ARG) {
-                assertEquals(TestEvents.MALFORMED_ERROR, mNextEvent);
+                Assert.assertEquals(TestEvents.MALFORMED_ERROR, mNextEvent);
             } else if (event.error.type == MediaErrorType.NOT_FOUND) {
-                assertEquals(TestEvents.NOT_FOUND_ERROR, mNextEvent);
+                Assert.assertEquals(TestEvents.NOT_FOUND_ERROR, mNextEvent);
             } else {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
         } else {
             if (event.cause == MediaAction.FETCH_MEDIA) {
-                assertEquals(TestEvents.FETCHED_MEDIA, mNextEvent);
+                Assert.assertEquals(TestEvents.FETCHED_MEDIA, mNextEvent);
             } else if (event.cause == MediaAction.PUSH_MEDIA) {
-                assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
+                Assert.assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
             } else if (event.cause == MediaAction.DELETE_MEDIA) {
-                assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
+                Assert.assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
             } else if (event.cause == MediaAction.REMOVE_MEDIA) {
-                assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
+                Assert.assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
             } else {
                 throw new AssertionError("Unexpected event: " + event.cause);
             }
@@ -580,7 +582,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
         boolean isMediaListEvent = mNextEvent == TestEvents.FETCHED_MEDIA_LIST
                 || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
-        assertTrue(isMediaListEvent);
+        Assert.assertTrue(isMediaListEvent);
         mCountDownLatch.countDown();
     }
 
@@ -616,7 +618,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         MediaPayload payload = new MediaPayload(sSite, media);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchMediaList() throws InterruptedException {
@@ -624,7 +626,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 sSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchMediaImageList() throws InterruptedException {
@@ -632,21 +634,21 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 sSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false, MediaUtils.MIME_TYPE_IMAGE);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(fetchPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchMedia(MediaModel media) throws InterruptedException {
         MediaPayload fetchPayload = new MediaPayload(sSite, media, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newFetchMediaAction(fetchPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void uploadMedia(MediaModel media) throws InterruptedException {
         MediaPayload payload = new MediaPayload(sSite, media);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void uploadMultipleMedia(List<MediaModel> mediaList) throws InterruptedException {
@@ -673,20 +675,20 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
             }
         }
 
-        assertTrue(mCountDownLatch.await(TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void deleteMedia(MediaModel media) throws InterruptedException {
         MediaPayload deletePayload = new MediaPayload(sSite, media);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newDeleteMediaAction(deletePayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void removeMedia(MediaModel media) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(media));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void removeAllSiteMedia() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -7,14 +9,16 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
-import org.wordpress.android.fluxc.model.SitePluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.SitePluginModel;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.PluginStore;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginErrorType;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType;
@@ -23,8 +27,6 @@ import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginConfigured;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginsFetched;
-import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginErrorType;
-import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
@@ -73,7 +75,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         SiteModel site = fetchSingleJetpackSitePlugins();
 
         List<SitePluginModel> plugins = mPluginStore.getSitePlugins(site);
-        assertTrue(plugins.size() > 0);
+        Assert.assertTrue(plugins.size() > 0);
 
         signOutWPCom();
     }
@@ -85,7 +87,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         SiteModel site = fetchSingleJetpackSitePlugins();
 
         List<SitePluginModel> plugins = mPluginStore.getSitePlugins(site);
-        assertTrue(plugins.size() > 0);
+        Assert.assertTrue(plugins.size() > 0);
         SitePluginModel plugin = plugins.get(0);
         boolean isActive = !plugin.isActive();
         plugin.setIsActive(isActive);
@@ -96,11 +98,11 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin);
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         SitePluginModel newPlugin = mPluginStore.getSitePluginByName(site, plugin.getName());
-        assertNotNull(newPlugin);
-        assertEquals(newPlugin.isActive(), isActive);
+        Assert.assertNotNull(newPlugin);
+        Assert.assertEquals(newPlugin.isActive(), isActive);
 
         signOutWPCom();
     }
@@ -129,7 +131,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         installSitePlugin(site, pluginSlugToInstall);
 
         // mInstalledPlugin should be set in onSitePluginInstalled
-        assertNotNull(mInstalledPlugin);
+        Assert.assertNotNull(mInstalledPlugin);
 
         // We need to deactivate the plugin to be able to uninstall it
         if (mInstalledPlugin.isActive()) {
@@ -141,7 +143,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         List<SitePluginModel> updatedPlugins = mPluginStore.getSitePlugins(site);
         for (SitePluginModel sitePlugin : updatedPlugins) {
-            assertFalse(sitePlugin.getSlug().equals(pluginSlugToInstall));
+            Assert.assertFalse(sitePlugin.getSlug().equals(pluginSlugToInstall));
         }
     }
 
@@ -157,7 +159,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin);
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testDeleteActivePluginError() throws InterruptedException {
@@ -188,7 +190,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         PluginSqlUtils.insertOrUpdateSitePlugin(plugin);
 
         SitePluginModel insertedPlugin = mPluginStore.getSitePluginByName(site, pluginName);
-        assertNotNull(insertedPlugin);
+        Assert.assertNotNull(insertedPlugin);
 
         mNextEvent = TestEvents.DELETED_SITE_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
@@ -196,7 +198,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         DeleteSitePluginPayload payload = new DeleteSitePluginPayload(site, plugin);
         mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(payload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Make sure the plugin is removed from DB
         assertNull(mPluginStore.getSitePluginByName(site, pluginName));
@@ -234,8 +236,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mSiteStore.hasSite());
-        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -246,7 +248,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
+        Assert.assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -258,7 +260,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred in onSitePluginsFetched with type: "
                     + event.error.type);
         }
-        assertEquals(mNextEvent, TestEvents.SITE_PLUGINS_FETCHED);
+        Assert.assertEquals(mNextEvent, TestEvents.SITE_PLUGINS_FETCHED);
         mCountDownLatch.countDown();
     }
 
@@ -268,13 +270,13 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         AppLog.i(T.API, "Received onSitePluginConfigured");
         if (event.isError()) {
             if (event.error.type.equals(ConfigureSitePluginErrorType.UNKNOWN_PLUGIN)) {
-                assertEquals(mNextEvent, TestEvents.UNKNOWN_SITE_PLUGIN);
+                Assert.assertEquals(mNextEvent, TestEvents.UNKNOWN_SITE_PLUGIN);
             } else {
                 throw new AssertionError("Unexpected error occurred in onSitePluginConfigured with type: "
                         + event.error.type);
             }
         } else {
-            assertEquals(mNextEvent, TestEvents.CONFIGURED_SITE_PLUGIN);
+            Assert.assertEquals(mNextEvent, TestEvents.CONFIGURED_SITE_PLUGIN);
         }
         mCountDownLatch.countDown();
     }
@@ -285,13 +287,13 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         AppLog.i(T.API, "Received onSitePluginDeleted");
         if (event.isError()) {
             if (event.error.type.equals(DeleteSitePluginErrorType.DELETE_PLUGIN_ERROR)) {
-                assertEquals(mNextEvent, TestEvents.DELETE_SITE_PLUGIN_ERROR);
+                Assert.assertEquals(mNextEvent, TestEvents.DELETE_SITE_PLUGIN_ERROR);
             } else {
                 throw new AssertionError("Unexpected error occurred in onSitePluginDeleted with type: "
                         + event.error.type);
             }
         } else {
-            assertEquals(mNextEvent, TestEvents.DELETED_SITE_PLUGIN);
+            Assert.assertEquals(mNextEvent, TestEvents.DELETED_SITE_PLUGIN);
         }
         mCountDownLatch.countDown();
     }
@@ -302,13 +304,13 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         AppLog.i(T.API, "Received onSitePluginInstalled");
         if (event.isError()) {
             if (event.error.type.equals(InstallSitePluginErrorType.NO_PACKAGE)) {
-                assertEquals(mNextEvent, TestEvents.INSTALL_SITE_PLUGIN_ERROR_NO_PACKAGE);
+                Assert.assertEquals(mNextEvent, TestEvents.INSTALL_SITE_PLUGIN_ERROR_NO_PACKAGE);
             } else {
                 throw new AssertionError("Unexpected error occurred in onSitePluginInstalled with type: "
                         + event.error.type);
             }
         } else {
-            assertEquals(mNextEvent, TestEvents.INSTALLED_SITE_PLUGIN);
+            Assert.assertEquals(mNextEvent, TestEvents.INSTALLED_SITE_PLUGIN);
         }
         mInstalledPlugin = event.plugin;
         mCountDownLatch.countDown();
@@ -322,20 +324,20 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         // Correct user we should get an OnAuthenticationChanged message
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch account from REST API, and wait for OnAccountChanged event
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch sites from REST API, and wait for onSiteChanged event
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertTrue(mSiteStore.getSitesCount() > 0);
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mSiteStore.getSitesCount() > 0);
     }
 
     private void signOutWPCom() throws InterruptedException {
@@ -344,7 +346,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.SITE_REMOVED;
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private SiteModel fetchSingleJetpackSitePlugins() throws InterruptedException {
@@ -354,7 +356,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(PluginActionBuilder.newFetchSitePluginsAction(site));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         return site;
     }
@@ -375,7 +377,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
                 new DeleteSitePluginPayload(site, plugin)));
         mNextEvent = testEvent;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void installSitePlugin(SiteModel site, String pluginSlug) throws InterruptedException {
@@ -388,7 +390,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
                 new InstallSitePluginPayload(site, pluginSlug)));
         mNextEvent = testEvent;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void deactivatePlugin(SiteModel site, SitePluginModel plugin) throws InterruptedException {
@@ -399,6 +401,6 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin);
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
@@ -56,7 +58,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
     private boolean mCanLoadMorePosts;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -77,9 +79,9 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.POST_REMOVED;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(mPost));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(0, PostSqlUtils.getPostsForSite(sSite, false).size());
+        Assert.assertEquals(0, PostSqlUtils.getPostsForSite(sSite, false).size());
     }
 
     public void testUploadNewPost() throws InterruptedException {
@@ -92,14 +94,14 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertNotSame(0, uploadedPost.getRemotePostId());
-        assertFalse(uploadedPost.isLocalDraft());
+        Assert.assertNotSame(0, uploadedPost.getRemotePostId());
+        Assert.assertFalse(uploadedPost.isLocalDraft());
 
         // The site should automatically assign the post the default category
-        assertFalse(uploadedPost.getCategoryIdList().isEmpty());
+        Assert.assertFalse(uploadedPost.getCategoryIdList().isEmpty());
     }
 
     public void testEditRemotePost() throws InterruptedException {
@@ -120,17 +122,17 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("From testEditingRemotePost", finalPost.getTitle());
+        Assert.assertEquals("From testEditingRemotePost", finalPost.getTitle());
 
         // The post should no longer be flagged as having local changes
-        assertFalse(finalPost.isLocallyChanged());
+        Assert.assertFalse(finalPost.isLocallyChanged());
 
         // The date created should not have been altered by the edits
-        assertFalse(finalPost.getDateCreated().isEmpty());
-        assertEquals(dateCreated, finalPost.getDateCreated());
+        Assert.assertFalse(finalPost.getDateCreated().isEmpty());
+        Assert.assertEquals(dateCreated, finalPost.getDateCreated());
     }
 
     public void testRevertLocallyChangedPost() throws InterruptedException {
@@ -150,11 +152,11 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         PostModel latestPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals(POST_DEFAULT_TITLE, latestPost.getTitle());
-        assertFalse(latestPost.isLocallyChanged());
+        Assert.assertEquals(POST_DEFAULT_TITLE, latestPost.getTitle());
+        Assert.assertFalse(latestPost.isLocallyChanged());
     }
 
     public void testChangeLocalDraft() throws InterruptedException {
@@ -165,9 +167,9 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         Date testStartDate = DateTimeUtils.localDateToUTC(new Date());
 
         // Check local change date is set and before "right now"
-        assertNotNull(mPost.getDateLocallyChanged());
+        Assert.assertNotNull(mPost.getDateLocallyChanged());
         Date postDate1 = DateTimeUtils.dateFromIso8601(mPost.getDateLocallyChanged());
-        assertTrue(testStartDate.after(postDate1));
+        Assert.assertTrue(testStartDate.after(postDate1));
 
         setupPostAttributes();
 
@@ -181,7 +183,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         // Check the locallyChanged date actually changed after the post update
         Date postDate2 = DateTimeUtils.dateFromIso8601(mPost.getDateLocallyChanged());
-        assertTrue(postDate2.after(postDate1));
+        Assert.assertTrue(postDate2.after(postDate1));
 
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
@@ -198,19 +200,19 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         // Check the locallyChanged date actually changed after the post update
         Date postDate3 = DateTimeUtils.dateFromIso8601(mPost.getDateLocallyChanged());
-        assertTrue(postDate3.after(postDate2));
+        Assert.assertTrue(postDate3.after(postDate2));
 
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("From testChangingLocalDraft, redux", mPost.getTitle());
-        assertEquals("Some new content", mPost.getContent());
-        assertEquals(7, mPost.getFeaturedImageId());
-        assertFalse(mPost.isLocallyChanged());
-        assertTrue(mPost.isLocalDraft());
+        Assert.assertEquals("From testChangingLocalDraft, redux", mPost.getTitle());
+        Assert.assertEquals("Some new content", mPost.getContent());
+        Assert.assertEquals(7, mPost.getFeaturedImageId());
+        Assert.assertFalse(mPost.isLocallyChanged());
+        Assert.assertTrue(mPost.isLocalDraft());
     }
 
     public void testMultipleLocalChangesToUploadedPost() throws InterruptedException {
@@ -240,14 +242,14 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("From testMultipleLocalChangesToUploadedPost, redux", mPost.getTitle());
-        assertEquals("Some different content", mPost.getContent());
-        assertEquals(5, mPost.getFeaturedImageId());
-        assertTrue(mPost.isLocallyChanged());
-        assertFalse(mPost.isLocalDraft());
+        Assert.assertEquals("From testMultipleLocalChangesToUploadedPost, redux", mPost.getTitle());
+        Assert.assertEquals("Some different content", mPost.getContent());
+        Assert.assertEquals(5, mPost.getFeaturedImageId());
+        Assert.assertTrue(mPost.isLocallyChanged());
+        Assert.assertFalse(mPost.isLocalDraft());
     }
 
     public void testChangePublishedPostToScheduled() throws InterruptedException {
@@ -268,11 +270,11 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         // The post should no longer be flagged as having local changes
-        assertFalse(finalPost.isLocallyChanged());
+        Assert.assertFalse(finalPost.isLocallyChanged());
 
         // The post should now have a future created date and should have 'future' status
-        assertEquals(futureDate, finalPost.getDateCreated());
-        assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
+        Assert.assertEquals(futureDate, finalPost.getDateCreated());
+        Assert.assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
     }
 
     public void testFetchPosts() throws InterruptedException {
@@ -281,28 +283,28 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(sSite, false)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         int firstFetchPosts = mPostStore.getPostsCountForSite(sSite);
 
         // Dangerous, will fail for a site with no posts
-        assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
-        assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
+        Assert.assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
+        Assert.assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
 
         // Dependent on site having more than NUM_POSTS_TO_REQUEST posts
-        assertTrue(mCanLoadMorePosts);
+        Assert.assertTrue(mCanLoadMorePosts);
 
         mNextEvent = TestEvents.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(sSite, true)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         int currentStoredPosts = mPostStore.getPostsCountForSite(sSite);
 
-        assertTrue(currentStoredPosts > firstFetchPosts);
-        assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
+        Assert.assertTrue(currentStoredPosts > firstFetchPosts);
+        Assert.assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
     }
 
     public void testFetchPages() throws InterruptedException {
@@ -311,13 +313,13 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPagesAction(new FetchPostsPayload(sSite, false)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         int firstFetchPosts = mPostStore.getPagesCountForSite(sSite);
 
         // Dangerous, will fail for a site with no pages
-        assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
-        assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
+        Assert.assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
+        Assert.assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
     }
 
     public void testFullFeaturedPostUpload() throws InterruptedException {
@@ -346,20 +348,20 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("A fully featured post", newPost.getTitle());
-        assertEquals("Some content here! <strong>Bold text</strong>.\r\n\r\nA new paragraph.", newPost.getContent());
-        assertEquals(date, newPost.getDateCreated());
+        Assert.assertEquals("A fully featured post", newPost.getTitle());
+        Assert.assertEquals("Some content here! <strong>Bold text</strong>.\r\n\r\nA new paragraph.", newPost.getContent());
+        Assert.assertEquals(date, newPost.getDateCreated());
 
-        assertTrue(categoryIds.containsAll(newPost.getCategoryIdList())
+        Assert.assertTrue(categoryIds.containsAll(newPost.getCategoryIdList())
                 && newPost.getCategoryIdList().containsAll(categoryIds));
 
-        assertTrue(tags.containsAll(newPost.getTagNameList())
+        Assert.assertTrue(tags.containsAll(newPost.getTagNameList())
                 && newPost.getTagNameList().containsAll(tags));
 
-        assertEquals(featuredImageId, newPost.getFeaturedImageId());
+        Assert.assertEquals(featuredImageId, newPost.getFeaturedImageId());
     }
 
     public void testUploadAndEditPage() throws InterruptedException {
@@ -369,11 +371,11 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         mPost.setContent("Some content here! <strong>Bold text</strong>.");
         mPost.setDateCreated(DateTimeUtils.iso8601UTCFromDate(new Date()));
         uploadPost(mPost);
-        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(sSite));
 
         // We should have one page and no post
-        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(sSite));
+        Assert.assertEquals(0, mPostStore.getPostsCountForSite(sSite));
 
         // Get the current copy of the page from the PostStore
         PostModel newPage = mPostStore.getPostByLocalPostId(mPost.getId());
@@ -384,8 +386,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         uploadPost(newPage);
 
         // We should still have one page and no post
-        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(sSite));
+        Assert.assertEquals(0, mPostStore.getPostsCountForSite(sSite));
     }
 
     public void testFullFeaturedPageUpload() throws InterruptedException {
@@ -405,26 +407,26 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the page from the PostStore
         PostModel newPage = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
 
         // Clear local data
         removeAllPosts();
 
-        assertEquals(0, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(0, WellSqlUtils.getTotalPostsCount());
 
         // Fetch the page
         fetchPost(newPage);
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(sSite));
 
-        assertNotSame(0, newPage.getRemotePostId());
+        Assert.assertNotSame(0, newPage.getRemotePostId());
 
-        assertEquals("A fully featured page", newPage.getTitle());
-        assertEquals("Some content here! <strong>Bold text</strong>.\r\n\r\nA new paragraph.", newPage.getContent());
-        assertEquals(date, newPage.getDateCreated());
+        Assert.assertEquals("A fully featured page", newPage.getTitle());
+        Assert.assertEquals("Some content here! <strong>Bold text</strong>.\r\n\r\nA new paragraph.", newPage.getContent());
+        Assert.assertEquals(date, newPage.getDateCreated());
 
-        assertEquals(0, newPage.getFeaturedImageId()); // The page should upload, but have the featured image stripped
+        Assert.assertEquals(0, newPage.getFeaturedImageId()); // The page should upload, but have the featured image stripped
     }
 
     public void testClearTagsFromPost() throws InterruptedException {
@@ -447,7 +449,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertFalse(newPost.getTagNameList().isEmpty());
+        Assert.assertFalse(newPost.getTagNameList().isEmpty());
 
         newPost.setTagNameList(Collections.<String>emptyList());
         newPost.setIsLocallyChanged(true);
@@ -457,7 +459,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertTrue(finalPost.getTagNameList().isEmpty());
+        Assert.assertTrue(finalPost.getTagNameList().isEmpty());
     }
 
     public void testClearFeaturedImageFromPost() throws InterruptedException {
@@ -474,11 +476,11 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertTrue(newPost.hasFeaturedImage());
-        assertEquals(featuredImageId, newPost.getFeaturedImageId());
+        Assert.assertTrue(newPost.hasFeaturedImage());
+        Assert.assertEquals(featuredImageId, newPost.getFeaturedImageId());
 
         newPost.clearFeaturedImage();
 
@@ -487,10 +489,10 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertFalse(finalPost.hasFeaturedImage());
+        Assert.assertFalse(finalPost.hasFeaturedImage());
     }
 
     public void testAddLocationToRemotePost() throws InterruptedException {
@@ -505,14 +507,14 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("A post with location", mPost.getTitle());
-        assertEquals("Some content", mPost.getContent());
+        Assert.assertEquals("A post with location", mPost.getTitle());
+        Assert.assertEquals("Some content", mPost.getContent());
 
         // The post should not have a location since we never set one
-        assertFalse(mPost.hasLocation());
+        Assert.assertFalse(mPost.hasLocation());
 
         // 2. Modify the post, setting some location data
         mPost.setLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
@@ -524,9 +526,9 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         // The set location should be stored in the remote post
-        assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        Assert.assertTrue(mPost.hasLocation());
+        Assert.assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        Assert.assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
     }
 
     public void testUploadPostWithLocation() throws InterruptedException {
@@ -543,16 +545,16 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("A post with location", mPost.getTitle());
-        assertEquals("Some content", mPost.getContent());
+        Assert.assertEquals("A post with location", mPost.getTitle());
+        Assert.assertEquals("Some content", mPost.getContent());
 
         // The set location should be stored in the remote post
-        assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        Assert.assertTrue(mPost.hasLocation());
+        Assert.assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        Assert.assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
 
         // 2. Modify the post without changing the location data and update
         mPost.setTitle("A new title");
@@ -563,12 +565,12 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals("A new title", mPost.getTitle());
+        Assert.assertEquals("A new title", mPost.getTitle());
 
         // The location data should not have been altered
-        assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        Assert.assertTrue(mPost.hasLocation());
+        Assert.assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        Assert.assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
 
         // 3. Clear location data from the post and update
         mPost.clearLocation();
@@ -580,7 +582,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         // The post should not have a location anymore
-        assertFalse(mPost.hasLocation());
+        Assert.assertFalse(mPost.hasLocation());
     }
 
     public void testDeleteRemotePost() throws InterruptedException {
@@ -596,12 +598,12 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(uploadedPost, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // The post should be removed from the db (regardless of whether it was deleted or just trashed on the server)
-        assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost.getId()));
-        assertEquals(0, WellSqlUtils.getTotalPostsCount());
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost.getId()));
+        Assert.assertEquals(0, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(0, mPostStore.getPostsCountForSite(sSite));
     }
 
     // Error handling tests
@@ -616,7 +618,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testEditInvalidPost() throws InterruptedException {
@@ -643,20 +645,20 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         PostModel persistedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // The locally saved post should still be marked as locally changed, and local changes should be preserved
-        assertEquals("From testEditInvalidPost", persistedPost.getTitle());
-        assertTrue(persistedPost.isLocallyChanged());
+        Assert.assertEquals("From testEditInvalidPost", persistedPost.getTitle());
+        Assert.assertTrue(persistedPost.isLocallyChanged());
 
         // The date created should not have been altered by the edit
-        assertFalse(persistedPost.getDateCreated().isEmpty());
-        assertEquals(dateCreated, persistedPost.getDateCreated());
+        Assert.assertFalse(persistedPost.getDateCreated().isEmpty());
+        Assert.assertEquals(dateCreated, persistedPost.getDateCreated());
     }
 
     public void testDeleteInvalidRemotePost() throws InterruptedException {
@@ -669,7 +671,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(invalidPost, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testFetchPostFromInvalidSite() throws InterruptedException {
@@ -687,7 +689,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, site)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")
@@ -697,13 +699,13 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             AppLog.i(T.API, "OnPostChanged has error: " + event.error.type + " - " + event.error.message);
             if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_POST)) {
-                assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_POST_TYPE)) {
-                assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             } else {
                 throw new AssertionError("Unexpected error with type: " + event.error.type);
@@ -755,23 +757,23 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             AppLog.i(T.API, "OnPostUploaded has error: " + event.error.type + " - " + event.error.message);
             if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_POST)) {
-                assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_POST_TYPE)) {
-                assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             } else {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
             return;
         }
-        assertEquals(TestEvents.POST_UPLOADED, mNextEvent);
-        assertFalse(event.post.isLocalDraft());
-        assertFalse(event.post.isLocallyChanged());
-        assertNotSame(0, event.post.getRemotePostId());
+        Assert.assertEquals(TestEvents.POST_UPLOADED, mNextEvent);
+        Assert.assertFalse(event.post.isLocalDraft());
+        Assert.assertFalse(event.post.isLocallyChanged());
+        Assert.assertNotSame(0, event.post.getRemotePostId());
 
         mCountDownLatch.countDown();
     }
@@ -784,10 +786,10 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
     private PostModel createNewPost() throws InterruptedException {
         PostModel post = mPostStore.instantiatePostModel(sSite, false);
 
-        assertTrue(post.isLocalDraft());
-        assertEquals(0, post.getRemotePostId());
-        assertNotSame(0, post.getId());
-        assertNotSame(0, post.getLocalSiteId());
+        Assert.assertTrue(post.isLocalDraft());
+        Assert.assertEquals(0, post.getRemotePostId());
+        Assert.assertNotSame(0, post.getId());
+        Assert.assertNotSame(0, post.getLocalSiteId());
 
         mPost = post;
         return post;
@@ -800,7 +802,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         RemotePostPayload pushPayload = new RemotePostPayload(post, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchPost(PostModel post) throws InterruptedException {
@@ -809,7 +811,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void savePost(PostModel post) throws InterruptedException {
@@ -818,7 +820,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void removeAllPosts() throws InterruptedException {
@@ -827,6 +829,6 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(PostActionBuilder.newRemoveAllPostsAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
@@ -84,14 +86,14 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertNotSame(0, uploadedPost.getRemotePostId());
-        assertFalse(uploadedPost.isLocalDraft());
+        Assert.assertNotSame(0, uploadedPost.getRemotePostId());
+        Assert.assertFalse(uploadedPost.isLocalDraft());
 
         // The site should automatically assign the post the default category
-        assertFalse(uploadedPost.getCategoryIdList().isEmpty());
+        Assert.assertFalse(uploadedPost.getCategoryIdList().isEmpty());
     }
 
     public void testEditRemotePost() throws InterruptedException {
@@ -112,17 +114,17 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("From testEditingRemotePost", finalPost.getTitle());
+        Assert.assertEquals("From testEditingRemotePost", finalPost.getTitle());
 
         // The post should no longer be flagged as having local changes
-        assertFalse(finalPost.isLocallyChanged());
+        Assert.assertFalse(finalPost.isLocallyChanged());
 
         // The date created should not have been altered by the edits
-        assertFalse(finalPost.getDateCreated().isEmpty());
-        assertEquals(dateCreated, finalPost.getDateCreated());
+        Assert.assertFalse(finalPost.getDateCreated().isEmpty());
+        Assert.assertEquals(dateCreated, finalPost.getDateCreated());
     }
 
     public void testRevertLocallyChangedPost() throws InterruptedException {
@@ -142,11 +144,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         PostModel latestPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals(POST_DEFAULT_TITLE, latestPost.getTitle());
-        assertFalse(latestPost.isLocallyChanged());
+        Assert.assertEquals(POST_DEFAULT_TITLE, latestPost.getTitle());
+        Assert.assertFalse(latestPost.isLocallyChanged());
     }
 
     public void testChangeLocalDraft() throws InterruptedException {
@@ -157,9 +159,9 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         Date testStartDate = DateTimeUtils.localDateToUTC(new Date());
 
         // Check local change date is set and before "right now"
-        assertNotNull(mPost.getDateLocallyChanged());
+        Assert.assertNotNull(mPost.getDateLocallyChanged());
         Date postDate1 = DateTimeUtils.dateFromIso8601(mPost.getDateLocallyChanged());
-        assertTrue(testStartDate.after(postDate1));
+        Assert.assertTrue(testStartDate.after(postDate1));
 
         setupPostAttributes();
 
@@ -173,7 +175,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Check the locallyChanged date actually changed after the post update
         Date postDate2 = DateTimeUtils.dateFromIso8601(mPost.getDateLocallyChanged());
-        assertTrue(postDate2.after(postDate1));
+        Assert.assertTrue(postDate2.after(postDate1));
 
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
@@ -190,19 +192,19 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Check the locallyChanged date actually changed after the post update
         Date postDate3 = DateTimeUtils.dateFromIso8601(mPost.getDateLocallyChanged());
-        assertTrue(postDate3.after(postDate2));
+        Assert.assertTrue(postDate3.after(postDate2));
 
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("From testChangingLocalDraft, redux", mPost.getTitle());
-        assertEquals("Some new content", mPost.getContent());
-        assertEquals(7, mPost.getFeaturedImageId());
-        assertFalse(mPost.isLocallyChanged());
-        assertTrue(mPost.isLocalDraft());
+        Assert.assertEquals("From testChangingLocalDraft, redux", mPost.getTitle());
+        Assert.assertEquals("Some new content", mPost.getContent());
+        Assert.assertEquals(7, mPost.getFeaturedImageId());
+        Assert.assertFalse(mPost.isLocallyChanged());
+        Assert.assertTrue(mPost.isLocalDraft());
     }
 
     public void testMultipleLocalChangesToUploadedPost() throws InterruptedException {
@@ -232,14 +234,14 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("From testMultipleLocalChangesToUploadedPost, redux", mPost.getTitle());
-        assertEquals("Some different content", mPost.getContent());
-        assertEquals(5, mPost.getFeaturedImageId());
-        assertTrue(mPost.isLocallyChanged());
-        assertFalse(mPost.isLocalDraft());
+        Assert.assertEquals("From testMultipleLocalChangesToUploadedPost, redux", mPost.getTitle());
+        Assert.assertEquals("Some different content", mPost.getContent());
+        Assert.assertEquals(5, mPost.getFeaturedImageId());
+        Assert.assertTrue(mPost.isLocallyChanged());
+        Assert.assertFalse(mPost.isLocalDraft());
     }
 
     public void testChangePublishedPostToScheduled() throws InterruptedException {
@@ -260,11 +262,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         // The post should no longer be flagged as having local changes
-        assertFalse(finalPost.isLocallyChanged());
+        Assert.assertFalse(finalPost.isLocallyChanged());
 
         // The post should now have a future created date and should have 'future' status
-        assertEquals(futureDate, finalPost.getDateCreated());
-        assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
+        Assert.assertEquals(futureDate, finalPost.getDateCreated());
+        Assert.assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
     }
 
     public void testFetchPosts() throws InterruptedException {
@@ -273,28 +275,28 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(sSite, false)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         int firstFetchPosts = mPostStore.getPostsCountForSite(sSite);
 
         // Dangerous, will fail for a site with no posts
-        assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
-        assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
+        Assert.assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
+        Assert.assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
 
         // Dependent on site having more than NUM_POSTS_TO_REQUEST posts
-        assertTrue(mCanLoadMorePosts);
+        Assert.assertTrue(mCanLoadMorePosts);
 
         mNextEvent = TestEvents.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(sSite, true)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         int currentStoredPosts = mPostStore.getPostsCountForSite(sSite);
 
-        assertTrue(currentStoredPosts > firstFetchPosts);
-        assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
+        Assert.assertTrue(currentStoredPosts > firstFetchPosts);
+        Assert.assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
     }
 
     public void testFetchPages() throws InterruptedException {
@@ -303,13 +305,13 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPagesAction(new FetchPostsPayload(sSite, false)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         int firstFetchPosts = mPostStore.getPagesCountForSite(sSite);
 
         // Dangerous, will fail for a site with no pages
-        assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
-        assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
+        Assert.assertTrue(firstFetchPosts > 0 && firstFetchPosts <= PostStore.NUM_POSTS_PER_FETCH);
+        Assert.assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
     }
 
     public void testFullFeaturedPostUpload() throws InterruptedException {
@@ -338,20 +340,20 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("A fully featured post", newPost.getTitle());
-        assertEquals("Some content here! <strong>Bold text</strong>.", newPost.getContent());
-        assertEquals(date, newPost.getDateCreated());
+        Assert.assertEquals("A fully featured post", newPost.getTitle());
+        Assert.assertEquals("Some content here! <strong>Bold text</strong>.", newPost.getContent());
+        Assert.assertEquals(date, newPost.getDateCreated());
 
-        assertTrue(categoryIds.containsAll(newPost.getCategoryIdList())
+        Assert.assertTrue(categoryIds.containsAll(newPost.getCategoryIdList())
                 && newPost.getCategoryIdList().containsAll(categoryIds));
 
-        assertTrue(tags.containsAll(newPost.getTagNameList())
+        Assert.assertTrue(tags.containsAll(newPost.getTagNameList())
                 && newPost.getTagNameList().containsAll(tags));
 
-        assertEquals(featuredImageId, newPost.getFeaturedImageId());
+        Assert.assertEquals(featuredImageId, newPost.getFeaturedImageId());
     }
 
     public void testUploadAndEditPage() throws InterruptedException {
@@ -361,11 +363,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mPost.setContent("Some content here! <strong>Bold text</strong>.");
         mPost.setDateCreated(DateTimeUtils.iso8601UTCFromDate(new Date()));
         uploadPost(mPost);
-        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(sSite));
 
         // We should have one page and no post
-        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(sSite));
+        Assert.assertEquals(0, mPostStore.getPostsCountForSite(sSite));
 
         // Get the current copy of the page from the PostStore
         PostModel newPage = mPostStore.getPostByLocalPostId(mPost.getId());
@@ -376,8 +378,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadPost(newPage);
 
         // We should still have one page and no post
-        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(sSite));
+        Assert.assertEquals(0, mPostStore.getPostsCountForSite(sSite));
     }
 
     public void testFullFeaturedPageUpload() throws InterruptedException {
@@ -394,24 +396,24 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Get the current copy of the page from the PostStore
         PostModel newPage = mPostStore.getPostByLocalPostId(mPost.getId());
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
 
         // Clear local data
         removeAllPosts();
 
-        assertEquals(0, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(0, WellSqlUtils.getTotalPostsCount());
 
         // Fetch the page
         fetchPost(newPage);
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPagesCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(sSite));
 
-        assertNotSame(0, newPage.getRemotePostId());
+        Assert.assertNotSame(0, newPage.getRemotePostId());
 
-        assertEquals("A fully featured page", newPage.getTitle());
-        assertEquals("Some content here! <strong>Bold text</strong>.", newPage.getContent());
-        assertEquals(date, newPage.getDateCreated());
+        Assert.assertEquals("A fully featured page", newPage.getTitle());
+        Assert.assertEquals("Some content here! <strong>Bold text</strong>.", newPage.getContent());
+        Assert.assertEquals(date, newPage.getDateCreated());
     }
 
     public void testClearTagsFromPost() throws InterruptedException {
@@ -434,7 +436,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertFalse(newPost.getTagNameList().isEmpty());
+        Assert.assertFalse(newPost.getTagNameList().isEmpty());
 
         newPost.setTagNameList(Collections.<String>emptyList());
         newPost.setIsLocallyChanged(true);
@@ -444,7 +446,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertTrue(finalPost.getTagNameList().isEmpty());
+        Assert.assertTrue(finalPost.getTagNameList().isEmpty());
     }
 
     public void testClearFeaturedImageFromPost() throws InterruptedException {
@@ -461,11 +463,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         PostModel newPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertTrue(newPost.hasFeaturedImage());
-        assertEquals(featuredImageId, newPost.getFeaturedImageId());
+        Assert.assertTrue(newPost.hasFeaturedImage());
+        Assert.assertEquals(featuredImageId, newPost.getFeaturedImageId());
 
         newPost.clearFeaturedImage();
 
@@ -474,10 +476,10 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         PostModel finalPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertFalse(finalPost.hasFeaturedImage());
+        Assert.assertFalse(finalPost.hasFeaturedImage());
     }
 
     public void testAddLocationToRemotePost() throws InterruptedException {
@@ -492,14 +494,14 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("A post with location", mPost.getTitle());
-        assertEquals("Some content", mPost.getContent());
+        Assert.assertEquals("A post with location", mPost.getTitle());
+        Assert.assertEquals("Some content", mPost.getContent());
 
         // The post should not have a location since we never set one
-        assertFalse(mPost.hasLocation());
+        Assert.assertFalse(mPost.hasLocation());
 
         // 2. Modify the post, setting some location data
         mPost.setLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE);
@@ -511,9 +513,9 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         // The set location should be stored in the remote post
-        assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        Assert.assertTrue(mPost.hasLocation());
+        Assert.assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        Assert.assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
     }
 
     public void testUploadPostWithLocation() throws InterruptedException {
@@ -530,16 +532,16 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
-        assertEquals("A post with location", mPost.getTitle());
-        assertEquals("Some content", mPost.getContent());
+        Assert.assertEquals("A post with location", mPost.getTitle());
+        Assert.assertEquals("Some content", mPost.getContent());
 
         // The set location should be stored in the remote post
-        assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        Assert.assertTrue(mPost.hasLocation());
+        Assert.assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        Assert.assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
 
         // 2. Modify the post without changing the location data and update
         mPost.setTitle("A new title");
@@ -550,12 +552,12 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Get the current copy of the post from the PostStore
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals("A new title", mPost.getTitle());
+        Assert.assertEquals("A new title", mPost.getTitle());
 
         // The location data should not have been altered
-        assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        Assert.assertTrue(mPost.hasLocation());
+        Assert.assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
+        Assert.assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
 
         // 3. Clear location data from the post and update
         mPost.clearLocation();
@@ -567,7 +569,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         // The post should not have a location anymore
-        assertFalse(mPost.hasLocation());
+        Assert.assertFalse(mPost.hasLocation());
     }
 
     public void testDeleteRemotePost() throws InterruptedException {
@@ -583,12 +585,12 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(uploadedPost, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // The post should be removed from the db (regardless of whether it was deleted or just trashed on the server)
-        assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost.getId()));
-        assertEquals(0, WellSqlUtils.getTotalPostsCount());
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost.getId()));
+        Assert.assertEquals(0, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(0, mPostStore.getPostsCountForSite(sSite));
     }
 
     // Error handling tests
@@ -602,11 +604,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // TODO: This will fail for non-English sites - we should be checking for an UNKNOWN_POST error instead
         // (once we make the fixes needed for PostXMLRPCClient to correctly identify post errors)
-        assertEquals("Invalid post ID.", mLastPostError.message);
+        Assert.assertEquals("Invalid post ID.", mLastPostError.message);
     }
 
     public void testEditInvalidPost() throws InterruptedException {
@@ -633,24 +635,24 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         PostModel persistedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // The locally saved post should still be marked as locally changed, and local changes should be preserved
-        assertEquals("From testEditInvalidPost", persistedPost.getTitle());
-        assertTrue(persistedPost.isLocallyChanged());
+        Assert.assertEquals("From testEditInvalidPost", persistedPost.getTitle());
+        Assert.assertTrue(persistedPost.isLocallyChanged());
 
         // The date created should not have been altered by the edit
-        assertFalse(persistedPost.getDateCreated().isEmpty());
-        assertEquals(dateCreated, persistedPost.getDateCreated());
+        Assert.assertFalse(persistedPost.getDateCreated().isEmpty());
+        Assert.assertEquals(dateCreated, persistedPost.getDateCreated());
 
         // TODO: This will fail for non-English sites - we should be checking for an UNKNOWN_POST error instead
         // (once we make the fixes needed for PostXMLRPCClient to correctly identify post errors)
-        assertEquals("Invalid post ID.", mLastPostError.message);
+        Assert.assertEquals("Invalid post ID.", mLastPostError.message);
     }
 
     public void testDeleteInvalidRemotePost() throws InterruptedException {
@@ -662,11 +664,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(invalidPost, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // TODO: This will fail for non-English sites - we should be checking for an UNKNOWN_POST error instead
         // (once we make the fixes needed for PostXMLRPCClient to correctly identify post errors)
-        assertEquals("Invalid post ID.", mLastPostError.message);
+        Assert.assertEquals("Invalid post ID.", mLastPostError.message);
     }
 
     public void testCreateNewPostWithInvalidCategory() throws InterruptedException {
@@ -685,11 +687,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemotePostPayload pushPayload = new RemotePostPayload(mPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // TODO: This will fail for non-English sites - we should be checking for an UNKNOWN_TERM error instead
         // (once we make the fixes needed for PostXMLRPCClient to correctly identify post errors)
-        assertEquals("Invalid term ID.", mLastPostError.message);
+        Assert.assertEquals("Invalid term ID.", mLastPostError.message);
     }
 
     public void testEditPostWithInvalidTerm() throws InterruptedException {
@@ -719,24 +721,24 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         PostModel persistedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // The locally saved post should still be marked as locally changed, and local changes should be preserved
-        assertEquals("From testEditInvalidPost", persistedPost.getTitle());
-        assertTrue(persistedPost.isLocallyChanged());
+        Assert.assertEquals("From testEditInvalidPost", persistedPost.getTitle());
+        Assert.assertTrue(persistedPost.isLocallyChanged());
 
         // The date created should not have been altered by the edit
-        assertFalse(persistedPost.getDateCreated().isEmpty());
-        assertEquals(dateCreated, persistedPost.getDateCreated());
+        Assert.assertFalse(persistedPost.getDateCreated().isEmpty());
+        Assert.assertEquals(dateCreated, persistedPost.getDateCreated());
 
         // TODO: This will fail for non-English sites - we should be checking for an UNKNOWN_TERM error instead
         // (once we make the fixes needed for PostXMLRPCClient to correctly identify post errors)
-        assertEquals("Invalid term ID.", mLastPostError.message);
+        Assert.assertEquals("Invalid term ID.", mLastPostError.message);
     }
 
     public void testCreateNewPostWithInvalidFeaturedImage() throws InterruptedException {
@@ -752,11 +754,11 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemotePostPayload pushPayload = new RemotePostPayload(mPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // TODO: This will fail for non-English sites - we should be checking for an UNKNOWN_ATTACHMENT error instead
         // (once we make the fixes needed for PostXMLRPCClient to correctly identify post errors)
-        assertEquals("Invalid attachment ID.", mLastPostError.message);
+        Assert.assertEquals("Invalid attachment ID.", mLastPostError.message);
     }
 
     public void testEditPostWithInvalidFeaturedImage() throws InterruptedException {
@@ -783,24 +785,24 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemotePostPayload pushPayload = new RemotePostPayload(uploadedPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         PostModel persistedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // The locally saved post should still be marked as locally changed, and local changes should be preserved
-        assertEquals("From testEditInvalidPost", persistedPost.getTitle());
-        assertTrue(persistedPost.isLocallyChanged());
+        Assert.assertEquals("From testEditInvalidPost", persistedPost.getTitle());
+        Assert.assertTrue(persistedPost.isLocallyChanged());
 
         // The date created should not have been altered by the edit
-        assertFalse(persistedPost.getDateCreated().isEmpty());
-        assertEquals(dateCreated, persistedPost.getDateCreated());
+        Assert.assertFalse(persistedPost.getDateCreated().isEmpty());
+        Assert.assertEquals(dateCreated, persistedPost.getDateCreated());
 
         // TODO: This will fail for non-English sites - we should be checking for an UNKNOWN_ATTACHMENT error instead
         // (once we make the fixes needed for PostXMLRPCClient to correctly identify post errors)
-        assertEquals("Invalid attachment ID.", mLastPostError.message);
+        Assert.assertEquals("Invalid attachment ID.", mLastPostError.message);
     }
 
     public void testFetchPostBadCredentials() throws InterruptedException {
@@ -819,9 +821,9 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, badSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("Incorrect username or password.", mLastPostError.message);
+        Assert.assertEquals("Incorrect username or password.", mLastPostError.message);
     }
 
     public void testFetchPostBadUrl() throws InterruptedException {
@@ -840,7 +842,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, badSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     // TODO: Test: Upload a page to a custom site that has pages disabled (should get a 403 'Invalid post type')
@@ -859,7 +861,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(site)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testCreatePostAsSubscriber() throws InterruptedException {
@@ -884,19 +886,19 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemotePostPayload pushPayload = new RemotePostPayload(mPost, subscriberSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals("Sorry, you are not allowed to post on this site.", mLastPostError.message);
+        Assert.assertEquals("Sorry, you are not allowed to post on this site.", mLastPostError.message);
 
         PostModel failedUploadPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         // Post should still exist locally, but not marked as uploaded
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(subscriberSite));
-        assertEquals(0, mPostStore.getUploadedPostsCountForSite(subscriberSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(subscriberSite));
+        Assert.assertEquals(0, mPostStore.getUploadedPostsCountForSite(subscriberSite));
 
-        assertEquals(0, failedUploadPost.getRemotePostId());
-        assertTrue(failedUploadPost.isLocalDraft());
+        Assert.assertEquals(0, failedUploadPost.getRemotePostId());
+        Assert.assertTrue(failedUploadPost.isLocalDraft());
     }
 
     @SuppressWarnings("unused")
@@ -907,16 +909,16 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
             AppLog.i(T.API, "OnPostChanged has error: " + event.error.type + " - " + event.error.message);
             mLastPostError = event.error;
             if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_POST)) {
-                assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_POST_TYPE)) {
-                assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
-                assertEquals(PostErrorType.UNAUTHORIZED, event.error.type);
+                Assert.assertEquals(PostErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             } else {
                 throw new AssertionError("Unexpected error with type: " + event.error.type);
@@ -964,26 +966,26 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
             AppLog.i(T.API, "OnPostUploaded has error: " + event.error.type + " - " + event.error.message);
             mLastPostError = event.error;
             if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_POST)) {
-                assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_POST_TYPE)) {
-                assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST_TYPE, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
-                assertEquals(PostErrorType.UNAUTHORIZED, event.error.type);
+                Assert.assertEquals(PostErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(PostErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
             } else {
                 throw new AssertionError("Unexpected error with type: " + event.error.type);
             }
             return;
         }
-        assertEquals(TestEvents.POST_UPLOADED, mNextEvent);
-        assertFalse(event.post.isLocalDraft());
-        assertFalse(event.post.isLocallyChanged());
-        assertNotSame(0, event.post.getRemotePostId());
+        Assert.assertEquals(TestEvents.POST_UPLOADED, mNextEvent);
+        Assert.assertFalse(event.post.isLocalDraft());
+        Assert.assertFalse(event.post.isLocallyChanged());
+        Assert.assertNotSame(0, event.post.getRemotePostId());
 
         mCountDownLatch.countDown();
     }
@@ -1003,10 +1005,10 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
         PostModel post = mPostStore.instantiatePostModel(site, false);
 
-        assertTrue(post.isLocalDraft());
-        assertEquals(0, post.getRemotePostId());
-        assertNotSame(0, post.getId());
-        assertNotSame(0, post.getLocalSiteId());
+        Assert.assertTrue(post.isLocalDraft());
+        Assert.assertEquals(0, post.getRemotePostId());
+        Assert.assertNotSame(0, post.getId());
+        Assert.assertNotSame(0, post.getLocalSiteId());
 
         mPost = post;
         return post;
@@ -1019,7 +1021,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemotePostPayload pushPayload = new RemotePostPayload(post, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchPost(PostModel post) throws InterruptedException {
@@ -1028,7 +1030,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(new RemotePostPayload(post, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void savePost(PostModel post) throws InterruptedException {
@@ -1037,7 +1039,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void removeAllPosts() throws InterruptedException {
@@ -1046,6 +1048,6 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(PostActionBuilder.newRemoveAllPostsAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.release;
 
 import android.text.TextUtils;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -56,52 +58,52 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
 
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
-        assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         SiteModel site = mSiteStore.getSites().get(0);
-        assertFalse(TextUtils.isEmpty(site.getJetpackVersion()));
+        Assert.assertFalse(TextUtils.isEmpty(site.getJetpackVersion()));
 
         signOutWPCom();
 
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
-        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
     }
 
     public void testWPComSingleJetpackSiteFetch() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_ONE_JETPACK,
                 BuildConfig.TEST_WPCOM_PASSWORD_ONE_JETPACK);
 
-        assertEquals(2, mSiteStore.getSitesCount());
-        assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
-        assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(2, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         signOutWPCom();
 
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testWPComMultipleJetpackSiteFetch() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_MULTIPLE_JETPACK,
                 BuildConfig.TEST_WPCOM_PASSWORD_MULTIPLE_JETPACK);
 
-        assertEquals(3, mSiteStore.getSitesCount());
-        assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(3, mSiteStore.getSitesAccessedViaWPComRestCount());
-        assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(3, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(3, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         signOutWPCom();
 
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testWPComJetpackMultisiteSiteFetch() throws InterruptedException {
@@ -111,15 +113,15 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         int sitesCount = mSiteStore.getSitesCount();
 
         // Only one non-Jetpack site exists, all the other fetched sites should be Jetpack sites
-        assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(sitesCount, mSiteStore.getSitesAccessedViaWPComRestCount());
-        assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(1, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(sitesCount, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(0, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
         signOutWPCom();
 
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testXMLRPCNonJetpackSiteFetch() throws InterruptedException {
@@ -131,16 +133,16 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         // Fetch site details (including Jetpack status)
         fetchSite(mSiteStore.getSites().get(0));
 
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
-        assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         SiteModel site = mSiteStore.getSites().get(0);
 
-        assertFalse(site.isJetpackConnected());
-        assertFalse(site.isJetpackInstalled());
-        assertEquals(0, site.getSiteId());
+        Assert.assertFalse(site.isJetpackConnected());
+        Assert.assertFalse(site.isJetpackInstalled());
+        Assert.assertEquals(0, site.getSiteId());
     }
 
     public void testXMLRPCJetpackConnectedSiteFetch() throws InterruptedException {
@@ -152,15 +154,15 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         // Fetch site details (including Jetpack status)
         fetchSite(mSiteStore.getSites().get(0));
 
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
-        assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         SiteModel site = mSiteStore.getSites().get(0);
 
-        assertTrue(site.isJetpackConnected());
-        assertNotSame(0, site.getSiteId());
+        Assert.assertTrue(site.isJetpackConnected());
+        Assert.assertNotSame(0, site.getSiteId());
     }
 
     public void testXMLRPCJetpackDisconnectedSiteFetch() throws InterruptedException {
@@ -172,16 +174,16 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         // Fetch site details (including Jetpack status)
         fetchSite(mSiteStore.getSites().get(0));
 
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
-        assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         SiteModel site = mSiteStore.getSites().get(0);
 
-        assertFalse(site.isJetpackConnected());
-        assertTrue(site.isJetpackInstalled());
-        assertEquals(0, site.getSiteId());
+        Assert.assertFalse(site.isJetpackConnected());
+        Assert.assertTrue(site.isJetpackInstalled());
+        Assert.assertEquals(0, site.getSiteId());
     }
 
     public void testWPComJetpackToXMLRPCDuplicateSiteFetch() throws InterruptedException {
@@ -189,10 +191,10 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
 
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         // Attempt to add the same Jetpack site as a self-hosted site
         RefreshSitesXMLRPCPayload xmlrpcPayload = new RefreshSitesXMLRPCPayload();
@@ -206,19 +208,19 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(xmlrpcPayload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Expect no DB changes
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         signOutWPCom();
 
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testXMLRPCJetpackToWPComDuplicateSiteFetch() throws InterruptedException {
@@ -230,30 +232,30 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         // Fetch site details (including Jetpack status)
         fetchSite(mSiteStore.getSites().get(0));
 
-        assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
         // We added the site from an XMLRPC call, but it's a Jetpack site accessible via the .com REST API but accessed
         // via XMLRPC (ie. not pull from the REST call).
-        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
         // not considered a .com site
-        assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
         // accessed via XMLRPC, that's why we consider it a "self hosted site"
-        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         // Authenticate as WP.com user with a single site, which is the Jetpack site we already added as self-hosted
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
 
         // We expect the XML-RPC Jetpack site to be 'upgraded' to a WPcom Jetpack site
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
 
         signOutWPCom();
 
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
     public void testWPComToXMLRPCJetpackDifferentAccountsSiteFetch() throws InterruptedException {
@@ -266,8 +268,8 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         int accessedViaWPComRestSiteCount = mSiteStore.getSitesAccessedViaWPComRestCount();
         int selfhostedSiteCount = mSiteStore.getSitesAccessedViaXMLRPCCount();
 
-        assertEquals(0, selfhostedSiteCount);
-        assertEquals(totalSiteCount, accessedViaWPComRestSiteCount);
+        Assert.assertEquals(0, selfhostedSiteCount);
+        Assert.assertEquals(totalSiteCount, accessedViaWPComRestSiteCount);
 
         // Add a Jetpack-connected site as self-hosted (connected to a different WP.com account than the one above)
         fetchSitesXMLRPC(BuildConfig.TEST_WPORG_USERNAME_SINGLE_JETPACK_ONLY,
@@ -278,26 +280,26 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         SiteModel selfHostedSite = mSiteStore.getSitesAccessedViaXMLRPC().get(0);
         fetchSite(selfHostedSite);
 
-        assertEquals(totalSiteCount + 1, mSiteStore.getSitesCount());
+        Assert.assertEquals(totalSiteCount + 1, mSiteStore.getSitesCount());
         // The site is accessible via WPCom (Jetpack connected) but accessed via XMLRPC, so previous
         // accessedViaWPComRestSiteCount must be the same
-        assertEquals(accessedViaWPComRestSiteCount, mSiteStore.getSitesAccessedViaWPComRestCount());
-        assertEquals(selfhostedSiteCount + 1, mSiteStore.getSitesAccessedViaXMLRPCCount());
-        assertEquals(wpComSiteCount, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(accessedViaWPComRestSiteCount, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(selfhostedSiteCount + 1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(wpComSiteCount, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
 
-        assertTrue(selfHostedSite.isJetpackConnected());
-        assertFalse(selfHostedSite.isWPCom());
+        Assert.assertTrue(selfHostedSite.isJetpackConnected());
+        Assert.assertFalse(selfHostedSite.isWPCom());
 
         signOutWPCom();
 
         // Expect all WP.com sites to be removed
-        assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(0, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(0, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         // Site accessed via XMLRPC should not be removed
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
     }
 
     @SuppressWarnings("unused")
@@ -325,14 +327,14 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
         if (event.isError()) {
             if (mNextEvent.equals(TestEvents.ERROR_DUPLICATE_SITE)) {
-                assertEquals(SiteErrorType.DUPLICATE_SITE, event.error.type);
+                Assert.assertEquals(SiteErrorType.DUPLICATE_SITE, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mSiteStore.hasSite());
-        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -343,7 +345,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
+        Assert.assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -355,20 +357,20 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         // Correct user we should get an OnAuthenticationChanged message
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch account from REST API, and wait for OnAccountChanged event
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch sites from REST API, and wait for onSiteChanged event
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertTrue(mSiteStore.getSitesCount() > 0);
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mSiteStore.getSitesCount() > 0);
     }
 
     private void signOutWPCom() throws InterruptedException {
@@ -377,7 +379,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.SITE_REMOVED;
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchSitesXMLRPC(String username, String password, String endpointUrl)
@@ -392,7 +394,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchSite(SiteModel site) throws InterruptedException {
@@ -401,6 +403,6 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
 
         mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -16,9 +18,9 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
-import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
+import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnWPComSiteFetched;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.util.AppLog;
@@ -73,7 +75,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mExpectedRowsAffected = mSiteStore.getSitesCount();
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testFetchPostFormats() throws InterruptedException {
@@ -87,11 +89,11 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mDispatcher.dispatch(SiteActionBuilder.newFetchPostFormatsAction(firstSite));
         mNextEvent = TestEvents.POST_FORMATS_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Test fetched Post Formats
         List<PostFormatModel> postFormats = mSiteStore.getPostFormats(firstSite);
-        assertNotSame(0, postFormats.size());
+        Assert.assertNotSame(0, postFormats.size());
     }
 
     public void testFetchUserRoles() throws InterruptedException {
@@ -105,11 +107,11 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mDispatcher.dispatch(SiteActionBuilder.newFetchUserRolesAction(firstSite));
         mNextEvent = TestEvents.USER_ROLES_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Test fetched user roles
         List<RoleModel> roles = mSiteStore.getUserRoles(firstSite);
-        assertNotSame(0, roles.size());
+        Assert.assertNotSame(0, roles.size());
     }
 
     public void testFetchConnectSiteInfo() throws InterruptedException {
@@ -117,13 +119,13 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mDispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(site));
         mNextEvent = TestEvents.FETCHED_CONNECT_SITE_INFO;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         site = "";
         mDispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(site));
         mNextEvent = TestEvents.ERROR_INVALID_SITE;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testFetchWPComSiteByUrl() throws InterruptedException {
@@ -131,33 +133,33 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
         mNextEvent = TestEvents.FETCHED_WPCOM_SITE_BY_URL;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Sites in subfolders should be handled and return a response distinct from their host
         site = "http://en.blog.wordpress.com/nonexistentsubdomain";
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
         mNextEvent = TestEvents.ERROR_UNKNOWN_SITE;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // A Jetpack-connected site in a subfolder should have a successful response
         site = BuildConfig.TEST_WPORG_URL_JETPACK_SUBFOLDER;
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
         mNextEvent = TestEvents.FETCHED_WPCOM_SITE_BY_URL;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         site = "http://definitelynotawpcomsite.impossible";
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
         mNextEvent = TestEvents.ERROR_UNKNOWN_SITE;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         site = "";
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
         mNextEvent = TestEvents.ERROR_INVALID_SITE;
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testWPComSiteFetchAndLogoutCollision() throws InterruptedException {
@@ -173,14 +175,14 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
 
         // Wait for OnAuthenticationChanged, OnAccountChanged and OnSiteRemoved from logout/site removal
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Wait for OnSiteChanged event from fetch
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(0, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getSitesCount());
     }
 
     @SuppressWarnings("unused")
@@ -211,9 +213,9 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         if (mSiteStore.getSitesCount() > 0) {
-            assertTrue(mSiteStore.hasWPComSite());
+            Assert.assertTrue(mSiteStore.hasWPComSite());
         }
-        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        Assert.assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -224,10 +226,10 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(mExpectedRowsAffected, event.mRowsAffected);
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasWPComSite());
-        assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
+        Assert.assertEquals(mExpectedRowsAffected, event.mRowsAffected);
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasWPComSite());
+        Assert.assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -237,7 +239,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.POST_FORMATS_CHANGED, mNextEvent);
+        Assert.assertEquals(TestEvents.POST_FORMATS_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -247,7 +249,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.USER_ROLES_CHANGED, mNextEvent);
+        Assert.assertEquals(TestEvents.USER_ROLES_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -256,13 +258,13 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     public void onFetchedConnectSiteInfo(OnConnectSiteInfoChecked event) {
         if (event.isError()) {
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_SITE)) {
-                assertEquals(SiteErrorType.INVALID_SITE, event.error.type);
+                Assert.assertEquals(SiteErrorType.INVALID_SITE, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }
             throw new AssertionError("Unexpected error occured with type: " + event.error.type);
         }
-        assertEquals(TestEvents.FETCHED_CONNECT_SITE_INFO, mNextEvent);
+        Assert.assertEquals(TestEvents.FETCHED_CONNECT_SITE_INFO, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -271,17 +273,17 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     public void onWPComSiteFetched(OnWPComSiteFetched event) {
         if (event.isError()) {
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_SITE)) {
-                assertEquals(SiteErrorType.INVALID_SITE, event.error.type);
+                Assert.assertEquals(SiteErrorType.INVALID_SITE, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNKNOWN_SITE)) {
-                assertEquals(SiteErrorType.UNKNOWN_SITE, event.error.type);
+                Assert.assertEquals(SiteErrorType.UNKNOWN_SITE, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.FETCHED_WPCOM_SITE_BY_URL, mNextEvent);
+        Assert.assertEquals(TestEvents.FETCHED_WPCOM_SITE_BY_URL, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -293,19 +295,19 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         // Correct user we should get an OnAuthenticationChanged message
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch account from REST API, and wait for OnAccountChanged event
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch sites from REST API, and wait for OnSiteChanged event
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertTrue(mSiteStore.getSitesCount() > 0);
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mSiteStore.getSitesCount() > 0);
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -104,7 +106,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
 
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
         // Wait for a network response / onAuthenticationChanged error event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         // Add an exception for the last certificate
         mMemorizingTrustManager.storeLastFailure();
         // Retry
@@ -112,7 +114,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
         // Wait for a network response
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         mMemorizingTrustManager.clearLocalTrustStore();
     }
@@ -130,7 +132,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
 
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
         // Wait for a network response / onAuthenticationChanged error event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         // Set known HTTP Auth credentials
         mHTTPAuthManager.addHTTPAuthCredentials(BuildConfig.TEST_WPORG_HTTPAUTH_USERNAME_SH_HTTPAUTH,
                 BuildConfig.TEST_WPORG_HTTPAUTH_PASSWORD_SH_HTTPAUTH, BuildConfig.TEST_WPORG_URL_SH_HTTPAUTH_ENDPOINT,
@@ -140,7 +142,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
         // Wait for a network response
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testXMLRPCHTTPAuthFetchSites2() throws InterruptedException {
@@ -158,7 +160,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         // Retry to fetch sites,we expect a site refresh
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
         // Wait for a network response
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testXMLRPCFetchAndDeleteSite() throws InterruptedException {
@@ -171,7 +173,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         SiteModel selfHostedSite = mSiteStore.getSitesAccessedViaXMLRPC().get(0);
         mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(selfHostedSite));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testXMLRPCFetchMultipleSites() throws InterruptedException {
@@ -184,14 +186,14 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
                 BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
 
         // The second fetch for the same site should have replaced the first site
-        assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
 
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_VALID_SSL,
                 BuildConfig.TEST_WPORG_URL_SH_VALID_SSL_ENDPOINT);
 
         // We should have two unique sites
-        assertEquals(2, mSiteStore.getSitesCount());
+        Assert.assertEquals(2, mSiteStore.getSitesCount());
     }
 
     public void testFetchPostFormats() throws InterruptedException {
@@ -206,12 +208,12 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TestEvents.POST_FORMATS_CHANGED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchPostFormatsAction(firstSite));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
         // Test fetched Post Formats
         List<PostFormatModel> postFormats = mSiteStore.getPostFormats(firstSite);
-        assertEquals(10, postFormats.size());
+        Assert.assertEquals(10, postFormats.size());
     }
 
     @SuppressWarnings("unused")
@@ -222,19 +224,19 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
             AppLog.i(T.TESTS, "OnSiteChanged has error: " + event.error.type);
             if (mNextEvent.equals(TestEvents.HTTP_AUTH_ERROR)) {
                 // SiteStore reports GENERIC_ERROR when it runs into authentication errors
-                assertEquals(SiteErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(SiteErrorType.GENERIC_ERROR, event.error.type);
             } else if (mNextEvent.equals(TestEvents.INVALID_SSL_CERTIFICATE)) {
                 // SiteStore reports GENERIC_ERROR when it runs into authentication errors
-                assertEquals(SiteErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(SiteErrorType.GENERIC_ERROR, event.error.type);
             } else {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
             mCountDownLatch.countDown();
             return;
         }
-        assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
-        assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -246,8 +248,8 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
             AppLog.i(T.TESTS, "OnProfileFetched has error: " + event.error.type);
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE, event.site.getDisplayName());
-        assertEquals(TestEvents.FETCHED_PROFILE, mNextEvent);
+        Assert.assertEquals(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE, event.site.getDisplayName());
+        Assert.assertEquals(TestEvents.FETCHED_PROFILE, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -258,9 +260,9 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertFalse(mSiteStore.hasSite());
-        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
-        assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -270,9 +272,9 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         if (event.isError()) {
             AppLog.i(T.TESTS, "OnAuthenticationChanged has error: " + event.error.type + " - " + event.error.message);
             if (event.error.type == AuthenticationErrorType.HTTP_AUTH_ERROR) {
-                assertEquals(TestEvents.HTTP_AUTH_ERROR, mNextEvent);
+                Assert.assertEquals(TestEvents.HTTP_AUTH_ERROR, mNextEvent);
             } else if (event.error.type == AuthenticationErrorType.INVALID_SSL_CERTIFICATE) {
-                assertEquals(TestEvents.INVALID_SSL_CERTIFICATE, mNextEvent);
+                Assert.assertEquals(TestEvents.INVALID_SSL_CERTIFICATE, mNextEvent);
             } else {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
@@ -286,7 +288,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.POST_FORMATS_CHANGED, mNextEvent);
+        Assert.assertEquals(TestEvents.POST_FORMATS_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -302,7 +304,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
 
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
         // Wait for a network response / onAuthenticationChanged error event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch the site user's Profile
         SiteModel site = mSiteStore.getSitesAccessedViaXMLRPC().get(0);
@@ -310,7 +312,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(SiteActionBuilder.newFetchProfileXmlRpcAction(site));
         // Wait for a network response
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchSites(String username, String password, String endpointUrl) throws InterruptedException {
@@ -324,6 +326,6 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(payload));
 
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
@@ -61,10 +63,10 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(sSite));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         List<TermModel> categories = mTaxonomyStore.getCategoriesForSite(sSite);
-        assertTrue(categories.size() > 0);
+        Assert.assertTrue(categories.size() > 0);
     }
 
     public void testFetchTags() throws InterruptedException {
@@ -73,10 +75,10 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTagsAction(sSite));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         List<TermModel> tags = mTaxonomyStore.getTagsForSite(sSite);
-        assertTrue(tags.size() > 0);
+        Assert.assertTrue(tags.size() > 0);
     }
 
     public void testFetchTermsForInvalidTaxonomy() throws InterruptedException {
@@ -89,7 +91,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         FetchTermsPayload payload = new FetchTermsPayload(sSite, taxonomyModel);
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermsAction(payload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testFetchSingleCategory() throws InterruptedException {
@@ -101,13 +103,13 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         term.setSlug("uncategorized");
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermAction(new RemoteTermPayload(term, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
         TermModel fetchedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
-        assertEquals("uncategorized", fetchedTerm.getSlug());
-        assertNotSame(0, fetchedTerm.getRemoteTermId());
+        Assert.assertEquals("uncategorized", fetchedTerm.getSlug());
+        Assert.assertNotSame(0, fetchedTerm.getRemoteTermId());
     }
 
     public void testUploadNewCategory() throws InterruptedException {
@@ -120,10 +122,10 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
 
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
+        Assert.assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
     public void testUpdateExistingCategory() throws InterruptedException {
@@ -141,10 +143,10 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
         TermModel uploadedTerm = mTaxonomyStore.getTagsForSite(sSite).get(0);
 
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getTagsForSite(sSite).size());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, mTaxonomyStore.getTagsForSite(sSite).size());
 
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
+        Assert.assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
     public void testUpdateExistingTag() throws InterruptedException {
@@ -157,11 +159,11 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         setupTermAttributes(term);
 
         uploadTerm(term);
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
 
         term = mTaxonomyStore.getTagsForSite(sSite).get(0);
         deleteTerm(term);
-        assertEquals(0, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(0, WellSqlUtils.getTotalTermsCount());
     }
 
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
@@ -177,10 +179,10 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
 
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
+        Assert.assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
     public void testUploadTermForInvalidTaxonomy() throws InterruptedException {
@@ -197,10 +199,10 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         TermModel failedTerm = mTaxonomyStore.getTermsForSite(sSite, "roads").get(0);
-        assertEquals(0, failedTerm.getRemoteTermId());
+        Assert.assertEquals(0, failedTerm.getRemoteTermId());
     }
 
     public void testUploadNewCategoryDuplicate() throws InterruptedException {
@@ -218,7 +220,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     // TODO: Add tests for existing custom taxonomies
@@ -230,15 +232,15 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
-                assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
-                assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }
@@ -285,26 +287,26 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             AppLog.i(T.API, "OnTermUploaded has error: " + event.error.type + " - " + event.error.message);
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
-                assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_DUPLICATE)) {
-                assertEquals(TaxonomyErrorType.DUPLICATE, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.DUPLICATE, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
-                assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.TERM_UPLOADED, mNextEvent);
-        assertNotSame(0, event.term.getRemoteTermId());
+        Assert.assertEquals(TestEvents.TERM_UPLOADED, mNextEvent);
+        Assert.assertNotSame(0, event.term.getRemoteTermId());
 
         mCountDownLatch.countDown();
     }
@@ -317,9 +319,9 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     private TermModel createNewCategory() {
         TermModel term = mTaxonomyStore.instantiateCategory(sSite);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        Assert.assertEquals(0, term.getRemoteTermId());
+        Assert.assertNotSame(0, term.getId());
+        Assert.assertNotSame(0, term.getLocalSiteId());
 
         return term;
     }
@@ -327,9 +329,9 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     private TermModel createNewTag() {
         TermModel term = mTaxonomyStore.instantiateTag(sSite);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        Assert.assertEquals(0, term.getRemoteTermId());
+        Assert.assertNotSame(0, term.getId());
+        Assert.assertNotSame(0, term.getLocalSiteId());
 
         return term;
     }
@@ -337,9 +339,9 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     private TermModel createNewTerm(TaxonomyModel taxonomy) {
         TermModel term = mTaxonomyStore.instantiateTerm(sSite, taxonomy);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        Assert.assertEquals(0, term.getRemoteTermId());
+        Assert.assertNotSame(0, term.getId());
+        Assert.assertNotSame(0, term.getLocalSiteId());
 
         return term;
     }
@@ -351,7 +353,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void deleteTerm(TermModel term) throws InterruptedException {
@@ -361,7 +363,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newDeleteTermAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void testUpdateExistingTerm(TermModel term) throws InterruptedException {
@@ -371,17 +373,17 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         uploadTerm(term);
 
         TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, term.getTaxonomy()).get(0);
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertNotSame(0, uploadedTerm.getRemoteTermId());
 
         String newDescription = "newDescription";
-        assertFalse(newDescription.equals(uploadedTerm.getDescription()));
+        Assert.assertFalse(newDescription.equals(uploadedTerm.getDescription()));
         uploadedTerm.setDescription(newDescription);
 
         uploadTerm(uploadedTerm);
-        assertEquals(1, WellSqlUtils.getTotalTermsCount()); // make sure we still have only one term
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount()); // make sure we still have only one term
         TermModel updatedTerm = mTaxonomyStore.getTermsForSite(sSite, term.getTaxonomy()).get(0);
-        assertEquals(updatedTerm.getRemoteTermId(), uploadedTerm.getRemoteTermId());
-        assertEquals(updatedTerm.getDescription(), newDescription);
+        Assert.assertEquals(updatedTerm.getRemoteTermId(), uploadedTerm.getRemoteTermId());
+        Assert.assertEquals(updatedTerm.getDescription(), newDescription);
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
@@ -65,10 +67,10 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(sSite));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         List<TermModel> categories = mTaxonomyStore.getCategoriesForSite(sSite);
-        assertTrue(categories.size() > 0);
+        Assert.assertTrue(categories.size() > 0);
     }
 
     public void testFetchTags() throws InterruptedException {
@@ -77,10 +79,10 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTagsAction(sSite));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         List<TermModel> tags = mTaxonomyStore.getTagsForSite(sSite);
-        assertTrue(tags.size() > 0);
+        Assert.assertTrue(tags.size() > 0);
     }
 
     public void testFetchTermsForInvalidTaxonomy() throws InterruptedException {
@@ -93,11 +95,11 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         FetchTermsPayload payload = new FetchTermsPayload(sSite, taxonomyModel);
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermsAction(payload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // TODO: This will fail for non-English sites - we should be checking for an INVALID_TAXONOMY error instead
         // (once we make the fixes needed for TaxonomyXMLRPCClient to correctly identify taxonomy errors)
-        assertEquals("Invalid taxonomy.", mLastTaxonomyError.message);
+        Assert.assertEquals("Invalid taxonomy.", mLastTaxonomyError.message);
     }
 
     public void testFetchSingleCategory() throws InterruptedException {
@@ -110,13 +112,13 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         term.setRemoteTermId(1);
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermAction(new RemoteTermPayload(term, sSite)));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
         TermModel fetchedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
-        assertEquals("uncategorized", fetchedTerm.getSlug());
-        assertNotSame(0, fetchedTerm.getRemoteTermId());
+        Assert.assertEquals("uncategorized", fetchedTerm.getSlug());
+        Assert.assertNotSame(0, fetchedTerm.getRemoteTermId());
     }
 
     public void testUploadNewCategory() throws InterruptedException {
@@ -129,10 +131,10 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
 
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
+        Assert.assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
     public void testUpdateExistingCategory() throws InterruptedException {
@@ -150,10 +152,10 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         TermModel uploadedTerm = mTaxonomyStore.getTagsForSite(sSite).get(0);
 
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getTagsForSite(sSite).size());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, mTaxonomyStore.getTagsForSite(sSite).size());
 
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
+        Assert.assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
     public void testUpdateExistingTag() throws InterruptedException {
@@ -174,10 +176,10 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         TermModel uploadedTerm = mTaxonomyStore.getCategoriesForSite(sSite).get(0);
 
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, mTaxonomyStore.getCategoriesForSite(sSite).size());
 
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
+        Assert.assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
     public void testUploadTermForInvalidTaxonomy() throws InterruptedException {
@@ -194,14 +196,14 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         TermModel failedTerm = mTaxonomyStore.getTermsForSite(sSite, "roads").get(0);
-        assertEquals(0, failedTerm.getRemoteTermId());
+        Assert.assertEquals(0, failedTerm.getRemoteTermId());
 
         // TODO: This will fail for non-English sites - we should be checking for an INVALID_TAXONOMY error instead
         // (once we make the fixes needed for TaxonomyXMLRPCClient to correctly identify taxonomy errors)
-        assertEquals("Invalid taxonomy.", mLastTaxonomyError.message);
+        Assert.assertEquals("Invalid taxonomy.", mLastTaxonomyError.message);
     }
 
     public void testUploadNewCategoryDuplicate() throws InterruptedException {
@@ -220,11 +222,11 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // TODO: This will fail for non-English sites - we should be checking for a DUPLICATE error instead
         // (once we make the fixes needed for TaxonomyXMLRPCClient to correctly identify taxonomy errors)
-        assertEquals("A term with the name provided already exists with this parent.", mLastTaxonomyError.message);
+        Assert.assertEquals("A term with the name provided already exists with this parent.", mLastTaxonomyError.message);
     }
 
     public void testDeleteTag() throws InterruptedException {
@@ -232,11 +234,11 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         setupTermAttributes(term);
 
         uploadTerm(term);
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
 
         term = mTaxonomyStore.getTagsForSite(sSite).get(0);
         deleteTerm(term);
-        assertEquals(0, WellSqlUtils.getTotalTermsCount());
+        Assert.assertEquals(0, WellSqlUtils.getTotalTermsCount());
     }
 
     @SuppressWarnings("unused")
@@ -247,15 +249,15 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
             AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);
             mLastTaxonomyError = event.error;
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
-                assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
-                assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }
@@ -303,26 +305,26 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
             AppLog.i(T.API, "OnTermUploaded has error: " + event.error.type + " - " + event.error.message);
             mLastTaxonomyError = event.error;
             if (mNextEvent.equals(TestEvents.ERROR_INVALID_TAXONOMY)) {
-                assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.INVALID_TAXONOMY, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_DUPLICATE)) {
-                assertEquals(TaxonomyErrorType.DUPLICATE, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.DUPLICATE, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_UNAUTHORIZED)) {
-                assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.UNAUTHORIZED, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             } else if (mNextEvent.equals(TestEvents.ERROR_GENERIC)) {
-                assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
+                Assert.assertEquals(TaxonomyErrorType.GENERIC_ERROR, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.TERM_UPLOADED, mNextEvent);
-        assertNotSame(0, event.term.getRemoteTermId());
+        Assert.assertEquals(TestEvents.TERM_UPLOADED, mNextEvent);
+        Assert.assertNotSame(0, event.term.getRemoteTermId());
 
         mCountDownLatch.countDown();
     }
@@ -335,9 +337,9 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private TermModel createNewCategory() throws InterruptedException {
         TermModel term = mTaxonomyStore.instantiateCategory(sSite);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        Assert.assertEquals(0, term.getRemoteTermId());
+        Assert.assertNotSame(0, term.getId());
+        Assert.assertNotSame(0, term.getLocalSiteId());
 
         return term;
     }
@@ -345,9 +347,9 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private TermModel createNewTag() throws InterruptedException {
         TermModel term = mTaxonomyStore.instantiateTag(sSite);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        Assert.assertEquals(0, term.getRemoteTermId());
+        Assert.assertNotSame(0, term.getId());
+        Assert.assertNotSame(0, term.getLocalSiteId());
 
         return term;
     }
@@ -355,9 +357,9 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private TermModel createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
         TermModel term = mTaxonomyStore.instantiateTerm(sSite, taxonomy);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        Assert.assertEquals(0, term.getRemoteTermId());
+        Assert.assertNotSame(0, term.getId());
+        Assert.assertNotSame(0, term.getLocalSiteId());
 
         return term;
     }
@@ -369,7 +371,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void testUpdateExistingTerm(TermModel term) throws InterruptedException {
@@ -379,18 +381,18 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         uploadTerm(term);
 
         TermModel uploadedTerm = mTaxonomyStore.getTermsForSite(sSite, term.getTaxonomy()).get(0);
-        assertEquals(1, WellSqlUtils.getTotalTermsCount());
-        assertNotSame(0, uploadedTerm.getRemoteTermId());
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount());
+        Assert.assertNotSame(0, uploadedTerm.getRemoteTermId());
 
         String newDescription = "newDescription";
-        assertFalse(newDescription.equals(uploadedTerm.getDescription()));
+        Assert.assertFalse(newDescription.equals(uploadedTerm.getDescription()));
         uploadedTerm.setDescription(newDescription);
 
         uploadTerm(uploadedTerm);
-        assertEquals(1, WellSqlUtils.getTotalTermsCount()); // make sure we still have only one term
+        Assert.assertEquals(1, WellSqlUtils.getTotalTermsCount()); // make sure we still have only one term
         TermModel updatedTerm = mTaxonomyStore.getTermsForSite(sSite, term.getTaxonomy()).get(0);
-        assertEquals(updatedTerm.getRemoteTermId(), uploadedTerm.getRemoteTermId());
-        assertEquals(updatedTerm.getDescription(), newDescription);
+        Assert.assertEquals(updatedTerm.getRemoteTermId(), uploadedTerm.getRemoteTermId());
+        Assert.assertEquals(updatedTerm.getDescription(), newDescription);
     }
 
     private void deleteTerm(TermModel term) throws InterruptedException {
@@ -400,6 +402,6 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         RemoteTermPayload pushPayload = new RemoteTermPayload(term, sSite);
         mDispatcher.dispatch(TaxonomyActionBuilder.newDeleteTermAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.release;
 
 import android.support.annotation.NonNull;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.TestUtils;
@@ -61,13 +63,13 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
         // verify that installed themes list is empty first
-        assertTrue(mThemeStore.getThemesForSite(jetpackSite).size() == 0);
+        Assert.assertTrue(mThemeStore.getThemesForSite(jetpackSite).size() == 0);
 
         // fetch installed themes
         fetchInstalledThemes(jetpackSite);
 
         // verify themes are available for the site
-        assertTrue(mThemeStore.getThemesForSite(jetpackSite).size() > 0);
+        Assert.assertTrue(mThemeStore.getThemesForSite(jetpackSite).size() > 0);
 
         signOutWPCom();
     }
@@ -80,7 +82,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // fetch active theme
         ThemeModel currentTheme = fetchCurrentTheme(jetpackSite);
-        assertNotNull(currentTheme);
+        Assert.assertNotNull(currentTheme);
 
         signOutWPCom();
     }
@@ -93,20 +95,20 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // make sure there are at least 2 themes, one that's active and one that will be activated
         List<ThemeModel> themes = mThemeStore.getThemesForSite(jetpackSite);
-        assertTrue(themes.size() > 1);
+        Assert.assertTrue(themes.size() > 1);
 
         // fetch active theme
         ThemeModel currentTheme = fetchCurrentTheme(jetpackSite);
-        assertNotNull(currentTheme);
+        Assert.assertNotNull(currentTheme);
 
         // select a different theme to activate
         ThemeModel themeToActivate = getOtherTheme(themes, currentTheme.getThemeId());
-        assertNotNull(themeToActivate);
+        Assert.assertNotNull(themeToActivate);
 
         // activate it
         ThemeModel activatedTheme = activateTheme(jetpackSite, themeToActivate);
-        assertNotNull(activatedTheme);
-        assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
+        Assert.assertNotNull(activatedTheme);
+        Assert.assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
 
         signOutWPCom();
     }
@@ -120,7 +122,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // make sure there are at least 2 themes, one that's active and one that may be activated
         List<ThemeModel> themes = mThemeStore.getThemesForSite(jetpackSite);
-        assertTrue(themes.size() > 1);
+        Assert.assertTrue(themes.size() > 1);
 
         // If the theme is already installed, delete it first
         ThemeModel installedTheme = mThemeStore.getInstalledThemeByThemeId(jetpackSite, themeId);
@@ -132,7 +134,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         ThemeModel themeToInstall = new ThemeModel();
         themeToInstall.setThemeId(themeId);
         installTheme(jetpackSite, themeToInstall);
-        assertTrue(isThemeInstalled(jetpackSite, themeId));
+        Assert.assertTrue(isThemeInstalled(jetpackSite, themeId));
 
         signOutWPCom();
     }
@@ -146,7 +148,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // make sure there are at least 2 themes, one that's active and one that may be activated
         List<ThemeModel> themes = mThemeStore.getThemesForSite(jetpackSite);
-        assertTrue(themes.size() > 1);
+        Assert.assertTrue(themes.size() > 1);
 
         // Install edin if necessary before attempting to delete
         if (!isThemeInstalled(jetpackSite, themeId)) {
@@ -155,7 +157,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             installTheme(jetpackSite, themeToInstall);
 
             // make sure theme is available for site (install was successful)
-            assertTrue(isThemeInstalled(jetpackSite, themeId));
+            Assert.assertTrue(isThemeInstalled(jetpackSite, themeId));
         }
 
         // Get the theme from store to make sure the "active" state is correct, so we can deactivate it before deletion
@@ -170,23 +172,23 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
         // verify initial state, no themes in store
-        assertTrue(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
-        assertTrue(mThemeStore.getWpComThemes().isEmpty());
+        Assert.assertTrue(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
+        Assert.assertTrue(mThemeStore.getWpComThemes().isEmpty());
 
         // fetch themes for site and WP.com themes
         fetchInstalledThemes(jetpackSite);
         fetchWpComThemes();
 
         // Verify fetches were successful
-        assertFalse(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
-        assertFalse(mThemeStore.getWpComThemes().isEmpty());
+        Assert.assertFalse(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
+        Assert.assertFalse(mThemeStore.getWpComThemes().isEmpty());
 
         // remove the site's themes
         removeSiteThemes(jetpackSite);
 
         // verify site themes are removed and that WP.com themes are still there
-        assertTrue(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
-        assertFalse(mThemeStore.getWpComThemes().isEmpty());
+        Assert.assertTrue(mThemeStore.getThemesForSite(jetpackSite).isEmpty());
+        Assert.assertFalse(mThemeStore.getWpComThemes().isEmpty());
 
         // sign out
         signOutWPCom();
@@ -199,10 +201,10 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         if (event.origin == ThemeAction.FETCH_INSTALLED_THEMES) {
-            assertEquals(mNextEvent, TestEvents.FETCHED_INSTALLED_THEMES);
+            Assert.assertEquals(mNextEvent, TestEvents.FETCHED_INSTALLED_THEMES);
             mCountDownLatch.countDown();
         } else if (event.origin == ThemeAction.REMOVE_SITE_THEMES) {
-            assertEquals(mNextEvent, TestEvents.REMOVED_SITE_THEMES);
+            Assert.assertEquals(mNextEvent, TestEvents.REMOVED_SITE_THEMES);
             mCountDownLatch.countDown();
         } else {
             throw new AssertionError("Unexpected event occurred from origin: " + event.origin);
@@ -215,7 +217,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(mNextEvent, TestEvents.FETCHED_WPCOM_THEMES);
+        Assert.assertEquals(mNextEvent, TestEvents.FETCHED_WPCOM_THEMES);
         mCountDownLatch.countDown();
     }
 
@@ -226,8 +228,8 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
 
-        assertTrue(mNextEvent == TestEvents.FETCHED_CURRENT_THEME);
-        assertNotNull(event.theme);
+        Assert.assertTrue(mNextEvent == TestEvents.FETCHED_CURRENT_THEME);
+        Assert.assertNotNull(event.theme);
         mCountDownLatch.countDown();
     }
 
@@ -237,7 +239,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME);
+        Assert.assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME);
         mCountDownLatch.countDown();
     }
 
@@ -247,7 +249,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mNextEvent == TestEvents.INSTALLED_THEME);
+        Assert.assertTrue(mNextEvent == TestEvents.INSTALLED_THEME);
         mCountDownLatch.countDown();
     }
 
@@ -257,7 +259,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mNextEvent == TestEvents.DELETED_THEME);
+        Assert.assertTrue(mNextEvent == TestEvents.DELETED_THEME);
         mCountDownLatch.countDown();
     }
 
@@ -267,7 +269,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.REMOVED_THEME, mNextEvent);
+        Assert.assertEquals(TestEvents.REMOVED_THEME, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -304,7 +306,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
+        Assert.assertEquals(TestEvents.SITE_REMOVED, mNextEvent);
         mCountDownLatch.countDown();
     }
 
@@ -315,7 +317,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // verify Jetpack site is available
         final SiteModel jetpackSite = getJetpackSite();
-        assertNotNull(jetpackSite);
+        Assert.assertNotNull(jetpackSite);
         return jetpackSite;
     }
 
@@ -327,20 +329,20 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         // Correct user we should get an OnAuthenticationChanged message
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch account from REST API, and wait for OnAccountChanged event
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Fetch sites from REST API, and wait for onSiteChanged event
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        assertTrue(mSiteStore.getSitesCount() > 0);
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mSiteStore.getSitesCount() > 0);
     }
 
     private void signOutWPCom() throws InterruptedException {
@@ -348,28 +350,28 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_REMOVED;
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchWpComThemes() throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_WPCOM_THEMES;
         mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void fetchInstalledThemes(@NonNull SiteModel jetpackSite) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_INSTALLED_THEMES;
         mDispatcher.dispatch(ThemeActionBuilder.newFetchInstalledThemesAction(jetpackSite));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private ThemeModel fetchCurrentTheme(@NonNull SiteModel jetpackSite) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(jetpackSite));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         return mThemeStore.getActiveThemeForSite(jetpackSite);
     }
@@ -380,7 +382,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.ACTIVATED_THEME;
         SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         return mThemeStore.getActiveThemeForSite(jetpackSite);
     }
@@ -391,23 +393,23 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (theme.getActive()) {
             ThemeModel otherThemeToActivate = getOtherTheme(mThemeStore.getThemesForSite(jetpackSite),
                     EDIN_THEME_ID);
-            assertNotNull(otherThemeToActivate);
+            Assert.assertNotNull(otherThemeToActivate);
             activateTheme(jetpackSite, otherThemeToActivate);
 
             // Make sure another theme is activated
-            assertFalse(theme.getThemeId().equals(mThemeStore.getActiveThemeForSite(jetpackSite).getThemeId()));
+            Assert.assertFalse(theme.getThemeId().equals(mThemeStore.getActiveThemeForSite(jetpackSite).getThemeId()));
         }
         // delete existing theme from site
         deleteTheme(jetpackSite, theme);
         // make sure theme is no longer available for site (delete was successful)
-        assertFalse(isThemeInstalled(jetpackSite, theme.getThemeId()));
+        Assert.assertFalse(isThemeInstalled(jetpackSite, theme.getThemeId()));
     }
 
     private void removeSiteThemes(@NonNull SiteModel site) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.REMOVED_SITE_THEMES;
         mDispatcher.dispatch(ThemeActionBuilder.newRemoveSiteThemesAction(site));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void installTheme(@NonNull SiteModel site, @NonNull ThemeModel theme) throws InterruptedException {
@@ -415,7 +417,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.INSTALLED_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newInstallThemeAction(install));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void deleteTheme(@NonNull SiteModel site, @NonNull ThemeModel theme) throws InterruptedException {
@@ -423,7 +425,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.DELETED_THEME;
         mDispatcher.dispatch(ThemeActionBuilder.newDeleteThemeAction(delete));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private SiteModel getJetpackSite() {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.TestUtils;
@@ -42,20 +44,20 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         // Make sure no theme is active at first
         assertNull(mThemeStore.getActiveThemeForSite(sSite));
         ThemeModel currentTheme = fetchCurrentTheme();
-        assertNotNull(currentTheme);
+        Assert.assertNotNull(currentTheme);
     }
 
     public void testFetchWPComThemes() throws InterruptedException {
         // verify themes don't already exist in store
-        assertTrue(mThemeStore.getWpComThemes().isEmpty());
+        Assert.assertTrue(mThemeStore.getWpComThemes().isEmpty());
         fetchWpComThemes();
         // verify response received and WP themes list is not empty
-        assertFalse(mThemeStore.getWpComThemes().isEmpty());
+        Assert.assertFalse(mThemeStore.getWpComThemes().isEmpty());
 
         // verify that we have the 3 mobile-friendly categories being non empty
         for (String category : new String[]{ThemeStore.MOBILE_FRIENDLY_CATEGORY_BLOG,
                 ThemeStore.MOBILE_FRIENDLY_CATEGORY_WEBSITE, ThemeStore.MOBILE_FRIENDLY_CATEGORY_PORTFOLIO}) {
-            assertTrue(mThemeStore.getWpComMobileFriendlyThemes(category).size() > 0);
+            Assert.assertTrue(mThemeStore.getWpComMobileFriendlyThemes(category).size() > 0);
         }
     }
 
@@ -63,20 +65,20 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         // Make sure no theme is active at first
         assertNull(mThemeStore.getActiveThemeForSite(sSite));
         ThemeModel currentTheme = fetchCurrentTheme();
-        assertNotNull(currentTheme);
+        Assert.assertNotNull(currentTheme);
 
         // Fetch wp.com themes to activate a different theme
         fetchWpComThemes();
 
         // activate a different theme
         ThemeModel themeToActivate = getNewNonPremiumTheme(currentTheme.getThemeId(), mThemeStore.getWpComThemes());
-        assertNotNull(themeToActivate);
+        Assert.assertNotNull(themeToActivate);
         activateTheme(themeToActivate);
 
         // Assert that the activation was successful
         ThemeModel activatedTheme = mThemeStore.getActiveThemeForSite(sSite);
-        assertNotNull(activatedTheme);
-        assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
+        Assert.assertNotNull(activatedTheme);
+        Assert.assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
     }
 
     @SuppressWarnings("unused")
@@ -85,7 +87,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME);
+        Assert.assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME);
         mCountDownLatch.countDown();
     }
 
@@ -95,7 +97,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(mNextEvent, TestEvents.FETCHED_WPCOM_THEMES);
+        Assert.assertEquals(mNextEvent, TestEvents.FETCHED_WPCOM_THEMES);
         mCountDownLatch.countDown();
     }
 
@@ -106,7 +108,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
 
-        assertTrue(mNextEvent == TestEvents.FETCHED_CURRENT_THEME);
+        Assert.assertTrue(mNextEvent == TestEvents.FETCHED_CURRENT_THEME);
         mCountDownLatch.countDown();
     }
 
@@ -151,7 +153,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.FETCHED_CURRENT_THEME;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(sSite));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         return mThemeStore.getActiveThemeForSite(sSite);
     }
@@ -161,7 +163,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_WPCOM_THEMES;
         mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void activateTheme(ThemeModel themeToActivate) throws InterruptedException {
@@ -169,6 +171,6 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.ACTIVATED_THEME;
         SiteThemePayload payload = new SiteThemePayload(sSite, themeToActivate);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;
@@ -86,20 +88,20 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
 
         // Check that a MediaUploadModel has been registered
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Verify and set media ID
-        assertTrue(mLastUploadedId >= 0);
+        Assert.assertTrue(mLastUploadedId >= 0);
         testMedia.setMediaId(mLastUploadedId);
-        assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
+        Assert.assertNotNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
 
         // Confirm that the corresponding MediaUploadModel's state has been updated automatically
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(1F, mUploadStore.getUploadProgressForMedia(testMedia));
-        assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
+        Assert.assertEquals(1F, mUploadStore.getUploadProgressForMedia(testMedia));
+        Assert.assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
 
         // Delete test image
         mNextEvent = TestEvents.DELETED_MEDIA;
@@ -117,16 +119,16 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         MediaPayload payload = new MediaPayload(sSite, testMedia);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // MediaModel and MediaUploadModel should both exist and be marked as FAILED
         MediaModel mediaModel = mMediaStore.getMediaWithLocalId(testMedia.getId());
-        assertNotNull(mediaModel);
-        assertEquals(MediaUploadState.FAILED, MediaUploadState.fromString(mediaModel.getUploadState()));
+        Assert.assertNotNull(mediaModel);
+        Assert.assertEquals(MediaUploadState.FAILED, MediaUploadState.fromString(mediaModel.getUploadState()));
 
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
 
         // Remove local test image
         mNextEvent = TestEvents.REMOVED_MEDIA;
@@ -151,9 +153,9 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         CancelMediaPayload cancelPayload = new CancelMediaPayload(sSite, testMedia);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(0, mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(0, mMediaStore.getSiteMediaCount(sSite));
 
         // The delete flag was on, so there should be no associated MediaUploadModel
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
@@ -172,16 +174,16 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         cancelPayload = new CancelMediaPayload(sSite, testMedia, false);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
+        Assert.assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
         MediaModel canceledMedia = mMediaStore.getMediaWithLocalId(testMedia.getId());
-        assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
+        Assert.assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
 
         // The delete flag was off, so we can expect an associated MediaUploadModel
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
     }
 
     public void testRegisterAndUploadPost() throws InterruptedException {
@@ -192,23 +194,23 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         // Register the post with the UploadStore and verify that it exists
         mUploadStore.registerPostModel(mPost, Collections.<MediaModel>emptyList());
 
-        assertEquals(1, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(1, mUploadStore.getPendingPosts().size());
         PostUploadModel postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertNotNull(postUploadModel);
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isPendingPost(mPost));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isPendingPost(mPost));
 
         // Upload new post to site
         uploadPost(mPost);
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // Since the post upload completed successfully, the PostUploadModel should have been deleted
-        assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
+        Assert.assertEquals(0, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
         assertNull(getPostUploadModelForPostModel(uploadedPost));
     }
 
@@ -223,9 +225,9 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         mUploadStore.registerPostModel(mPost, Collections.<MediaModel>emptyList());
 
         PostUploadModel postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertNotNull(postUploadModel);
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isPendingPost(mPost));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isPendingPost(mPost));
 
         mNextEvent = TestEvents.POST_ERROR_UNKNOWN;
         mCountDownLatch = new CountDownLatch(1);
@@ -233,18 +235,18 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         RemotePostPayload pushPayload = new RemotePostPayload(mPost, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
         // Since the post upload had an error, the PostUploadModel should still exist and be marked as FAILED
-        assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(1, mUploadStore.getFailedPosts().size());
-        assertEquals(1, mUploadStore.getAllRegisteredPosts().size());
+        Assert.assertEquals(0, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(1, mUploadStore.getFailedPosts().size());
+        Assert.assertEquals(1, mUploadStore.getAllRegisteredPosts().size());
         postUploadModel = getPostUploadModelForPostModel(uploadedPost);
-        assertEquals(PostUploadModel.FAILED, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isFailedPost(mPost));
-        assertEquals(PostErrorType.UNKNOWN_POST, PostErrorType.fromString(postUploadModel.getErrorType()));
+        Assert.assertEquals(PostUploadModel.FAILED, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isFailedPost(mPost));
+        Assert.assertEquals(PostErrorType.UNKNOWN_POST, PostErrorType.fromString(postUploadModel.getErrorType()));
     }
 
     public void testRegisterPostAndUploadMedia() throws InterruptedException {
@@ -268,76 +270,76 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         mUploadStore.registerPostModel(mPost, mediaModelList);
 
         // PostUploadModel exists and has correct state and associated media
-        assertEquals(1, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(1, mUploadStore.getPendingPosts().size());
         PostUploadModel postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertNotNull(postUploadModel);
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isPendingPost(mPost));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isPendingPost(mPost));
         Set<Integer> associatedMedia = postUploadModel.getAssociatedMediaIdSet();
-        assertEquals(1, associatedMedia.size());
-        assertTrue(associatedMedia.contains(testMedia.getId()));
+        Assert.assertEquals(1, associatedMedia.size());
+        Assert.assertTrue(associatedMedia.contains(testMedia.getId()));
 
         // MediaUploadModel exists and has correct state
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
         // UploadStore returns the correct sets of media for the post by type
-        assertEquals(1, mUploadStore.getUploadingMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
+        Assert.assertEquals(1, mUploadStore.getUploadingMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Media upload completed
         // PostUploadModel still exists and has correct state and associated media
         postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertNotNull(postUploadModel);
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isPendingPost(mPost));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isPendingPost(mPost));
         associatedMedia = postUploadModel.getAssociatedMediaIdSet();
-        assertEquals(1, associatedMedia.size());
-        assertTrue(associatedMedia.contains(testMedia.getId()));
+        Assert.assertEquals(1, associatedMedia.size());
+        Assert.assertTrue(associatedMedia.contains(testMedia.getId()));
 
         // MediaUploadModel still exists and has correct state
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
+        Assert.assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
 
         // UploadStore returns the correct sets of media for the post by type
-        assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
-        assertEquals(1, mUploadStore.getCompletedMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
+        Assert.assertEquals(1, mUploadStore.getCompletedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
 
         // Remove the completed media references from the post
         clearMedia(mPost, mUploadStore.getCompletedMediaForPost(mPost));
 
         // PostUploadModel still exists and has correct state and associated media
-        assertEquals(1, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(1, mUploadStore.getPendingPosts().size());
         postUploadModel = getPostUploadModelForPostModel(mPost);
-        assertNotNull(postUploadModel);
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isPendingPost(mPost));
-        assertTrue(postUploadModel.getAssociatedMediaIdSet().isEmpty());
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isPendingPost(mPost));
+        Assert.assertTrue(postUploadModel.getAssociatedMediaIdSet().isEmpty());
 
         // MediaUploadModel should have been deleted
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
         assertNull(mediaUploadModel);
 
         // UploadStore returns the correct sets of media for the post by type
-        assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
-        assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getUploadingMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getCompletedMediaForPost(mPost).size());
+        Assert.assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
 
         // Upload post to site
         uploadPost(mPost);
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        assertEquals(1, WellSqlUtils.getTotalPostsCount());
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
+        Assert.assertEquals(1, WellSqlUtils.getTotalPostsCount());
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(sSite));
 
         // Since the post upload completed successfully, the PostUploadModel should have been deleted
-        assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
+        Assert.assertEquals(0, mUploadStore.getPendingPosts().size());
+        Assert.assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
         assertNull(getPostUploadModelForPostModel(uploadedPost));
     }
 
@@ -346,7 +348,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
     public void onMediaUploaded(OnMediaUploaded event) {
         if (event.isError()) {
             if (mNextEvent == TestEvents.MEDIA_ERROR_MALFORMED) {
-                assertEquals(MediaErrorType.MALFORMED_MEDIA_ARG, event.error.type);
+                Assert.assertEquals(MediaErrorType.MALFORMED_MEDIA_ARG, event.error.type);
                 mCountDownLatch.countDown();
                 return;
             }
@@ -368,8 +370,8 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         } else {
             // General checks that the UploadStore is keeping an updated progress value for the media
             if (getMediaUploadModelForMediaModel(event.media) != null) {
-                assertTrue(mUploadStore.getUploadProgressForMedia(event.media) > 0F);
-                assertTrue(mUploadStore.getUploadProgressForMedia(event.media) < 1F);
+                Assert.assertTrue(mUploadStore.getUploadProgressForMedia(event.media) > 0F);
+                Assert.assertTrue(mUploadStore.getUploadProgressForMedia(event.media) < 1F);
             }
         }
     }
@@ -381,11 +383,11 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         if (event.cause == MediaAction.PUSH_MEDIA) {
-            assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
+            Assert.assertEquals(TestEvents.PUSHED_MEDIA, mNextEvent);
         } else if (event.cause == MediaAction.DELETE_MEDIA) {
-            assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
+            Assert.assertEquals(TestEvents.DELETED_MEDIA, mNextEvent);
         } else if (event.cause == MediaAction.REMOVE_MEDIA) {
-            assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
+            Assert.assertEquals(TestEvents.REMOVED_MEDIA, mNextEvent);
         } else {
             throw new AssertionError("Unexpected event: " + event.cause);
         }
@@ -399,17 +401,17 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         if (event.isError()) {
             AppLog.i(T.API, "OnPostUploaded has error: " + event.error.type + " - " + event.error.message);
             if (mNextEvent == TestEvents.POST_ERROR_UNKNOWN) {
-                assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
+                Assert.assertEquals(PostErrorType.UNKNOWN_POST, event.error.type);
                 mCountDownLatch.countDown();
             } else {
                 throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
             }
             return;
         }
-        assertEquals(TestEvents.UPLOADED_POST, mNextEvent);
-        assertFalse(event.post.isLocalDraft());
-        assertFalse(event.post.isLocallyChanged());
-        assertNotSame(0, event.post.getRemotePostId());
+        Assert.assertEquals(TestEvents.UPLOADED_POST, mNextEvent);
+        Assert.assertFalse(event.post.isLocalDraft());
+        Assert.assertFalse(event.post.isLocallyChanged());
+        Assert.assertNotSame(0, event.post.getRemotePostId());
 
         mCountDownLatch.countDown();
     }
@@ -434,7 +436,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         }
 
         if (mNextEvent.equals(TestEvents.CLEARED_MEDIA)) {
-            assertEquals(UploadAction.CLEAR_MEDIA_FOR_POST, event.cause);
+            Assert.assertEquals(UploadAction.CLEAR_MEDIA_FOR_POST, event.cause);
             mCountDownLatch.countDown();
         } else {
             throw new AssertionError("Unexpected OnUploadChanged event with cause: " + event.cause);
@@ -478,13 +480,13 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         MediaPayload deletePayload = new MediaPayload(sSite, media);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newDeleteMediaAction(deletePayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void removeMedia(MediaModel media) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(media));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void uploadPost(PostModel post) throws InterruptedException {
@@ -494,7 +496,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         RemotePostPayload pushPayload = new RemotePostPayload(post, sSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(pushPayload));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void clearMedia(PostModel post, Set<MediaModel> media) throws InterruptedException {
@@ -502,7 +504,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         ClearMediaPayload clearMediaPayload = new ClearMediaPayload(post, media);
         mDispatcher.dispatch(UploadActionBuilder.newClearMediaForPostAction(clearMediaPayload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private static MediaUploadModel getMediaUploadModelForMediaModel(MediaModel mediaModel) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
@@ -39,7 +41,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
 
         mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginAction(mSlug));
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")
@@ -49,9 +51,9 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
 
-        assertEquals(TestEvents.WPORG_PLUGIN_FETCHED, mNextEvent);
+        Assert.assertEquals(TestEvents.WPORG_PLUGIN_FETCHED, mNextEvent);
         WPOrgPluginModel wpOrgPlugin = mPluginStore.getWPOrgPluginBySlug(mSlug);
-        assertNotNull(wpOrgPlugin);
+        Assert.assertNotNull(wpOrgPlugin);
         mCountDownLatch.countDown();
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/EndpointNodeTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/EndpointNodeTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -10,10 +12,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class EndpointNodeTest {
@@ -26,34 +24,34 @@ public class EndpointNodeTest {
         childNode.addChild(grandchildNode);
         root.addChild(childNode);
 
-        assertEquals("posts/", root.getChildren().get(0).getChildren().get(0).getLocalEndpoint());
+        Assert.assertEquals("posts/", root.getChildren().get(0).getChildren().get(0).getLocalEndpoint());
 
-        assertEquals("/sites/", grandchildNode.getRoot().getLocalEndpoint());
-        assertEquals(root, grandchildNode.getParent().getParent());
-        assertEquals("$site/", grandchildNode.getParent().getLocalEndpoint());
-        assertEquals("/sites/$site/posts/", grandchildNode.getFullEndpoint());
+        Assert.assertEquals("/sites/", grandchildNode.getRoot().getLocalEndpoint());
+        Assert.assertEquals(root, grandchildNode.getParent().getParent());
+        Assert.assertEquals("$site/", grandchildNode.getParent().getLocalEndpoint());
+        Assert.assertEquals("/sites/$site/posts/", grandchildNode.getFullEndpoint());
     }
 
     @Test
     public void testGetCleanEndpointName() {
         EndpointNode node = new EndpointNode("$post_ID/");
-        assertEquals("post", node.getCleanEndpointName());
+        Assert.assertEquals("post", node.getCleanEndpointName());
 
         EndpointNode nodeWithType = new EndpointNode("$taxonomy#String/");
-        assertEquals("taxonomy", nodeWithType.getCleanEndpointName());
+        Assert.assertEquals("taxonomy", nodeWithType.getCleanEndpointName());
 
         EndpointNode emptyNode = new EndpointNode("");
-        assertEquals("", emptyNode.getCleanEndpointName());
+        Assert.assertEquals("", emptyNode.getCleanEndpointName());
     }
 
     @Test
     public void testGetEndpointTypes() {
         EndpointNode typedNode = new EndpointNode("$taxonomy#String/");
-        assertEquals(1, typedNode.getEndpointTypes().size());
-        assertEquals("String", typedNode.getEndpointTypes().get(0));
+        Assert.assertEquals(1, typedNode.getEndpointTypes().size());
+        Assert.assertEquals("String", typedNode.getEndpointTypes().get(0));
 
         EndpointNode normalNode = new EndpointNode("$post_ID/");
-        assertTrue(normalNode.getEndpointTypes().isEmpty());
+        Assert.assertTrue(normalNode.getEndpointTypes().isEmpty());
     }
 
     @Test
@@ -64,7 +62,7 @@ public class EndpointNodeTest {
         // An empty file should return a root EndpointNode with no children
         EndpointNode endpointTree = EndpointTreeGenerator.process(temp);
 
-        assertFalse(endpointTree.hasChildren());
+        Assert.assertFalse(endpointTree.hasChildren());
 
         // An empty file (except for a newline) should return a root EndpointNode with no children
         BufferedWriter out = new BufferedWriter(new FileWriter(temp));
@@ -73,7 +71,7 @@ public class EndpointNodeTest {
 
         endpointTree = EndpointTreeGenerator.process(temp);
 
-        assertFalse(endpointTree.hasChildren());
+        Assert.assertFalse(endpointTree.hasChildren());
 
         // A series of nested endpoints should be processed correctly as a single branch
         out = new BufferedWriter(new FileWriter(temp));
@@ -86,8 +84,8 @@ public class EndpointNodeTest {
 
         endpointTree = EndpointTreeGenerator.process(temp);
 
-        assertEquals(1, endpointTree.getChildren().size());
-        assertEquals("/sites/$site/posts/",
+        Assert.assertEquals(1, endpointTree.getChildren().size());
+        Assert.assertEquals("/sites/$site/posts/",
                 endpointTree.getChildren().get(0).getChildren().get(0).getChildren().get(0).getFullEndpoint());
 
         // A duplicate endpoint entry should be ignored
@@ -103,8 +101,8 @@ public class EndpointNodeTest {
 
         endpointTree = EndpointTreeGenerator.process(temp);
 
-        assertEquals(1, endpointTree.getChildren().size());
-        assertEquals("/sites/$site/posts/",
+        Assert.assertEquals(1, endpointTree.getChildren().size());
+        Assert.assertEquals("/sites/$site/posts/",
                 endpointTree.getChildren().get(0).getChildren().get(0).getChildren().get(0).getFullEndpoint());
 
         // A single nested endpoint should be processed as nested nodes
@@ -114,8 +112,8 @@ public class EndpointNodeTest {
 
         endpointTree = EndpointTreeGenerator.process(temp);
 
-        assertEquals(1, endpointTree.getChildren().size());
-        assertEquals("/sites/$site/posts/",
+        Assert.assertEquals(1, endpointTree.getChildren().size());
+        Assert.assertEquals("/sites/$site/posts/",
                 endpointTree.getChildren().get(0).getChildren().get(0).getChildren().get(0).getFullEndpoint());
 
         // Two separate top-level endpoints should be processed correctly
@@ -127,7 +125,7 @@ public class EndpointNodeTest {
 
         endpointTree = EndpointTreeGenerator.process(temp);
 
-        assertEquals(2, endpointTree.getChildren().size());
-        assertEquals("/", endpointTree.getLocalEndpoint());
+        Assert.assertEquals(2, endpointTree.getChildren().size());
+        Assert.assertEquals("/", endpointTree.getLocalEndpoint());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/PayloadTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/PayloadTest.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.fluxc;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
@@ -31,7 +31,7 @@ public class PayloadTest {
 
         CloneablePayload errorlessClone = errorlessPayload.clone();
 
-        assertFalse(errorlessPayload == errorlessClone);
+        Assert.assertFalse(errorlessPayload == errorlessClone);
         assertNull(errorlessPayload.error);
         assertNull(errorlessClone.error);
 
@@ -42,10 +42,10 @@ public class PayloadTest {
 
         CloneablePayload errorClone = errorPayload.clone();
 
-        assertFalse(errorPayload == errorClone);
+        Assert.assertFalse(errorPayload == errorClone);
 
         // The error field should be cloned
         assertNotEquals(errorClone.error, errorPayload.error);
-        assertEquals(errorClone.error.type, errorPayload.error.type);
+        Assert.assertEquals(errorClone.error.type, errorPayload.error.type);
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/WPAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPAPIEndpointTest.java
@@ -1,42 +1,42 @@
 package org.wordpress.android.fluxc;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class WPAPIEndpointTest {
     @Test
     public void testAllEndpoints() {
         // Posts
-        assertEquals("/posts/", WPAPI.posts.getEndpoint());
-        assertEquals("/posts/56/", WPAPI.posts.id(56).getEndpoint());
+        Assert.assertEquals("/posts/", WPAPI.posts.getEndpoint());
+        Assert.assertEquals("/posts/56/", WPAPI.posts.id(56).getEndpoint());
 
         // Pages
-        assertEquals("/pages/", WPAPI.pages.getEndpoint());
-        assertEquals("/pages/56/", WPAPI.pages.id(56).getEndpoint());
+        Assert.assertEquals("/pages/", WPAPI.pages.getEndpoint());
+        Assert.assertEquals("/pages/56/", WPAPI.pages.id(56).getEndpoint());
 
         // Media
-        assertEquals("/media/", WPAPI.media.getEndpoint());
-        assertEquals("/media/56/", WPAPI.media.id(56).getEndpoint());
+        Assert.assertEquals("/media/", WPAPI.media.getEndpoint());
+        Assert.assertEquals("/media/56/", WPAPI.media.id(56).getEndpoint());
 
         // Comments
-        assertEquals("/comments/", WPAPI.comments.getEndpoint());
-        assertEquals("/comments/56/", WPAPI.comments.id(56).getEndpoint());
+        Assert.assertEquals("/comments/", WPAPI.comments.getEndpoint());
+        Assert.assertEquals("/comments/56/", WPAPI.comments.id(56).getEndpoint());
 
         // Settings
-        assertEquals("/settings/", WPAPI.settings.getEndpoint());
+        Assert.assertEquals("/settings/", WPAPI.settings.getEndpoint());
     }
 
     @Test
     public void testUrls() {
-        assertEquals("wp/v2/posts/", WPAPI.posts.getUrlV2());
-        assertEquals("wp/v2/pages/", WPAPI.pages.getUrlV2());
-        assertEquals("wp/v2/media/", WPAPI.media.getUrlV2());
-        assertEquals("wp/v2/comments/", WPAPI.comments.getUrlV2());
-        assertEquals("wp/v2/settings/", WPAPI.settings.getUrlV2());
+        Assert.assertEquals("wp/v2/posts/", WPAPI.posts.getUrlV2());
+        Assert.assertEquals("wp/v2/pages/", WPAPI.pages.getUrlV2());
+        Assert.assertEquals("wp/v2/media/", WPAPI.media.getUrlV2());
+        Assert.assertEquals("wp/v2/comments/", WPAPI.comments.getUrlV2());
+        Assert.assertEquals("wp/v2/settings/", WPAPI.settings.getUrlV2());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -1,87 +1,87 @@
 package org.wordpress.android.fluxc;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class WPComEndpointTest {
     @Test
     public void testAllEndpoints() {
         // Sites
-        assertEquals("/sites/", WPCOMREST.sites.getEndpoint());
-        assertEquals("/sites/new/", WPCOMREST.sites.new_.getEndpoint());
-        assertEquals("/sites/56/", WPCOMREST.sites.site(56).getEndpoint());
-        assertEquals("/sites/56/post-formats/", WPCOMREST.sites.site(56).post_formats.getEndpoint());
+        Assert.assertEquals("/sites/", WPCOMREST.sites.getEndpoint());
+        Assert.assertEquals("/sites/new/", WPCOMREST.sites.new_.getEndpoint());
+        Assert.assertEquals("/sites/56/", WPCOMREST.sites.site(56).getEndpoint());
+        Assert.assertEquals("/sites/56/post-formats/", WPCOMREST.sites.site(56).post_formats.getEndpoint());
 
-        assertEquals("/sites/mysite.wordpress.com/", WPCOMREST.sites.siteUrl("mysite.wordpress.com").getEndpoint());
+        Assert.assertEquals("/sites/mysite.wordpress.com/", WPCOMREST.sites.siteUrl("mysite.wordpress.com").getEndpoint());
 
         // Sites - Posts
-        assertEquals("/sites/56/posts/", WPCOMREST.sites.site(56).posts.getEndpoint());
-        assertEquals("/sites/56/posts/78/", WPCOMREST.sites.site(56).posts.post(78).getEndpoint());
-        assertEquals("/sites/56/posts/78/delete/", WPCOMREST.sites.site(56).posts.post(78).delete.getEndpoint());
-        assertEquals("/sites/56/posts/new/", WPCOMREST.sites.site(56).posts.new_.getEndpoint());
-        assertEquals("/sites/56/posts/slug:fluxc/", WPCOMREST.sites.site(56).posts.slug("fluxc").getEndpoint());
+        Assert.assertEquals("/sites/56/posts/", WPCOMREST.sites.site(56).posts.getEndpoint());
+        Assert.assertEquals("/sites/56/posts/78/", WPCOMREST.sites.site(56).posts.post(78).getEndpoint());
+        Assert.assertEquals("/sites/56/posts/78/delete/", WPCOMREST.sites.site(56).posts.post(78).delete.getEndpoint());
+        Assert.assertEquals("/sites/56/posts/new/", WPCOMREST.sites.site(56).posts.new_.getEndpoint());
+        Assert.assertEquals("/sites/56/posts/slug:fluxc/", WPCOMREST.sites.site(56).posts.slug("fluxc").getEndpoint());
 
         // Sites - Media
-        assertEquals("/sites/56/media/", WPCOMREST.sites.site(56).media.getEndpoint());
-        assertEquals("/sites/56/media/78/", WPCOMREST.sites.site(56).media.item(78).getEndpoint());
-        assertEquals("/sites/56/media/78/delete/", WPCOMREST.sites.site(56).media.item(78).delete.getEndpoint());
-        assertEquals("/sites/56/media/new/", WPCOMREST.sites.site(56).media.new_.getEndpoint());
+        Assert.assertEquals("/sites/56/media/", WPCOMREST.sites.site(56).media.getEndpoint());
+        Assert.assertEquals("/sites/56/media/78/", WPCOMREST.sites.site(56).media.item(78).getEndpoint());
+        Assert.assertEquals("/sites/56/media/78/delete/", WPCOMREST.sites.site(56).media.item(78).delete.getEndpoint());
+        Assert.assertEquals("/sites/56/media/new/", WPCOMREST.sites.site(56).media.new_.getEndpoint());
 
         // Plugins
-        assertEquals("/sites/56/plugins/", WPCOMREST.sites.site(56).plugins.getEndpoint());
-        assertEquals("/sites/56/plugins/akismet/", WPCOMREST.sites.site(56).plugins.name("akismet").getEndpoint());
-        assertEquals("/sites/56/plugins/akismet/install/", WPCOMREST.sites.site(56).plugins.name("akismet")
+        Assert.assertEquals("/sites/56/plugins/", WPCOMREST.sites.site(56).plugins.getEndpoint());
+        Assert.assertEquals("/sites/56/plugins/akismet/", WPCOMREST.sites.site(56).plugins.name("akismet").getEndpoint());
+        Assert.assertEquals("/sites/56/plugins/akismet/install/", WPCOMREST.sites.site(56).plugins.name("akismet")
                 .install.getEndpoint());
-        assertEquals("/sites/56/plugins/akismet/delete/", WPCOMREST.sites.site(56).plugins.name("akismet")
+        Assert.assertEquals("/sites/56/plugins/akismet/delete/", WPCOMREST.sites.site(56).plugins.name("akismet")
                 .delete.getEndpoint());
 
         // Sites - Taxonomies
-        assertEquals("/sites/56/taxonomies/category/terms/",
+        Assert.assertEquals("/sites/56/taxonomies/category/terms/",
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.getEndpoint());
-        assertEquals("/sites/56/taxonomies/category/terms/new/",
+        Assert.assertEquals("/sites/56/taxonomies/category/terms/new/",
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.new_.getEndpoint());
-        assertEquals("/sites/56/taxonomies/category/terms/slug:fluxc/",
+        Assert.assertEquals("/sites/56/taxonomies/category/terms/slug:fluxc/",
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("category").terms.slug("fluxc").getEndpoint());
-        assertEquals("/sites/56/taxonomies/post_tag/terms/",
+        Assert.assertEquals("/sites/56/taxonomies/post_tag/terms/",
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("post_tag").terms.getEndpoint());
-        assertEquals("/sites/56/taxonomies/post_tag/terms/new/",
+        Assert.assertEquals("/sites/56/taxonomies/post_tag/terms/new/",
                 WPCOMREST.sites.site(56).taxonomies.taxonomy("post_tag").terms.new_.getEndpoint());
 
         // Me
-        assertEquals("/me/", WPCOMREST.me.getEndpoint());
-        assertEquals("/me/settings/", WPCOMREST.me.settings.getEndpoint());
-        assertEquals("/me/sites/", WPCOMREST.me.sites.getEndpoint());
-        assertEquals("/me/username/", WPCOMREST.me.username.getEndpoint());
+        Assert.assertEquals("/me/", WPCOMREST.me.getEndpoint());
+        Assert.assertEquals("/me/settings/", WPCOMREST.me.settings.getEndpoint());
+        Assert.assertEquals("/me/sites/", WPCOMREST.me.sites.getEndpoint());
+        Assert.assertEquals("/me/username/", WPCOMREST.me.username.getEndpoint());
 
         // Users
-        assertEquals("/users/new/", WPCOMREST.users.new_.getEndpoint());
-        assertEquals("/users/new/", WPCOMREST.users.new_.getEndpoint());
+        Assert.assertEquals("/users/new/", WPCOMREST.users.new_.getEndpoint());
+        Assert.assertEquals("/users/new/", WPCOMREST.users.new_.getEndpoint());
 
         // Availability
-        assertEquals("/is-available/email/", WPCOMREST.is_available.email.getEndpoint());
-        assertEquals("/is-available/username/", WPCOMREST.is_available.username.getEndpoint());
-        assertEquals("/is-available/blog/", WPCOMREST.is_available.blog.getEndpoint());
-        assertEquals("/is-available/domain/", WPCOMREST.is_available.domain.getEndpoint());
+        Assert.assertEquals("/is-available/email/", WPCOMREST.is_available.email.getEndpoint());
+        Assert.assertEquals("/is-available/username/", WPCOMREST.is_available.username.getEndpoint());
+        Assert.assertEquals("/is-available/blog/", WPCOMREST.is_available.blog.getEndpoint());
+        Assert.assertEquals("/is-available/domain/", WPCOMREST.is_available.domain.getEndpoint());
 
         // Magic link email sender
-        assertEquals("/auth/send-login-email/", WPCOMREST.auth.send_login_email.getEndpoint());
-        assertEquals("/auth/send-signup-email/", WPCOMREST.auth.send_signup_email.getEndpoint());
+        Assert.assertEquals("/auth/send-login-email/", WPCOMREST.auth.send_login_email.getEndpoint());
+        Assert.assertEquals("/auth/send-signup-email/", WPCOMREST.auth.send_signup_email.getEndpoint());
 
-        assertEquals("/read/feed/56/", WPCOMREST.read.feed.feed_url_or_id(56).getEndpoint());
-        assertEquals("/read/feed/somewhere.site/", WPCOMREST.read.feed.feed_url_or_id("somewhere.site").getEndpoint());
+        Assert.assertEquals("/read/feed/56/", WPCOMREST.read.feed.feed_url_or_id(56).getEndpoint());
+        Assert.assertEquals("/read/feed/somewhere.site/", WPCOMREST.read.feed.feed_url_or_id("somewhere.site").getEndpoint());
     }
 
     @Test
     public void testUrls() {
-        assertEquals("https://public-api.wordpress.com/rest/v1/sites/", WPCOMREST.sites.getUrlV1());
-        assertEquals("https://public-api.wordpress.com/rest/v1.1/sites/", WPCOMREST.sites.getUrlV1_1());
-        assertEquals("https://public-api.wordpress.com/rest/v1.2/sites/", WPCOMREST.sites.getUrlV1_2());
-        assertEquals("https://public-api.wordpress.com/rest/v1.3/sites/", WPCOMREST.sites.getUrlV1_3());
-        assertEquals("https://public-api.wordpress.com/is-available/email/", WPCOMREST.is_available.email.getUrlV0());
+        Assert.assertEquals("https://public-api.wordpress.com/rest/v1/sites/", WPCOMREST.sites.getUrlV1());
+        Assert.assertEquals("https://public-api.wordpress.com/rest/v1.1/sites/", WPCOMREST.sites.getUrlV1_1());
+        Assert.assertEquals("https://public-api.wordpress.com/rest/v1.2/sites/", WPCOMREST.sites.getUrlV1_2());
+        Assert.assertEquals("https://public-api.wordpress.com/rest/v1.3/sites/", WPCOMREST.sites.getUrlV1_3());
+        Assert.assertEquals("https://public-api.wordpress.com/is-available/email/", WPCOMREST.is_available.email.getUrlV0());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComV2EndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComV2EndpointTest.java
@@ -1,23 +1,23 @@
 package org.wordpress.android.fluxc;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class WPComV2EndpointTest {
     @Test
     public void testAllEndpoints() {
         // Users
-        assertEquals("/users/username/suggestions/", WPCOMV2.users.username.suggestions.getEndpoint());
+        Assert.assertEquals("/users/username/suggestions/", WPCOMV2.users.username.suggestions.getEndpoint());
     }
 
     @Test
     public void testUrls() {
-        assertEquals("https://public-api.wordpress.com/wpcom/v2/users/username/suggestions/",
+        Assert.assertEquals("https://public-api.wordpress.com/wpcom/v2/users/username/suggestions/",
                 WPCOMV2.users.username.suggestions.getUrl());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/WPOrgAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPOrgAPIEndpointTest.java
@@ -1,26 +1,26 @@
 package org.wordpress.android.fluxc;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.generated.endpoint.WPORGAPI;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class WPOrgAPIEndpointTest {
     @Test
     public void testAllEndpoints() {
         // Plugins info
-        assertEquals("/plugins/info/1.0/akismet/", WPORGAPI.plugins.info.version("1.0").slug("akismet").getEndpoint());
-        assertEquals("/plugins/info/1.1/", WPORGAPI.plugins.info.version("1.1").getEndpoint());
+        Assert.assertEquals("/plugins/info/1.0/akismet/", WPORGAPI.plugins.info.version("1.0").slug("akismet").getEndpoint());
+        Assert.assertEquals("/plugins/info/1.1/", WPORGAPI.plugins.info.version("1.1").getEndpoint());
     }
 
     @Test
     public void testUrls() {
-        assertEquals("https://api.wordpress.org/plugins/info/1.0/akismet.json",
+        Assert.assertEquals("https://api.wordpress.org/plugins/info/1.0/akismet.json",
                 WPORGAPI.plugins.info.version("1.0").slug("akismet").getUrl());
-        assertEquals("https://api.wordpress.org/plugins/info/1.1/",
+        Assert.assertEquals("https://api.wordpress.org/plugins/info/1.1/",
                 WPORGAPI.plugins.info.version("1.1").getUrl());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import com.yarolegovich.wellsql.SelectQuery;
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,9 +22,6 @@ import org.wordpress.android.util.DateTimeUtils;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class CommentStoreUnitTest {
@@ -49,7 +48,7 @@ public class CommentStoreUnitTest {
 
         // Get comment by site and remote id
         CommentModel queriedComment = CommentSqlUtils.getCommentBySiteAndRemoteId(siteModel, remoteCommentId);
-        assertEquals("Best ponies come from the future.", queriedComment.getContent());
+        Assert.assertEquals("Best ponies come from the future.", queriedComment.getContent());
     }
 
     @Test
@@ -61,20 +60,20 @@ public class CommentStoreUnitTest {
 
         // Get comment by site and remote id
         CommentModel queriedComment = CommentSqlUtils.getCommentBySiteAndRemoteId(siteModel, 10);
-        assertEquals("Pony #10", queriedComment.getContent());
+        Assert.assertEquals("Pony #10", queriedComment.getContent());
 
         // Get comment by site and remote id
         queriedComment = CommentSqlUtils.getCommentBySiteAndRemoteId(siteModel, 11);
-        assertEquals("Pony #11", queriedComment.getContent());
+        Assert.assertEquals("Pony #11", queriedComment.getContent());
 
         // Get comment by site and remote id
         queriedComment = CommentSqlUtils.getCommentBySiteAndRemoteId(siteModel, 12);
-        assertEquals("Pony #12", queriedComment.getContent());
+        Assert.assertEquals("Pony #12", queriedComment.getContent());
     }
 
     @Test
     public void testFailToGetCommentBySiteAndRemoteId() {
-        assertEquals(null, CommentSqlUtils.getCommentBySiteAndRemoteId(new SiteModel(), 42));
+        Assert.assertEquals(null, CommentSqlUtils.getCommentBySiteAndRemoteId(new SiteModel(), 42));
     }
 
 
@@ -90,7 +89,7 @@ public class CommentStoreUnitTest {
         for (CommentModel comment : ascComments.subList(1, ascComments.size())) {
             Date d0 = DateTimeUtils.dateFromIso8601(previousComment.getDatePublished());
             Date d1 = DateTimeUtils.dateFromIso8601(comment.getDatePublished());
-            assertTrue("ascending comment list seems incorrectly ordered", d0.before(d1));
+            Assert.assertTrue("ascending comment list seems incorrectly ordered", d0.before(d1));
             previousComment = comment;
         }
     }
@@ -107,7 +106,7 @@ public class CommentStoreUnitTest {
         for (CommentModel comment : ascComments.subList(1, ascComments.size())) {
             Date d0 = DateTimeUtils.dateFromIso8601(previousComment.getDatePublished());
             Date d1 = DateTimeUtils.dateFromIso8601(comment.getDatePublished());
-            assertTrue("descending comment list seems incorrectly ordered", d1.before(d0));
+            Assert.assertTrue("descending comment list seems incorrectly ordered", d1.before(d0));
             previousComment = comment;
         }
     }
@@ -122,16 +121,16 @@ public class CommentStoreUnitTest {
         // Get APPROVED comments
         List<CommentModel> queriedComments = CommentSqlUtils.getCommentsForSite(siteModel, SelectQuery.ORDER_ASCENDING,
                 CommentStatus.APPROVED);
-        assertEquals(8, queriedComments.size());
+        Assert.assertEquals(8, queriedComments.size());
 
         // Get TRASH comments
         queriedComments = CommentSqlUtils.getCommentsForSite(siteModel, SelectQuery.ORDER_ASCENDING,
                 CommentStatus.TRASH);
-        assertEquals(1, queriedComments.size());
+        Assert.assertEquals(1, queriedComments.size());
 
         // Get ALL comments
         queriedComments = CommentSqlUtils.getCommentsForSite(siteModel, SelectQuery.ORDER_ASCENDING, CommentStatus.ALL);
-        assertEquals(15, queriedComments.size());
+        Assert.assertEquals(15, queriedComments.size());
     }
 
     @Test
@@ -144,12 +143,12 @@ public class CommentStoreUnitTest {
         // Get APPROVED, UNAPPROVED and SPAM comments
         List<CommentModel> queriedComments = CommentSqlUtils.getCommentsForSite(siteModel, SelectQuery.ORDER_ASCENDING,
                 CommentStatus.APPROVED, CommentStatus.SPAM, CommentStatus.UNAPPROVED);
-        assertEquals(14, queriedComments.size());
+        Assert.assertEquals(14, queriedComments.size());
 
         // Get SPAM and UNAPPROVED comments
         queriedComments = CommentSqlUtils.getCommentsForSite(siteModel, SelectQuery.ORDER_ASCENDING,
                 CommentStatus.SPAM, CommentStatus.UNAPPROVED);
-        assertEquals(6, queriedComments.size());
+        Assert.assertEquals(6, queriedComments.size());
     }
 
     @Test
@@ -160,13 +159,13 @@ public class CommentStoreUnitTest {
         insertTestComments(siteModel);
 
         // Get APPROVED count
-        assertEquals(8, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.APPROVED));
+        Assert.assertEquals(8, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.APPROVED));
 
         // Get TRASH count
-        assertEquals(1, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.TRASH));
+        Assert.assertEquals(1, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.TRASH));
 
         // Get ALL comments
-        assertEquals(15, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.ALL));
+        Assert.assertEquals(15, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.ALL));
     }
 
     @Test
@@ -177,11 +176,11 @@ public class CommentStoreUnitTest {
         insertTestComments(siteModel);
 
         // Get SPAM and UNAPPROVED comments
-        assertEquals(6, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.SPAM,
+        Assert.assertEquals(6, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.SPAM,
                 CommentStatus.UNAPPROVED));
 
         // Get ALL (and SPAM) comments
-        assertEquals(15, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.SPAM, CommentStatus.ALL));
+        Assert.assertEquals(15, CommentSqlUtils.getCommentsCountForSite(siteModel, CommentStatus.SPAM, CommentStatus.ALL));
     }
 
     @Test
@@ -195,14 +194,14 @@ public class CommentStoreUnitTest {
         insertTestComments(site2);
 
         // Make sure the comments are inserted successfully before
-        assertEquals(15, CommentSqlUtils.getCommentsCountForSite(site1, CommentStatus.ALL));
-        assertEquals(15, CommentSqlUtils.getCommentsCountForSite(site2, CommentStatus.ALL));
+        Assert.assertEquals(15, CommentSqlUtils.getCommentsCountForSite(site1, CommentStatus.ALL));
+        Assert.assertEquals(15, CommentSqlUtils.getCommentsCountForSite(site2, CommentStatus.ALL));
 
         CommentSqlUtils.deleteAllComments();
 
         // Test if all the comments are deleted successfully
-        assertEquals(0, CommentSqlUtils.getCommentsCountForSite(site1, CommentStatus.ALL));
-        assertEquals(0, CommentSqlUtils.getCommentsCountForSite(site2, CommentStatus.ALL));
+        Assert.assertEquals(0, CommentSqlUtils.getCommentsCountForSite(site1, CommentStatus.ALL));
+        Assert.assertEquals(0, CommentSqlUtils.getCommentsCountForSite(site2, CommentStatus.ALL));
     }
 
     private void insertTestComments(SiteModel siteModel) {

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,11 +28,7 @@ import org.wordpress.android.fluxc.utils.MediaUtils;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
 import static org.wordpress.android.fluxc.media.MediaTestUtils.generateMedia;
 import static org.wordpress.android.fluxc.media.MediaTestUtils.generateMediaFromPath;
 import static org.wordpress.android.fluxc.media.MediaTestUtils.generateRandomizedMedia;
@@ -58,13 +56,13 @@ public class MediaStoreTest {
 
         // get all media via MediaStore
         List<MediaModel> storeMedia = mMediaStore.getAllSiteMedia(getTestSiteWithLocalId(testSiteId));
-        assertNotNull(storeMedia);
-        assertEquals(testMedia.size(), storeMedia.size());
+        Assert.assertNotNull(storeMedia);
+        Assert.assertEquals(testMedia.size(), storeMedia.size());
 
         // verify media
         for (MediaModel media : storeMedia) {
-            assertEquals(testSiteId, media.getLocalSiteId());
-            assertTrue(testMedia.contains(media));
+            Assert.assertEquals(testSiteId, media.getLocalSiteId());
+            Assert.assertTrue(testMedia.contains(media));
         }
     }
 
@@ -72,19 +70,19 @@ public class MediaStoreTest {
     public void testMediaCount() {
         final int testSiteId = 2;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 0);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite) == 0);
 
         // count after insertion
         insertRandomMediaIntoDatabase(testSiteId, 5);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 5);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite) == 5);
 
         // count after inserting with different site ID
         final int wrongSiteId = testSiteId + 1;
         SiteModel wrongSite = getTestSiteWithLocalId(wrongSiteId);
-        assertTrue(mMediaStore.getSiteMediaCount(wrongSite) == 0);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(wrongSite) == 0);
         insertRandomMediaIntoDatabase(wrongSiteId, 1);
-        assertTrue(mMediaStore.getSiteMediaCount(wrongSite) == 1);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 5);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(wrongSite) == 1);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite) == 5);
     }
 
     @Test
@@ -92,18 +90,18 @@ public class MediaStoreTest {
         final int testSiteId = 24;
         final long testMediaId = 22;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 0);
-        assertFalse(mMediaStore.hasSiteMediaWithId(testSite, testMediaId));
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite) == 0);
+        Assert.assertFalse(mMediaStore.hasSiteMediaWithId(testSite, testMediaId));
 
         // add test media
         MediaModel testMedia = getBasicMedia();
         testMedia.setLocalSiteId(testSiteId);
         testMedia.setMediaId(testMediaId);
-        assertTrue(insertMediaIntoDatabase(testMedia) == 1);
+        Assert.assertTrue(insertMediaIntoDatabase(testMedia) == 1);
 
         // verify store has inserted media
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 1);
-        assertTrue(mMediaStore.hasSiteMediaWithId(testSite, testMediaId));
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite) == 1);
+        Assert.assertTrue(mMediaStore.hasSiteMediaWithId(testSite, testMediaId));
     }
 
     @Test
@@ -111,13 +109,13 @@ public class MediaStoreTest {
         final int testSiteId = 25;
         final long testMediaId = 11;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertFalse(mMediaStore.hasSiteMediaWithId(testSite, testMediaId));
+        Assert.assertFalse(mMediaStore.hasSiteMediaWithId(testSite, testMediaId));
 
         // add test media
         MediaModel testMedia = getBasicMedia();
         testMedia.setLocalSiteId(testSiteId);
         testMedia.setMediaId(testMediaId);
-        assertTrue(insertMediaIntoDatabase(testMedia) == 1);
+        Assert.assertTrue(insertMediaIntoDatabase(testMedia) == 1);
 
         // cannot get media with incorrect site ID
         final int wrongSiteId = testSiteId + 1;
@@ -126,8 +124,8 @@ public class MediaStoreTest {
 
         // verify stored media
         final MediaModel storeMedia = mMediaStore.getSiteMediaWithId(testSite, testMediaId);
-        assertNotNull(storeMedia);
-        assertEquals(testMedia, storeMedia);
+        Assert.assertNotNull(storeMedia);
+        Assert.assertEquals(testMedia, storeMedia);
     }
 
     @Test
@@ -137,7 +135,7 @@ public class MediaStoreTest {
         final int testSiteId = 55;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
         List<MediaModel> insertedMedia = insertRandomMediaIntoDatabase(testSiteId, testListSize);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == testListSize);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite) == testListSize);
 
         // create whitelist
         List<Long> whitelist = new ArrayList<>(testListSize / 2);
@@ -146,10 +144,10 @@ public class MediaStoreTest {
         }
 
         final List<MediaModel> storeMedia = mMediaStore.getSiteMediaWithIds(testSite, whitelist);
-        assertNotNull(storeMedia);
-        assertTrue(storeMedia.size() == whitelist.size());
+        Assert.assertNotNull(storeMedia);
+        Assert.assertTrue(storeMedia.size() == whitelist.size());
         for (MediaModel media : storeMedia) {
-            assertTrue(whitelist.contains(media.getMediaId()));
+            Assert.assertTrue(whitelist.contains(media.getMediaId()));
         }
     }
 
@@ -163,24 +161,24 @@ public class MediaStoreTest {
 
         // insert media of different types
         MediaModel videoMedia = generateMediaFromPath(testSiteId, testVideoId, testVideoPath);
-        assertTrue(MediaUtils.isVideoMimeType(videoMedia.getMimeType()));
+        Assert.assertTrue(MediaUtils.isVideoMimeType(videoMedia.getMimeType()));
         MediaModel imageMedia = generateMediaFromPath(testSiteId, testImageId, testImagePath);
-        assertTrue(MediaUtils.isImageMimeType(imageMedia.getMimeType()));
+        Assert.assertTrue(MediaUtils.isImageMimeType(imageMedia.getMimeType()));
         insertMediaIntoDatabase(videoMedia);
         insertMediaIntoDatabase(imageMedia);
 
         final List<MediaModel> storeImages = mMediaStore.getSiteImages(getTestSiteWithLocalId(testSiteId));
-        assertNotNull(storeImages);
-        assertTrue(storeImages.size() == 1);
-        assertEquals(testImageId, storeImages.get(0).getMediaId());
-        assertTrue(MediaUtils.isImageMimeType(storeImages.get(0).getMimeType()));
+        Assert.assertNotNull(storeImages);
+        Assert.assertTrue(storeImages.size() == 1);
+        Assert.assertEquals(testImageId, storeImages.get(0).getMediaId());
+        Assert.assertTrue(MediaUtils.isImageMimeType(storeImages.get(0).getMimeType()));
     }
 
     @Test
     public void testGetSiteImageCount() {
         final int testSiteId = 9001;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertTrue(mMediaStore.getSiteImageCount(testSite) == 0);
+        Assert.assertTrue(mMediaStore.getSiteImageCount(testSite) == 0);
 
         // insert both images and videos
         final int testListSize = 10;
@@ -191,31 +189,31 @@ public class MediaStoreTest {
         for (int i = 0; i < testListSize; ++i) {
             MediaModel testImage = generateMediaFromPath(testSiteId, i, String.format(testImagePath, i));
             MediaModel testVideo = generateMediaFromPath(testSiteId, i + testListSize, String.format(testVideoPath, i));
-            assertTrue(insertMediaIntoDatabase(testImage) == 1);
-            assertTrue(insertMediaIntoDatabase(testVideo) == 1);
+            Assert.assertTrue(insertMediaIntoDatabase(testImage) == 1);
+            Assert.assertTrue(insertMediaIntoDatabase(testVideo) == 1);
             testImages.add(testImage);
             testVideos.add(testVideo);
         }
 
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == testImages.size() + testVideos.size());
-        assertTrue(mMediaStore.getSiteImageCount(testSite) == testImages.size());
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite) == testImages.size() + testVideos.size());
+        Assert.assertTrue(mMediaStore.getSiteImageCount(testSite) == testImages.size());
     }
 
     @Test
     public void testGetSiteImagesBlacklist() {
         final int testSiteId = 3;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertTrue(mMediaStore.getSiteImageCount(testSite) == 0);
+        Assert.assertTrue(mMediaStore.getSiteImageCount(testSite) == 0);
 
         final int testListSize = 10;
         final List<MediaModel> testImages = new ArrayList<>(testListSize);
         final String testImagePath = "/test/test_image%d.png";
         for (int i = 0; i < testListSize; ++i) {
             MediaModel image = generateMediaFromPath(testSiteId, i, String.format(testImagePath, i));
-            assertTrue(insertMediaIntoDatabase(image) == 1);
+            Assert.assertTrue(insertMediaIntoDatabase(image) == 1);
             testImages.add(image);
         }
-        assertTrue(mMediaStore.getSiteImageCount(testSite) == testListSize);
+        Assert.assertTrue(mMediaStore.getSiteImageCount(testSite) == testListSize);
 
         // create blacklist
         List<Long> blacklist = new ArrayList<>(testListSize / 2);
@@ -224,10 +222,10 @@ public class MediaStoreTest {
         }
 
         final List<MediaModel> storeMedia = mMediaStore.getSiteImagesExcludingIds(testSite, blacklist);
-        assertNotNull(storeMedia);
-        assertEquals(testListSize - blacklist.size(), storeMedia.size());
+        Assert.assertNotNull(storeMedia);
+        Assert.assertEquals(testListSize - blacklist.size(), storeMedia.size());
         for (MediaModel media : storeMedia) {
-            assertFalse(blacklist.contains(media.getMediaId()));
+            Assert.assertFalse(blacklist.contains(media.getMediaId()));
         }
     }
 
@@ -249,10 +247,10 @@ public class MediaStoreTest {
         }
 
         final List<MediaModel> storeMedia = mMediaStore.getUnattachedSiteMedia(getTestSiteWithLocalId(testSiteId));
-        assertNotNull(storeMedia);
-        assertTrue(storeMedia.size() == unattachedMedia.size());
+        Assert.assertNotNull(storeMedia);
+        Assert.assertTrue(storeMedia.size() == unattachedMedia.size());
         for (int i = 0; i < storeMedia.size(); ++i) {
-            assertTrue(storeMedia.contains(unattachedMedia.get(i)));
+            Assert.assertTrue(storeMedia.contains(unattachedMedia.get(i)));
         }
     }
 
@@ -270,7 +268,7 @@ public class MediaStoreTest {
             insertMediaIntoDatabase(attached);
             insertMediaIntoDatabase(unattached);
         }
-        assertTrue(mMediaStore.getUnattachedSiteMediaCount(getTestSiteWithLocalId(testSiteId)) == testPoolSize);
+        Assert.assertTrue(mMediaStore.getUnattachedSiteMediaCount(getTestSiteWithLocalId(testSiteId)) == testPoolSize);
     }
 
     @Test
@@ -295,22 +293,22 @@ public class MediaStoreTest {
         insertMediaIntoDatabase(remoteMedia);
 
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertEquals(2, mMediaStore.getSiteMediaCount(testSite));
+        Assert.assertEquals(2, mMediaStore.getSiteMediaCount(testSite));
 
         // verify local store media
         final List<MediaModel> localSiteMedia = mMediaStore.getLocalSiteMedia(testSite);
-        assertNotNull(localSiteMedia);
-        assertEquals(1, localSiteMedia.size());
-        assertNotNull(localSiteMedia.get(0));
-        assertEquals(localMediaId, localSiteMedia.get(0).getMediaId());
+        Assert.assertNotNull(localSiteMedia);
+        Assert.assertEquals(1, localSiteMedia.size());
+        Assert.assertNotNull(localSiteMedia.get(0));
+        Assert.assertEquals(localMediaId, localSiteMedia.get(0).getMediaId());
 
         // verify uploaded store media
         final List<MediaModel> uploadedSiteMedia = mMediaStore.getSiteMediaWithState(testSite,
                 MediaUploadState.UPLOADED);
-        assertNotNull(uploadedSiteMedia);
-        assertEquals(1, uploadedSiteMedia.size());
-        assertNotNull(uploadedSiteMedia.get(0));
-        assertEquals(remoteMediaId, uploadedSiteMedia.get(0).getMediaId());
+        Assert.assertNotNull(uploadedSiteMedia);
+        Assert.assertEquals(1, uploadedSiteMedia.size());
+        Assert.assertNotNull(uploadedSiteMedia.get(0));
+        Assert.assertEquals(remoteMediaId, uploadedSiteMedia.get(0).getMediaId());
     }
 
     @Test
@@ -324,13 +322,13 @@ public class MediaStoreTest {
         final String testVideoPressGuid = "thisisonlyatest";
         testVideo.setUrl(testUrl);
         testVideo.setVideoPressGuid(testVideoPressGuid);
-        assertTrue(insertMediaIntoDatabase(testVideo) == 1);
+        Assert.assertTrue(insertMediaIntoDatabase(testVideo) == 1);
 
         // retrieve video and verify
         final String storeUrl = mMediaStore
                 .getUrlForSiteVideoWithVideoPressGuid(getTestSiteWithLocalId(testSiteId), testVideoPressGuid);
-        assertNotNull(storeUrl);
-        assertEquals(testUrl, storeUrl);
+        Assert.assertNotNull(storeUrl);
+        Assert.assertEquals(testUrl, storeUrl);
     }
 
     @Test
@@ -342,13 +340,13 @@ public class MediaStoreTest {
         final String testUrl = "http://notarealurl.testfluxc.org/not/a/real/resource/path.mp4";
         testMedia.setThumbnailUrl(testUrl);
         testMedia.setMediaId(testMediaId);
-        assertTrue(insertMediaIntoDatabase(testMedia) == 1);
+        Assert.assertTrue(insertMediaIntoDatabase(testMedia) == 1);
 
         // retrieve media and verify
         final String storeUrl = mMediaStore
                 .getThumbnailUrlForSiteMediaWithId(getTestSiteWithLocalId(testSiteId), testMediaId);
-        assertNotNull(storeUrl);
-        assertEquals(testUrl, storeUrl);
+        Assert.assertNotNull(storeUrl);
+        Assert.assertEquals(testUrl, storeUrl);
     }
 
     @Test
@@ -363,15 +361,15 @@ public class MediaStoreTest {
             MediaModel testMedia = generateMedia(baseString, null, null, null);
             testMedia.setLocalSiteId(testSiteId);
             testMedia.setMediaId(i);
-            assertTrue(insertMediaIntoDatabase(testMedia) == 1);
+            Assert.assertTrue(insertMediaIntoDatabase(testMedia) == 1);
             baseString += String.valueOf(i);
         }
 
         for (int i = 0; i < testPoolSize; ++i) {
             List<MediaModel> storeMedia = mMediaStore
                     .searchSiteMedia(getTestSiteWithLocalId(testSiteId), testTitles[i]);
-            assertNotNull(storeMedia);
-            assertTrue(storeMedia.size() == testPoolSize - i);
+            Assert.assertNotNull(storeMedia);
+            Assert.assertTrue(storeMedia.size() == testPoolSize - i);
         }
     }
 
@@ -412,18 +410,18 @@ public class MediaStoreTest {
         PostModel post = new PostModel();
         post.setId(testLocalPostId);
         final MediaModel storeMedia = mMediaStore.getMediaForPostWithPath(post, testPath);
-        assertNotNull(storeMedia);
-        assertEquals(testPath, storeMedia.getFilePath());
-        assertEquals(postMediaId, storeMedia.getMediaId());
-        assertEquals(3, mMediaStore.getSiteMediaCount(getTestSiteWithLocalId(testSiteId)));
+        Assert.assertNotNull(storeMedia);
+        Assert.assertEquals(testPath, storeMedia.getFilePath());
+        Assert.assertEquals(postMediaId, storeMedia.getMediaId());
+        Assert.assertEquals(3, mMediaStore.getSiteMediaCount(getTestSiteWithLocalId(testSiteId)));
 
         // verify the correct media is in the store
         List<MediaModel> mediaModelList = mMediaStore.getMediaForPost(post);
-        assertNotNull(mediaModelList);
-        assertEquals(3, mediaModelList.size());
+        Assert.assertNotNull(mediaModelList);
+        Assert.assertEquals(3, mediaModelList.size());
         for (MediaModel media : mediaModelList) {
-            assertNotNull(media);
-            assertEquals(post.getId(), media.getLocalPostId());
+            Assert.assertNotNull(media);
+            Assert.assertEquals(post.getId(), media.getLocalPostId());
         }
     }
 
@@ -445,16 +443,16 @@ public class MediaStoreTest {
         }
 
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertEquals(count * 2, mMediaStore.getSiteMediaCount(testSite));
+        Assert.assertEquals(count * 2, mMediaStore.getSiteMediaCount(testSite));
 
         // verify store media updates as media is deleted
         for (int i = 0; i < count; ++i) {
             MediaModel next = mMediaStore.getNextSiteMediaToDelete(testSite);
-            assertNotNull(next);
-            assertEquals(MediaUploadState.DELETING, MediaUploadState.fromString(next.getUploadState()));
-            assertTrue(pendingDelete.contains(next));
+            Assert.assertNotNull(next);
+            Assert.assertEquals(MediaUploadState.DELETING, MediaUploadState.fromString(next.getUploadState()));
+            Assert.assertTrue(pendingDelete.contains(next));
             MediaSqlUtils.deleteMedia(next);
-            assertEquals(count * 2 - i - 1, mMediaStore.getSiteMediaCount(testSite));
+            Assert.assertEquals(count * 2 - i - 1, mMediaStore.getSiteMediaCount(testSite));
             pendingDelete.remove(next);
         }
     }
@@ -477,40 +475,40 @@ public class MediaStoreTest {
         }
 
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertEquals(count * 2, mMediaStore.getSiteMediaCount(testSite));
+        Assert.assertEquals(count * 2, mMediaStore.getSiteMediaCount(testSite));
 
         // verify store still has media to delete after deleting one
-        assertTrue(mMediaStore.hasSiteMediaToDelete(testSite));
+        Assert.assertTrue(mMediaStore.hasSiteMediaToDelete(testSite));
         MediaModel next = mMediaStore.getNextSiteMediaToDelete(testSite);
-        assertNotNull(next);
-        assertTrue(pendingDelete.contains(next));
+        Assert.assertNotNull(next);
+        Assert.assertTrue(pendingDelete.contains(next));
         MediaSqlUtils.deleteMedia(next);
         pendingDelete.remove(next);
-        assertEquals(count * 2 - 1, mMediaStore.getSiteMediaCount(testSite));
-        assertTrue(mMediaStore.hasSiteMediaToDelete(testSite));
+        Assert.assertEquals(count * 2 - 1, mMediaStore.getSiteMediaCount(testSite));
+        Assert.assertTrue(mMediaStore.hasSiteMediaToDelete(testSite));
 
         // verify store has no media to delete after removing all
         for (MediaModel pending : pendingDelete) {
             MediaSqlUtils.deleteMedia(pending);
         }
-        assertEquals(count, mMediaStore.getSiteMediaCount(testSite));
-        assertFalse(mMediaStore.hasSiteMediaToDelete(testSite));
+        Assert.assertEquals(count, mMediaStore.getSiteMediaCount(testSite));
+        Assert.assertFalse(mMediaStore.hasSiteMediaToDelete(testSite));
     }
 
     @Test
     public void testRemoveAllMedia() {
         SiteModel testSite1 = getTestSiteWithLocalId(1);
         insertRandomMediaIntoDatabase(testSite1.getId(), 5);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite1) == 5);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite1) == 5);
 
         SiteModel testSite2 = getTestSiteWithLocalId(2);
         insertRandomMediaIntoDatabase(testSite2.getId(), 7);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite2) == 7);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite2) == 7);
 
         MediaSqlUtils.deleteAllMedia();
 
-        assertTrue(mMediaStore.getSiteMediaCount(testSite1) == 0);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite2) == 0);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite1) == 0);
+        Assert.assertTrue(mMediaStore.getSiteMediaCount(testSite2) == 0);
     }
 
     private MediaModel getBasicMedia() {

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaTestUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.media;
 
+import junit.framework.Assert;
+
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.persistence.MediaSqlUtils;
 import org.wordpress.android.fluxc.utils.MediaUtils;
@@ -7,8 +9,6 @@ import org.wordpress.android.fluxc.utils.MediaUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import static org.junit.Assert.assertTrue;
 
 public class MediaTestUtils {
     public static int insertMediaIntoDatabase(MediaModel media) {
@@ -18,7 +18,7 @@ public class MediaTestUtils {
     public static List<MediaModel> insertRandomMediaIntoDatabase(int localSiteId, int count) {
         List<MediaModel> insertedMedia = generateRandomizedMediaList(count, localSiteId);
         for (MediaModel media : insertedMedia) {
-            assertTrue(MediaSqlUtils.insertOrUpdateMedia(media) == 1);
+            Assert.assertTrue(MediaSqlUtils.insertOrUpdateMedia(media) == 1);
         }
         return insertedMedia;
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostLocationTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostLocationTest.java
@@ -27,32 +27,32 @@ public class PostLocationTest {
     @Test
     public void testInstantiateValidLocation() {
         PostLocation locationZero = new PostLocation(EQUATOR_LAT, EQUATOR_LNG);
-        assertTrue("ZeroLoc did not instantiate valid location", locationZero.isValid());
-        assertEquals("ZeroLoc did not return correct lat", EQUATOR_LAT, locationZero.getLatitude());
-        assertEquals("ZeroLoc did not return correct lng", EQUATOR_LNG, locationZero.getLongitude());
+        Assert.assertTrue("ZeroLoc did not instantiate valid location", locationZero.isValid());
+        Assert.assertEquals("ZeroLoc did not return correct lat", EQUATOR_LAT, locationZero.getLatitude());
+        Assert.assertEquals("ZeroLoc did not return correct lng", EQUATOR_LNG, locationZero.getLongitude());
 
         PostLocation locationMax = new PostLocation(MAX_LAT, MAX_LNG);
-        assertTrue("MaxLoc did not instantiate valid location", locationMax.isValid());
-        assertEquals("MaxLoc did not return correct lat", MAX_LAT, locationMax.getLatitude());
-        assertEquals("MaxLoc did not return correct lng", MAX_LNG, locationMax.getLongitude());
+        Assert.assertTrue("MaxLoc did not instantiate valid location", locationMax.isValid());
+        Assert.assertEquals("MaxLoc did not return correct lat", MAX_LAT, locationMax.getLatitude());
+        Assert.assertEquals("MaxLoc did not return correct lng", MAX_LNG, locationMax.getLongitude());
 
         PostLocation locationMin = new PostLocation(MIN_LAT, MIN_LNG);
-        assertTrue("MinLoc did not instantiate valid location", locationMin.isValid());
-        assertEquals("MinLoc did not return correct lat", MIN_LAT, locationMin.getLatitude());
-        assertEquals("MinLoc did not return correct lng", MIN_LNG, locationMin.getLongitude());
+        Assert.assertTrue("MinLoc did not instantiate valid location", locationMin.isValid());
+        Assert.assertEquals("MinLoc did not return correct lat", MIN_LAT, locationMin.getLatitude());
+        Assert.assertEquals("MinLoc did not return correct lng", MIN_LNG, locationMin.getLongitude());
 
         double miscLat = 34;
         double miscLng = -60;
         PostLocation locationMisc = new PostLocation(miscLat, miscLng);
-        assertTrue("MiscLoc did not instantiate valid location", locationMisc.isValid());
-        assertEquals("MiscLoc did not return correct lat", miscLat, locationMisc.getLatitude());
-        assertEquals("MiscLoc did not return correct lng", miscLng, locationMisc.getLongitude());
+        Assert.assertTrue("MiscLoc did not instantiate valid location", locationMisc.isValid());
+        Assert.assertEquals("MiscLoc did not return correct lat", miscLat, locationMisc.getLatitude());
+        Assert.assertEquals("MiscLoc did not return correct lng", miscLng, locationMisc.getLongitude());
     }
 
     @Test
     public void testDefaultLocationInvalid() {
         PostLocation location = new PostLocation();
-        assertFalse("Empty location should be invalid", location.isValid());
+        Assert.assertFalse("Empty location should be invalid", location.isValid());
     }
 
     @Test
@@ -63,14 +63,14 @@ public class PostLocationTest {
             location.setLatitude(INVALID_LAT_MAX);
             Assert.fail("Lat less than min should have failed");
         } catch (IllegalArgumentException e) {
-            assertFalse("Invalid setLatitude and still valid", location.isValid());
+            Assert.assertFalse("Invalid setLatitude and still valid", location.isValid());
         }
 
         try {
             location.setLatitude(INVALID_LAT_MIN);
             Assert.fail("Lat less than min should have failed");
         } catch (IllegalArgumentException e) {
-            assertFalse("Invalid setLatitude and still valid", location.isValid());
+            Assert.assertFalse("Invalid setLatitude and still valid", location.isValid());
         }
     }
 
@@ -82,14 +82,14 @@ public class PostLocationTest {
             location.setLongitude(INVALID_LNG_MAX);
             Assert.fail("Lng less than min should have failed");
         } catch (IllegalArgumentException e) {
-            assertFalse("Invalid setLongitude and still valid", location.isValid());
+            Assert.assertFalse("Invalid setLongitude and still valid", location.isValid());
         }
 
         try {
             location.setLongitude(INVALID_LNG_MIN);
             Assert.fail("Lat less than min should have failed");
         } catch (IllegalArgumentException e) {
-            assertFalse("Invalid setLongitude and still valid", location.isValid());
+            Assert.assertFalse("Invalid setLongitude and still valid", location.isValid());
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.post;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -11,9 +13,6 @@ import org.wordpress.android.fluxc.network.BaseRequest;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.wordpress.android.fluxc.post.PostTestUtils.EXAMPLE_LATITUDE;
 import static org.wordpress.android.fluxc.post.PostTestUtils.EXAMPLE_LONGITUDE;
 
@@ -25,9 +24,9 @@ public class PostModelTest {
         PostModel testPost2 = PostTestUtils.generateSampleUploadedPost();
 
         testPost2.setRemotePostId(testPost.getRemotePostId() + 1);
-        assertFalse(testPost.equals(testPost2));
+        Assert.assertFalse(testPost.equals(testPost2));
         testPost2.setRemotePostId(testPost.getRemotePostId());
-        assertTrue(testPost.equals(testPost2));
+        Assert.assertTrue(testPost.equals(testPost2));
     }
 
     @Test
@@ -45,11 +44,11 @@ public class PostModelTest {
 
         PostModel clonedPost = (PostModel) testPost.clone();
 
-        assertFalse(testPost == clonedPost);
-        assertTrue(testPost.equals(clonedPost));
+        Assert.assertFalse(testPost == clonedPost);
+        Assert.assertTrue(testPost.equals(clonedPost));
 
         // The inherited error should also be cloned
-        assertFalse(testPost.error == clonedPost.error);
+        Assert.assertFalse(testPost.error == clonedPost.error);
     }
 
     @Test
@@ -57,18 +56,18 @@ public class PostModelTest {
         PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
 
         testPost.setCategoryIdList(null);
-        assertTrue(testPost.getCategoryIdList().isEmpty());
+        Assert.assertTrue(testPost.getCategoryIdList().isEmpty());
 
         List<Long> categoryIds = new ArrayList<>();
         testPost.setCategoryIdList(categoryIds);
-        assertTrue(testPost.getCategoryIdList().isEmpty());
+        Assert.assertTrue(testPost.getCategoryIdList().isEmpty());
 
         categoryIds.add((long) 5);
         categoryIds.add((long) 6);
         testPost.setCategoryIdList(categoryIds);
 
-        assertEquals(2, testPost.getCategoryIdList().size());
-        assertTrue(categoryIds.containsAll(testPost.getCategoryIdList())
+        Assert.assertEquals(2, testPost.getCategoryIdList().size());
+        Assert.assertTrue(categoryIds.containsAll(testPost.getCategoryIdList())
                    && testPost.getCategoryIdList().containsAll(categoryIds));
     }
 
@@ -77,38 +76,38 @@ public class PostModelTest {
         PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
 
         // Expect no location if none was set
-        assertFalse(testPost.hasLocation());
-        assertFalse(testPost.getLocation().isValid());
-        assertFalse(testPost.shouldDeleteLatitude());
-        assertFalse(testPost.shouldDeleteLongitude());
+        Assert.assertFalse(testPost.hasLocation());
+        Assert.assertFalse(testPost.getLocation().isValid());
+        Assert.assertFalse(testPost.shouldDeleteLatitude());
+        Assert.assertFalse(testPost.shouldDeleteLongitude());
 
         // Verify state when location is set
         testPost.setLocation(new PostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE));
 
-        assertTrue(testPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, testPost.getLatitude(), 0);
-        assertEquals(EXAMPLE_LONGITUDE, testPost.getLongitude(), 0);
-        assertEquals(new PostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE), testPost.getLocation());
-        assertFalse(testPost.shouldDeleteLatitude());
-        assertFalse(testPost.shouldDeleteLongitude());
+        Assert.assertTrue(testPost.hasLocation());
+        Assert.assertEquals(EXAMPLE_LATITUDE, testPost.getLatitude(), 0);
+        Assert.assertEquals(EXAMPLE_LONGITUDE, testPost.getLongitude(), 0);
+        Assert.assertEquals(new PostLocation(EXAMPLE_LATITUDE, EXAMPLE_LONGITUDE), testPost.getLocation());
+        Assert.assertFalse(testPost.shouldDeleteLatitude());
+        Assert.assertFalse(testPost.shouldDeleteLongitude());
 
         // (0, 0) is a valid location
         testPost.setLocation(0, 0);
 
-        assertTrue(testPost.hasLocation());
-        assertEquals(0, testPost.getLatitude(), 0);
-        assertEquals(0, testPost.getLongitude(), 0);
-        assertEquals(new PostLocation(0, 0), testPost.getLocation());
-        assertFalse(testPost.shouldDeleteLatitude());
-        assertFalse(testPost.shouldDeleteLongitude());
+        Assert.assertTrue(testPost.hasLocation());
+        Assert.assertEquals(0, testPost.getLatitude(), 0);
+        Assert.assertEquals(0, testPost.getLongitude(), 0);
+        Assert.assertEquals(new PostLocation(0, 0), testPost.getLocation());
+        Assert.assertFalse(testPost.shouldDeleteLatitude());
+        Assert.assertFalse(testPost.shouldDeleteLongitude());
 
         // Clearing the location should remove the location, and flag it for deletion on the server
         testPost.clearLocation();
 
-        assertFalse(testPost.hasLocation());
-        assertFalse(testPost.getLocation().isValid());
-        assertTrue(testPost.shouldDeleteLatitude());
-        assertTrue(testPost.shouldDeleteLongitude());
+        Assert.assertFalse(testPost.hasLocation());
+        Assert.assertFalse(testPost.getLocation().isValid());
+        Assert.assertTrue(testPost.shouldDeleteLatitude());
+        Assert.assertTrue(testPost.shouldDeleteLongitude());
     }
 
     @Test
@@ -117,9 +116,9 @@ public class PostModelTest {
 
         testPost.setTagNames("pony,             ,ponies");
         List<String> tags = testPost.getTagNameList();
-        assertTrue(tags.contains("pony"));
-        assertTrue(tags.contains("ponies"));
-        assertEquals(2, tags.size());
+        Assert.assertTrue(tags.contains("pony"));
+        Assert.assertTrue(tags.contains("ponies"));
+        Assert.assertEquals(2, tags.size());
     }
 
     @Test
@@ -129,9 +128,9 @@ public class PostModelTest {
         testPost.setTagNames("    pony   , ponies    , #popopopopopony");
         List<String> tags = testPost.getTagNameList();
 
-        assertTrue(tags.contains("pony"));
-        assertTrue(tags.contains("ponies"));
-        assertTrue(tags.contains("#popopopopopony"));
-        assertEquals(3, tags.size());
+        Assert.assertTrue(tags.contains("pony"));
+        Assert.assertTrue(tags.contains("ponies"));
+        Assert.assertTrue(tags.contains("#popopopopopony"));
+        Assert.assertEquals(3, tags.size());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStatusTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStatusTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.post;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -8,8 +10,6 @@ import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class PostStatusTest {
@@ -20,11 +20,11 @@ public class PostStatusTest {
 
         // Test published post with past date
         post.setDateCreated(DateTimeUtils.iso8601UTCFromDate(new Date()));
-        assertEquals(PostStatus.PUBLISHED, PostStatus.fromPost(post));
+        Assert.assertEquals(PostStatus.PUBLISHED, PostStatus.fromPost(post));
 
         // Test "published" post with future date
         post.setDateCreated(DateTimeUtils.iso8601UTCFromDate(new Date(System.currentTimeMillis() + 500000)));
-        assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(post));
+        Assert.assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(post));
     }
 
     @Test
@@ -32,6 +32,6 @@ public class PostStatusTest {
         PostModel post = new PostModel();
         post.setStatus("publish");
 
-        assertEquals(PostStatus.PUBLISHED, PostStatus.fromPost(post));
+        Assert.assertEquals(PostStatus.PUBLISHED, PostStatus.fromPost(post));
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,9 +27,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 @RunWith(RobolectricTestRunner.class)
@@ -46,9 +45,9 @@ public class PostStoreUnitTest {
 
     @Test
     public void testInsertNullPost() {
-        assertEquals(0, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(null));
+        Assert.assertEquals(0, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(null));
 
-        assertEquals(0, PostTestUtils.getPostsCount());
+        Assert.assertEquals(0, PostTestUtils.getPostsCount());
     }
 
     @Test
@@ -57,9 +56,9 @@ public class PostStoreUnitTest {
         postModel.setRemotePostId(42);
         PostModel result = PostSqlUtils.insertPostForResult(postModel);
 
-        assertEquals(1, PostTestUtils.getPostsCount());
-        assertEquals(42, PostTestUtils.getPosts().get(0).getRemotePostId());
-        assertEquals(postModel, result);
+        Assert.assertEquals(1, PostTestUtils.getPostsCount());
+        Assert.assertEquals(42, PostTestUtils.getPosts().get(0).getRemotePostId());
+        Assert.assertEquals(postModel, result);
     }
 
     @Test
@@ -71,11 +70,11 @@ public class PostStoreUnitTest {
         String newTitle = "A different title";
         postModel.setTitle(newTitle);
 
-        assertEquals(0, PostSqlUtils.insertOrUpdatePostKeepingLocalChanges(postModel));
-        assertEquals("A test post", PostTestUtils.getPosts().get(0).getTitle());
+        Assert.assertEquals(0, PostSqlUtils.insertOrUpdatePostKeepingLocalChanges(postModel));
+        Assert.assertEquals("A test post", PostTestUtils.getPosts().get(0).getTitle());
 
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel));
-        assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
+        Assert.assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel));
+        Assert.assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
     }
 
     @Test
@@ -97,11 +96,11 @@ public class PostStoreUnitTest {
         PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromPostListFetch);
         PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromUploadResponse);
 
-        assertEquals(1, PostTestUtils.getPosts().size());
+        Assert.assertEquals(1, PostTestUtils.getPosts().size());
 
         PostModel finalPost = PostTestUtils.getPosts().get(0);
-        assertEquals(42, finalPost.getRemotePostId());
-        assertEquals(postModel.getLocalSiteId(), finalPost.getLocalSiteId());
+        Assert.assertEquals(42, finalPost.getRemotePostId());
+        Assert.assertEquals(postModel.getLocalSiteId(), finalPost.getLocalSiteId());
     }
 
     @Test
@@ -112,14 +111,14 @@ public class PostStoreUnitTest {
         String newTitle = "A different title";
         postModel.setTitle(newTitle);
 
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostKeepingLocalChanges(postModel));
-        assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
+        Assert.assertEquals(1, PostSqlUtils.insertOrUpdatePostKeepingLocalChanges(postModel));
+        Assert.assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
 
         newTitle = "Another different title";
         postModel.setTitle(newTitle);
 
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel));
-        assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
+        Assert.assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel));
+        Assert.assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
     }
 
     @Test
@@ -137,10 +136,10 @@ public class PostStoreUnitTest {
         SiteModel site2 = new SiteModel();
         site2.setId(uploadedPost2.getLocalSiteId());
 
-        assertEquals(2, PostTestUtils.getPostsCount());
+        Assert.assertEquals(2, PostTestUtils.getPostsCount());
 
-        assertEquals(1, mPostStore.getPostsCountForSite(site1));
-        assertEquals(1, mPostStore.getPostsCountForSite(site2));
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(site1));
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(site2));
     }
 
     @Test
@@ -160,10 +159,10 @@ public class PostStoreUnitTest {
         postFormat.add("video");
         List<PostModel> postList = mPostStore.getPostsForSiteWithFormat(site, postFormat);
 
-        assertEquals(2, postList.size());
-        assertTrue(postList.contains(imagePost));
-        assertTrue(postList.contains(videoPost));
-        assertFalse(postList.contains(textPost));
+        Assert.assertEquals(2, postList.size());
+        Assert.assertTrue(postList.contains(imagePost));
+        Assert.assertTrue(postList.contains(videoPost));
+        Assert.assertFalse(postList.contains(textPost));
     }
 
     @Test
@@ -177,10 +176,10 @@ public class PostStoreUnitTest {
         PostModel localDraft = PostTestUtils.generateSampleLocalDraftPost();
         PostSqlUtils.insertPostForResult(localDraft);
 
-        assertEquals(2, PostTestUtils.getPostsCount());
-        assertEquals(2, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(2, PostTestUtils.getPostsCount());
+        Assert.assertEquals(2, mPostStore.getPostsCountForSite(site));
 
-        assertEquals(1, mPostStore.getUploadedPostsCountForSite(site));
+        Assert.assertEquals(1, mPostStore.getUploadedPostsCountForSite(site));
     }
 
     @Test
@@ -188,7 +187,7 @@ public class PostStoreUnitTest {
         PostModel post = PostTestUtils.generateSampleLocalDraftPost();
         PostSqlUtils.insertPostForResult(post);
 
-        assertEquals(post, mPostStore.getPostByLocalPostId(post.getId()));
+        Assert.assertEquals(post, mPostStore.getPostByLocalPostId(post.getId()));
     }
 
     @Test
@@ -199,7 +198,7 @@ public class PostStoreUnitTest {
         SiteModel site = new SiteModel();
         site.setId(6);
 
-        assertEquals(post, mPostStore.getPostByRemotePostId(post.getRemotePostId(), site));
+        Assert.assertEquals(post, mPostStore.getPostByRemotePostId(post.getRemotePostId(), site));
     }
 
     @Test
@@ -220,11 +219,11 @@ public class PostStoreUnitTest {
         PostModel locallyChangedPost = PostTestUtils.generateSampleLocallyChangedPost();
         PostSqlUtils.insertPostForResult(locallyChangedPost);
 
-        assertEquals(4, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(4, mPostStore.getPostsCountForSite(site));
 
         PostSqlUtils.deleteUploadedPostsForSite(site, false);
 
-        assertEquals(2, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(2, mPostStore.getPostsCountForSite(site));
     }
 
     @Test
@@ -245,24 +244,24 @@ public class PostStoreUnitTest {
         PostModel locallyChangedPost = PostTestUtils.generateSampleLocallyChangedPost();
         PostSqlUtils.insertPostForResult(locallyChangedPost);
 
-        assertEquals(4, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(4, mPostStore.getPostsCountForSite(site));
 
         PostSqlUtils.deletePost(uploadedPost1);
 
-        assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost1.getId()));
-        assertEquals(3, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost1.getId()));
+        Assert.assertEquals(3, mPostStore.getPostsCountForSite(site));
 
         PostSqlUtils.deletePost(uploadedPost2);
         PostSqlUtils.deletePost(localDraft);
 
         assertNotEquals(null, mPostStore.getPostByLocalPostId(locallyChangedPost.getId()));
-        assertEquals(1, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(site));
 
         PostSqlUtils.deletePost(locallyChangedPost);
 
-        assertEquals(null, mPostStore.getPostByLocalPostId(locallyChangedPost.getId()));
-        assertEquals(0, mPostStore.getPostsCountForSite(site));
-        assertEquals(0, PostTestUtils.getPostsCount());
+        Assert.assertEquals(null, mPostStore.getPostByLocalPostId(locallyChangedPost.getId()));
+        Assert.assertEquals(0, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(0, PostTestUtils.getPostsCount());
     }
 
     @Test
@@ -281,16 +280,16 @@ public class PostStoreUnitTest {
         page.setRemotePostId(43);
         PostSqlUtils.insertPostForResult(page);
 
-        assertEquals(2, PostTestUtils.getPostsCount());
+        Assert.assertEquals(2, PostTestUtils.getPostsCount());
 
-        assertEquals(1, mPostStore.getPostsCountForSite(site));
-        assertEquals(1, mPostStore.getPagesCountForSite(site));
+        Assert.assertEquals(1, mPostStore.getPostsCountForSite(site));
+        Assert.assertEquals(1, mPostStore.getPagesCountForSite(site));
 
-        assertFalse(PostTestUtils.getPosts().get(0).isPage());
-        assertTrue(PostTestUtils.getPosts().get(1).isPage());
+        Assert.assertFalse(PostTestUtils.getPosts().get(0).isPage());
+        Assert.assertTrue(PostTestUtils.getPosts().get(1).isPage());
 
-        assertEquals(1, mPostStore.getUploadedPostsCountForSite(site));
-        assertEquals(1, mPostStore.getUploadedPagesCountForSite(site));
+        Assert.assertEquals(1, mPostStore.getUploadedPostsCountForSite(site));
+        Assert.assertEquals(1, mPostStore.getUploadedPagesCountForSite(site));
     }
 
     @Test
@@ -319,9 +318,9 @@ public class PostStoreUnitTest {
         List<PostModel> posts = PostSqlUtils.getPostsForSite(site, false);
 
         // Expect order draft > scheduled > published
-        assertTrue(posts.get(0).isLocalDraft());
-        assertEquals(23, posts.get(1).getRemotePostId());
-        assertEquals(42, posts.get(2).getRemotePostId());
+        Assert.assertTrue(posts.get(0).isLocalDraft());
+        Assert.assertEquals(23, posts.get(1).getRemotePostId());
+        Assert.assertEquals(42, posts.get(2).getRemotePostId());
     }
 
     @Test
@@ -333,10 +332,10 @@ public class PostStoreUnitTest {
         uploadedPost2.setLocalSiteId(8);
         PostSqlUtils.insertPostForResult(uploadedPost2);
 
-        assertEquals(2, PostTestUtils.getPostsCount());
+        Assert.assertEquals(2, PostTestUtils.getPostsCount());
 
         PostSqlUtils.deleteAllPosts();
 
-        assertEquals(0, PostTestUtils.getPostsCount());
+        Assert.assertEquals(0, PostTestUtils.getPostsCount());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -6,6 +6,8 @@ import android.database.sqlite.SQLiteException;
 import com.wellsql.generated.SiteModelTable;
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,12 +32,8 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.wordpress.android.fluxc.site.SiteUtils.generateJetpackSiteOverRestOnly;
 import static org.wordpress.android.fluxc.site.SiteUtils.generateJetpackSiteOverXMLRPC;
 import static org.wordpress.android.fluxc.site.SiteUtils.generatePostFormats;
@@ -64,9 +62,9 @@ public class SiteStoreUnitTest {
         siteModel.setSiteId(42);
         WellSql.insert(siteModel).execute();
 
-        assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
 
-        assertEquals(42, mSiteStore.getSites().get(0).getSiteId());
+        Assert.assertEquals(42, mSiteStore.getSites().get(0).getSiteId());
     }
 
     @Test
@@ -76,53 +74,53 @@ public class SiteStoreUnitTest {
         SiteModel site = generateWPComSite();
         SiteSqlUtils.insertOrUpdateSite(site);
 
-        assertTrue(mSiteStore.hasSiteWithLocalId(site.getId()));
-        assertEquals(site.getSiteId(), mSiteStore.getSiteByLocalId(site.getId()).getSiteId());
+        Assert.assertTrue(mSiteStore.hasSiteWithLocalId(site.getId()));
+        Assert.assertEquals(site.getSiteId(), mSiteStore.getSiteByLocalId(site.getId()).getSiteId());
     }
 
     @Test
     public void testHasSiteAndgetCountMethods() throws DuplicateSiteException {
         WellSqlTestUtils.setupWordPressComAccount();
 
-        assertFalse(mSiteStore.hasSite());
-        assertTrue(mSiteStore.getSites().isEmpty());
+        Assert.assertFalse(mSiteStore.hasSite());
+        Assert.assertTrue(mSiteStore.getSites().isEmpty());
 
         // Test counts with .COM site
         SiteModel wpComSite = generateWPComSite();
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
 
-        assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasWPComSite());
-        assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertTrue(mSiteStore.hasWPComSite());
+        Assert.assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
 
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertEquals(1, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getWPComSitesCount());
 
         // Test counts with one .COM and one self-hosted site
         SiteModel selfHostedSite = generateSelfHostedNonJPSite();
         SiteSqlUtils.insertOrUpdateSite(selfHostedSite);
 
-        assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasWPComSite());
-        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertTrue(mSiteStore.hasWPComSite());
+        Assert.assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
 
-        assertEquals(2, mSiteStore.getSitesCount());
-        assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(2, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         // Test counts with one .COM, one self-hosted and one Jetpack site
         SiteModel jetpackSiteOverRest = generateJetpackSiteOverRestOnly();
         SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverRest);
 
-        assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasWPComSite());
-        assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
+        Assert.assertTrue(mSiteStore.hasSite());
+        Assert.assertTrue(mSiteStore.hasWPComSite());
+        Assert.assertTrue(mSiteStore.hasSiteAccessedViaXMLRPC());
 
-        assertEquals(3, mSiteStore.getSitesCount());
-        assertEquals(1, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
-        assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(3, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
     }
 
     @Test
@@ -155,10 +153,10 @@ public class SiteStoreUnitTest {
         jetpackOverRest.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         SiteSqlUtils.insertOrUpdateSite(jetpackOverRest);
 
-        assertEquals(3, mSiteStore.getSitesCount());
-        assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(2, mSiteStore.getSitesAccessedViaXMLRPCCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(3, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(2, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaWPComRestCount());
 
         // User "install and connect" ponySite site to Jetpack via his connected .com account
 
@@ -167,11 +165,11 @@ public class SiteStoreUnitTest {
         ponySite.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         SiteSqlUtils.insertOrUpdateSite(ponySite);
 
-        assertEquals(3, mSiteStore.getSitesCount());
-        assertEquals(0, mSiteStore.getWPComSitesCount());
-        assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
+        Assert.assertEquals(3, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesAccessedViaXMLRPCCount());
         // Now ponySite is accessed via the WPCom REST API
-        assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
+        Assert.assertEquals(2, mSiteStore.getSitesAccessedViaWPComRestCount());
     }
 
     @Test
@@ -188,7 +186,7 @@ public class SiteStoreUnitTest {
         // Attempt to use with id of self-hosted site
         SiteSqlUtils.setSiteVisibility(selfHostedNonJPSite, false);
         // The self-hosted site should not be affected
-        assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
+        Assert.assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
 
 
         SiteModel wpComSite = generateWPComSite();
@@ -196,8 +194,8 @@ public class SiteStoreUnitTest {
 
         // Attempt to use with legitimate .com site
         SiteSqlUtils.setSiteVisibility(selfHostedNonJPSite, false);
-        assertFalse(mSiteStore.getSiteByLocalId(wpComSite.getId()).isVisible());
-        assertFalse(mSiteStore.isWPComSiteVisibleByLocalId(wpComSite.getId()));
+        Assert.assertFalse(mSiteStore.getSiteByLocalId(wpComSite.getId()).isVisible());
+        Assert.assertFalse(mSiteStore.isWPComSiteVisibleByLocalId(wpComSite.getId()));
     }
 
     @Test
@@ -212,7 +210,7 @@ public class SiteStoreUnitTest {
             SiteSqlUtils.setSiteVisibility(site, false);
         }
         // The self-hosted site should not be affected
-        assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
+        Assert.assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
 
         SiteModel wpComSite1 = generateWPComSite();
         SiteModel wpComSite2 = generateWPComSite();
@@ -226,18 +224,18 @@ public class SiteStoreUnitTest {
         for (SiteModel site : mSiteStore.getWPComSites()) {
             SiteSqlUtils.setSiteVisibility(site, false);
         }
-        assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
-        assertFalse(mSiteStore.getSiteByLocalId(wpComSite1.getId()).isVisible());
-        assertFalse(mSiteStore.getSiteByLocalId(wpComSite2.getId()).isVisible());
+        Assert.assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
+        Assert.assertFalse(mSiteStore.getSiteByLocalId(wpComSite1.getId()).isVisible());
+        Assert.assertFalse(mSiteStore.getSiteByLocalId(wpComSite2.getId()).isVisible());
     }
 
     @Test
     public void testGetIdForIdMethods() throws DuplicateSiteException {
         WellSqlTestUtils.setupWordPressComAccount();
 
-        assertEquals(0, mSiteStore.getLocalIdForRemoteSiteId(555));
-        assertEquals(0, mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(2626, ""));
-        assertEquals(0, mSiteStore.getSiteIdForLocalId(5577));
+        Assert.assertEquals(0, mSiteStore.getLocalIdForRemoteSiteId(555));
+        Assert.assertEquals(0, mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(2626, ""));
+        Assert.assertEquals(0, mSiteStore.getSiteIdForLocalId(5577));
 
         SiteModel selfHostedSite = generateSelfHostedNonJPSite();
         SiteModel wpComSite = generateWPComSite();
@@ -246,22 +244,22 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
         SiteSqlUtils.insertOrUpdateSite(jetpackSite);
 
-        assertEquals(selfHostedSite.getId(),
+        Assert.assertEquals(selfHostedSite.getId(),
                 mSiteStore.getLocalIdForRemoteSiteId(selfHostedSite.getSelfHostedSiteId()));
-        assertEquals(wpComSite.getId(), mSiteStore.getLocalIdForRemoteSiteId(wpComSite.getSiteId()));
+        Assert.assertEquals(wpComSite.getId(), mSiteStore.getLocalIdForRemoteSiteId(wpComSite.getSiteId()));
 
         // Should be able to look up a Jetpack site by .com and by .org id (assuming it's been set)
-        assertEquals(jetpackSite.getId(), mSiteStore.getLocalIdForRemoteSiteId(jetpackSite.getSiteId()));
-        assertEquals(jetpackSite.getId(), mSiteStore.getLocalIdForRemoteSiteId(jetpackSite.getSelfHostedSiteId()));
+        Assert.assertEquals(jetpackSite.getId(), mSiteStore.getLocalIdForRemoteSiteId(jetpackSite.getSiteId()));
+        Assert.assertEquals(jetpackSite.getId(), mSiteStore.getLocalIdForRemoteSiteId(jetpackSite.getSelfHostedSiteId()));
 
-        assertEquals(selfHostedSite.getId(), mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(
+        Assert.assertEquals(selfHostedSite.getId(), mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(
                 selfHostedSite.getSelfHostedSiteId(), selfHostedSite.getXmlRpcUrl()));
-        assertEquals(jetpackSite.getId(), mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(
+        Assert.assertEquals(jetpackSite.getId(), mSiteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(
                 jetpackSite.getSelfHostedSiteId(), jetpackSite.getXmlRpcUrl()));
 
-        assertEquals(selfHostedSite.getSelfHostedSiteId(), mSiteStore.getSiteIdForLocalId(selfHostedSite.getId()));
-        assertEquals(wpComSite.getSiteId(), mSiteStore.getSiteIdForLocalId(wpComSite.getId()));
-        assertEquals(jetpackSite.getSiteId(), mSiteStore.getSiteIdForLocalId(jetpackSite.getId()));
+        Assert.assertEquals(selfHostedSite.getSelfHostedSiteId(), mSiteStore.getSiteIdForLocalId(selfHostedSite.getId()));
+        Assert.assertEquals(wpComSite.getSiteId(), mSiteStore.getSiteIdForLocalId(wpComSite.getId()));
+        Assert.assertEquals(jetpackSite.getSiteId(), mSiteStore.getSiteIdForLocalId(jetpackSite.getId()));
     }
 
     @Test
@@ -277,9 +275,9 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
         SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverXMLRPC);
 
-        assertEquals(1, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
-        assertNotNull(mSiteStore.getSiteBySiteId(wpComSite.getSiteId()));
-        assertNotNull(mSiteStore.getSiteBySiteId(jetpackSiteOverXMLRPC.getSiteId()));
+        Assert.assertEquals(1, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
+        Assert.assertNotNull(mSiteStore.getSiteBySiteId(wpComSite.getSiteId()));
+        Assert.assertNotNull(mSiteStore.getSiteBySiteId(jetpackSiteOverXMLRPC.getSiteId()));
         assertNull(mSiteStore.getSiteBySiteId(selfHostedSite.getSiteId()));
     }
 
@@ -295,8 +293,8 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(wpComSite);
         int affectedRows = SiteSqlUtils.deleteSite(wpComSite);
 
-        assertEquals(1, affectedRows);
-        assertEquals(0, mSiteStore.getSitesCount());
+        Assert.assertEquals(1, affectedRows);
+        Assert.assertEquals(0, mSiteStore.getSitesCount());
     }
 
     @Test
@@ -311,10 +309,10 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverXMLRPC);
         SiteSqlUtils.insertOrUpdateSite(jetpackSiteOverRestOnly);
 
-        assertEquals(2, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
+        Assert.assertEquals(2, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
 
         List<SiteModel> wpComSites = SiteSqlUtils.getWPComSites().getAsModel();
-        assertEquals(1, wpComSites.size());
+        Assert.assertEquals(1, wpComSites.size());
         for (SiteModel site : wpComSites) {
             assertNotEquals(jetpackSiteOverXMLRPC.getId(), site.getId());
         }
@@ -335,16 +333,16 @@ public class SiteStoreUnitTest {
 
         // Previous site should be converted to a Jetpack site and we should see only one site
         int sitesCount = WellSql.select(SiteModel.class).getAsCursor().getCount();
-        assertEquals(1, sitesCount);
+        Assert.assertEquals(1, sitesCount);
 
         List<SiteModel> wpComSites = SiteSqlUtils.getWPComSites().getAsModel();
-        assertEquals(0, wpComSites.size());
-        assertEquals(1, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
+        Assert.assertEquals(0, wpComSites.size());
+        Assert.assertEquals(1, SiteSqlUtils.getSitesAccessedViaWPComRest().getAsCursor().getCount());
         List<SiteModel> jetpackSites =
                 SiteSqlUtils.getSitesWith(SiteModelTable.IS_JETPACK_CONNECTED, true).getAsModel();
-        assertEquals(jetpack.getSiteId(), jetpackSites.get(0).getSiteId());
-        assertTrue(jetpackSites.get(0).isJetpackConnected());
-        assertFalse(jetpackSites.get(0).isWPCom());
+        Assert.assertEquals(jetpack.getSiteId(), jetpackSites.get(0).getSiteId());
+        Assert.assertTrue(jetpackSites.get(0).isJetpackConnected());
+        Assert.assertFalse(jetpackSites.get(0).isWPCom());
     }
 
     @Test
@@ -364,9 +362,9 @@ public class SiteStoreUnitTest {
             // Caught !
             duplicate = true;
         }
-        assertTrue(duplicate);
+        Assert.assertTrue(duplicate);
         int sitesCount = WellSql.select(SiteModel.class).getAsCursor().getCount();
-        assertEquals(1, sitesCount);
+        Assert.assertEquals(1, sitesCount);
     }
 
     @Test
@@ -389,9 +387,9 @@ public class SiteStoreUnitTest {
             // Caught !
             duplicate = true;
         }
-        assertTrue(duplicate);
+        Assert.assertTrue(duplicate);
         int sitesCount = WellSql.select(SiteModel.class).getAsCursor().getCount();
-        assertEquals(1, sitesCount);
+        Assert.assertEquals(1, sitesCount);
     }
 
     @Test
@@ -414,9 +412,9 @@ public class SiteStoreUnitTest {
             // Caught !
             duplicate = true;
         }
-        assertTrue(duplicate);
+        Assert.assertTrue(duplicate);
         int sitesCount = WellSql.select(SiteModel.class).getAsCursor().getCount();
-        assertEquals(1, sitesCount);
+        Assert.assertEquals(1, sitesCount);
     }
 
     @Test
@@ -447,9 +445,9 @@ public class SiteStoreUnitTest {
             // Caught !
             duplicate = true;
         }
-        assertFalse(duplicate);
+        Assert.assertFalse(duplicate);
         int sitesCount = WellSql.select(SiteModel.class).getAsCursor().getCount();
-        assertEquals(1, sitesCount);
+        Assert.assertEquals(1, sitesCount);
     }
 
     @Test
@@ -460,12 +458,12 @@ public class SiteStoreUnitTest {
         // Set 3 post formats
         SiteSqlUtils.insertOrReplacePostFormats(site, generatePostFormats("Video", "Image", "Standard"));
         List<PostFormatModel> postFormats = mSiteStore.getPostFormats(site);
-        assertEquals(3, postFormats.size());
+        Assert.assertEquals(3, postFormats.size());
 
         // Set 1 post format
         SiteSqlUtils.insertOrReplacePostFormats(site, generatePostFormats("Standard"));
         postFormats = mSiteStore.getPostFormats(site);
-        assertEquals("Standard", postFormats.get(0).getDisplayName());
+        Assert.assertEquals("Standard", postFormats.get(0).getDisplayName());
     }
 
     @Test
@@ -486,10 +484,10 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(wpComSite3);
 
         List<SiteModel> matchingSites = SiteSqlUtils.getSitesByNameOrUrlMatching("eye");
-        assertEquals(2, matchingSites.size());
+        Assert.assertEquals(2, matchingSites.size());
 
         matchingSites = SiteSqlUtils.getSitesByNameOrUrlMatching("EYE");
-        assertEquals(2, matchingSites.size());
+        Assert.assertEquals(2, matchingSites.size());
     }
 
     @Test
@@ -508,10 +506,10 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(selfHostedSite);
 
         List<SiteModel> matchingSites = SiteSqlUtils.getSitesByNameOrUrlMatching("eye");
-        assertEquals(2, matchingSites.size());
+        Assert.assertEquals(2, matchingSites.size());
 
         matchingSites = SiteSqlUtils.getSitesByNameOrUrlMatching("EYE");
-        assertEquals(2, matchingSites.size());
+        Assert.assertEquals(2, matchingSites.size());
     }
 
     @Test
@@ -530,10 +528,10 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(selfHostedSite);
 
         List<SiteModel> matchingSites = SiteSqlUtils.getSitesAccessedViaWPComRestByNameOrUrlMatching("eye");
-        assertEquals(1, matchingSites.size());
+        Assert.assertEquals(1, matchingSites.size());
 
         matchingSites = SiteSqlUtils.getSitesAccessedViaWPComRestByNameOrUrlMatching("EYE");
-        assertEquals(1, matchingSites.size());
+        Assert.assertEquals(1, matchingSites.size());
     }
 
     @Test
@@ -551,11 +549,11 @@ public class SiteStoreUnitTest {
         SiteSqlUtils.insertOrUpdateSite(selfHostedSite);
 
         // first make sure sites are inserted successfully
-        assertEquals(4, mSiteStore.getSitesCount());
+        Assert.assertEquals(4, mSiteStore.getSitesCount());
 
         SiteSqlUtils.deleteAllSites();
 
-        assertEquals(0, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getSitesCount());
     }
 
     @Test
@@ -574,8 +572,8 @@ public class SiteStoreUnitTest {
 
         SiteSqlUtils.insertOrUpdateSite(automatedTransferSite);
 
-        assertEquals(1, mSiteStore.getSitesCount());
-        assertEquals(0, mSiteStore.getWPComSitesCount());
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertEquals(0, mSiteStore.getWPComSitesCount());
     }
 
     @Test
@@ -599,9 +597,9 @@ public class SiteStoreUnitTest {
         createOrUpdateSites.setAccessible(true);
         UpdateSitesResult res = (UpdateSitesResult) createOrUpdateSites.invoke(mSiteStore, sites);
 
-        assertTrue(res.duplicateSiteFound);
-        assertEquals(5, res.rowsAffected);
-        assertEquals(5, mSiteStore.getSitesCount());
+        Assert.assertTrue(res.duplicateSiteFound);
+        Assert.assertEquals(5, res.rowsAffected);
+        Assert.assertEquals(5, mSiteStore.getSitesCount());
     }
 
     @Test
@@ -623,9 +621,9 @@ public class SiteStoreUnitTest {
         createOrUpdateSites.setAccessible(true);
         UpdateSitesResult res = (UpdateSitesResult) createOrUpdateSites.invoke(mSiteStore, sites);
 
-        assertFalse(res.duplicateSiteFound);
-        assertEquals(5, res.rowsAffected);
-        assertEquals(5, mSiteStore.getSitesCount());
+        Assert.assertFalse(res.duplicateSiteFound);
+        Assert.assertEquals(5, res.rowsAffected);
+        Assert.assertEquals(5, mSiteStore.getSitesCount());
     }
 
     @Test
@@ -642,9 +640,9 @@ public class SiteStoreUnitTest {
         createOrUpdateSites.setAccessible(true);
         UpdateSitesResult res = (UpdateSitesResult) createOrUpdateSites.invoke(mSiteStore, sites);
 
-        assertFalse(res.duplicateSiteFound);
-        assertEquals(1, res.rowsAffected);
-        assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertFalse(res.duplicateSiteFound);
+        Assert.assertEquals(1, res.rowsAffected);
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
 
         // Insert same site with different id (considered a duplicate)
         List<SiteModel> siteList2 = new ArrayList<>();
@@ -653,9 +651,9 @@ public class SiteStoreUnitTest {
         createOrUpdateSites.setAccessible(true);
         UpdateSitesResult res2 = (UpdateSitesResult) createOrUpdateSites.invoke(mSiteStore, sites2);
 
-        assertTrue(res2.duplicateSiteFound);
-        assertEquals(0, res2.rowsAffected);
-        assertEquals(1, mSiteStore.getSitesCount());
+        Assert.assertTrue(res2.duplicateSiteFound);
+        Assert.assertEquals(0, res2.rowsAffected);
+        Assert.assertEquals(1, mSiteStore.getSitesCount());
     }
 
     @Test
@@ -680,9 +678,9 @@ public class SiteStoreUnitTest {
             // Caught !
             duplicate = true;
         }
-        assertFalse(duplicate);
+        Assert.assertFalse(duplicate);
         int sitesCount = WellSql.select(SiteModel.class).getAsCursor().getCount();
-        assertEquals(1, sitesCount);
+        Assert.assertEquals(1, sitesCount);
     }
 
     @Test
@@ -709,9 +707,9 @@ public class SiteStoreUnitTest {
             // Caught !
             duplicate = true;
         }
-        assertFalse(duplicate);
+        Assert.assertFalse(duplicate);
         int sitesCount = WellSql.select(SiteModel.class).getAsCursor().getCount();
-        assertEquals(1, sitesCount);
+        Assert.assertEquals(1, sitesCount);
     }
 
     @Test
@@ -732,36 +730,36 @@ public class SiteStoreUnitTest {
             // can't catch `SQLiteConstraintException` in SiteSqlUtils.insertOrUpdateSite.
             duplicate = true;
         }
-        assertTrue(duplicate);
+        Assert.assertTrue(duplicate);
     }
 
     @Test
     public void testJetpackSelfHostedAndForceXMLRPC() {
         SiteModel jetpackSite = generateJetpackSiteOverXMLRPC();
         jetpackSite.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
-        assertTrue(jetpackSite.isUsingWpComRestApi());
+        Assert.assertTrue(jetpackSite.isUsingWpComRestApi());
 
         // Force the origin, it should now use XMLRPC instead of REST.
         jetpackSite.setOrigin(SiteModel.ORIGIN_XMLRPC);
-        assertFalse(jetpackSite.isUsingWpComRestApi());
+        Assert.assertFalse(jetpackSite.isUsingWpComRestApi());
     }
 
     @Test
     public void testDefaultUsageWpComRestApi() {
         SiteModel wpComSite = generateWPComSite();
-        assertTrue(wpComSite.isUsingWpComRestApi());
+        Assert.assertTrue(wpComSite.isUsingWpComRestApi());
 
         SiteModel jetpack1 = generateJetpackSiteOverRestOnly();
-        assertTrue(jetpack1.isUsingWpComRestApi());
+        Assert.assertTrue(jetpack1.isUsingWpComRestApi());
 
         SiteModel jetpack2 = generateJetpackSiteOverXMLRPC();
-        assertFalse(jetpack2.isUsingWpComRestApi());
+        Assert.assertFalse(jetpack2.isUsingWpComRestApi());
 
         SiteModel pureSelfHosted1 = generateSelfHostedNonJPSite();
-        assertFalse(pureSelfHosted1.isUsingWpComRestApi());
+        Assert.assertFalse(pureSelfHosted1.isUsingWpComRestApi());
 
         SiteModel pureSelfHosted2 = generateSelfHostedSiteFutureJetpack();
-        assertFalse(pureSelfHosted2.isUsingWpComRestApi());
+        Assert.assertFalse(pureSelfHosted2.isUsingWpComRestApi());
     }
 
     @Test
@@ -806,9 +804,9 @@ public class SiteStoreUnitTest {
         createOrUpdateSites.setAccessible(true);
         UpdateSitesResult res = (UpdateSitesResult) createOrUpdateSites.invoke(mSiteStore, new SitesModel(allSites));
 
-        assertFalse(res.duplicateSiteFound);
-        assertTrue(res.rowsAffected == 15);
-        assertTrue(mSiteStore.getSitesCount() == 15);
+        Assert.assertFalse(res.duplicateSiteFound);
+        Assert.assertTrue(res.rowsAffected == 15);
+        Assert.assertTrue(mSiteStore.getSitesCount() == 15);
 
         // add 2 of each kind of site to keep
         sitesToKeep.addAll(allSites.subList(0, 6));
@@ -816,11 +814,11 @@ public class SiteStoreUnitTest {
         // remove six sites (2/3 * (15 - 6))
         SiteSqlUtils.removeWPComRestSitesAbsentFromList(sitesToKeep);
 
-        assertTrue(mSiteStore.getSitesCount() == 9);
+        Assert.assertTrue(mSiteStore.getSitesCount() == 9);
 
         // make sure all sites in sitesToKeep are in the store
         for (SiteModel site : sitesToKeep) {
-            assertTrue(mSiteStore.getSiteBySiteId(site.getSiteId()) != null);
+            Assert.assertTrue(mSiteStore.getSiteBySiteId(site.getSiteId()) != null);
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -8,6 +8,8 @@ import com.android.volley.RequestQueue;
 import com.android.volley.Response;
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,8 +36,6 @@ import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -75,7 +75,7 @@ public class SiteXMLRPCClientTest {
                     deliverResponse.setAccessible(true);
                     deliverResponse.invoke(request, o.result);
                 } catch (Exception e) {
-                    assertTrue("Unexpected exception: " + e, false);
+                    Assert.assertTrue("Unexpected exception: " + e, false);
                 }
                 mCountDownLatch.countDown();
                 return null;
@@ -139,7 +139,7 @@ public class SiteXMLRPCClientTest {
                           + "  </struct>\n"
                           + "</value></param></params></methodResponse>";
         mSiteXMLRPCClient.fetchSite(site);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -159,9 +159,9 @@ public class SiteXMLRPCClientTest {
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect an OnUnexpectedError to be emitted with a parse error
                 OnUnexpectedError event = invocation.getArgumentAt(0, OnUnexpectedError.class);
-                assertEquals(site.getXmlRpcUrl(), event.extras.get(OnUnexpectedError.KEY_URL));
-                assertEquals("whoops", event.extras.get(OnUnexpectedError.KEY_RESPONSE));
-                assertEquals(ClassCastException.class, event.exception.getClass());
+                Assert.assertEquals(site.getXmlRpcUrl(), event.extras.get(OnUnexpectedError.KEY_URL));
+                Assert.assertEquals("whoops", event.extras.get(OnUnexpectedError.KEY_RESPONSE));
+                Assert.assertEquals(ClassCastException.class, event.exception.getClass());
 
                 mCountDownLatch.countDown();
                 return null;
@@ -173,11 +173,11 @@ public class SiteXMLRPCClientTest {
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect UPDATE_SITE to be dispatched with an INVALID_RESPONSE error
                 Action action = invocation.getArgumentAt(0, Action.class);
-                assertEquals(SiteAction.UPDATE_SITE, action.getType());
+                Assert.assertEquals(SiteAction.UPDATE_SITE, action.getType());
 
                 SiteModel result = (SiteModel) action.getPayload();
-                assertTrue(result.isError());
-                assertEquals(GenericErrorType.INVALID_RESPONSE, result.error.type);
+                Assert.assertTrue(result.isError());
+                Assert.assertEquals(GenericErrorType.INVALID_RESPONSE, result.error.type);
 
                 mCountDownLatch.countDown();
                 return null;
@@ -186,7 +186,7 @@ public class SiteXMLRPCClientTest {
 
         mCountDownLatch = new CountDownLatch(3);
         mSiteXMLRPCClient.fetchSite(site);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -208,7 +208,7 @@ public class SiteXMLRPCClientTest {
 
         mCountDownLatch = new CountDownLatch(1);
         mSiteXMLRPCClient.fetchSites(xmlrpcUrl, "thedoc", "gr3@tsc0tt");
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -224,9 +224,9 @@ public class SiteXMLRPCClientTest {
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect an OnUnexpectedError to be emitted with a parse error
                 OnUnexpectedError event = invocation.getArgumentAt(0, OnUnexpectedError.class);
-                assertEquals(xmlrpcUrl, event.extras.get(OnUnexpectedError.KEY_URL));
-                assertEquals("disaster!", event.extras.get(OnUnexpectedError.KEY_RESPONSE));
-                assertEquals(ClassCastException.class, event.exception.getClass());
+                Assert.assertEquals(xmlrpcUrl, event.extras.get(OnUnexpectedError.KEY_URL));
+                Assert.assertEquals("disaster!", event.extras.get(OnUnexpectedError.KEY_RESPONSE));
+                Assert.assertEquals(ClassCastException.class, event.exception.getClass());
 
                 mCountDownLatch.countDown();
                 return null;
@@ -238,11 +238,11 @@ public class SiteXMLRPCClientTest {
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect UPDATE_SITES to be dispatched with an INVALID_RESPONSE error
                 Action action = invocation.getArgumentAt(0, Action.class);
-                assertEquals(SiteAction.FETCHED_SITES_XML_RPC, action.getType());
+                Assert.assertEquals(SiteAction.FETCHED_SITES_XML_RPC, action.getType());
 
                 SitesModel result = (SitesModel) action.getPayload();
-                assertTrue(result.isError());
-                assertEquals(GenericErrorType.INVALID_RESPONSE, result.error.type);
+                Assert.assertTrue(result.isError());
+                Assert.assertEquals(GenericErrorType.INVALID_RESPONSE, result.error.type);
 
                 mCountDownLatch.countDown();
                 return null;
@@ -251,6 +251,6 @@ public class SiteXMLRPCClientTest {
 
         mCountDownLatch = new CountDownLatch(3);
         mSiteXMLRPCClient.fetchSites(xmlrpcUrl, "thedoc", "gr3@tsc0tt");
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +25,6 @@ import org.wordpress.android.fluxc.store.TaxonomyStore;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY;
 import static org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_TAG;
 
@@ -43,9 +44,9 @@ public class TaxonomyStoreUnitTest {
 
     @Test
     public void testInsertNullTerm() {
-        assertEquals(0, TaxonomySqlUtils.insertOrUpdateTerm(null));
+        Assert.assertEquals(0, TaxonomySqlUtils.insertOrUpdateTerm(null));
 
-        assertEquals(0, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(0, TaxonomyTestUtils.getTermsCount());
     }
 
     @Test
@@ -54,8 +55,8 @@ public class TaxonomyStoreUnitTest {
         termModel.setRemoteTermId(42);
         TaxonomySqlUtils.insertOrUpdateTerm(termModel);
 
-        assertEquals(1, TaxonomyTestUtils.getTermsCount());
-        assertEquals(termModel, TaxonomyTestUtils.getTerms().get(0));
+        Assert.assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(termModel, TaxonomyTestUtils.getTerms().get(0));
     }
 
     @Test
@@ -66,17 +67,17 @@ public class TaxonomyStoreUnitTest {
         TermModel category = TaxonomyTestUtils.generateSampleCategory();
         TaxonomySqlUtils.insertOrUpdateTerm(category);
 
-        assertEquals(1, TaxonomyTestUtils.getTermsCount());
-        assertEquals(category, TaxonomyTestUtils.getTerms().get(0));
+        Assert.assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(category, TaxonomyTestUtils.getTerms().get(0));
 
-        assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY).size());
-        assertEquals(1, mTaxonomyStore.getCategoriesForSite(site).size());
+        Assert.assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY).size());
+        Assert.assertEquals(1, mTaxonomyStore.getCategoriesForSite(site).size());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG).size());
-        assertEquals(0, mTaxonomyStore.getTagsForSite(site).size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG).size());
+        Assert.assertEquals(0, mTaxonomyStore.getTagsForSite(site).size());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, "author").size());
-        assertEquals(0, mTaxonomyStore.getTermsForSite(site, "author").size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, "author").size());
+        Assert.assertEquals(0, mTaxonomyStore.getTermsForSite(site, "author").size());
     }
 
     @Test
@@ -87,17 +88,17 @@ public class TaxonomyStoreUnitTest {
         TermModel tag = TaxonomyTestUtils.generateSampleTag();
         TaxonomySqlUtils.insertOrUpdateTerm(tag);
 
-        assertEquals(1, TaxonomyTestUtils.getTermsCount());
-        assertEquals(tag, TaxonomyTestUtils.getTerms().get(0));
+        Assert.assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(tag, TaxonomyTestUtils.getTerms().get(0));
 
-        assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG).size());
-        assertEquals(1, mTaxonomyStore.getTagsForSite(site).size());
+        Assert.assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG).size());
+        Assert.assertEquals(1, mTaxonomyStore.getTagsForSite(site).size());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY).size());
-        assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY).size());
+        Assert.assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, "author").size());
-        assertEquals(0, mTaxonomyStore.getTermsForSite(site, "author").size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, "author").size());
+        Assert.assertEquals(0, mTaxonomyStore.getTermsForSite(site, "author").size());
     }
 
     @Test
@@ -108,17 +109,17 @@ public class TaxonomyStoreUnitTest {
         TermModel author = TaxonomyTestUtils.generateSampleAuthor();
         TaxonomySqlUtils.insertOrUpdateTerm(author);
 
-        assertEquals(1, TaxonomyTestUtils.getTermsCount());
-        assertEquals(author, TaxonomyTestUtils.getTerms().get(0));
+        Assert.assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(author, TaxonomyTestUtils.getTerms().get(0));
 
-        assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, "author").size());
-        assertEquals(1, mTaxonomyStore.getTermsForSite(site, "author").size());
+        Assert.assertEquals(1, TaxonomySqlUtils.getTermsForSite(site, "author").size());
+        Assert.assertEquals(1, mTaxonomyStore.getTermsForSite(site, "author").size());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY).size());
-        assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY).size());
+        Assert.assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG).size());
-        assertEquals(0, mTaxonomyStore.getTagsForSite(site).size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG).size());
+        Assert.assertEquals(0, mTaxonomyStore.getTagsForSite(site).size());
     }
 
     @Test
@@ -129,14 +130,14 @@ public class TaxonomyStoreUnitTest {
         TermModel category = TaxonomyTestUtils.generateSampleCategory();
         TaxonomySqlUtils.insertOrUpdateTerm(category);
 
-        assertEquals(category, mTaxonomyStore.getCategoryByRemoteId(site, category.getRemoteTermId()));
+        Assert.assertEquals(category, mTaxonomyStore.getCategoryByRemoteId(site, category.getRemoteTermId()));
 
         // An identical category on a different site should be ignored in the match
         TermModel otherSiteIdenticalCategory = TaxonomyTestUtils.generateSampleCategory();
         otherSiteIdenticalCategory.setLocalSiteId(7);
         TaxonomySqlUtils.insertOrUpdateTerm(otherSiteIdenticalCategory);
 
-        assertEquals(category, mTaxonomyStore.getCategoryByRemoteId(site, category.getRemoteTermId()));
+        Assert.assertEquals(category, mTaxonomyStore.getCategoryByRemoteId(site, category.getRemoteTermId()));
     }
 
     @Test
@@ -147,17 +148,17 @@ public class TaxonomyStoreUnitTest {
         TermModel category = TaxonomyTestUtils.generateSampleCategory();
         TaxonomySqlUtils.insertOrUpdateTerm(category);
 
-        assertEquals(category, mTaxonomyStore.getCategoryByName(site, category.getName()));
+        Assert.assertEquals(category, mTaxonomyStore.getCategoryByName(site, category.getName()));
     }
 
     @Test
     public void testRemoveTag() {
         TermModel tag = TaxonomyTestUtils.generateSampleTag();
         TaxonomySqlUtils.insertOrUpdateTerm(tag);
-        assertEquals(1, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(1, TaxonomyTestUtils.getTermsCount());
 
         TaxonomySqlUtils.removeTerm(tag);
-        assertEquals(0, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(0, TaxonomyTestUtils.getTermsCount());
     }
 
     @Test
@@ -179,13 +180,13 @@ public class TaxonomyStoreUnitTest {
         TermModel author = TaxonomyTestUtils.generateSampleAuthor();
         TaxonomySqlUtils.insertOrUpdateTerm(author);
 
-        assertEquals(4, TaxonomyTestUtils.getTermsCount());
-        assertEquals(2, mTaxonomyStore.getCategoriesForSite(site).size());
+        Assert.assertEquals(4, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(2, mTaxonomyStore.getCategoriesForSite(site).size());
 
         TaxonomySqlUtils.clearTaxonomyForSite(site, DEFAULT_TAXONOMY_CATEGORY);
 
-        assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
-        assertEquals(2, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
+        Assert.assertEquals(2, TaxonomyTestUtils.getTermsCount());
     }
 
     @Test
@@ -205,7 +206,7 @@ public class TaxonomyStoreUnitTest {
         idList.add(category.getRemoteTermId());
         idList.add(category2.getRemoteTermId());
 
-        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
+        Assert.assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
 
         // Unsynced category ID should be ignored in the final list
         TermModel unsyncedCategory = TaxonomyTestUtils.generateSampleCategory();
@@ -213,17 +214,17 @@ public class TaxonomyStoreUnitTest {
         unsyncedCategory.setName("More");
         idList.add(unsyncedCategory.getRemoteTermId());
 
-        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
+        Assert.assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
 
         // Empty list should return empty category list
         idList.clear();
 
-        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
 
         // List with only unsynced categories should return empty category list
         idList.add(unsyncedCategory.getRemoteTermId());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
 
         // An identical category on a different site should be ignored in the match
         TermModel otherSiteIdenticalCategory = TaxonomyTestUtils.generateSampleCategory();
@@ -234,7 +235,7 @@ public class TaxonomyStoreUnitTest {
         idList.add(category.getRemoteTermId());
         idList.add(category2.getRemoteTermId());
 
-        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
+        Assert.assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteIdList(idList, site, DEFAULT_TAXONOMY_CATEGORY).size());
     }
 
     @Test
@@ -254,7 +255,7 @@ public class TaxonomyStoreUnitTest {
         nameList.add(tag.getName());
         nameList.add(tag2.getName());
 
-        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
+        Assert.assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
 
         // Unsynced tag ID should be ignored in the final list
         TermModel unsyncedTag = TaxonomyTestUtils.generateSampleTag();
@@ -262,17 +263,17 @@ public class TaxonomyStoreUnitTest {
         unsyncedTag.setName("More");
         nameList.add(unsyncedTag.getName());
 
-        assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
+        Assert.assertEquals(2, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
 
         // Empty list should return empty tag list
         nameList.clear();
 
-        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
 
         // List with only unsynced tags should return empty tag list
         nameList.add(unsyncedTag.getName());
 
-        assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
+        Assert.assertEquals(0, TaxonomySqlUtils.getTermsFromRemoteNameList(nameList, site, DEFAULT_TAXONOMY_TAG).size());
     }
 
     @Test
@@ -304,10 +305,10 @@ public class TaxonomyStoreUnitTest {
         author2.setLocalSiteId(7);
         TaxonomySqlUtils.insertOrUpdateTerm(author2);
 
-        assertEquals(6, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(6, TaxonomyTestUtils.getTermsCount());
 
         TaxonomySqlUtils.deleteAllTerms();
 
-        assertEquals(0, TaxonomyTestUtils.getTermsCount());
+        Assert.assertEquals(0, TaxonomyTestUtils.getTermsCount());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TermModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TermModelTest.java
@@ -1,12 +1,11 @@
 package org.wordpress.android.fluxc.taxonomy;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.TermModel;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class TermModelTest {
@@ -16,8 +15,8 @@ public class TermModelTest {
         TermModel testCategory2 = TaxonomyTestUtils.generateSampleCategory();
 
         testCategory2.setRemoteTermId(testCategory.getRemoteTermId() + 1);
-        assertFalse(testCategory.equals(testCategory2));
+        Assert.assertFalse(testCategory.equals(testCategory2));
         testCategory2.setRemoteTermId(testCategory.getRemoteTermId());
-        assertTrue(testCategory.equals(testCategory2));
+        Assert.assertTrue(testCategory.equals(testCategory2));
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,10 +25,7 @@ import org.wordpress.android.fluxc.store.ThemeStore;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class ThemeStoreUnitTest {
@@ -54,20 +53,20 @@ public class ThemeStoreUnitTest {
         // set first theme active and verify
         mThemeStore.setActiveThemeForSite(site, firstTheme);
         List<ThemeModel> activeThemes = ThemeSqlUtils.getActiveThemeForSite(site);
-        assertNotNull(activeThemes);
-        assertTrue(activeThemes.size() == 1);
+        Assert.assertNotNull(activeThemes);
+        Assert.assertTrue(activeThemes.size() == 1);
         ThemeModel firstActiveTheme = activeThemes.get(0);
-        assertEquals(firstTheme.getThemeId(), firstActiveTheme.getThemeId());
-        assertEquals(firstTheme.getName(), firstActiveTheme.getName());
+        Assert.assertEquals(firstTheme.getThemeId(), firstActiveTheme.getThemeId());
+        Assert.assertEquals(firstTheme.getName(), firstActiveTheme.getName());
 
         // set second theme active and verify
         mThemeStore.setActiveThemeForSite(site, secondTheme);
         activeThemes = ThemeSqlUtils.getActiveThemeForSite(site);
-        assertNotNull(activeThemes);
-        assertTrue(activeThemes.size() == 1);
+        Assert.assertNotNull(activeThemes);
+        Assert.assertTrue(activeThemes.size() == 1);
         ThemeModel secondActiveTheme = activeThemes.get(0);
-        assertEquals(secondTheme.getThemeId(), secondActiveTheme.getThemeId());
-        assertEquals(secondTheme.getName(), secondActiveTheme.getName());
+        Assert.assertEquals(secondTheme.getThemeId(), secondActiveTheme.getThemeId());
+        Assert.assertEquals(secondTheme.getName(), secondActiveTheme.getName());
     }
 
     @Test
@@ -86,15 +85,15 @@ public class ThemeStoreUnitTest {
         // insert new theme and verify it exists
         ThemeSqlUtils.insertOrUpdateSiteTheme(site, insertTheme);
         ThemeModel insertedTheme = mThemeStore.getInstalledThemeByThemeId(site, testThemeId);
-        assertNotNull(insertedTheme);
-        assertEquals(testThemeName, insertedTheme.getName());
+        Assert.assertNotNull(insertedTheme);
+        Assert.assertEquals(testThemeName, insertedTheme.getName());
 
         // update the theme and verify the updated attributes
         insertedTheme.setName(testUpdatedName);
         ThemeSqlUtils.insertOrUpdateSiteTheme(site, insertedTheme);
         insertedTheme = mThemeStore.getInstalledThemeByThemeId(site, testThemeId);
-        assertNotNull(insertedTheme);
-        assertEquals(testUpdatedName, insertedTheme.getName());
+        Assert.assertNotNull(insertedTheme);
+        Assert.assertEquals(testUpdatedName, insertedTheme.getName());
     }
 
     @Test
@@ -105,15 +104,15 @@ public class ThemeStoreUnitTest {
 
         // first add 20 themes and make sure the count is correct
         ThemeSqlUtils.insertOrReplaceWpComThemes(firstTestThemes);
-        assertEquals(20, mThemeStore.getWpComThemes().size());
+        Assert.assertEquals(20, mThemeStore.getWpComThemes().size());
 
         // next add a larger list of themes (with 20 being duplicates) and make sure the count is correct
         ThemeSqlUtils.insertOrReplaceWpComThemes(secondTestThemes);
-        assertEquals(30, mThemeStore.getWpComThemes().size());
+        Assert.assertEquals(30, mThemeStore.getWpComThemes().size());
 
         // lastly add a smaller list of themes (all duplicates) and make sure count is correct
         ThemeSqlUtils.insertOrReplaceWpComThemes(thirdTestThemes);
-        assertEquals(10, mThemeStore.getWpComThemes().size());
+        Assert.assertEquals(10, mThemeStore.getWpComThemes().size());
     }
 
     @Test
@@ -127,15 +126,15 @@ public class ThemeStoreUnitTest {
 
         // first add 5 installed themes
         ThemeSqlUtils.insertOrReplaceInstalledThemes(site, firstTestThemes);
-        assertEquals(firstTestThemes.size(), mThemeStore.getThemesForSite(site).size());
+        Assert.assertEquals(firstTestThemes.size(), mThemeStore.getThemesForSite(site).size());
 
         // then replace them all with a new list of 10
         ThemeSqlUtils.insertOrReplaceInstalledThemes(site, secondTestThemes);
-        assertEquals(secondTestThemes.size(), mThemeStore.getThemesForSite(site).size());
+        Assert.assertEquals(secondTestThemes.size(), mThemeStore.getThemesForSite(site).size());
 
         // then replace them all with a single theme
         ThemeSqlUtils.insertOrReplaceInstalledThemes(site, thirdTestThemes);
-        assertEquals(thirdTestThemes.size(), mThemeStore.getThemesForSite(site).size());
+        Assert.assertEquals(thirdTestThemes.size(), mThemeStore.getThemesForSite(site).size());
     }
 
     @Test
@@ -144,13 +143,13 @@ public class ThemeStoreUnitTest {
         final List<ThemeModel> secondTestThemes = generateThemesTestList(30);
 
         // insert themes and verify count
-        assertEquals(0, mThemeStore.getWpComThemesCursor().getCount());
+        Assert.assertEquals(0, mThemeStore.getWpComThemesCursor().getCount());
         ThemeSqlUtils.insertOrReplaceWpComThemes(firstTestThemes);
-        assertEquals(firstTestThemes.size(), mThemeStore.getWpComThemesCursor().getCount());
+        Assert.assertEquals(firstTestThemes.size(), mThemeStore.getWpComThemesCursor().getCount());
 
         // insert new themes list and verify count
         ThemeSqlUtils.insertOrReplaceWpComThemes(secondTestThemes);
-        assertEquals(secondTestThemes.size(), mThemeStore.getWpComThemesCursor().getCount());
+        Assert.assertEquals(secondTestThemes.size(), mThemeStore.getWpComThemesCursor().getCount());
     }
 
     @Test
@@ -158,13 +157,13 @@ public class ThemeStoreUnitTest {
         final List<ThemeModel> testThemes = generateThemesTestList(20);
 
         // insert and verify count
-        assertEquals(0, mThemeStore.getWpComThemesCursor().getCount());
+        Assert.assertEquals(0, mThemeStore.getWpComThemesCursor().getCount());
         ThemeSqlUtils.insertOrReplaceWpComThemes(testThemes);
-        assertEquals(testThemes.size(), mThemeStore.getWpComThemes().size());
+        Assert.assertEquals(testThemes.size(), mThemeStore.getWpComThemes().size());
 
         // remove and verify count
         ThemeSqlUtils.removeWpComThemes();
-        assertEquals(0, mThemeStore.getWpComThemes().size());
+        Assert.assertEquals(0, mThemeStore.getWpComThemes().size());
     }
 
     @Test
@@ -176,11 +175,11 @@ public class ThemeStoreUnitTest {
 
         // add site themes and verify count
         ThemeSqlUtils.insertOrReplaceInstalledThemes(site, testThemes);
-        assertEquals(testThemes.size(), mThemeStore.getThemesForSite(site).size());
+        Assert.assertEquals(testThemes.size(), mThemeStore.getThemesForSite(site).size());
 
         // remove and verify count
         ThemeSqlUtils.removeSiteThemes(site);
-        assertEquals(0, mThemeStore.getThemesForSite(site).size());
+        Assert.assertEquals(0, mThemeStore.getThemesForSite(site).size());
     }
 
     private ThemeModel generateTestTheme(int siteId, String themeId, String themeName) {

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/MediaUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/MediaUploadModelTest.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.upload;
 
 import android.text.TextUtils;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,11 +12,7 @@ import org.wordpress.android.fluxc.model.MediaUploadModel;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class MediaUploadModelTest {
@@ -28,18 +26,18 @@ public class MediaUploadModelTest {
         MediaUploadModel mediaUploadModel2 = new MediaUploadModel(1);
 
         mediaUploadModel1.setUploadState(MediaUploadModel.FAILED);
-        assertFalse(mediaUploadModel1.equals(mediaUploadModel2));
+        Assert.assertFalse(mediaUploadModel1.equals(mediaUploadModel2));
 
         mediaUploadModel2.setUploadState(MediaUploadModel.FAILED);
 
         MediaError mediaError = new MediaError(MediaErrorType.EXCEEDS_MEMORY_LIMIT, "Too large!");
         mediaUploadModel1.setMediaError(mediaError);
-        assertFalse(mediaUploadModel1.equals(mediaUploadModel2));
+        Assert.assertFalse(mediaUploadModel1.equals(mediaUploadModel2));
 
         mediaUploadModel2.setErrorType(mediaError.type.toString());
         mediaUploadModel2.setErrorMessage(mediaError.message);
 
-        assertTrue(mediaUploadModel1.equals(mediaUploadModel2));
+        Assert.assertTrue(mediaUploadModel1.equals(mediaUploadModel2));
     }
 
     @Test
@@ -47,12 +45,12 @@ public class MediaUploadModelTest {
         MediaUploadModel mediaUploadModel = new MediaUploadModel(1);
 
         assertNull(mediaUploadModel.getMediaError());
-        assertTrue(TextUtils.isEmpty(mediaUploadModel.getErrorType()));
-        assertTrue(TextUtils.isEmpty(mediaUploadModel.getErrorMessage()));
+        Assert.assertTrue(TextUtils.isEmpty(mediaUploadModel.getErrorType()));
+        Assert.assertTrue(TextUtils.isEmpty(mediaUploadModel.getErrorMessage()));
 
         mediaUploadModel.setMediaError(new MediaError(MediaErrorType.EXCEEDS_MEMORY_LIMIT, "Too large!"));
-        assertNotNull(mediaUploadModel.getMediaError());
-        assertEquals(MediaErrorType.EXCEEDS_MEMORY_LIMIT, MediaErrorType.fromString(mediaUploadModel.getErrorType()));
-        assertEquals("Too large!", mediaUploadModel.getErrorMessage());
+        Assert.assertNotNull(mediaUploadModel.getMediaError());
+        Assert.assertEquals(MediaErrorType.EXCEEDS_MEMORY_LIMIT, MediaErrorType.fromString(mediaUploadModel.getErrorType()));
+        Assert.assertEquals("Too large!", mediaUploadModel.getErrorMessage());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.upload;
 
 import android.text.TextUtils;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,11 +15,7 @@ import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class PostUploadModelTest {
@@ -34,19 +32,19 @@ public class PostUploadModelTest {
         idSet.add(6);
         idSet.add(5);
         postUploadModel1.setAssociatedMediaIdSet(idSet);
-        assertFalse(postUploadModel1.equals(postUploadModel2));
+        Assert.assertFalse(postUploadModel1.equals(postUploadModel2));
 
         postUploadModel2.setAssociatedMediaIdSet(idSet);
 
         PostError postError = new PostError(PostErrorType.UNKNOWN_POST, "Unknown post");
         postUploadModel1.setPostError(postError);
 
-        assertFalse(postUploadModel1.equals(postUploadModel2));
+        Assert.assertFalse(postUploadModel1.equals(postUploadModel2));
 
         postUploadModel2.setErrorType(postError.type.toString());
         postUploadModel2.setErrorMessage(postError.message);
 
-        assertTrue(postUploadModel1.equals(postUploadModel2));
+        Assert.assertTrue(postUploadModel1.equals(postUploadModel2));
     }
 
     @Test
@@ -56,9 +54,9 @@ public class PostUploadModelTest {
         idSet.add(6);
         idSet.add(5);
         postUploadModel.setAssociatedMediaIdSet(idSet);
-        assertEquals("5,6", postUploadModel.getAssociatedMediaIds());
-        assertTrue(idSet.containsAll(postUploadModel.getAssociatedMediaIdSet()));
-        assertTrue(postUploadModel.getAssociatedMediaIdSet().containsAll(idSet));
+        Assert.assertEquals("5,6", postUploadModel.getAssociatedMediaIds());
+        Assert.assertTrue(idSet.containsAll(postUploadModel.getAssociatedMediaIdSet()));
+        Assert.assertTrue(postUploadModel.getAssociatedMediaIdSet().containsAll(idSet));
     }
 
     @Test
@@ -66,12 +64,12 @@ public class PostUploadModelTest {
         PostUploadModel postUploadModel = new PostUploadModel(1);
 
         assertNull(postUploadModel.getPostError());
-        assertTrue(TextUtils.isEmpty(postUploadModel.getErrorType()));
-        assertTrue(TextUtils.isEmpty(postUploadModel.getErrorMessage()));
+        Assert.assertTrue(TextUtils.isEmpty(postUploadModel.getErrorType()));
+        Assert.assertTrue(TextUtils.isEmpty(postUploadModel.getErrorMessage()));
 
         postUploadModel.setPostError(new PostError(PostErrorType.UNKNOWN_POST, "Unknown post"));
-        assertNotNull(postUploadModel.getPostError());
-        assertEquals(PostErrorType.UNKNOWN_POST, PostErrorType.fromString(postUploadModel.getErrorType()));
-        assertEquals("Unknown post", postUploadModel.getErrorMessage());
+        Assert.assertNotNull(postUploadModel.getPostError());
+        Assert.assertEquals(PostErrorType.UNKNOWN_POST, PostErrorType.fromString(postUploadModel.getErrorType()));
+        Assert.assertEquals("Unknown post", postUploadModel.getErrorMessage());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/UploadSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/UploadSqlUtilsTest.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,11 +26,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNotSame;
 import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class UploadSqlUtilsTest {
@@ -46,18 +44,18 @@ public class UploadSqlUtilsTest {
     // Attempts to insert null then verifies there is no media
     @Test
     public void testInsertNullMedia() {
-        assertEquals(0, UploadSqlUtils.insertOrUpdateMedia(null));
-        assertEquals(0, WellSql.select(MediaUploadModel.class).getAsCursor().getCount());
+        Assert.assertEquals(0, UploadSqlUtils.insertOrUpdateMedia(null));
+        Assert.assertEquals(0, WellSql.select(MediaUploadModel.class).getAsCursor().getCount());
     }
 
     @Test
     public void testInsertMedia() {
         long testId = Math.abs(mRandom.nextLong());
         MediaModel testMedia = UploadTestUtils.getTestMedia(testId);
-        assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia));
+        Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia));
         List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(UploadTestUtils.getTestSite(), testId);
-        assertEquals(1, media.size());
-        assertNotNull(media.get(0));
+        Assert.assertEquals(1, media.size());
+        Assert.assertNotNull(media.get(0));
 
         // Store a MediaUploadModel corresponding to this MediaModel
         testMedia = media.get(0);
@@ -66,9 +64,9 @@ public class UploadSqlUtilsTest {
         UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel);
 
         mediaUploadModel = UploadSqlUtils.getMediaUploadModelForLocalId(testMedia.getId());
-        assertNotNull(mediaUploadModel);
-        assertEquals(testMedia.getId(), mediaUploadModel.getId());
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(testMedia.getId(), mediaUploadModel.getId());
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
 
         // Update the stored MediaUploadModel, marking it as completed
         mediaUploadModel.setUploadState(MediaUploadModel.COMPLETED);
@@ -76,15 +74,15 @@ public class UploadSqlUtilsTest {
         UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel);
 
         mediaUploadModel = UploadSqlUtils.getMediaUploadModelForLocalId(testMedia.getId());
-        assertNotNull(mediaUploadModel);
-        assertEquals(testMedia.getId(), mediaUploadModel.getId());
-        assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(testMedia.getId(), mediaUploadModel.getId());
+        Assert.assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
 
         // Deleting the MediaModel should cause the corresponding MediaUploadModel to be deleted also
         MediaSqlUtils.deleteMedia(testMedia);
 
         media = MediaSqlUtils.getSiteMediaWithId(UploadTestUtils.getTestSite(), testId);
-        assertTrue(media.isEmpty());
+        Assert.assertTrue(media.isEmpty());
 
         mediaUploadModel = UploadSqlUtils.getMediaUploadModelForLocalId(testMedia.getId());
         assertNull(mediaUploadModel);
@@ -103,22 +101,22 @@ public class UploadSqlUtilsTest {
         UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel);
 
         mediaUploadModel = UploadSqlUtils.getMediaUploadModelForLocalId(testMedia.getId());
-        assertNotNull(mediaUploadModel);
-        assertEquals(0.65F, mediaUploadModel.getProgress());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(0.65F, mediaUploadModel.getProgress());
 
         // Update the progress for the MediaUploadModel
         mediaUploadModel.setProgress(0.87F);
-        assertEquals(1, UploadSqlUtils.updateMediaProgressOnly(mediaUploadModel));
+        Assert.assertEquals(1, UploadSqlUtils.updateMediaProgressOnly(mediaUploadModel));
 
         mediaUploadModel = UploadSqlUtils.getMediaUploadModelForLocalId(testMedia.getId());
-        assertNotNull(mediaUploadModel);
-        assertEquals(testMedia.getId(), mediaUploadModel.getId());
-        assertEquals(0.87F, mediaUploadModel.getProgress());
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(testMedia.getId(), mediaUploadModel.getId());
+        Assert.assertEquals(0.87F, mediaUploadModel.getProgress());
 
         // Attempting to update the progress for a MediaUploadModel that doesn't exist in the db should fail
         MediaUploadModel mediaUploadModel2 = new MediaUploadModel(mRandom.nextInt());
         mediaUploadModel2.setProgress(0.45F);
-        assertEquals(0, UploadSqlUtils.updateMediaProgressOnly(mediaUploadModel2));
+        Assert.assertEquals(0, UploadSqlUtils.updateMediaProgressOnly(mediaUploadModel2));
         assertNull(UploadSqlUtils.getMediaUploadModelForLocalId(mediaUploadModel2.getId()));
     }
 
@@ -127,10 +125,10 @@ public class UploadSqlUtilsTest {
         MediaModel testMedia1 = UploadTestUtils.getTestMedia(65);
         MediaModel testMedia2 = UploadTestUtils.getTestMedia(35);
 
-        assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia1));
-        assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia2));
+        Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia1));
+        Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia2));
         List<MediaModel> mediaModels = MediaSqlUtils.getAllSiteMedia(UploadTestUtils.getTestSite());
-        assertEquals(2, mediaModels.size());
+        Assert.assertEquals(2, mediaModels.size());
 
         // Store MediaUploadModels corresponding to the MediaModels
         testMedia1 = mediaModels.get(0);
@@ -144,39 +142,39 @@ public class UploadSqlUtilsTest {
         UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel2);
 
         // Delete one of the MediaUploadModels
-        assertEquals(1, UploadSqlUtils.deleteMediaUploadModelWithLocalId(testMedia2.getId()));
+        Assert.assertEquals(1, UploadSqlUtils.deleteMediaUploadModelWithLocalId(testMedia2.getId()));
 
         List<MediaUploadModel> mediaUploadModels = WellSql.select(MediaUploadModel.class).getAsModel();
-        assertEquals(1, mediaUploadModels.size());
-        assertEquals(testMedia1.getId(), mediaUploadModels.get(0).getId());
+        Assert.assertEquals(1, mediaUploadModels.size());
+        Assert.assertEquals(testMedia1.getId(), mediaUploadModels.get(0).getId());
 
         // Delete the other MediaUploadModel
         Set<Integer> mediaIdSet = new HashSet<>();
         mediaIdSet.add(testMedia1.getId());
-        assertEquals(1, UploadSqlUtils.deleteMediaUploadModelsWithLocalIds(mediaIdSet));
+        Assert.assertEquals(1, UploadSqlUtils.deleteMediaUploadModelsWithLocalIds(mediaIdSet));
 
         mediaUploadModels = WellSql.select(MediaUploadModel.class).getAsModel();
-        assertEquals(0, mediaUploadModels.size());
+        Assert.assertEquals(0, mediaUploadModels.size());
 
         // The corresponding MediaModels should be untouched
         mediaModels = MediaSqlUtils.getAllSiteMedia(UploadTestUtils.getTestSite());
-        assertEquals(2, mediaModels.size());
+        Assert.assertEquals(2, mediaModels.size());
     }
 
     // Attempts to insert null then verifies there is no post
     @Test
     public void testInsertNullPost() {
-        assertEquals(0, UploadSqlUtils.insertOrUpdatePost(null));
-        assertEquals(0, WellSql.select(PostUploadModel.class).getAsCursor().getCount());
+        Assert.assertEquals(0, UploadSqlUtils.insertOrUpdatePost(null));
+        Assert.assertEquals(0, WellSql.select(PostUploadModel.class).getAsCursor().getCount());
     }
 
     @Test
     public void testInsertPost() {
         PostModel testPost = UploadTestUtils.getTestPost();
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost));
+        Assert.assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost));
         List<PostModel> postList = PostTestUtils.getPosts();
-        assertEquals(1, postList.size());
-        assertNotNull(postList.get(0));
+        Assert.assertEquals(1, postList.size());
+        Assert.assertNotNull(postList.get(0));
 
         // Store a PostUploadModel corresponding to this PostModel
         testPost = postList.get(0);
@@ -184,15 +182,15 @@ public class UploadSqlUtilsTest {
         UploadSqlUtils.insertOrUpdatePost(postUploadModel);
 
         postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(testPost.getId());
-        assertNotNull(postUploadModel);
-        assertEquals(testPost.getId(), postUploadModel.getId());
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(testPost.getId(), postUploadModel.getId());
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
 
         // Deleting the PostModel should cause the corresponding PostUploadModel to be deleted also
         PostSqlUtils.deletePost(testPost);
 
         postList = PostTestUtils.getPosts();
-        assertTrue(postList.isEmpty());
+        Assert.assertTrue(postList.isEmpty());
 
         postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(testPost.getId());
         assertNull(postUploadModel);
@@ -202,12 +200,12 @@ public class UploadSqlUtilsTest {
     public void testGetPostModelsByState() {
         PostModel testPost1 = UploadTestUtils.getTestPost();
         testPost1.setIsLocalDraft(true);
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost1));
+        Assert.assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost1));
         PostModel testPost2 = UploadTestUtils.getTestPost();
         testPost2.setIsLocalDraft(true);
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost2));
+        Assert.assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost2));
         List<PostModel> postList = PostTestUtils.getPosts();
-        assertEquals(2, postList.size());
+        Assert.assertEquals(2, postList.size());
 
         // Store PostUploadModels corresponding to the PostModels
         testPost1 = postList.get(0);
@@ -220,15 +218,15 @@ public class UploadSqlUtilsTest {
         // Both PostUploadModels should be PENDING
         List<PostUploadModel> pendingPostUploadModels =
                 UploadSqlUtils.getPostUploadModelsWithState(PostUploadModel.PENDING);
-        assertEquals(2, pendingPostUploadModels.size());
-        assertEquals(0, UploadSqlUtils.getPostUploadModelsWithState(PostUploadModel.FAILED).size());
-        assertEquals(0, UploadSqlUtils.getPostUploadModelsWithState(PostUploadModel.CANCELLED).size());
-        assertEquals(2, UploadSqlUtils.getAllPostUploadModels().size());
+        Assert.assertEquals(2, pendingPostUploadModels.size());
+        Assert.assertEquals(0, UploadSqlUtils.getPostUploadModelsWithState(PostUploadModel.FAILED).size());
+        Assert.assertEquals(0, UploadSqlUtils.getPostUploadModelsWithState(PostUploadModel.CANCELLED).size());
+        Assert.assertEquals(2, UploadSqlUtils.getAllPostUploadModels().size());
 
         // Fetch the corresponding PostModels
         List<PostModel> pendingPostModels = UploadSqlUtils.getPostModelsForPostUploadModels(pendingPostUploadModels);
-        assertEquals(2, pendingPostModels.size());
-        assertNotSame(pendingPostModels.get(0), pendingPostModels.get(1));
+        Assert.assertEquals(2, pendingPostModels.size());
+        Assert.assertNotSame(pendingPostModels.get(0), pendingPostModels.get(1));
 
         // Set one PostUploadModel to CANCELLED
         postUploadModel1.setUploadState(PostUploadModel.CANCELLED);
@@ -238,15 +236,15 @@ public class UploadSqlUtilsTest {
         List<PostUploadModel> cancelledPostUploadModels =
                 UploadSqlUtils.getPostUploadModelsWithState(PostUploadModel.CANCELLED);
 
-        assertEquals(1, pendingPostUploadModels.size());
-        assertEquals(1, cancelledPostUploadModels.size());
-        assertEquals(0, UploadSqlUtils.getPostUploadModelsWithState(PostUploadModel.FAILED).size());
-        assertEquals(2, UploadSqlUtils.getAllPostUploadModels().size());
+        Assert.assertEquals(1, pendingPostUploadModels.size());
+        Assert.assertEquals(1, cancelledPostUploadModels.size());
+        Assert.assertEquals(0, UploadSqlUtils.getPostUploadModelsWithState(PostUploadModel.FAILED).size());
+        Assert.assertEquals(2, UploadSqlUtils.getAllPostUploadModels().size());
 
         // Fetch the corresponding PostModels
         pendingPostModels = UploadSqlUtils.getPostModelsForPostUploadModels(pendingPostUploadModels);
-        assertEquals(1, pendingPostModels.size());
-        assertEquals(postUploadModel2.getId(), pendingPostModels.get(0).getId());
+        Assert.assertEquals(1, pendingPostModels.size());
+        Assert.assertEquals(postUploadModel2.getId(), pendingPostModels.get(0).getId());
     }
 
     @Test
@@ -255,10 +253,10 @@ public class UploadSqlUtilsTest {
         testPost1.setIsLocalDraft(true);
         PostModel testPost2 = UploadTestUtils.getTestPost();
         testPost2.setIsLocalDraft(true);
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost1));
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost2));
+        Assert.assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost1));
+        Assert.assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost2));
         List<PostModel> postModels = PostTestUtils.getPosts();
-        assertEquals(2, postModels.size());
+        Assert.assertEquals(2, postModels.size());
 
         // Store PostUploadModels corresponding to the PostModels
         testPost1 = postModels.get(0);
@@ -270,35 +268,35 @@ public class UploadSqlUtilsTest {
         UploadSqlUtils.insertOrUpdatePost(postUploadModel2);
 
         // Delete one of the PostUploadModels
-        assertEquals(1, UploadSqlUtils.deletePostUploadModelWithLocalId(testPost2.getId()));
+        Assert.assertEquals(1, UploadSqlUtils.deletePostUploadModelWithLocalId(testPost2.getId()));
 
         List<PostUploadModel> postUploadModels = WellSql.select(PostUploadModel.class).getAsModel();
-        assertEquals(1, postUploadModels.size());
-        assertEquals(testPost1.getId(), postUploadModels.get(0).getId());
+        Assert.assertEquals(1, postUploadModels.size());
+        Assert.assertEquals(testPost1.getId(), postUploadModels.get(0).getId());
 
         // Delete the other PostUploadModel
         Set<Integer> postIdSet = new HashSet<>();
         postIdSet.add(testPost1.getId());
-        assertEquals(1, UploadSqlUtils.deletePostUploadModelsWithLocalIds(postIdSet));
+        Assert.assertEquals(1, UploadSqlUtils.deletePostUploadModelsWithLocalIds(postIdSet));
 
         postUploadModels = WellSql.select(PostUploadModel.class).getAsModel();
-        assertEquals(0, postUploadModels.size());
+        Assert.assertEquals(0, postUploadModels.size());
 
         // The corresponding PostModels should be untouched
         postModels = PostTestUtils.getPosts();
-        assertEquals(2, postModels.size());
+        Assert.assertEquals(2, postModels.size());
     }
 
     @Test
     public void testGetMediaUploadModelsForPost() {
         // Check case where there are no matching MediaUploadModels for the post
-        assertEquals(0, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
+        Assert.assertEquals(0, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
 
         // Set up a MediaModel with a local post ID
         long testId = Math.abs(mRandom.nextLong());
         MediaModel testMedia = UploadTestUtils.getTestMedia(testId);
         testMedia.setLocalPostId(98);
-        assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia));
+        Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia));
 
         // Store a MediaUploadModel corresponding to the MediaModel
         MediaUploadModel mediaUploadModel = new MediaUploadModel(testMedia.getId());
@@ -306,46 +304,46 @@ public class UploadSqlUtilsTest {
         UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel);
 
         // Test retrieving MediaUploadModels by post id
-        assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
+        Assert.assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
 
         // Set up a second MediaModel with a different post ID
         long testId2 = Math.abs(mRandom.nextLong());
         MediaModel testMedia2 = UploadTestUtils.getTestMedia(testId2);
         testMedia2.setLocalPostId(97);
-        assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia2));
+        Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia2));
 
         // Results for the first post ID should be unchanged
-        assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
+        Assert.assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
         // Expect empty result since we haven't created a MediaUploadModel for this yet
-        assertEquals(0, UploadSqlUtils.getMediaUploadModelsForPostId(97).size());
+        Assert.assertEquals(0, UploadSqlUtils.getMediaUploadModelsForPostId(97).size());
 
         // Store a MediaUploadModel corresponding to the second MediaModel
         MediaUploadModel mediaUploadModel2 = new MediaUploadModel(testMedia2.getId());
         mediaUploadModel2.setProgress(0.66F);
         UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel2);
 
-        assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
-        assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(97).size());
+        Assert.assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
+        Assert.assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(97).size());
 
         // Set up a third MediaModel, with the same post ID as the second
         long testId3 = Math.abs(mRandom.nextLong());
         MediaModel testMedia3 = UploadTestUtils.getTestMedia(testId3);
         testMedia3.setLocalPostId(97);
-        assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia3));
+        Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testMedia3));
 
         // Store a MediaUploadModel corresponding to the third MediaModel
         MediaUploadModel mediaUploadModel3 = new MediaUploadModel(testMedia3.getId());
         mediaUploadModel3.setProgress(0.67F);
         UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel3);
 
-        assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
-        assertEquals(2, UploadSqlUtils.getMediaUploadModelsForPostId(97).size());
+        Assert.assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
+        Assert.assertEquals(2, UploadSqlUtils.getMediaUploadModelsForPostId(97).size());
 
         // Delete two MediaModels and verify the results
         MediaSqlUtils.deleteMedia(testMedia);
         MediaSqlUtils.deleteMedia(testMedia2);
 
-        assertEquals(0, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
-        assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(97).size());
+        Assert.assertEquals(0, UploadSqlUtils.getMediaUploadModelsForPostId(98).size());
+        Assert.assertEquals(1, UploadSqlUtils.getMediaUploadModelsForPostId(97).size());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/UploadStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/UploadStoreUnitTest.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,10 +34,7 @@ import org.wordpress.android.fluxc.store.UploadStore.UploadError;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class UploadStoreUnitTest {
@@ -67,10 +66,10 @@ public class UploadStoreUnitTest {
 
         // Check that the stored MediaUploadModel has the right state
         mediaUploadModel = UploadTestUtils.getMediaUploadModelForMediaModel(testMedia);
-        assertNotNull(mediaUploadModel);
-        assertEquals(testMedia.getId(), mediaUploadModel.getId());
-        assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
-        assertEquals(0.65F, mUploadStore.getUploadProgressForMedia(testMedia), 0.1F);
+        Assert.assertNotNull(mediaUploadModel);
+        Assert.assertEquals(testMedia.getId(), mediaUploadModel.getId());
+        Assert.assertEquals(MediaUploadModel.UPLOADING, mediaUploadModel.getUploadState());
+        Assert.assertEquals(0.65F, mUploadStore.getUploadProgressForMedia(testMedia), 0.1F);
     }
 
     @Test
@@ -80,7 +79,7 @@ public class UploadStoreUnitTest {
         postModel.setId(55);
         PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel);
         postModel = mPostStore.getPostByLocalPostId(postModel.getId());
-        assertNotNull(postModel);
+        Assert.assertNotNull(postModel);
 
         // Register the PostModel with the UploadStore, creating a PostUploadModel with some associated media
         List<MediaModel> associatedMedia = new ArrayList<>();
@@ -94,12 +93,12 @@ public class UploadStoreUnitTest {
 
         // Confirm that the PostUploadModel has been created and has the expected status
         PostUploadModel postUploadModel = UploadTestUtils.getPostUploadModelForPostModel(postModel);
-        assertNotNull(postUploadModel);
-        assertEquals(2, postUploadModel.getAssociatedMediaIdSet().size());
-        assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(5));
-        assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(6));
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isPendingPost(postModel));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(2, postUploadModel.getAssociatedMediaIdSet().size());
+        Assert.assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(5));
+        Assert.assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(6));
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isPendingPost(postModel));
 
         // Register the same post again with media changes
         MediaModel media3 = UploadTestUtils.getLocalTestMedia();
@@ -112,13 +111,13 @@ public class UploadStoreUnitTest {
 
         // Expect the updated model to have both the original media and the new one
         postUploadModel = UploadTestUtils.getPostUploadModelForPostModel(postModel);
-        assertNotNull(postUploadModel);
-        assertEquals(3, postUploadModel.getAssociatedMediaIdSet().size());
-        assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(5));
-        assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(6));
-        assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(8));
-        assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
-        assertTrue(mUploadStore.isPendingPost(postModel));
+        Assert.assertNotNull(postUploadModel);
+        Assert.assertEquals(3, postUploadModel.getAssociatedMediaIdSet().size());
+        Assert.assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(5));
+        Assert.assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(6));
+        Assert.assertTrue(postUploadModel.getAssociatedMediaIdSet().contains(8));
+        Assert.assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
+        Assert.assertTrue(mUploadStore.isPendingPost(postModel));
     }
 
     @Test
@@ -128,7 +127,7 @@ public class UploadStoreUnitTest {
         postModel.setId(55);
         PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel);
         postModel = mPostStore.getPostByLocalPostId(postModel.getId());
-        assertNotNull(postModel);
+        Assert.assertNotNull(postModel);
 
         // Create some MediaModels and add them to both the MediaModelTable and the MediaUploadTable
         // (simulating an upload action)
@@ -149,7 +148,7 @@ public class UploadStoreUnitTest {
 
         // Confirm that the PostUploadModel has been created and has a null error state
         PostUploadModel postUploadModel = UploadTestUtils.getPostUploadModelForPostModel(postModel);
-        assertNotNull(postUploadModel);
+        Assert.assertNotNull(postUploadModel);
         assertNull(mUploadStore.getUploadErrorForPost(postModel));
 
         // Add an error to this PostUploadModel
@@ -158,10 +157,10 @@ public class UploadStoreUnitTest {
 
         // Confirm that the store represents the post error correctly
         UploadError uploadError = mUploadStore.getUploadErrorForPost(postModel);
-        assertNotNull(uploadError);
+        Assert.assertNotNull(uploadError);
         assertNull(uploadError.mediaError);
-        assertNotNull(uploadError.postError);
-        assertEquals(PostErrorType.UNKNOWN_POST, uploadError.postError.type);
+        Assert.assertNotNull(uploadError.postError);
+        Assert.assertEquals(PostErrorType.UNKNOWN_POST, uploadError.postError.type);
 
         // Null out the post error again
         postUploadModel.setPostError(null);
@@ -179,10 +178,10 @@ public class UploadStoreUnitTest {
         // Confirm that the store now returns a media error for the post, since it has an associated media item
         // with an error
         uploadError = mUploadStore.getUploadErrorForPost(postModel);
-        assertNotNull(uploadError);
+        Assert.assertNotNull(uploadError);
         assertNull(uploadError.postError);
-        assertNotNull(uploadError.mediaError);
-        assertEquals(MediaErrorType.EXCEEDS_MEMORY_LIMIT, uploadError.mediaError.type);
+        Assert.assertNotNull(uploadError.mediaError);
+        Assert.assertEquals(MediaErrorType.EXCEEDS_MEMORY_LIMIT, uploadError.mediaError.type);
 
         // Create another PostModel and add it to the PostStore - this time, without registering it with the UploadStore
         PostModel unregisteredPostModel = UploadTestUtils.getTestPost();
@@ -203,9 +202,9 @@ public class UploadStoreUnitTest {
 
         // Confirm that the store returns a media error for the post (even though there's no associated PostUploadModel)
         uploadError = mUploadStore.getUploadErrorForPost(unregisteredPostModel);
-        assertNotNull(uploadError);
+        Assert.assertNotNull(uploadError);
         assertNull(uploadError.postError);
-        assertNotNull(uploadError.mediaError);
-        assertEquals(MediaErrorType.EXCEEDS_MEMORY_LIMIT, uploadError.mediaError.type);
+        Assert.assertNotNull(uploadError.mediaError);
+        Assert.assertEquals(MediaErrorType.EXCEEDS_MEMORY_LIMIT, uploadError.mediaError.type);
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/DateTimeUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/DateTimeUtilsTest.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.fluxc.utils;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class DateTimeUtilsTest {
@@ -18,10 +18,10 @@ public class DateTimeUtilsTest {
 
         // A UTC ISO 8601 date converted to Date and back should be unaltered
         Date result = DateTimeUtils.dateUTCFromIso8601(iso8601dateUTC);
-        assertEquals(iso8601dateUTC, DateTimeUtils.iso8601UTCFromDate(result));
+        Assert.assertEquals(iso8601dateUTC, DateTimeUtils.iso8601UTCFromDate(result));
 
         // An ISO 8601 date with timezone offset converted to Date and back should be in UTC format
         result = DateTimeUtils.dateUTCFromIso8601(iso8601date);
-        assertEquals(iso8601dateUTC, DateTimeUtils.iso8601UTCFromDate(result));
+        Assert.assertEquals(iso8601dateUTC, DateTimeUtils.iso8601UTCFromDate(result));
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/RequestQueryParametersTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/RequestQueryParametersTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.utils;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -7,8 +9,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class RequestQueryParametersTest {
@@ -19,20 +19,20 @@ public class RequestQueryParametersTest {
         WPComGsonRequest<Object> wpComGsonRequest = WPComGsonRequest.buildGetRequest(baseUrl, null, null, null, null);
 
         wpComGsonRequest.addQueryParameter("type", "post");
-        assertEquals(baseUrl + "?type=post", wpComGsonRequest.getUrl());
+        Assert.assertEquals(baseUrl + "?type=post", wpComGsonRequest.getUrl());
 
         Map<String, String> params = new HashMap<>();
         params.put("offset", "20");
         params.put("favorite_pet", "pony");
         wpComGsonRequest.addQueryParameters(params);
-        assertEquals(baseUrl + "?type=post&offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
+        Assert.assertEquals(baseUrl + "?type=post&offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
 
         // No change to URL if params are null or empty
         wpComGsonRequest.addQueryParameters(null);
-        assertEquals(baseUrl + "?type=post&offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
+        Assert.assertEquals(baseUrl + "?type=post&offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
 
         wpComGsonRequest.addQueryParameters(new HashMap<String, String>());
-        assertEquals(baseUrl + "?type=post&offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
+        Assert.assertEquals(baseUrl + "?type=post&offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
     }
 
     @Test
@@ -44,7 +44,7 @@ public class RequestQueryParametersTest {
         params.put("favorite_pet", "pony");
 
         WPComGsonRequest wpComGsonRequest = WPComGsonRequest.buildGetRequest(baseUrl, params, null, null, null);
-        assertEquals(baseUrl + "?offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
+        Assert.assertEquals(baseUrl + "?offset=20&favorite_pet=pony", wpComGsonRequest.getUrl());
     }
 
     @Test
@@ -57,6 +57,6 @@ public class RequestQueryParametersTest {
 
         WPComGsonRequest wpComGsonRequest = WPComGsonRequest.buildPostRequest(baseUrl, body, null, null, null);
         // No change if the request != GET
-        assertEquals(baseUrl, wpComGsonRequest.getUrl());
+        Assert.assertEquals(baseUrl, wpComGsonRequest.getUrl());
     }
 }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation ('org.wordpress:utils:1.16.0') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley";
+        exclude group: "com.android.support";
     }
 
     // Custom WellSql version

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
@@ -15,7 +15,11 @@ public class UserAgent {
         // E.g.:
         //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
         //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
-        mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
+        try {
+            mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
+        } catch (RuntimeException re) {
+            mDefaultUserAgent = "Mozilla/5.0 (Linux; Android 6.0; default FluxC UA; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36";
+        }
         // User-Agent string when making HTTP connections, for both API traffic and WebViews.
         // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
         // to get the full feature list of the browser and serve content accordingly, e.g.:

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation ('org.wordpress:utils:1.16.0') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley";
+        exclude group: "com.android.support";
     }
 
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"


### PR DESCRIPTION
Warning: This is not ready for review yet, and kind of a rabbit hole. 

Purpose of the PR is to replace InstrumentationTestCase by JUnit tests. Tests will run independently and if one crashes, the test suite will continue.