### PR TITLE
Plugin Sql Tests for WPOrgPluginModel & PluginDirectoryModel

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
@@ -44,7 +44,7 @@ public class PluginDirectorySqlUtilsTest {
         PluginDirectoryType directoryType = PluginDirectoryType.NEW;
         for (int i = 0; i < numberOfDirectories; i++) {
             PluginDirectoryModel directoryModel = new PluginDirectoryModel();
-            directoryModel.setSlug(randomSlug());
+            directoryModel.setSlug(randomString("slug" + i));
             directoryModel.setDirectoryType(directoryType.toString());
             directoryModel.setPage(1);
             pluginDirectoryList.add(directoryModel);
@@ -63,7 +63,7 @@ public class PluginDirectorySqlUtilsTest {
     @Test
     public void testInsertSinglePluginDirectoryModel() throws NoSuchMethodException,
             InvocationTargetException, IllegalAccessException {
-        String slug = randomSlug();
+        String slug = randomString("slug");
         int page = 5;
         List<PluginDirectoryModel> pluginDirectoryList = new ArrayList<>();
         String directoryType = PluginDirectoryType.NEW.toString();
@@ -95,7 +95,7 @@ public class PluginDirectorySqlUtilsTest {
         // value of the page we have set so far is always the last requested page
         for (int i = 0; i < numberOfTimesToTry; i++) {
             PluginDirectoryModel directoryModel = new PluginDirectoryModel();
-            directoryModel.setSlug(randomSlug());
+            directoryModel.setSlug(randomString("slug" + i));
             directoryModel.setDirectoryType(directoryType.toString());
             int page = mRandom.nextInt(maxPossiblePage);
             directoryModel.setPage(page);
@@ -109,7 +109,7 @@ public class PluginDirectorySqlUtilsTest {
         }
     }
 
-    private String randomSlug() {
-        return "slug-" + mRandom.nextInt();
+    private String randomString(String prefix) {
+        return prefix + "-" + mRandom.nextInt();
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
@@ -1,0 +1,78 @@
+package org.wordpress.android.fluxc.plugin;
+
+import android.content.Context;
+
+import com.yarolegovich.wellsql.WellSql;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
+import org.wordpress.android.fluxc.model.plugin.PluginDirectoryModel;
+import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType;
+import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
+import org.wordpress.android.fluxc.persistence.WellSqlConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+@RunWith(RobolectricTestRunner.class)
+public class PluginDirectorySqlUtilsTest {
+    private Random mRandom = new Random(System.currentTimeMillis());
+
+    @Before
+    public void setUp() {
+        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+
+        WellSqlConfig config = new SingleStoreWellSqlConfigForTests(appContext, PluginDirectoryModel.class);
+        WellSql.init(config);
+        config.reset();
+    }
+
+    @Test
+    public void insertPluginDirectoryList() {
+        int numberOfDirectories = 10;
+        List<PluginDirectoryModel> pluginDirectoryList = new ArrayList<>();
+        for (int i = 0; i < numberOfDirectories; i++) {
+            PluginDirectoryModel directoryModel = new PluginDirectoryModel();
+            directoryModel.setSlug(randomSlug());
+            directoryModel.setDirectoryType(PluginDirectoryType.NEW.toString());
+            directoryModel.setPage(1);
+            pluginDirectoryList.add(directoryModel);
+        }
+        Assert.assertEquals(numberOfDirectories, PluginSqlUtils.insertOrUpdatePluginDirectoryList(pluginDirectoryList));
+    }
+
+    @Test
+    public void testGetLastRequestedPageForDirectoryType() {
+        int numberOfTimesToTry = 10;
+        int lastRequestedPage = 0;
+        int maxPossiblePage = 100;
+        PluginDirectoryType directoryType = PluginDirectoryType.NEW;
+        // We insert a PluginDirectoryModel in each iteration with a random page number and assert that the max
+        // value of the page we have set so far is always the last requested page
+        for (int i = 0; i < numberOfTimesToTry; i++) {
+            PluginDirectoryModel directoryModel = new PluginDirectoryModel();
+            directoryModel.setSlug(randomSlug());
+            directoryModel.setDirectoryType(directoryType.toString());
+            int page = mRandom.nextInt(maxPossiblePage);
+            directoryModel.setPage(page);
+            // Add PluginDirectoryModels one by one
+            List<PluginDirectoryModel> pluginDirectoryList = new ArrayList<>();
+            pluginDirectoryList.add(directoryModel);
+            Assert.assertEquals(1, PluginSqlUtils.insertOrUpdatePluginDirectoryList(pluginDirectoryList));
+            // Last requested page is the max value of the `page` column for that directory type
+            lastRequestedPage = Math.max(lastRequestedPage, page);
+            Assert.assertEquals(lastRequestedPage, PluginSqlUtils.getLastRequestedPageForDirectoryType(directoryType));
+        }
+    }
+
+    private String randomSlug() {
+        return "slug-" + mRandom.nextInt();
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/SitePluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/SitePluginSqlUtilsTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Random;
 
 @RunWith(RobolectricTestRunner.class)
-public class PluginSqlUtilsTest {
+public class SitePluginSqlUtilsTest {
     private static final int TEST_LOCAL_SITE_ID = 1;
     private static final int SMALL_TEST_POOL = 10;
 

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
@@ -1,0 +1,57 @@
+package org.wordpress.android.fluxc.plugin;
+
+import android.content.Context;
+
+import com.yarolegovich.wellsql.WellSql;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
+import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
+import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
+import org.wordpress.android.fluxc.persistence.WellSqlConfig;
+
+import java.util.Random;
+
+@RunWith(RobolectricTestRunner.class)
+public class WPOrgPluginSqlUtilsTest {
+    private Random mRandom = new Random(System.currentTimeMillis());
+
+    @Before
+    public void setUp() {
+        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+
+        WellSqlConfig config = new SingleStoreWellSqlConfigForTests(appContext, WPOrgPluginModel.class);
+        WellSql.init(config);
+        config.reset();
+    }
+
+    @Test
+    public void testInsertWPOrgPlugin() {
+        String slug = randomString("slug");
+        String name = randomString("name");
+
+        // Assert no plugin exist with the slug
+        Assert.assertNull(PluginSqlUtils.getWPOrgPluginBySlug(slug));
+
+        // Create wporg plugin
+        WPOrgPluginModel plugin = new WPOrgPluginModel();
+        plugin.setSlug(slug);
+        plugin.setName(name);
+
+        // Insert the plugin and assert that it was successful
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateWPOrgPlugin(plugin));
+        WPOrgPluginModel insertedPlugin = PluginSqlUtils.getWPOrgPluginBySlug(slug);
+        Assert.assertNotNull(insertedPlugin);
+        Assert.assertEquals(insertedPlugin.getName(), name);
+    }
+
+    private String randomString(String prefix) {
+        return prefix + "-" + mRandom.nextInt();
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
@@ -16,6 +16,8 @@ import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 @RunWith(RobolectricTestRunner.class)
@@ -80,6 +82,26 @@ public class WPOrgPluginSqlUtilsTest {
         Assert.assertNotNull(updatedPlugin);
         Assert.assertEquals(insertedPlugin.getSlug(), updatedPlugin.getSlug());
         Assert.assertEquals(updatedPlugin.getName(), name2);
+    }
+
+    @Test
+    public void testInsertWPOrgPluginList() {
+        int numberOfPlugins = 10;
+        List<WPOrgPluginModel> plugins = new ArrayList<>();
+        List<String> slugList = new ArrayList<>();
+        for (int i = 0; i < numberOfPlugins; i++) {
+            String slug = randomString("slug" + i);
+            slugList.add(slug);
+            WPOrgPluginModel wpOrgPluginModel = new WPOrgPluginModel();
+            wpOrgPluginModel.setSlug(slug);
+            plugins.add(wpOrgPluginModel);
+        }
+        Assert.assertEquals(numberOfPlugins, PluginSqlUtils.insertOrUpdateWPOrgPluginList(plugins));
+
+        for (String slug : slugList) {
+            WPOrgPluginModel wpOrgPluginModel = PluginSqlUtils.getWPOrgPluginBySlug(slug);
+            Assert.assertNotNull(wpOrgPluginModel);
+        }
     }
 
     private String randomString(String prefix) {

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
 import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
+import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,7 +91,7 @@ public class WPOrgPluginSqlUtilsTest {
         List<WPOrgPluginModel> plugins = new ArrayList<>();
         List<String> slugList = new ArrayList<>();
         for (int i = 0; i < numberOfPlugins; i++) {
-            String slug = randomString("slug" + i);
+            String slug = randomString("slug");
             slugList.add(slug);
             WPOrgPluginModel wpOrgPluginModel = new WPOrgPluginModel();
             wpOrgPluginModel.setSlug(slug);
@@ -101,6 +102,51 @@ public class WPOrgPluginSqlUtilsTest {
         for (String slug : slugList) {
             WPOrgPluginModel wpOrgPluginModel = PluginSqlUtils.getWPOrgPluginBySlug(slug);
             Assert.assertNotNull(wpOrgPluginModel);
+        }
+    }
+
+    @Test
+    public void testUpdateWPOrgPluginList() {
+        int numberOfPlugins = 2;
+        List<WPOrgPluginModel> plugins = new ArrayList<>();
+        List<String> slugList = new ArrayList<>();
+        List<String> nameList = new ArrayList<>();
+        for (int i = 0; i < numberOfPlugins; i++) {
+            String slug = randomString("slug");
+            String name = randomString("name");
+            slugList.add(slug);
+            nameList.add(name);
+            WPOrgPluginModel wpOrgPluginModel = new WPOrgPluginModel();
+            wpOrgPluginModel.setSlug(slug);
+            wpOrgPluginModel.setName(name);
+            plugins.add(wpOrgPluginModel);
+        }
+        // Insert plugins
+        Assert.assertEquals(numberOfPlugins, PluginSqlUtils.insertOrUpdateWPOrgPluginList(plugins));
+
+        List<String> updatedNameList = new ArrayList<>();
+        List<WPOrgPluginModel> updatedPlugins = new ArrayList<>();
+        for (String slug : slugList) {
+            String newName = randomString("newName");
+            updatedNameList.add(newName);
+            WPOrgPluginModel wpOrgPluginModel = PluginSqlUtils.getWPOrgPluginBySlug(slug);
+            Assert.assertNotNull(wpOrgPluginModel);
+            // Update plugin name
+            wpOrgPluginModel.setName(newName);
+            updatedPlugins.add(wpOrgPluginModel);
+        }
+        // Update plugins
+        Assert.assertEquals(numberOfPlugins, PluginSqlUtils.insertOrUpdateWPOrgPluginList(updatedPlugins));
+
+        // Assert the plugins are updated
+        for (int i = 0; i < numberOfPlugins; i++) {
+            String slug = slugList.get(i);
+            String previousName = nameList.get(i);
+            String expectedName = updatedNameList.get(i);
+            WPOrgPluginModel wpOrgPluginModel = PluginSqlUtils.getWPOrgPluginBySlug(slug);
+            Assert.assertNotNull(wpOrgPluginModel);
+            Assert.assertFalse(StringUtils.equals(wpOrgPluginModel.getName(), previousName));
+            Assert.assertTrue(StringUtils.equals(wpOrgPluginModel.getName(), expectedName));
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
@@ -32,6 +32,11 @@ public class WPOrgPluginSqlUtilsTest {
     }
 
     @Test
+    public void testInsertNullWPOrgPlugin() {
+        Assert.assertEquals(0, PluginSqlUtils.insertOrUpdateWPOrgPlugin(null));
+    }
+
+    @Test
     public void testInsertWPOrgPlugin() {
         String slug = randomString("slug");
         String name = randomString("name");

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
@@ -56,6 +56,32 @@ public class WPOrgPluginSqlUtilsTest {
         Assert.assertEquals(insertedPlugin.getName(), name);
     }
 
+    @Test
+    public void testUpdateWPOrgPlugin() {
+        String slug = randomString("slug");
+        String name = randomString("name");
+
+        WPOrgPluginModel plugin = new WPOrgPluginModel();
+        plugin.setSlug(slug);
+        plugin.setName(name);
+
+        // Insert a wporg plugin and assert the state
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateWPOrgPlugin(plugin));
+        WPOrgPluginModel insertedPlugin = PluginSqlUtils.getWPOrgPluginBySlug(slug);
+        Assert.assertNotNull(insertedPlugin);
+        Assert.assertEquals(insertedPlugin.getName(), name);
+
+        // Update the name of the plugin and try insertOrUpdate and make sure the plugin is updated
+        String name2 = randomString("name2");
+        Assert.assertTrue(!name.equals(name2));
+        insertedPlugin.setName(name2);
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateWPOrgPlugin(insertedPlugin));
+        WPOrgPluginModel updatedPlugin = PluginSqlUtils.getWPOrgPluginBySlug(slug);
+        Assert.assertNotNull(updatedPlugin);
+        Assert.assertEquals(insertedPlugin.getSlug(), updatedPlugin.getSlug());
+        Assert.assertEquals(updatedPlugin.getName(), name2);
+    }
+
     private String randomString(String prefix) {
         return prefix + "-" + mRandom.nextInt();
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
@@ -91,7 +91,7 @@ public class WPOrgPluginSqlUtilsTest {
         List<WPOrgPluginModel> plugins = new ArrayList<>();
         List<String> slugList = new ArrayList<>();
         for (int i = 0; i < numberOfPlugins; i++) {
-            String slug = randomString("slug");
+            String slug = randomString("slug") + i;
             slugList.add(slug);
             WPOrgPluginModel wpOrgPluginModel = new WPOrgPluginModel();
             wpOrgPluginModel.setSlug(slug);
@@ -112,8 +112,8 @@ public class WPOrgPluginSqlUtilsTest {
         List<String> slugList = new ArrayList<>();
         List<String> nameList = new ArrayList<>();
         for (int i = 0; i < numberOfPlugins; i++) {
-            String slug = randomString("slug");
-            String name = randomString("name");
+            String slug = randomString("slug") + i;
+            String name = randomString("name") + i;
             slugList.add(slug);
             nameList.add(name);
             WPOrgPluginModel wpOrgPluginModel = new WPOrgPluginModel();
@@ -126,8 +126,9 @@ public class WPOrgPluginSqlUtilsTest {
 
         List<String> updatedNameList = new ArrayList<>();
         List<WPOrgPluginModel> updatedPlugins = new ArrayList<>();
-        for (String slug : slugList) {
-            String newName = randomString("newName");
+        for (int i = 0; i < slugList.size(); i++) {
+            String slug = slugList.get(i);
+            String newName = randomString("newName") + i;
             updatedNameList.add(newName);
             WPOrgPluginModel wpOrgPluginModel = PluginSqlUtils.getWPOrgPluginBySlug(slug);
             Assert.assertNotNull(wpOrgPluginModel);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -197,7 +197,7 @@ public class PluginSqlUtils {
         }
 
         PluginDirectoryModel existing = getPluginDirectoryModel(pluginDirectory.getDirectoryType(),
-                pluginDirectory.getDirectoryType());
+                pluginDirectory.getSlug());
         if (existing == null) {
             WellSql.insert(pluginDirectory).execute();
             return 1;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -152,14 +152,16 @@ public class PluginSqlUtils {
                 .endWhere().execute();
     }
 
-    public static void insertOrUpdatePluginDirectoryList(List<PluginDirectoryModel> pluginDirectories) {
+    public static int insertOrUpdatePluginDirectoryList(List<PluginDirectoryModel> pluginDirectories) {
         if (pluginDirectories == null) {
-            return;
+            return 0;
         }
 
+        int result = 0;
         for (PluginDirectoryModel pluginDirectory : pluginDirectories) {
-            insertOrUpdatePluginDirectoryModel(pluginDirectory);
+            result += insertOrUpdatePluginDirectoryModel(pluginDirectory);
         }
+        return result;
     }
 
     public static int getLastRequestedPageForDirectoryType(PluginDirectoryType directoryType) {
@@ -189,17 +191,18 @@ public class PluginSqlUtils {
         return result.isEmpty() ? null : result.get(0);
     }
 
-    private static void insertOrUpdatePluginDirectoryModel(PluginDirectoryModel pluginDirectory) {
+    private static int insertOrUpdatePluginDirectoryModel(PluginDirectoryModel pluginDirectory) {
         if (pluginDirectory == null) {
-            return;
+            return 0;
         }
 
         PluginDirectoryModel existing = getPluginDirectoryModel(pluginDirectory.getDirectoryType(),
                 pluginDirectory.getDirectoryType());
         if (existing == null) {
             WellSql.insert(pluginDirectory).execute();
+            return 1;
         } else {
-            WellSql.update(WPOrgPluginModel.class).whereId(existing.getId())
+            return WellSql.update(WPOrgPluginModel.class).whereId(existing.getId())
                     .put(pluginDirectory, new UpdateAllExceptId<>(PluginDirectoryModel.class)).execute();
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -131,18 +131,16 @@ public class PluginSqlUtils {
         }
     }
 
-    public static void insertOrUpdateWPOrgPluginList(List<WPOrgPluginModel> wpOrgPluginModels) {
+    public static int insertOrUpdateWPOrgPluginList(List<WPOrgPluginModel> wpOrgPluginModels) {
         if (wpOrgPluginModels == null) {
-            return;
+            return 0;
         }
 
-        WellSql.giveMeWritableDb().beginTransaction();
-
+        int result = 0;
         for (WPOrgPluginModel pluginModel : wpOrgPluginModels) {
-            insertOrUpdateWPOrgPlugin(pluginModel);
+            result += insertOrUpdateWPOrgPlugin(pluginModel);
         }
-
-        WellSql.giveMeWritableDb().endTransaction();
+        return result;
     }
 
     // Plugin Directory

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -113,9 +113,9 @@ public class PluginSqlUtils {
         return wpOrgPluginModels;
     }
 
-    public static void insertOrUpdateWPOrgPlugin(WPOrgPluginModel wpOrgPluginModel) {
+    public static int insertOrUpdateWPOrgPlugin(WPOrgPluginModel wpOrgPluginModel) {
         if (wpOrgPluginModel == null) {
-            return;
+            return 0;
         }
 
         // Slug is the primary key in remote, so we should use that to identify WPOrgPluginModels
@@ -123,9 +123,10 @@ public class PluginSqlUtils {
 
         if (oldPlugin == null) {
             WellSql.insert(wpOrgPluginModel).execute();
+            return 1;
         } else {
             int oldId = oldPlugin.getId();
-            WellSql.update(WPOrgPluginModel.class).whereId(oldId)
+            return WellSql.update(WPOrgPluginModel.class).whereId(oldId)
                     .put(wpOrgPluginModel, new UpdateAllExceptId<>(WPOrgPluginModel.class)).execute();
         }
     }
@@ -135,9 +136,13 @@ public class PluginSqlUtils {
             return;
         }
 
+        WellSql.giveMeWritableDb().beginTransaction();
+
         for (WPOrgPluginModel pluginModel : wpOrgPluginModels) {
             insertOrUpdateWPOrgPlugin(pluginModel);
         }
+
+        WellSql.giveMeWritableDb().endTransaction();
     }
 
     // Plugin Directory


### PR DESCRIPTION
This PR adds some unit tests for `PluginSqlUtils` methods. While working on this PR, I realized that we are using a class called `SingleStoreWellSqlConfigForTests` which setups the tests for a single type of model. Since `PluginSqlUtils` deals with 3 different models, I was unable to add these tests to the same class and had to separate each one. Due to this limitation, the only method I couldn't test that I wanted to was `getWPOrgPluginsForDirectory`. We'd need a different setup to make this work, but that's not something I am looking to do right now. Aside from that the PR is pretty straightforward to review & test.

This is the last PR before we merge `feature/plugin-directory-master` to `develop`. I'll open that PR as soon as this is merged. The remaining minor issues about plugins will be handled separately.