### PR TITLE
Implements remove site plugins action

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -145,6 +145,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         for (SitePluginModel sitePlugin : updatedPlugins) {
             assertFalse(sitePlugin.getSlug().equals(pluginSlugToInstall));
         }
+
+        signOutWPCom();
     }
 
     public void testConfigureUnknownPluginError() throws InterruptedException {
@@ -160,6 +162,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        signOutWPCom();
     }
 
     public void testDeleteActivePluginError() throws InterruptedException {
@@ -177,6 +181,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         // Trying to delete an active plugin should result in DELETE_SITE_PLUGIN_ERROR
         deleteSitePlugin(site, activePluginToTest, TestEvents.DELETE_SITE_PLUGIN_ERROR);
+
+        signOutWPCom();
     }
 
     // Trying to remove a plugin that doesn't exist in remote should remove the plugin from DB
@@ -202,12 +208,16 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         // Make sure the plugin is removed from DB
         assertNull(mPluginStore.getSitePluginByName(site, pluginName));
+
+        signOutWPCom();
     }
 
     public void testInstallPluginNoPackageError() throws InterruptedException {
         SiteModel site = fetchSingleJetpackSitePlugins();
         installSitePlugin(site, "this-plugin-does-not-exist", TestEvents.INSTALL_SITE_PLUGIN_ERROR_NO_PACKAGE);
         assertNull(mInstalledPlugin);
+
+        signOutWPCom();
     }
 
     public void testRemoveSitePlugins() throws InterruptedException {

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/SitePluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/SitePluginSqlUtilsTest.java
@@ -146,6 +146,23 @@ public class SitePluginSqlUtilsTest {
     }
 
     @Test
+    public void testDeleteSitePlugins() {
+        // Create site and plugin
+        SiteModel site = getTestSite();
+        SitePluginModel plugin1 = getTestPluginByName(randomString("name"));
+        SitePluginModel plugin2 = getTestPluginByName(randomString("name"));
+
+        // Insert the plugins and verify that site plugin size is 2
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin1));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin2));
+        Assert.assertEquals(2, PluginSqlUtils.getSitePlugins(site).size());
+
+        // Delete the plugins and verify that site plugin list is empty
+        Assert.assertEquals(2, PluginSqlUtils.deleteSitePlugins(site));
+        Assert.assertTrue(PluginSqlUtils.getSitePlugins(site).isEmpty());
+    }
+
+    @Test
     public void testGetSitePluginByName() {
         // Create site and 2 plugins
         SiteModel site = getTestSite();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -55,5 +55,9 @@ public enum PluginAction implements IAction {
     @Action(payloadType = SearchedPluginDirectoryPayload.class)
     SEARCHED_PLUGIN_DIRECTORY,
     @Action(payloadType = UpdatedSitePluginPayload.class)
-    UPDATED_SITE_PLUGIN
+    UPDATED_SITE_PLUGIN,
+
+    // Local actions
+    @Action(payloadType = SiteModel.class)
+    REMOVE_SITE_PLUGINS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -65,6 +65,13 @@ public class PluginSqlUtils {
         }
     }
 
+    public static int deleteSitePlugins(@NonNull SiteModel site) {
+        return WellSql.delete(SitePluginModel.class)
+                .where()
+                .equals(SitePluginModelTable.LOCAL_SITE_ID, site.getId())
+                .endWhere().execute();
+    }
+
     public static int deleteSitePlugin(SiteModel site, SitePluginModel plugin) {
         if (plugin == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -303,6 +303,8 @@ public class PluginStore extends Store {
         }
     }
 
+    static class RemoveSitePluginsError implements OnChangedError {}
+
     // Error types
 
     public enum ConfigureSitePluginErrorType {
@@ -494,6 +496,16 @@ public class PluginStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
+    public static class OnSitePluginsRemoved extends OnChanged<RemoveSitePluginsError> {
+        public SiteModel site;
+        public int rowsAffected;
+        public OnSitePluginsRemoved(SiteModel site, int rowsAffected) {
+            this.site = site;
+            this.rowsAffected = rowsAffected;
+        }
+    }
+
     private final PluginRestClient mPluginRestClient;
     private final PluginWPOrgClient mPluginWPOrgClient;
 
@@ -541,6 +553,10 @@ public class PluginStore extends Store {
                 break;
             case UPDATE_SITE_PLUGIN:
                 updateSitePlugin((UpdateSitePluginPayload) action.getPayload());
+                break;
+            // Local actions
+            case REMOVE_SITE_PLUGINS:
+                removeSitePlugins((SiteModel) action.getPayload());
                 break;
             // Network callbacks
             case CONFIGURED_SITE_PLUGIN:
@@ -657,6 +673,15 @@ public class PluginStore extends Store {
             UpdatedSitePluginPayload errorPayload = new UpdatedSitePluginPayload(payload.site, error);
             updatedSitePlugin(errorPayload);
         }
+    }
+
+    // Local actions
+    private void removeSitePlugins(SiteModel site) {
+        if (site == null) {
+            return;
+        }
+        int rowsAffected = PluginSqlUtils.deleteSitePlugins(site);
+        emitChange(new OnSitePluginsRemoved(site, rowsAffected));
     }
 
     // Network callbacks


### PR DESCRIPTION
Fixes #673. To keep our DB clean, we need to remove the site plugins when the user logs out. This PR adds a new plugin action called `REMOVE_SITE_PLUGINS` to do that. This PR implements the action, necessary sql method, its unit test and connected test. Just like other logout actions, this action will be dispatched from `WordPress.removeWpComUserRelatedData` in WPAndroid.

I realized that I forgot the `signOutWPCom` calls in a few tests and even though I don't like fixing here, I just don't think it's worth its own PR.

@nbradbury Would you like to review this since you reviewed all the other plugin PRs so far? It's totally fine if you can't though!