### PR TITLE
Plugin payloads updated in preparation of ImmutablePluginModel

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -172,7 +172,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     private void fetchPluginDirectory(PluginDirectoryType directoryType, boolean loadMore) throws InterruptedException {
         mNextEvent = TestEvents.PLUGIN_DIRECTORY_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
-        FetchPluginDirectoryPayload payload = new FetchPluginDirectoryPayload(directoryType, loadMore);
+        FetchPluginDirectoryPayload payload = new FetchPluginDirectoryPayload(directoryType, null, loadMore);
         mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -181,7 +181,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         mSearchPage = page;
         mNextEvent = TestEvents.PLUGIN_DIRECTORY_SEARCHED;
         mCountDownLatch = new CountDownLatch(1);
-        SearchPluginDirectoryPayload payload = new SearchPluginDirectoryPayload(searchTerm, page);
+        SearchPluginDirectoryPayload payload = new SearchPluginDirectoryPayload(null, searchTerm, page);
         mDispatcher.dispatch(PluginActionBuilder.newSearchPluginDirectoryAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/WPComEndpointTest.java
@@ -32,7 +32,7 @@ public class WPComEndpointTest {
         // Plugins
         assertEquals("/sites/56/plugins/", WPCOMREST.sites.site(56).plugins.getEndpoint());
         assertEquals("/sites/56/plugins/akismet/", WPCOMREST.sites.site(56).plugins.name("akismet").getEndpoint());
-        assertEquals("/sites/56/plugins/akismet/install/", WPCOMREST.sites.site(56).plugins.name("akismet")
+        assertEquals("/sites/56/plugins/akismet/install/", WPCOMREST.sites.site(56).plugins.slug("akismet")
                 .install.getEndpoint());
         assertEquals("/sites/56/plugins/akismet/delete/", WPCOMREST.sites.site(56).plugins.name("akismet")
                 .delete.getEndpoint());

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/SitePluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/SitePluginSqlUtilsTest.java
@@ -26,7 +26,7 @@ public class SitePluginSqlUtilsTest {
     private static final int TEST_LOCAL_SITE_ID = 1;
     private static final int SMALL_TEST_POOL = 10;
 
-    private Random mRandom = new Random(System.currentTimeMillis());
+    private final Random mRandom = new Random(System.currentTimeMillis());
 
     @Before
     public void setUp() {
@@ -40,7 +40,7 @@ public class SitePluginSqlUtilsTest {
     @Test
     public void testInsertNullSitePlugin() {
         SiteModel site = getTestSite();
-        Assert.assertEquals(0, PluginSqlUtils.insertOrUpdateSitePlugin(null));
+        Assert.assertEquals(0, PluginSqlUtils.insertOrUpdateSitePlugin(site, null));
         Assert.assertTrue(PluginSqlUtils.getSitePlugins(site).isEmpty());
     }
 
@@ -48,31 +48,31 @@ public class SitePluginSqlUtilsTest {
     public void testInsertSitePlugin() {
         // Create site and plugin
         SiteModel site = getTestSite();
-        String name = randomString("name");
-        SitePluginModel plugin = getTestPluginByName(name);
+        String slug = randomString("slug");
+        SitePluginModel plugin = getTestPluginBySlug(slug);
 
         // Insert the plugin and assert that it was successful
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin));
         List<SitePluginModel> sitePlugins = PluginSqlUtils.getSitePlugins(site);
         Assert.assertEquals(1, sitePlugins.size());
 
-        // Assert that the inserted plugin is not null and has the correct name
+        // Assert that the inserted plugin is not null and has the correct slug
         SitePluginModel insertedPlugin = sitePlugins.get(0);
         Assert.assertNotNull(insertedPlugin);
-        Assert.assertEquals(plugin.getName(), insertedPlugin.getName());
+        Assert.assertEquals(plugin.getSlug(), insertedPlugin.getSlug());
         Assert.assertEquals(site.getId(), insertedPlugin.getLocalSiteId());
     }
 
     @Test
     public void testUpdateSitePlugin() {
         SiteModel site = getTestSite();
-        String name = randomString("name");
+        String slug = randomString("slug");
         String displayName = randomString("displayName");
 
         // First install a plugin and retrieve the DB copy
-        SitePluginModel plugin = getTestPluginByName(name);
+        SitePluginModel plugin = getTestPluginBySlug(slug);
         plugin.setDisplayName(displayName);
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin));
         List<SitePluginModel> sitePlugins = PluginSqlUtils.getSitePlugins(site);
         Assert.assertEquals(1, sitePlugins.size());
         SitePluginModel insertedPlugin = sitePlugins.get(0);
@@ -81,7 +81,7 @@ public class SitePluginSqlUtilsTest {
         // Then, update the plugin's display name
         String newDisplayName = randomString("newDisplayName");
         insertedPlugin.setDisplayName(newDisplayName);
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(insertedPlugin));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, insertedPlugin));
 
         // Assert that we still have only one plugin in DB and it has the new display name
         List<SitePluginModel> updatedSitePluginList = PluginSqlUtils.getSitePlugins(site);
@@ -93,18 +93,18 @@ public class SitePluginSqlUtilsTest {
         Assert.assertEquals(insertedPlugin.getId(), updatedPlugin.getId());
     }
 
-    // Inserts 10 plugins with known IDs then retrieves all site plugins and validates names
+    // Inserts 10 plugins with known IDs then retrieves all site plugins and validates slugs
     @Test
     public void testGetSitePlugins() {
         SiteModel site = getTestSite();
-        List<String> pluginNames = insertBasicTestPlugins(site, SMALL_TEST_POOL);
+        List<String> pluginSlugs = insertBasicTestPlugins(site, SMALL_TEST_POOL);
         List<SitePluginModel> sitePlugins = PluginSqlUtils.getSitePlugins(site);
         Assert.assertEquals(SMALL_TEST_POOL, sitePlugins.size());
 
-        for (int i = 0; i < pluginNames.size(); i++) {
+        for (int i = 0; i < pluginSlugs.size(); i++) {
             SitePluginModel sitePlugin = sitePlugins.get(i);
             Assert.assertNotNull(sitePlugin);
-            Assert.assertEquals(pluginNames.get(i), sitePlugin.getName());
+            Assert.assertEquals(pluginSlugs.get(i), sitePlugin.getSlug());
         }
     }
 
@@ -118,30 +118,30 @@ public class SitePluginSqlUtilsTest {
 
         // Create a single plugin and update the site plugin list and assert that now we have a single plugin
         List<SitePluginModel> newSitePlugins = new ArrayList<>();
-        String newSitePluginName = randomString("newPluginName");
-        SitePluginModel singleSitePlugin = getTestPluginByName(newSitePluginName);
+        String newSitePluginSlug = randomString("newPluginSlug");
+        SitePluginModel singleSitePlugin = getTestPluginBySlug(newSitePluginSlug);
         newSitePlugins.add(singleSitePlugin);
         PluginSqlUtils.insertOrReplaceSitePlugins(site, newSitePlugins);
 
         List<SitePluginModel> updatedSitePluginList = PluginSqlUtils.getSitePlugins(site);
         Assert.assertEquals(1, updatedSitePluginList.size());
         SitePluginModel onlyPluginFromUpdatedList = updatedSitePluginList.get(0);
-        Assert.assertEquals(onlyPluginFromUpdatedList.getName(), newSitePluginName);
+        Assert.assertEquals(onlyPluginFromUpdatedList.getSlug(), newSitePluginSlug);
     }
 
     @Test
     public void testDeleteSitePlugin() {
         // Create site and plugin
         SiteModel site = getTestSite();
-        String name = randomString("name");
-        SitePluginModel plugin = getTestPluginByName(name);
+        String slug = randomString("slug");
+        SitePluginModel plugin = getTestPluginBySlug(slug);
 
         // Insert the plugin and verify that site plugin size is 1
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin));
         Assert.assertEquals(1, PluginSqlUtils.getSitePlugins(site).size());
 
         // Delete the plugin and verify that site plugin list is empty
-        Assert.assertEquals(1, PluginSqlUtils.deleteSitePlugin(site, plugin));
+        Assert.assertEquals(1, PluginSqlUtils.deleteSitePlugin(site, slug));
         Assert.assertTrue(PluginSqlUtils.getSitePlugins(site).isEmpty());
     }
 
@@ -149,48 +149,17 @@ public class SitePluginSqlUtilsTest {
     public void testDeleteSitePlugins() {
         // Create site and plugin
         SiteModel site = getTestSite();
-        SitePluginModel plugin1 = getTestPluginByName(randomString("name"));
-        SitePluginModel plugin2 = getTestPluginByName(randomString("name"));
+        SitePluginModel plugin1 = getTestPluginBySlug(randomString("slug"));
+        SitePluginModel plugin2 = getTestPluginBySlug(randomString("slug"));
 
         // Insert the plugins and verify that site plugin size is 2
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin1));
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin2));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin1));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin2));
         Assert.assertEquals(2, PluginSqlUtils.getSitePlugins(site).size());
 
         // Delete the plugins and verify that site plugin list is empty
         Assert.assertEquals(2, PluginSqlUtils.deleteSitePlugins(site));
         Assert.assertTrue(PluginSqlUtils.getSitePlugins(site).isEmpty());
