### PR TITLE
Handle plugin doesn't exist error

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -22,7 +22,6 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     }
 
     private TestEvents mNextEvent;
-    private final String mSlug = "akismet";
 
     @Override
     protected void setUp() throws Exception {
@@ -35,12 +34,15 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     }
 
     public void testFetchWPOrgPlugin() throws InterruptedException {
+        String slug = "akismet";
         mNextEvent = TestEvents.WPORG_PLUGIN_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
-
-        mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginAction(mSlug));
-
+        mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginAction(slug));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+
+        WPOrgPluginModel wpOrgPlugin = mPluginStore.getWPOrgPluginBySlug(slug);
+        assertNotNull(wpOrgPlugin);
     }
 
     public void testFetchWPOrgPluginDoesNotExistError() throws InterruptedException {
@@ -62,8 +64,6 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         }
 
         assertEquals(TestEvents.WPORG_PLUGIN_FETCHED, mNextEvent);
-        WPOrgPluginModel wpOrgPlugin = mPluginStore.getWPOrgPluginBySlug(mSlug);
-        assertNotNull(wpOrgPlugin);
         mCountDownLatch.countDown();
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -18,6 +18,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     enum TestEvents {
         NONE,
         WPORG_PLUGIN_FETCHED,
+        WPORG_PLUGIN_DOES_NOT_EXIST
     }
 
     private TestEvents mNextEvent;
@@ -42,11 +43,22 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    public void testFetchWPOrgPluginDoesNotExistError() throws InterruptedException {
+        String slug = "hello";
+        mNextEvent = TestEvents.WPORG_PLUGIN_DOES_NOT_EXIST;
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginAction(slug));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onWPOrgPluginFetched(OnWPOrgPluginFetched event) {
         if (event.isError()) {
-            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+            assertEquals(mNextEvent, TestEvents.WPORG_PLUGIN_DOES_NOT_EXIST);
+            mCountDownLatch.countDown();
+            return;
         }
 
         assertEquals(TestEvents.WPORG_PLUGIN_FETCHED, mNextEvent);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -51,7 +51,6 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(PluginActionBuilder.newFetchWporgPluginAction(slug));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
     }
 
     @SuppressWarnings("unused")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.wporg.plugin;
 
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
@@ -47,6 +48,14 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
                                 if (response == null) {
                                     FetchWPOrgPluginError error = new FetchWPOrgPluginError(
                                             FetchWPOrgPluginErrorType.EMPTY_RESPONSE);
+                                    mDispatcher.dispatch(PluginActionBuilder.newFetchedWporgPluginAction(
+                                            new FetchedWPOrgPluginPayload(pluginSlug, error)));
+                                    return;
+                                }
+                                if (!TextUtils.isEmpty(response.errorMessage)) {
+                                    // Plugin does not exist error returned with success code
+                                    FetchWPOrgPluginError error = new FetchWPOrgPluginError(
+                                            FetchWPOrgPluginErrorType.PLUGIN_DOES_NOT_EXIST);
                                     mDispatcher.dispatch(PluginActionBuilder.newFetchedWporgPluginAction(
                                             new FetchedWPOrgPluginPayload(pluginSlug, error)));
                                     return;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/WPOrgPluginResponse.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.wporg.plugin;
 
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -39,6 +40,9 @@ public class WPOrgPluginResponse {
     public int numberOfRatingsOfThree;
     public int numberOfRatingsOfFour;
     public int numberOfRatingsOfFive;
+
+    // Errors are returned with success code
+    public String errorMessage;
 }
 
 class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
@@ -47,6 +51,11 @@ class WPOrgPluginDeserializer implements JsonDeserializer<WPOrgPluginResponse> {
                                            JsonDeserializationContext context) throws JsonParseException {
         JsonObject jsonObject = json.getAsJsonObject();
         WPOrgPluginResponse response = new WPOrgPluginResponse();
+        response.errorMessage = getStringFromJsonIfAvailable(jsonObject, "error");
+        // Response has an error instead of the plugin information
+        if (!TextUtils.isEmpty(response.errorMessage)) {
+            return response;
+        }
         response.authorAsHtml = getStringFromJsonIfAvailable(jsonObject, "author");
         response.banner = getBannerFromJson(jsonObject);
         response.downloadCount = getIntFromJsonIfAvailable(jsonObject, "downloaded");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -264,7 +264,8 @@ public class PluginStore extends Store {
 
     public enum FetchWPOrgPluginErrorType {
         EMPTY_RESPONSE,
-        GENERIC_ERROR
+        GENERIC_ERROR,
+        PLUGIN_DOES_NOT_EXIST
     }
 
     public enum FetchSitePluginsErrorType {


### PR DESCRIPTION
Fixes #704. The wporg api for plugins returns `{"error":"Plugin not found."}` with 200 status code when a plugin doesn't exist in the directory: https://api.wordpress.org/plugins/info/1.0/hello.json. This PR handles this special case by returning `PLUGIN_DOES_NOT_EXIST` error. As far as I know, this is the only error we get with 200 status code, so we are currently ignoring the message itself. If we find more situations like this, we can improve upon this.

The PR also adds a test for this case as well as making some minor improvements to the existing test.

/cc @nbradbury @theck13 