### PR TITLE
AccountStore connected test tweaks

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
@@ -2,10 +2,14 @@ package org.wordpress.android.fluxc.mocked;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -16,7 +20,8 @@ public class MockedStack_AccountTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
 
-    public boolean mIsError;
+    private boolean mIsError;
+    private CountDownLatch mCountDownLatch;
 
     @Override
     protected void setUp() throws Exception {
@@ -35,22 +40,27 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         super.tearDown();
     }
 
-    public void testAuthenticationOK() {
+    public void testAuthenticationOK() throws InterruptedException {
         AuthenticatePayload payload = new AuthenticatePayload("test", "test");
         mIsError = false;
         // Correct user we should get an OnAuthenticationChanged message
+        mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
-    public void testAuthenticationKO() {
+    public void testAuthenticationKO() throws InterruptedException {
         AuthenticatePayload payload = new AuthenticatePayload("error", "error");
         mIsError = true;
         // Correct user we should get an OnAuthenticationChanged message
+        mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
         assertEquals(mIsError, event.isError());
+        mCountDownLatch.countDown();
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
@@ -3,9 +3,11 @@ package org.wordpress.android.fluxc.mocked;
 import org.greenrobot.eventbus.Subscribe;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 
 import java.util.concurrent.CountDownLatch;
@@ -41,6 +43,10 @@ public class MockedStack_AccountTest extends MockedStack_Base {
     }
 
     public void testAuthenticationOK() throws InterruptedException {
+        if (mAccountStore.hasAccessToken()) {
+            signOut();
+        }
+
         AuthenticatePayload payload = new AuthenticatePayload("test", "test");
         mIsError = false;
         // Correct user we should get an OnAuthenticationChanged message
@@ -50,6 +56,10 @@ public class MockedStack_AccountTest extends MockedStack_Base {
     }
 
     public void testAuthenticationKO() throws InterruptedException {
+        if (mAccountStore.hasAccessToken()) {
+            signOut();
+        }
+
         AuthenticatePayload payload = new AuthenticatePayload("error", "error");
         mIsError = true;
         // Correct user we should get an OnAuthenticationChanged message
@@ -58,9 +68,26 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @SuppressWarnings("unused")
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
         assertEquals(mIsError, event.isError());
         mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onAccountChanged(OnAccountChanged event) {
+        if (event.isError()) {
+            throw new AssertionError("Got unexpected error in OnAccountChanged: " + event.error.type);
+        }
+        mCountDownLatch.countDown();
+    }
+
+    private void signOut() throws InterruptedException {
+        mIsError = false;
+        mCountDownLatch = new CountDownLatch(2); // Wait for OnAuthenticationChanged and OnAccountChanged
+        mDispatcher.dispatch(AccountActionBuilder.newSignOutAction());
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
@@ -27,6 +27,14 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         mDispatcher.register(this);
     }
 
+    @Override
+    protected void tearDown() throws Exception {
+        if (mAccountStore.hasAccessToken()) {
+            throw new AssertionError("Mock account tests should clear the AccountStore!");
+        }
+        super.tearDown();
+    }
+
     public void testAuthenticationOK() {
         AuthenticatePayload payload = new AuthenticatePayload("test", "test");
         mIsError = false;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
@@ -53,6 +53,9 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Log out and clear stored dummy account
+        signOut();
     }
 
     public void testAuthenticationKO() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -66,6 +66,10 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     }
 
     public void testWPComAuthenticationOK() throws InterruptedException {
+        if (mAccountStore.hasAccessToken()) {
+            signOut();
+        }
+
         mNextEvent = TestEvents.AUTHENTICATE;
         authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -85,6 +85,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
             mNextEvent = TestEvents.AUTHENTICATE;
             authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         }
+
         mNextEvent = TestEvents.FETCHED;
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
         mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
@@ -96,7 +97,14 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         if (!mAccountStore.hasAccessToken()) {
             mNextEvent = TestEvents.AUTHENTICATE;
             authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        } else if (!mAccountStore.getAccount().getUserName().equals(BuildConfig.TEST_WPCOM_USERNAME_TEST1)) {
+            // If we're logged in as any user other than the test user, switch accounts
+            // This is to avoid surprise changes to the description of non-test accounts
+            signOut();
+            mNextEvent = TestEvents.AUTHENTICATE;
+            authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         }
+
         mNextEvent = TestEvents.POSTED;
         PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
         String newValue = String.valueOf(System.currentTimeMillis());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -207,10 +207,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.AUTHENTICATE;
         authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
 
-        mCountDownLatch = new CountDownLatch(2); // Wait for OnAuthenticationChanged and OnAccountChanged
-        mNextEvent = TestEvents.AUTHENTICATE;
-        mDispatcher.dispatch(AccountActionBuilder.newSignOutAction());
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        signOut();
 
         assertFalse(mAccountStore.hasAccessToken());
         assertEquals(0, mAccountStore.getAccount().getUserId());
@@ -422,6 +419,13 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         AuthenticatePayload payload = new AuthenticatePayload(username, password);
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void signOut() throws InterruptedException {
+        mCountDownLatch = new CountDownLatch(2); // Wait for OnAuthenticationChanged and OnAccountChanged
+        mNextEvent = TestEvents.AUTHENTICATE;
+        mDispatcher.dispatch(AccountActionBuilder.newSignOutAction());
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -91,9 +91,9 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         }
 
         mNextEvent = TestEvents.FETCHED;
+        mCountDownLatch = new CountDownLatch(2);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
         mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
-        mCountDownLatch = new CountDownLatch(2);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -115,8 +115,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mExpectAccountInfosChanged = true;
         payload.params = new HashMap<>();
         payload.params.put("description", newValue);
-        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
@@ -130,9 +130,9 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
         // First, fetch account settings
         mNextEvent = TestEvents.FETCHED;
+        mCountDownLatch = new CountDownLatch(2);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
         mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
-        mCountDownLatch = new CountDownLatch(2);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         mNextEvent = TestEvents.POSTED;
@@ -141,8 +141,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mExpectAccountInfosChanged = false;
         payload.params = new HashMap<>();
         payload.params.put("description", newValue);
-        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
@@ -156,9 +156,9 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
         // First, fetch account settings
         mNextEvent = TestEvents.FETCHED;
+        mCountDownLatch = new CountDownLatch(2);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
         mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
-        mCountDownLatch = new CountDownLatch(2);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         mNextEvent = TestEvents.POSTED;
@@ -167,8 +167,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mExpectAccountInfosChanged = false;
         payload.params = new HashMap<>();
         payload.params.put("primary_site_ID", newValue);
-        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         assertEquals(newValue, String.valueOf(mAccountStore.getAccount().getPrimarySiteId()));
@@ -186,9 +186,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
         PushUsernamePayload payload = new PushUsernamePayload(username,
                 AccountUsernameActionType.KEEP_OLD_SITE_AND_ADDRESS);
-        mDispatcher.dispatch(AccountActionBuilder.newPushUsernameAction(payload));
-
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AccountActionBuilder.newPushUsernameAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         assertEquals(username, String.valueOf(mAccountStore.getAccount().getUserName()));
@@ -199,9 +198,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME;
 
         FetchUsernameSuggestionsPayload payload = new FetchUsernameSuggestionsPayload("");
-        mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
-
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -209,9 +207,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.FETCH_USERNAME_SUGGESTIONS_SUCCESS;
 
         FetchUsernameSuggestionsPayload payload = new FetchUsernameSuggestionsPayload("username");
-        mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
-
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AccountActionBuilder.newFetchUsernameSuggestionsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -251,16 +248,16 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     public void testSendAuthEmail() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailViaUsername() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -268,8 +265,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         AuthEmailPayload payload = new AuthEmailPayload("email@domain", false);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -277,8 +274,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
         AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -286,24 +283,24 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
         AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailSignupInvalid() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
         AuthEmailPayload payload = new AuthEmailPayload("email@domain", true);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSendAuthEmailSignupUserExists() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -433,8 +430,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     private void authenticate(String username, String password) throws InterruptedException {
         AuthenticatePayload payload = new AuthenticatePayload(username, password);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -204,8 +204,10 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     }
 
     public void testWPComSignOut() throws InterruptedException {
-        mNextEvent = TestEvents.AUTHENTICATE;
-        authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        if (!mAccountStore.hasAccessToken()) {
+            mNextEvent = TestEvents.AUTHENTICATE;
+            authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        }
 
         signOut();
 
@@ -214,8 +216,10 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     }
 
     public void testWPComSignOutCollision() throws InterruptedException {
-        mNextEvent = TestEvents.AUTHENTICATE;
-        authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        if (!mAccountStore.hasAccessToken()) {
+            mNextEvent = TestEvents.AUTHENTICATE;
+            authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        }
 
         mCountDownLatch = new CountDownLatch(2); // Wait for OnAuthenticationChanged and OnAccountChanged
         mNextEvent = TestEvents.AUTHENTICATE;


### PR DESCRIPTION
Some improvements to the connected `AccountStore` tests:

* Ensure we start with consistent state (e.g., logged out if we're testing logging in)
* Dispatches are no longer sent before `CountDownLatch`es were set - this was a race condition risk
* The one test that makes changes to the account (`testWPComPost()`) now makes sure we're logged into the test account first

Overall, we could make these 100% atomic by always making sure to log out and back in at the start of tests - I'm hesitant to do that since many of the tests don't rely on being logged into any particular account, and all that extra network activity will slow down the tests. We can do that if we're running into problems otherwise.

cc @maxme - not sure whether this addresses the issues you were seeing, might need more info from you