-    }
-
-    @Test
-    public void testGetSitePluginByName() {
-        // Create site and 2 plugins
-        SiteModel site = getTestSite();
-        String pluginName1 = randomString("name1");
-        String pluginName2 = randomString("name2");
-        String displayName1 = randomString("displayName1");
-        String displayName2 = randomString("displayName2");
-
-        SitePluginModel plugin1 = getTestPluginByName(pluginName1);
-        plugin1.setDisplayName(displayName1);
-        SitePluginModel plugin2 = getTestPluginByName(pluginName2);
-        plugin2.setDisplayName(displayName2);
-
-        // Insert the plugins and verify that site plugin size is 2
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin1));
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin2));
-        Assert.assertEquals(2, PluginSqlUtils.getSitePlugins(site).size());
-
-        // Assert that getSitePluginByName retrieves the correct plugins
-        SitePluginModel pluginByName1 = PluginSqlUtils.getSitePluginByName(site, pluginName1);
-        Assert.assertNotNull(pluginByName1);
-        Assert.assertEquals(pluginByName1.getName(), pluginName1);
-        Assert.assertEquals(pluginByName1.getDisplayName(), displayName1);
-
-        SitePluginModel pluginByName2 = PluginSqlUtils.getSitePluginByName(site, pluginName2);
-        Assert.assertNotNull(pluginByName2);
-        Assert.assertEquals(pluginByName2.getName(), pluginName2);
-        Assert.assertEquals(pluginByName2.getDisplayName(), displayName2);
     }
 
     @Test
@@ -204,8 +173,8 @@ public class SitePluginSqlUtilsTest {
         SitePluginModel plugin2 = getTestPluginBySlug(pluginSlug2);
 
         // Insert the plugins and verify that site plugin size is 2
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin1));
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin2));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin1));
+        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin2));
         Assert.assertEquals(2, PluginSqlUtils.getSitePlugins(site).size());
 
         // Assert that getSitePluginBySlug retrieves the correct plugins
@@ -220,13 +189,6 @@ public class SitePluginSqlUtilsTest {
 
     // Helper methods
 
-    private SitePluginModel getTestPluginByName(String name) {
-        SitePluginModel plugin = new SitePluginModel();
-        plugin.setLocalSiteId(TEST_LOCAL_SITE_ID);
-        plugin.setName(name);
-        return plugin;
-    }
-
     private SitePluginModel getTestPluginBySlug(String slug) {
         SitePluginModel plugin = new SitePluginModel();
         plugin.setLocalSiteId(TEST_LOCAL_SITE_ID);
@@ -235,15 +197,15 @@ public class SitePluginSqlUtilsTest {
     }
 
     private List<String> insertBasicTestPlugins(SiteModel site, int numberOfPlugins) {
-        List<String> pluginNames = new ArrayList<>();
+        List<String> pluginSlugs = new ArrayList<>();
         for (int i = 0; i < numberOfPlugins; i++) {
-            String name = randomString("name");
-            pluginNames.add(name);
-            SitePluginModel plugin = getTestPluginByName(name);
+            String slug = randomString("slug" + i + "-");
+            pluginSlugs.add(slug);
+            SitePluginModel plugin = getTestPluginBySlug(slug);
             plugin.setLocalSiteId(site.getId());
-            Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(plugin));
+            Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateSitePlugin(site, plugin));
         }
-        return pluginNames;
+        return pluginSlugs;
     }
 
     private String randomString(String prefix) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -10,7 +10,6 @@ import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginDirectoryPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginDirectoryPayload;
