### PR TITLE
Support only_wordpressdotcom domain suggestions

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -55,7 +55,6 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     private TestEvents mNextEvent;
     private int mExpectedRowsAffected;
-    private OnSuggestedDomains mLastOnSuggestedDomainsEvent;
 
     @Override
     protected void setUp() throws Exception {
@@ -195,12 +194,6 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mNextEvent = TestEvents.FETCHED_WPCOM_SUBDOMAIN_SUGGESTIONS;
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        assertEquals(20, mLastOnSuggestedDomainsEvent.suggestions.size());
-        final String suffix = ".wordpress.com";
-        for (DomainSuggestionResponse suggestionResponse : mLastOnSuggestedDomainsEvent.suggestions) {
-            assertTrue("Was expecting the domain to end in " + suffix, suggestionResponse.domain_name.endsWith(suffix));
-        }
     }
 
     @SuppressWarnings("unused")
@@ -308,11 +301,16 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     @SuppressWarnings("unused")
     @Subscribe
     public void onSuggestedDomains(OnSuggestedDomains event) {
-        mLastOnSuggestedDomainsEvent = event;
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertEquals(TestEvents.FETCHED_WPCOM_SUBDOMAIN_SUGGESTIONS, mNextEvent);
+
+        final String suffix = ".wordpress.com";
+        for (DomainSuggestionResponse suggestionResponse : event.suggestions) {
+            assertTrue("Was expecting the domain to end in " + suffix, suggestionResponse.domain_name.endsWith(suffix));
+        }
+
         mCountDownLatch.countDown();
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -154,7 +154,7 @@ public class SignedOutActionsFragment extends Fragment {
         alert.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 String keyword = editText.getText().toString();
-                SuggestDomainsPayload payload = new SuggestDomainsPayload(keyword, true, false, 5);
+                SuggestDomainsPayload payload = new SuggestDomainsPayload(keyword, false, true, false, 5);
                 mDispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(payload));
             }
         });

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -460,12 +460,13 @@ public class SiteRestClient extends BaseWPComRestClient {
         addUnauthedRequest(request);
     }
 
-    public void suggestDomains(@NonNull final String query, final boolean includeWordpressCom,
-                               final boolean includeDotBlogSubdomain, final int quantity) {
+    public void suggestDomains(@NonNull final String query, final boolean onlyWordpressCom,
+                               final boolean includeWordpressCom, final boolean includeDotBlogSubdomain,
+                               final int quantity) {
         String url = WPCOMREST.domains.suggestions.getUrlV1_1();
         Map<String, String> params = new HashMap<>(4);
         params.put("query", query);
-        // ugly trick to bypass checkstyle and its dot com rule
+        params.put("only_wordpressdotcom", String.valueOf(onlyWordpressCom));
         params.put("include_wordpressdotcom", String.valueOf(includeWordpressCom)); // CHECKSTYLE IGNORE
         params.put("include_dotblogsubdomain", String.valueOf(includeDotBlogSubdomain));
         params.put("quantity", String.valueOf(quantity));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -466,7 +466,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         String url = WPCOMREST.domains.suggestions.getUrlV1_1();
         Map<String, String> params = new HashMap<>(4);
         params.put("query", query);
-        params.put("only_wordpressdotcom", String.valueOf(onlyWordpressCom));
+        params.put("only_wordpressdotcom", String.valueOf(onlyWordpressCom)); // CHECKSTYLE IGNORE
         params.put("include_wordpressdotcom", String.valueOf(includeWordpressCom)); // CHECKSTYLE IGNORE
         params.put("include_dotblogsubdomain", String.valueOf(includeDotBlogSubdomain));
         params.put("quantity", String.valueOf(quantity));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -92,12 +92,14 @@ public class SiteStore extends Store {
 
     public static class SuggestDomainsPayload extends Payload<BaseNetworkError> {
         public String query;
+        public boolean onlyWordpressCom;
         public boolean includeWordpressCom;
         public boolean includeDotBlogSubdomain;
         public int quantity;
-        public SuggestDomainsPayload(@NonNull String query, boolean includeWordpressCom,
+        public SuggestDomainsPayload(@NonNull String query, boolean onlyWordpressCom, boolean includeWordpressCom,
                                      boolean includeDotBlogSubdomain, int quantity) {
             this.query = query;
+            this.onlyWordpressCom = onlyWordpressCom;
             this.includeWordpressCom = includeWordpressCom;
             this.includeDotBlogSubdomain = includeDotBlogSubdomain;
             this.quantity = quantity;
@@ -1069,8 +1071,8 @@ public class SiteStore extends Store {
     }
 
     private void suggestDomains(SuggestDomainsPayload payload) {
-        mSiteRestClient.suggestDomains(payload.query, payload.includeWordpressCom, payload.includeDotBlogSubdomain,
-                payload.quantity);
+        mSiteRestClient.suggestDomains(payload.query, payload.onlyWordpressCom, payload.includeWordpressCom,
+                payload.includeDotBlogSubdomain, payload.quantity);
     }
 
     private void handleSuggestedDomains(SuggestDomainsResponsePayload payload) {


### PR DESCRIPTION
Fixes #706 

Adds support for the `only_wordpressdotcom` flag to the WPCOM domain suggestions REST API call.

To test: run the `ReleaseStack_SiteTestWPCom.testWpcomSubdomainSuggestions()` test which calls the API and tests that the suggested domains are only subdomains to `.wordpress.com`.