### PR TITLE
Use the correct table for updating PluginDirectoryModel

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -91,6 +91,25 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         Assert.assertTrue(firstPluginList.size() == fourthPluginList.size());
     }
 
+    // This simulates the pull to refresh feature a client might implement
+    public void testFetchSamePageOfPluginDirectory() throws InterruptedException {
+        PluginDirectoryType directoryType = PluginDirectoryType.NEW;
+        Assert.assertTrue(mPluginStore.getPluginDirectory(directoryType).size() == 0);
+
+        // Fetch plugin directory's first page
+        fetchPluginDirectory(directoryType, false);
+
+        List<WPOrgPluginModel> pluginsAfterFirstFetch = mPluginStore.getPluginDirectory(directoryType);
+        Assert.assertTrue(pluginsAfterFirstFetch.size() > 0);
+
+        // Re-fetch plugin directory's first page
+        fetchPluginDirectory(directoryType, false);
+
+        // Same number of items should have been fetched and the existing plugin directories should be updated
+        List<WPOrgPluginModel> pluginsAfterSecondFetch = mPluginStore.getPluginDirectory(directoryType);
+        Assert.assertEquals(pluginsAfterFirstFetch.size(), pluginsAfterSecondFetch.size());
+    }
+
     public void testFetchWPOrgPluginDoesNotExistError() throws InterruptedException {
         String slug = "hello";
         mNextEvent = TestEvents.WPORG_PLUGIN_DOES_NOT_EXIST;

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
@@ -87,6 +87,45 @@ public class PluginDirectorySqlUtilsTest {
     }
 
     @Test
+    public void testUpdatePluginDirectoryModel() throws NoSuchMethodException,
+            InvocationTargetException, IllegalAccessException {
+        String slug = randomString("slug");
+        int oldPage = 1;
+        String directoryType = PluginDirectoryType.NEW.toString();
+        PluginDirectoryModel directoryModel = new PluginDirectoryModel();
+        directoryModel.setSlug(slug);
+        directoryModel.setDirectoryType(directoryType);
+        directoryModel.setPage(oldPage);
+
+        Method insertOrUpdatePluginDirectoryModel =
+                PluginSqlUtils.class.getDeclaredMethod("insertOrUpdatePluginDirectoryModel",
+                        PluginDirectoryModel.class);
+        insertOrUpdatePluginDirectoryModel.setAccessible(true);
+        Assert.assertEquals(1, insertOrUpdatePluginDirectoryModel.invoke(PluginSqlUtils.class, directoryModel));
+
+        // Use reflection to assert PluginSqlUtils.getPluginDirectoriesForType
+        Method getPluginDirectoryModel = PluginSqlUtils.class.getDeclaredMethod("getPluginDirectoryModel",
+                String.class, String.class);
+        getPluginDirectoryModel.setAccessible(true);
+        Object firstObject = getPluginDirectoryModel.invoke(PluginSqlUtils.class, directoryType, slug);
+        Assert.assertNotNull(firstObject);
+        Assert.assertTrue(firstObject instanceof PluginDirectoryModel);
+        PluginDirectoryModel insertedDirectoryModel = (PluginDirectoryModel) firstObject;
+        Assert.assertEquals(insertedDirectoryModel.getPage(), oldPage);
+
+        int newPage = 2;
+        directoryModel.setPage(newPage);
+        Assert.assertEquals(1, insertOrUpdatePluginDirectoryModel.invoke(PluginSqlUtils.class, directoryModel));
+
+        Object secondObject = getPluginDirectoryModel.invoke(PluginSqlUtils.class, directoryType, slug);
+        Assert.assertNotNull(secondObject);
+        Assert.assertTrue(secondObject instanceof PluginDirectoryModel);
+        PluginDirectoryModel updatedDirectoryModel = (PluginDirectoryModel) secondObject;
+        Assert.assertEquals(updatedDirectoryModel.getPage(), newPage);
+        Assert.assertEquals(insertedDirectoryModel.getSlug(), updatedDirectoryModel.getSlug());
+    }
+
+    @Test
     public void testGetLastRequestedPageForDirectoryType() {
         int numberOfTimesToTry = 10;
         int lastRequestedPage = 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -209,7 +209,7 @@ public class PluginSqlUtils {
             WellSql.insert(pluginDirectory).execute();
             return 1;
         } else {
-            return WellSql.update(WPOrgPluginModel.class).whereId(existing.getId())
+            return WellSql.update(PluginDirectoryModel.class).whereId(existing.getId())
                     .put(pluginDirectory, new UpdateAllExceptId<>(PluginDirectoryModel.class)).execute();
         }
     }


### PR DESCRIPTION
This PR fixes an embarrassing little mistake. Somehow I used the `WPOrgPluginModel`s table where I needed to use `PluginDirectoryModel`s. It was hard to catch this mistake because we didn't have a unit test for `PluginSqlUtils.insertOrUpdatePluginDirectoryModel`. Since it's a private method, I didn't add it initially, then forgot to do so when I added test for other private methods.

Aside from the fix, this PR adds 2 tests. The `testUpdatePluginDirectoryModel` would have caught this issue, that's why it's added. I found out about this bug while working on pull to refresh, so I also added a test for that `testFetchSamePageOfPluginDirectory`.

/cc @nbradbury & @theck13 whoever can (and want to) review it. This is a blocker for the pull to refresh PR which I'll open soon.