-import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedWPOrgPluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
@@ -28,8 +27,6 @@ public enum PluginAction implements IAction {
     DELETE_SITE_PLUGIN,
     @Action(payloadType = FetchPluginDirectoryPayload.class)
     FETCH_PLUGIN_DIRECTORY,
-    @Action(payloadType = SiteModel.class)
-    FETCH_SITE_PLUGINS,
     @Action(payloadType = String.class)
     FETCH_WPORG_PLUGIN,
     @Action(payloadType = InstallSitePluginPayload.class)
@@ -46,8 +43,6 @@ public enum PluginAction implements IAction {
     DELETED_SITE_PLUGIN,
     @Action(payloadType = FetchedPluginDirectoryPayload.class)
     FETCHED_PLUGIN_DIRECTORY,
-    @Action(payloadType = FetchedSitePluginsPayload.class)
-    FETCHED_SITE_PLUGINS,
     @Action(payloadType = FetchedWPOrgPluginPayload.class)
     FETCHED_WPORG_PLUGIN,
     @Action(payloadType = InstalledSitePluginPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryType.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/PluginDirectoryType.java
@@ -4,7 +4,8 @@ import java.util.Locale;
 
 public enum PluginDirectoryType {
     NEW,
-    POPULAR;
+    POPULAR,
+    SITE;
 
     @Override
     public String toString() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -10,8 +10,9 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
-import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType;
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
@@ -20,14 +21,14 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginWPComRestResponse.FetchPluginsResponse;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
-import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginsError;
-import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginsPayload;
+import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginDirectoryPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
-import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginError;
+import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryError;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginPayload;
 
@@ -45,7 +46,7 @@ import javax.inject.Singleton;
 public class PluginRestClient extends BaseWPComRestClient {
     @Inject
     public PluginRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
-                              AccessToken accessToken, UserAgent userAgent) {
+                            AccessToken accessToken, UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
     }
 
@@ -62,33 +63,37 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 plugins.add(pluginModelFromResponse(site, pluginResponse));
                             }
                         }
-                        mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginsAction(
-                                new FetchedSitePluginsPayload(site, plugins)));
+                        FetchedPluginDirectoryPayload payload =
+                                new FetchedPluginDirectoryPayload(site, plugins);
+                        mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginDirectoryAction(payload));
                     }
                 },
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        FetchSitePluginsError fetchPluginsError = new FetchSitePluginsError(((WPComGsonNetworkError)
+                        PluginDirectoryError directoryError = new PluginDirectoryError(((WPComGsonNetworkError)
                                 networkError).apiError, networkError.message);
-                        FetchedSitePluginsPayload payload = new FetchedSitePluginsPayload(fetchPluginsError);
-                        mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginsAction(payload));
+                        FetchedPluginDirectoryPayload payload =
+                                new FetchedPluginDirectoryPayload(PluginDirectoryType.SITE, false, directoryError);
+                        mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginDirectoryAction(payload));
                     }
                 }
         );
         add(request);
     }
 
-    public void configureSitePlugin(@NonNull final SiteModel site, @NonNull final SitePluginModel plugin) {
-        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(getEncodedPluginName(plugin)).getUrlV1_2();
-        Map<String, Object> params = paramsFromPluginModel(plugin);
+    public void configureSitePlugin(@NonNull final SiteModel site, @NonNull final String pluginName, boolean isActive,
+                                    boolean isAutoUpdatesEnabled) {
+        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(getEncodedPluginName(pluginName)).getUrlV1_2();
+        Map<String, Object> params = new HashMap<>();
+        params.put("active", isActive);
+        params.put("autoupdate", isAutoUpdatesEnabled);
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, params,
                 PluginWPComRestResponse.class,
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
                         SitePluginModel pluginFromResponse = pluginModelFromResponse(site, response);
-                        pluginFromResponse.setId(plugin.getId());
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(
                                 new ConfiguredSitePluginPayload(site, pluginFromResponse)));
                     }
@@ -99,7 +104,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         ConfigureSitePluginError configurePluginError = new ConfigureSitePluginError(((
                                 WPComGsonNetworkError) networkError).apiError, networkError.message);
                         ConfiguredSitePluginPayload payload =
-                                new ConfiguredSitePluginPayload(site, configurePluginError);
+                                new ConfiguredSitePluginPayload(site, pluginName, configurePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload));
                     }
                 }
@@ -107,27 +112,26 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void deleteSitePlugin(@NonNull final SiteModel site, @NonNull final SitePluginModel plugin) {
+    public void deleteSitePlugin(@NonNull final SiteModel site, @NonNull final String slug,
+                                 @NonNull final String pluginName) {
         String url = WPCOMREST.sites.site(site.getSiteId()).
-                plugins.name(getEncodedPluginName(plugin)).delete.getUrlV1_2();
+                plugins.name(getEncodedPluginName(pluginName)).delete.getUrlV1_2();
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 PluginWPComRestResponse.class,
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
-                        SitePluginModel pluginFromResponse = pluginModelFromResponse(site, response);
-                        pluginFromResponse.setId(plugin.getId());
                         mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(
-                                new DeletedSitePluginPayload(site, pluginFromResponse)));
+                                new DeletedSitePluginPayload(site, slug, pluginName)));
                     }
                 },
                 new BaseErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        DeleteSitePluginError deletePluginError = new DeleteSitePluginError(((WPComGsonNetworkError)
-                                networkError).apiError, networkError.message);
                         DeletedSitePluginPayload payload =
-                                new DeletedSitePluginPayload(site, plugin, deletePluginError);
+                                new DeletedSitePluginPayload(site, slug, pluginName);
+                        payload.error = new DeleteSitePluginError(((WPComGsonNetworkError)
+                                networkError).apiError, networkError.message);
                         mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(payload));
                     }
                 }
