### PR TITLE
Robolectric unit test tweaks + Kotlin support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.20'
+    ext.kotlinVersion = '1.2.21'
 
     repositories {
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 buildscript {
+    ext.kotlinVersion = '1.2.20'
+
     repositories {
         jcenter()
         google()
@@ -33,6 +35,17 @@ allprojects {
 }
 
 subprojects {
+    configurations.all {
+        resolutionStrategy {
+            forcedModules = [
+                    // Needed for com.nhaarman:mockito-kotlin-kt1.1
+                    // Can possibly be dropped when v2 of mockito-kotlin is released
+                    "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+            ]
+        }
+    }
+
     configurations {
         ktlint
     }
@@ -55,8 +68,6 @@ subprojects {
 }
 
 ext {
-    kotlinVersion = '1.2.20'
-
     daggerVersion = '2.11'
     supportLibraryVersion = '25.3.1'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -88,8 +88,8 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
-    testImplementation 'org.robolectric:robolectric:3.0'
+    testImplementation 'org.mockito:mockito-core:2.8.9'
+    testImplementation 'org.robolectric:robolectric:3.6.1'
     androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestImplementation 'org.mockito:mockito-core:1.10.19'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.8.9'
     testImplementation 'org.robolectric:robolectric:3.6.1'
+    testImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
     androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestImplementation 'org.mockito:mockito-core:1.10.19'

--- a/example/src/test/java/android/text/TextUtils.java
+++ b/example/src/test/java/android/text/TextUtils.java
@@ -1,0 +1,32 @@
+package android.text;
+
+import java.util.Iterator;
+
+/**
+ * Allows unit tests to call methods that rely on {@link android.text.TextUtils} without requiring mocks
+ * of the Android framework (i.e., no need to use Robolectric).
+ */
+public class TextUtils {
+    /**
+     * Duplicates {@link android.text.TextUtils#isEmpty(CharSequence)}.
+     */
+    public static boolean isEmpty(CharSequence str) {
+        return str == null || str.length() == 0;
+    }
+
+    /**
+     * Duplicates {@link android.text.TextUtils#join(CharSequence, Iterable)}.
+     */
+    public static String join(CharSequence delimiter, Iterable tokens) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<?> it = tokens.iterator();
+        if (it.hasNext()) {
+            sb.append(it.next());
+            while (it.hasNext()) {
+                sb.append(delimiter);
+                sb.append(it.next());
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/EndpointNodeTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/EndpointNodeTest.java
@@ -1,8 +1,6 @@
 package org.wordpress.android.fluxc;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointNode;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointTreeGenerator;
 
@@ -15,7 +13,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
 public class EndpointNodeTest {
     @Test
     public void testEndpointNodeSetup() {

--- a/example/src/test/java/org/wordpress/android/fluxc/PayloadTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/PayloadTest.java
@@ -1,8 +1,6 @@
 package org.wordpress.android.fluxc;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 
@@ -11,7 +9,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(RobolectricTestRunner.class)
 public class PayloadTest {
     private class CloneablePayload extends Payload<BaseNetworkError> implements Cloneable {
         @Override

--- a/example/src/test/java/org/wordpress/android/fluxc/WPAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPAPIEndpointTest.java
@@ -1,13 +1,10 @@
 package org.wordpress.android.fluxc;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class WPAPIEndpointTest {
     @Test
     public void testAllEndpoints() {

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -1,13 +1,10 @@
 package org.wordpress.android.fluxc;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class WPComEndpointTest {
     @Test
     public void testAllEndpoints() {

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComV2EndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComV2EndpointTest.java
@@ -1,13 +1,10 @@
 package org.wordpress.android.fluxc;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class WPComV2EndpointTest {
     @Test
     public void testAllEndpoints() {

--- a/example/src/test/java/org/wordpress/android/fluxc/WPOrgAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPOrgAPIEndpointTest.java
@@ -1,13 +1,10 @@
 package org.wordpress.android.fluxc;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.generated.endpoint.WPORGAPI;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class WPOrgAPIEndpointTest {
     @Test
     public void testAllEndpoints() {

--- a/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
@@ -4,11 +4,8 @@ import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.AccountModel;
 
-@RunWith(RobolectricTestRunner.class)
 public class AccountModelTest {
     @Before
     public void setUp() {
@@ -19,7 +16,7 @@ public class AccountModelTest {
         AccountModel testAccount = getTestAccount();
         AccountModel testAccount2 = getTestAccount();
         Assert.assertFalse(testAccount.equals(new Object()));
-        Assert.assertFalse(testAccount.equals(null));
+        Assert.assertNotNull(testAccount);
         testAccount2.setUserId(testAccount.getUserId() + 1);
         Assert.assertFalse(testAccount.equals(testAccount2));
         testAccount2.setUserId(testAccount.getUserId());

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostLocationTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostLocationTest.java
@@ -3,15 +3,12 @@ package org.wordpress.android.fluxc.post;
 import junit.framework.Assert;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.post.PostLocation;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
 public class PostLocationTest {
     private static final double MAX_LAT = 90;
     private static final double MIN_LAT = -90;

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostModelTest.java
@@ -1,8 +1,6 @@
 package org.wordpress.android.fluxc.post;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.post.PostLocation;
 import org.wordpress.android.fluxc.model.post.PostStatus;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertTrue;
 import static org.wordpress.android.fluxc.post.PostTestUtils.EXAMPLE_LATITUDE;
 import static org.wordpress.android.fluxc.post.PostTestUtils.EXAMPLE_LONGITUDE;
 
-@RunWith(RobolectricTestRunner.class)
 public class PostModelTest {
     @Test
     public void testEquals() {
@@ -43,7 +40,7 @@ public class PostModelTest {
 
         testPost.error = new BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.PARSE_ERROR);
 
-        PostModel clonedPost = (PostModel) testPost.clone();
+        PostModel clonedPost = testPost.clone();
 
         assertFalse(testPost == clonedPost);
         assertTrue(testPost.equals(clonedPost));

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStatusTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStatusTest.java
@@ -1,8 +1,6 @@
 package org.wordpress.android.fluxc.post;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.util.DateTimeUtils;
@@ -11,7 +9,6 @@ import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class PostStatusTest {
     @Test
     public void testPostStatusFromPost() {

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.site;
 
 import android.content.Context;
-import android.database.sqlite.SQLiteException;
 
 import com.wellsql.generated.SiteModelTable;
 import com.yarolegovich.wellsql.WellSql;
@@ -727,9 +726,7 @@ public class SiteStoreUnitTest {
         boolean duplicate = false;
         try {
             SiteSqlUtils.insertOrUpdateSite(site2);
-        } catch (SQLiteException e) {
-            // We should catch a DuplicateSiteException here, but since Roboelectric uses a different SQL stack, we
-            // can't catch `SQLiteConstraintException` in SiteSqlUtils.insertOrUpdateSite.
+        } catch (DuplicateSiteException e) {
             duplicate = true;
         }
         assertTrue(duplicate);

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -158,7 +158,7 @@ public class SiteXMLRPCClientTest {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect an OnUnexpectedError to be emitted with a parse error
-                OnUnexpectedError event = invocation.getArgumentAt(0, OnUnexpectedError.class);
+                OnUnexpectedError event = invocation.getArgument(0);
                 assertEquals(site.getXmlRpcUrl(), event.extras.get(OnUnexpectedError.KEY_URL));
                 assertEquals("whoops", event.extras.get(OnUnexpectedError.KEY_RESPONSE));
                 assertEquals(ClassCastException.class, event.exception.getClass());
@@ -172,7 +172,7 @@ public class SiteXMLRPCClientTest {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect UPDATE_SITE to be dispatched with an INVALID_RESPONSE error
-                Action action = invocation.getArgumentAt(0, Action.class);
+                Action action = invocation.getArgument(0);
                 assertEquals(SiteAction.UPDATE_SITE, action.getType());
 
                 SiteModel result = (SiteModel) action.getPayload();
@@ -223,7 +223,7 @@ public class SiteXMLRPCClientTest {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect an OnUnexpectedError to be emitted with a parse error
-                OnUnexpectedError event = invocation.getArgumentAt(0, OnUnexpectedError.class);
+                OnUnexpectedError event = invocation.getArgument(0);
                 assertEquals(xmlrpcUrl, event.extras.get(OnUnexpectedError.KEY_URL));
                 assertEquals("disaster!", event.extras.get(OnUnexpectedError.KEY_RESPONSE));
                 assertEquals(ClassCastException.class, event.exception.getClass());
@@ -237,7 +237,7 @@ public class SiteXMLRPCClientTest {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 // Expect UPDATE_SITES to be dispatched with an INVALID_RESPONSE error
-                Action action = invocation.getArgumentAt(0, Action.class);
+                Action action = invocation.getArgument(0);
                 assertEquals(SiteAction.FETCHED_SITES_XML_RPC, action.getType());
 
                 SitesModel result = (SitesModel) action.getPayload();

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TermModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TermModelTest.java
@@ -1,14 +1,11 @@
 package org.wordpress.android.fluxc.taxonomy;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.TermModel;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
 public class TermModelTest {
     @Test
     public void testEquals() {

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/MediaUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/MediaUploadModelTest.java
@@ -2,10 +2,7 @@ package org.wordpress.android.fluxc.upload;
 
 import android.text.TextUtils;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.MediaUploadModel;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
@@ -16,12 +13,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
 public class MediaUploadModelTest {
-    @Before
-    public void setUp() {
-    }
-
     @Test
     public void testEquals() {
         MediaUploadModel mediaUploadModel1 = new MediaUploadModel(1);

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
@@ -2,10 +2,7 @@ package org.wordpress.android.fluxc.upload;
 
 import android.text.TextUtils;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.model.PostUploadModel;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
@@ -13,18 +10,13 @@ import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
 public class PostUploadModelTest {
-    @Before
-    public void setUp() {
-    }
-
     @Test
     public void testEquals() {
         PostUploadModel postUploadModel1 = new PostUploadModel(1);

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/DateTimeUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/DateTimeUtilsTest.java
@@ -1,15 +1,12 @@
 package org.wordpress.android.fluxc.utils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class DateTimeUtilsTest {
     @Test
     public void test8601DateStringToDateObject() {

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MediaUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MediaUtilsTest.java
@@ -3,10 +3,7 @@ package org.wordpress.android.fluxc.utils;
 import junit.framework.Assert;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
-@RunWith(RobolectricTestRunner.class)
 public class MediaUtilsTest {
     @Test
     public void testImageMimeTypeRecognition() {

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/XMLRPCUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/XMLRPCUtilsTest.java
@@ -1,8 +1,6 @@
 package org.wordpress.android.fluxc.utils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCUtils;
 
 import java.sql.Time;
@@ -14,7 +12,6 @@ import java.util.Random;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@RunWith(RobolectricTestRunner.class)
 public class XMLRPCUtilsTest {
     @Test
     public void testDefaultValueString() {

--- a/example/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/example/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Extracts some work I've had to do for unit test support for the WooCommerce plugin into a standalone PR, with some improvements that also apply to Java unit tests.

* Updated Robolectric and Mockito for unit tests to latest versions (required to play nicely with Kotlin)
* Dropped Robolectric from tests that didn't require it (good speed optimization when running those tests standalone)
* Added the `MockMaker` trick required to mock closed classes in Kotlin (for example, any network client class)