@@ -135,8 +139,8 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void installSitePlugin(@NonNull final SiteModel site, String pluginName) {
-        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(pluginName).install.getUrlV1_2();
+    public void installSitePlugin(@NonNull final SiteModel site, final String pluginSlug) {
+        String url = WPCOMREST.sites.site(site.getSiteId()).plugins.slug(pluginSlug).install.getUrlV1_2();
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 PluginWPComRestResponse.class,
                 new Listener<PluginWPComRestResponse>() {
@@ -152,7 +156,8 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull BaseNetworkError networkError) {
                         InstallSitePluginError installPluginError = new InstallSitePluginError(((WPComGsonNetworkError)
                                 networkError).apiError, networkError.message);
-                        InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, installPluginError);
+                        InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, pluginSlug,
+                                installPluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(payload));
                     }
                 }
@@ -160,16 +165,15 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void updateSitePlugin(@NonNull final SiteModel site, @NonNull final SitePluginModel plugin) {
+    public void updateSitePlugin(@NonNull final SiteModel site, @NonNull final String pluginName) {
         String url = WPCOMREST.sites.site(site.getSiteId()).
-                plugins.name(getEncodedPluginName(plugin)).update.getUrlV1_2();
+                plugins.name(getEncodedPluginName(pluginName)).update.getUrlV1_2();
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 PluginWPComRestResponse.class,
                 new Listener<PluginWPComRestResponse>() {
                     @Override
                     public void onResponse(PluginWPComRestResponse response) {
                         SitePluginModel pluginFromResponse = pluginModelFromResponse(site, response);
-                        pluginFromResponse.setId(plugin.getId());
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(
                                 new UpdatedSitePluginPayload(site, pluginFromResponse)));
                     }
@@ -180,7 +184,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         UpdateSitePluginError updatePluginError
                                 = new UpdateSitePluginError(((WPComGsonNetworkError) networkError).apiError,
                                 networkError.message);
-                        UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site,
+                        UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, pluginName,
                                 updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));
                     }
@@ -208,19 +212,12 @@ public class PluginRestClient extends BaseWPComRestClient {
         return sitePluginModel;
     }
 
-    private Map<String, Object> paramsFromPluginModel(SitePluginModel sitePluginModel) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("active", sitePluginModel.isActive());
-        params.put("autoupdate", sitePluginModel.isAutoUpdateEnabled());
-        return params;
-    }
-
-    private String getEncodedPluginName(SitePluginModel plugin) {
+    private String getEncodedPluginName(String pluginName) {
         try {
             // We need to encode plugin name otherwise names like "akismet/akismet" would fail
-            return URLEncoder.encode(plugin.getName(), "UTF-8");
+            return URLEncoder.encode(pluginName, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            return plugin.getName();
+            return pluginName;
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.PluginAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.PluginDirectoryModel;
 import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType;
@@ -30,33 +31,44 @@ import javax.inject.Singleton;
 @Singleton
 public class PluginStore extends Store {
     // Request payloads
+    @SuppressWarnings("WeakerAccess")
     public static class ConfigureSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
-        public SitePluginModel plugin;
+        public String pluginName;
+        public boolean isActive;
+        public boolean isAutoUpdateEnabled;
 
-        public ConfigureSitePluginPayload(SiteModel site, SitePluginModel plugin) {
+        public ConfigureSitePluginPayload(SiteModel site, String pluginName, boolean isActive,
+                                          boolean isAutoUpdateEnabled) {
             this.site = site;
-            this.plugin = plugin;
+            this.pluginName = pluginName;
+            this.isActive = isActive;
+            this.isAutoUpdateEnabled = isAutoUpdateEnabled;
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class DeleteSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
-        public SitePluginModel plugin;
+        public String slug;
+        public String pluginName;
 
-        public DeleteSitePluginPayload(SiteModel site, SitePluginModel plugin) {
+        public DeleteSitePluginPayload(SiteModel site, String slug, String pluginName) {
             this.site = site;
-            this.plugin = plugin;
+            this.slug = slug;
+            this.pluginName = pluginName;
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public static class FetchPluginDirectoryPayload extends Payload<BaseNetworkError> {
         public PluginDirectoryType type;
+        public @Nullable SiteModel site;
         public boolean loadMore;
 
-        public FetchPluginDirectoryPayload(PluginDirectoryType type, boolean loadMore) {
+        public FetchPluginDirectoryPayload(PluginDirectoryType type, @Nullable SiteModel site, boolean loadMore) {
             this.type = type;
+            this.site = site;
             this.loadMore = loadMore;
         }
     }
@@ -64,93 +76,105 @@ public class PluginStore extends Store {
     @SuppressWarnings("WeakerAccess")
     public static class InstallSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
-        public String pluginName;
+        public String slug;
 
-        public InstallSitePluginPayload(SiteModel site, String pluginName) {
+        public InstallSitePluginPayload(SiteModel site, String slug) {
             this.site = site;
-            this.pluginName = pluginName;
+            this.slug = slug;
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public static class SearchPluginDirectoryPayload extends Payload<BaseNetworkError> {
+        public SiteModel site; // required to add the SitePluginModels to the OnPluginDirectorySearched
         public String searchTerm;
         public int page;
 
-        public SearchPluginDirectoryPayload(String searchTerm, int page) {
+        public SearchPluginDirectoryPayload(@Nullable SiteModel site, String searchTerm, int page) {
+            this.site = site;
             this.searchTerm = searchTerm;
             this.page = page;
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class UpdateSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
-        public SitePluginModel plugin;
+        public String pluginName;
 
-        public UpdateSitePluginPayload(SiteModel site, SitePluginModel plugin) {
+        public UpdateSitePluginPayload(SiteModel site, String pluginName) {
             this.site = site;
-            this.plugin = plugin;
+            this.pluginName = pluginName;
         }
     }
 
     // Response payloads
 
+    @SuppressWarnings("WeakerAccess")
     public static class ConfiguredSitePluginPayload extends Payload<ConfigureSitePluginError> {
         public SiteModel site;
+        public String pluginName;
         public SitePluginModel plugin;
 
         public ConfiguredSitePluginPayload(SiteModel site, SitePluginModel plugin) {
             this.site = site;
             this.plugin = plugin;
+            this.pluginName = this.plugin.getName();
         }
 
-        public ConfiguredSitePluginPayload(SiteModel site, ConfigureSitePluginError error) {
+        public ConfiguredSitePluginPayload(SiteModel site, String pluginName, ConfigureSitePluginError error) {
             this.site = site;
+            this.pluginName = pluginName;
             this.error = error;
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class DeletedSitePluginPayload extends Payload<DeleteSitePluginError> {
         public SiteModel site;
-        public SitePluginModel plugin;
+        public String slug;
+        public String pluginName;
 
-        public DeletedSitePluginPayload(SiteModel site, SitePluginModel plugin) {
+        public DeletedSitePluginPayload(SiteModel site, String slug, String pluginName) {
             this.site = site;
-            this.plugin = plugin;
-        }
-
-        public DeletedSitePluginPayload(SiteModel site, SitePluginModel plugin, DeleteSitePluginError error) {
-            this.site = site;
-            this.plugin = plugin;
-            this.error = error;
+            this.slug = slug;
+            this.pluginName = pluginName;
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public static class FetchedPluginDirectoryPayload extends Payload<PluginDirectoryError> {
         public PluginDirectoryType type;
-        public boolean loadMore;
-        public boolean canLoadMore;
-        public int page;
-        public List<WPOrgPluginModel> plugins;
+        public boolean loadMore = false;
+        public boolean canLoadMore = false;
 
-        public FetchedPluginDirectoryPayload(PluginDirectoryType type, boolean loadMore) {
+        // Used for PluginDirectoryType.NEW & PluginDirectoryType.Popular
+        public int page;
+        public List<WPOrgPluginModel> wpOrgPlugins;
+
+        // Used for PluginDirectoryType.SITE
+        public SiteModel site;
+        public List<SitePluginModel> sitePlugins;
+
+        public FetchedPluginDirectoryPayload(PluginDirectoryType type, List<WPOrgPluginModel> wpOrgPlugins,
+                                             boolean loadMore, boolean canLoadMore, int page) {
+            this.type = type;
+            this.wpOrgPlugins = wpOrgPlugins;
+            this.loadMore = loadMore;
+            this.canLoadMore = canLoadMore;
+            this.page = page;
+        }
+
+        public FetchedPluginDirectoryPayload(SiteModel site, List<SitePluginModel> sitePlugins) {
+            this.type = PluginDirectoryType.SITE;
+            this.site = site;
+            this.sitePlugins = sitePlugins;
+        }
+
+        public FetchedPluginDirectoryPayload(PluginDirectoryType type, boolean loadMore, PluginDirectoryError error) {
             this.type = type;
             this.loadMore = loadMore;
-        }
-    }
-
-    public static class FetchedSitePluginsPayload extends Payload<FetchSitePluginsError> {
-        public SiteModel site;
-        public List<SitePluginModel> plugins;
-
-        public FetchedSitePluginsPayload(FetchSitePluginsError error) {
             this.error = error;
-        }
-
-        public FetchedSitePluginsPayload(@NonNull SiteModel site, @NonNull List<SitePluginModel> plugins) {
-            this.site = site;
-            this.plugins = plugins;
         }
     }
 
@@ -170,45 +194,55 @@ public class PluginStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class InstalledSitePluginPayload extends Payload<InstallSitePluginError> {
         public SiteModel site;
+        public String slug;
         public SitePluginModel plugin;
 
         public InstalledSitePluginPayload(SiteModel site, SitePluginModel plugin) {
             this.site = site;
             this.plugin = plugin;
+            this.slug = this.plugin.getSlug();
         }
 
-        public InstalledSitePluginPayload(SiteModel site, InstallSitePluginError error) {
+        public InstalledSitePluginPayload(SiteModel site, String slug, InstallSitePluginError error) {
             this.site = site;
+            this.slug = slug;
             this.error = error;
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public static class SearchedPluginDirectoryPayload extends Payload<PluginDirectoryError> {
+        public SiteModel site;
         public String searchTerm;
         public int page;
         public boolean canLoadMore;
         public List<WPOrgPluginModel> plugins;
 
-        public SearchedPluginDirectoryPayload(String searchTerm, int page) {
+        public SearchedPluginDirectoryPayload(@Nullable SiteModel site, String searchTerm, int page) {
+            this.site = site;
             this.searchTerm = searchTerm;
             this.page = page;
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class UpdatedSitePluginPayload extends Payload<UpdateSitePluginError> {
         public SiteModel site;
+        public String pluginName;
         public SitePluginModel plugin;
 
         public UpdatedSitePluginPayload(SiteModel site, SitePluginModel plugin) {
             this.site = site;
             this.plugin = plugin;
+            this.pluginName = this.plugin.getName();
         }
 
-        public UpdatedSitePluginPayload(SiteModel site, UpdateSitePluginError error) {
+        public UpdatedSitePluginPayload(SiteModel site, String pluginName, UpdateSitePluginError error) {
             this.site = site;
+            this.pluginName = pluginName;
             this.error = error;
         }
     }
@@ -251,18 +285,9 @@ public class PluginStore extends Store {
             this.type = type;
             this.message = message;
         }
-    }
 
-    public static class FetchSitePluginsError implements OnChangedError {
-        public FetchSitePluginsErrorType type;
-        @Nullable public String message;
-
-        FetchSitePluginsError(FetchSitePluginsErrorType type) {
-            this.type = type;
-        }
-
-        public FetchSitePluginsError(String type, @Nullable String message) {
-            this.type = FetchSitePluginsErrorType.fromString(type);
+        public PluginDirectoryError(String type, @Nullable String message) {
+            this.type = PluginDirectoryErrorType.fromString(type);
             this.message = message;
         }
     }
@@ -347,18 +372,14 @@ public class PluginStore extends Store {
     }
 
     public enum PluginDirectoryErrorType {
-        EMPTY_RESPONSE,
-        GENERIC_ERROR
-    }
-
-    public enum FetchSitePluginsErrorType {
+        EMPTY_RESPONSE, // Should be used for NEW & POPULAR plugin directory
         GENERIC_ERROR,
-        UNAUTHORIZED,
-        NOT_AVAILABLE; // Return for non-jetpack sites
+        NOT_AVAILABLE, // Return for non-jetpack sites for SITE plugin directory
+        UNAUTHORIZED; // Should only be used for SITE plugin directory
 
-        public static FetchSitePluginsErrorType fromString(String string) {
+        public static PluginDirectoryErrorType fromString(String string) {
             if (string != null) {
-                for (FetchSitePluginsErrorType v : FetchSitePluginsErrorType.values()) {
+                for (PluginDirectoryErrorType v : PluginDirectoryErrorType.values()) {
                     if (string.equalsIgnoreCase(v.name())) {
                         return v;
                     }
@@ -432,12 +453,14 @@ public class PluginStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class OnPluginDirectorySearched extends OnChanged<PluginDirectoryError> {
+        public @Nullable SiteModel site;
         public String searchTerm;
         public int page;
         public boolean canLoadMore;
         public List<WPOrgPluginModel> plugins;
 
-        public OnPluginDirectorySearched(String searchTerm, int page) {
+        public OnPluginDirectorySearched(@Nullable SiteModel site, String searchTerm, int page) {
+            this.site = site;
             this.searchTerm = searchTerm;
             this.page = page;
         }
@@ -446,44 +469,40 @@ public class PluginStore extends Store {
     @SuppressWarnings("WeakerAccess")
     public static class OnSitePluginConfigured extends OnChanged<ConfigureSitePluginError> {
         public SiteModel site;
-        public SitePluginModel plugin;
-        public OnSitePluginConfigured(SiteModel site) {
+        public String pluginName;
+        public OnSitePluginConfigured(SiteModel site, String pluginName) {
             this.site = site;
+            this.pluginName = pluginName;
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public static class OnSitePluginDeleted extends OnChanged<DeleteSitePluginError> {
         public SiteModel site;
-        public SitePluginModel plugin;
-        public OnSitePluginDeleted(SiteModel site) {
+        public String pluginName;
+        public OnSitePluginDeleted(SiteModel site, String pluginName) {
             this.site = site;
-        }
-    }
-
-    @SuppressWarnings("WeakerAccess")
-    public static class OnSitePluginsFetched extends OnChanged<FetchSitePluginsError> {
-        public SiteModel site;
-        public OnSitePluginsFetched(SiteModel site) {
-            this.site = site;
+            this.pluginName = pluginName;
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public static class OnSitePluginInstalled extends OnChanged<InstallSitePluginError> {
         public SiteModel site;
-        public SitePluginModel plugin;
-        public OnSitePluginInstalled(SiteModel site) {
+        public String slug;
+        public OnSitePluginInstalled(SiteModel site, String slug) {
             this.site = site;
+            this.slug = slug;
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public static class OnSitePluginUpdated extends OnChanged<UpdateSitePluginError> {
         public SiteModel site;
-        public SitePluginModel plugin;
-        public OnSitePluginUpdated(SiteModel site) {
+        public String pluginName;
+        public OnSitePluginUpdated(SiteModel site, String pluginName) {
             this.site = site;
+            this.pluginName = pluginName;
         }
     }
 
@@ -510,6 +529,7 @@ public class PluginStore extends Store {
     private final PluginWPOrgClient mPluginWPOrgClient;
 
     @Inject
+    @SuppressWarnings("WeakerAccess")
     public PluginStore(Dispatcher dispatcher, PluginRestClient pluginRestClient, PluginWPOrgClient pluginWPOrgClient) {
         super(dispatcher);
         mPluginRestClient = pluginRestClient;
@@ -539,9 +559,6 @@ public class PluginStore extends Store {
             case FETCH_PLUGIN_DIRECTORY:
                 fetchPluginDirectory((FetchPluginDirectoryPayload) action.getPayload());
                 break;
-            case FETCH_SITE_PLUGINS:
-                fetchSitePlugins((SiteModel) action.getPayload());
-                break;
             case FETCH_WPORG_PLUGIN:
                 fetchWPOrgPlugin((String) action.getPayload());
                 break;
@@ -568,9 +585,6 @@ public class PluginStore extends Store {
             case FETCHED_PLUGIN_DIRECTORY:
                 fetchedPluginDirectory((FetchedPluginDirectoryPayload) action.getPayload());
                 break;
-            case FETCHED_SITE_PLUGINS:
-                fetchedSitePlugins((FetchedSitePluginsPayload) action.getPayload());
-                break;
             case FETCHED_WPORG_PLUGIN:
                 fetchedWPOrgPlugin((FetchedWPOrgPluginPayload) action.getPayload());
                 break;
@@ -590,10 +604,6 @@ public class PluginStore extends Store {
         return PluginSqlUtils.getWPOrgPluginsForDirectory(type);
     }
 
-    public @Nullable SitePluginModel getSitePluginByName(SiteModel site, String name) {
-        return PluginSqlUtils.getSitePluginByName(site, name);
-    }
-
     public SitePluginModel getSitePluginBySlug(SiteModel site, String slug) {
         return PluginSqlUtils.getSitePluginBySlug(site, slug);
     }
@@ -610,39 +620,48 @@ public class PluginStore extends Store {
 
     private void configureSitePlugin(ConfigureSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.configureSitePlugin(payload.site, payload.plugin);
+            mPluginRestClient.configureSitePlugin(payload.site, payload.pluginName, payload.isActive,
+                    payload.isAutoUpdateEnabled);
         } else {
             ConfigureSitePluginError error = new ConfigureSitePluginError(ConfigureSitePluginErrorType.NOT_AVAILABLE);
-            ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site, error);
-            configuredSitePlugin(errorPayload);
+            ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site,
+                    payload.pluginName, error);
+            mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(errorPayload));
         }
     }
 
     private void deleteSitePlugin(DeleteSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.deleteSitePlugin(payload.site, payload.plugin);
+            mPluginRestClient.deleteSitePlugin(payload.site, payload.slug, payload.pluginName);
         } else {
             DeleteSitePluginError error = new DeleteSitePluginError(DeleteSitePluginErrorType.NOT_AVAILABLE);
-            DeletedSitePluginPayload errorPayload = new DeletedSitePluginPayload(payload.site, payload.plugin, error);
-            deletedSitePlugin(errorPayload);
+            DeletedSitePluginPayload errorPayload = new DeletedSitePluginPayload(payload.site, payload.slug,
+                    payload.pluginName);
+            errorPayload.error = error;
+            mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(errorPayload));
         }
     }
 
     private void fetchPluginDirectory(FetchPluginDirectoryPayload payload) {
-        int page = 1;
-        if (payload.loadMore) {
-            page = PluginSqlUtils.getLastRequestedPageForDirectoryType(payload.type) + 1;
+        if (payload.type == PluginDirectoryType.SITE) {
+            fetchSitePlugins(payload.site);
+        } else {
+            int page = 1;
+            if (payload.loadMore) {
+                page = PluginSqlUtils.getLastRequestedPageForDirectoryType(payload.type) + 1;
+            }
+            mPluginWPOrgClient.fetchPluginDirectory(payload.type, page);
         }
-        mPluginWPOrgClient.fetchPluginDirectory(payload.type, page);
     }
 
-    private void fetchSitePlugins(SiteModel site) {
-        if (site.isUsingWpComRestApi() && site.isJetpackConnected()) {
+    private void fetchSitePlugins(@Nullable SiteModel site) {
+        if (site != null && site.isUsingWpComRestApi() && site.isJetpackConnected()) {
             mPluginRestClient.fetchSitePlugins(site);
         } else {
-            FetchSitePluginsError error = new FetchSitePluginsError(FetchSitePluginsErrorType.NOT_AVAILABLE);
-            FetchedSitePluginsPayload payload = new FetchedSitePluginsPayload(error);
-            fetchedSitePlugins(payload);
+            PluginDirectoryError error = new PluginDirectoryError(PluginDirectoryErrorType.NOT_AVAILABLE, null);
+            FetchedPluginDirectoryPayload errorPayload = new FetchedPluginDirectoryPayload(PluginDirectoryType.SITE,
+                    false, error);
+            mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginDirectoryAction(errorPayload));
         }
     }
 
@@ -652,26 +671,28 @@ public class PluginStore extends Store {
 
     private void installSitePlugin(InstallSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.installSitePlugin(payload.site, payload.pluginName);
+            mPluginRestClient.installSitePlugin(payload.site, payload.slug);
         } else {
             InstallSitePluginError error = new InstallSitePluginError(InstallSitePluginErrorType.NOT_AVAILABLE);
-            InstalledSitePluginPayload errorPayload = new InstalledSitePluginPayload(payload.site, error);
-            installedSitePlugin(errorPayload);
+            InstalledSitePluginPayload errorPayload = new InstalledSitePluginPayload(payload.site,
+                    payload.slug, error);
+            mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(errorPayload));
         }
     }
 
     private void searchPluginDirectory(SearchPluginDirectoryPayload payload) {
-        mPluginWPOrgClient.searchPluginDirectory(payload.searchTerm, payload.page);
+        mPluginWPOrgClient.searchPluginDirectory(payload.site, payload.searchTerm, payload.page);
     }
 
     private void updateSitePlugin(UpdateSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.updateSitePlugin(payload.site, payload.plugin);
+            mPluginRestClient.updateSitePlugin(payload.site, payload.pluginName);
         } else {
             UpdateSitePluginError error = new UpdateSitePluginError(
                     UpdateSitePluginErrorType.NOT_AVAILABLE);
-            UpdatedSitePluginPayload errorPayload = new UpdatedSitePluginPayload(payload.site, error);
-            updatedSitePlugin(errorPayload);
+            UpdatedSitePluginPayload errorPayload = new UpdatedSitePluginPayload(payload.site,
+                    payload.pluginName, error);
+            mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(errorPayload));
         }
     }
 
@@ -687,19 +708,17 @@ public class PluginStore extends Store {
     // Network callbacks
 
     private void configuredSitePlugin(ConfiguredSitePluginPayload payload) {
-        OnSitePluginConfigured event = new OnSitePluginConfigured(payload.site);
+        OnSitePluginConfigured event = new OnSitePluginConfigured(payload.site, payload.pluginName);
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            payload.plugin.setLocalSiteId(payload.site.getId());
-            event.plugin = payload.plugin;
-            PluginSqlUtils.insertOrUpdateSitePlugin(payload.plugin);
+            PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
         }
         emitChange(event);
     }
 
     private void deletedSitePlugin(DeletedSitePluginPayload payload) {
-        OnSitePluginDeleted event = new OnSitePluginDeleted(payload.site);
+        OnSitePluginDeleted event = new OnSitePluginDeleted(payload.site, payload.pluginName);
         // If the remote returns `UNKNOWN_PLUGIN` error, it means the plugin is not installed in remote anymore
         // most likely because the plugin is already removed on a different client and it was not synced yet.
         // Since we are trying to remove an already removed plugin, we should just remove it from DB and treat it as a
@@ -707,8 +726,7 @@ public class PluginStore extends Store {
         if (payload.isError() && payload.error.type != DeleteSitePluginErrorType.UNKNOWN_PLUGIN) {
             event.error = payload.error;
         } else {
-            event.plugin = payload.plugin;
-            PluginSqlUtils.deleteSitePlugin(payload.site, payload.plugin);
+            PluginSqlUtils.deleteSitePlugin(payload.site, payload.slug);
         }
         emitChange(event);
     }
@@ -719,30 +737,24 @@ public class PluginStore extends Store {
             event.error = payload.error;
         } else {
             event.canLoadMore = payload.canLoadMore;
-            if (!payload.loadMore) {
-                // This is a fresh list, we need to remove the directory records for the fetched type
-                PluginSqlUtils.deletePluginDirectoryForType(payload.type);
+            if (event.type == PluginDirectoryType.SITE) {
+                PluginSqlUtils.insertOrReplaceSitePlugins(payload.site, payload.sitePlugins);
+            } else {
+                if (!payload.loadMore) {
+                    // This is a fresh list, we need to remove the directory records for the fetched type
+                    PluginSqlUtils.deletePluginDirectoryForType(payload.type);
+                }
+                if (payload.wpOrgPlugins != null) {
+                    // For pagination to work correctly, we need to separate the actual plugin data from the list of
+                    // plugins for each directory type. This is important because the same data will be fetched from
+                    // multiple sources. We fetch different directory types (same plugin can be in both new and popular)
+                    // as well as do standalone fetches for plugins with `FETCH_WPORG_PLUGIN` action. We also need to
+                    // keep track of the page the plugin belongs to, because the `per_page` parameter is unreliable.
+                    PluginSqlUtils.insertOrUpdatePluginDirectoryList(
+                            pluginDirectoryListFromWPOrgPlugins(payload.wpOrgPlugins, payload.type, payload.page));
+                    PluginSqlUtils.insertOrUpdateWPOrgPluginList(payload.wpOrgPlugins);
+                }
             }
-            if (payload.plugins != null) {
-                // For pagination to work correctly, we need to separate the actual plugin data from the list of plugins
-                // for each directory type. This is important because the same data will be fetched from multiple
-                // sources. We fetch different directory types (same plugin can be in both new and popular) as well as
-                // do standalone fetches for plugins with `FETCH_WPORG_PLUGIN` action. We also need to keep track of the
-                // page the plugin belongs to, because the `per_page` parameter is unreliable.
-                PluginSqlUtils.insertOrUpdatePluginDirectoryList(pluginDirectoryListFromWPOrgPlugins(payload.plugins,
-                        payload.type, payload.page));
-                PluginSqlUtils.insertOrUpdateWPOrgPluginList(payload.plugins);
-            }
-        }
-        emitChange(event);
-    }
-
-    private void fetchedSitePlugins(FetchedSitePluginsPayload payload) {
-        OnSitePluginsFetched event = new OnSitePluginsFetched(payload.site);
-        if (payload.isError()) {
-            event.error = payload.error;
-        } else {
-            PluginSqlUtils.insertOrReplaceSitePlugins(payload.site, payload.plugins);
         }
         emitChange(event);
     }
@@ -758,18 +770,17 @@ public class PluginStore extends Store {
     }
 
     private void installedSitePlugin(InstalledSitePluginPayload payload) {
-        OnSitePluginInstalled event = new OnSitePluginInstalled(payload.site);
+        OnSitePluginInstalled event = new OnSitePluginInstalled(payload.site, payload.slug);
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            event.plugin = payload.plugin;
-            PluginSqlUtils.insertOrUpdateSitePlugin(payload.plugin);
+            PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
         }
         emitChange(event);
     }
 
     private void searchedPluginDirectory(SearchedPluginDirectoryPayload payload) {
-        OnPluginDirectorySearched event = new OnPluginDirectorySearched(payload.searchTerm, payload.page);
+        OnPluginDirectorySearched event = new OnPluginDirectorySearched(payload.site, payload.searchTerm, payload.page);
         if (payload.isError()) {
             event.error = payload.error;
         } else {
@@ -780,12 +791,11 @@ public class PluginStore extends Store {
     }
 
     private void updatedSitePlugin(UpdatedSitePluginPayload payload) {
-        OnSitePluginUpdated event = new OnSitePluginUpdated(payload.site);
+        OnSitePluginUpdated event = new OnSitePluginUpdated(payload.site, payload.pluginName);
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            event.plugin = payload.plugin;
-            PluginSqlUtils.insertOrUpdateSitePlugin(payload.plugin);
+            PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
         }
         emitChange(event);
     }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -41,7 +41,7 @@
 /sites/$site/plugins
 /sites/$site/plugins/$name#String
 /sites/$site/plugins/$name#String/delete
-/sites/$site/plugins/$name#String/install
+/sites/$site/plugins/$slug#String/install
 /sites/$site/plugins/$name#String/update
 
 /sites/$site/posts/


### PR DESCRIPTION
I've been unhappy that WPAndroid had to do a lot of work and create a lot of DB queries to handle the `SitePluginModel` & `WPOrgPluginModel` mess. I worked on this issue in `issue/plugin-store-optimizations-1` and after trying a few things and making a lot of changes, I found something I am happy with. However, that change set turned out to be a really big one and it was not very well contained. To help with that, I am creating this pre-PR. The reasons will be much more clearer when I open the actual PR, but since this is being merged to a WIP branch, I hope it's OK not to list them here. Also, these changes alone does make sense to me anyway. Note that PR is single commit only because the actual changes are in a different branch.

Since we are making changes to some common methods/classes, the changeset for the PR is a little big, but the actual changes are pretty limited. **Going through this list _should_ make the review easier!**

**Payload Changes**

There are 2 main goals for these changes:
* Request payloads, such as `ConfigureSitePluginPayload` should not depend on actual models such as `SitePluginModel`. If we only need 2 fields from this model, there is no reason to pass it around. This will prepare the payloads to work with a different (combined) model. **_P.S:_** I really think we should do this for all request payloads to simplify the client and use immutable models. We could add `getPayload()` to our models if we need a lot of properties, of course this is a separate discussion.
* Request payloads and `OnChanged` events should closely match each other. We need a way to identify the `OnChanged` events, such as plugin name, slug, site etc. Ideally, these properties should be the same for the request and `OnChanged` event so the client can easily check them.

**Note:** Some payloads now have `SiteModel` as a property. It's usage might not be clear in this PR, but will later be used to combine `SitePluginModel`s & `WPOrgPluginModel`s, stay tuned for that!

**PluginSqlUtils changes**

* `insertOrUpdateSitePlugin` now considers `slug` as the unique identifier. Most important reason for this is it makes the method less error prone. We no longer need to set the id of a plugin we get from a network response in advance. It also makes things a lot more consistent as we use slug everywhere else anyway. We'll soon add index for the `slug` property which should help with the performance.
* `deleteSitePlugin` no longer needs the plugin. If a plugin is deleted, we should only need the slug, this was an oversight on my part in the original implementation.

**PluginStore changes**

* Removed `getSitePluginByName`. Adding this was a mistake and we should never rely on anything else but `slug` and sometimes local id for plugin models.

Every other change (aside from really minor fixes) are a result of these base changes. Hope this PR description will help with the review and please let me know if anything is not clear!

/cc @nbradbury 