### PR TITLE
Plugin model & sql improvements

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
@@ -38,7 +38,7 @@ public class PluginDirectorySqlUtilsTest {
     }
 
     @Test
-    public void insertPluginDirectoryList() throws NoSuchMethodException,
+    public void testInsertPluginDirectoryList() throws NoSuchMethodException,
             InvocationTargetException, IllegalAccessException {
         int numberOfDirectories = 10;
         List<PluginDirectoryModel> pluginDirectoryList = new ArrayList<>();
@@ -51,14 +51,7 @@ public class PluginDirectorySqlUtilsTest {
             pluginDirectoryList.add(directoryModel);
         }
         PluginSqlUtils.insertPluginDirectoryList(pluginDirectoryList);
-
-        // Use reflection to assert PluginSqlUtils.getPluginDirectoriesForType
-        Method getPluginDirectoriesForType = PluginSqlUtils.class.getDeclaredMethod("getPluginDirectoriesForType",
-                PluginDirectoryType.class);
-        getPluginDirectoriesForType.setAccessible(true);
-        Object directoryList = getPluginDirectoriesForType.invoke(PluginSqlUtils.class, directoryType);
-        Assert.assertTrue(directoryList instanceof List);
-        Assert.assertEquals(numberOfDirectories, ((List) directoryList).size());
+        Assert.assertEquals(numberOfDirectories, getPluginDirectoriesForType(directoryType).size());
     }
 
     @Test
@@ -75,15 +68,9 @@ public class PluginDirectorySqlUtilsTest {
         pluginDirectoryList.add(directoryModel);
         PluginSqlUtils.insertPluginDirectoryList(pluginDirectoryList);
 
-        // Use reflection to assert PluginSqlUtils.getPluginDirectoriesForType
-        Method getPluginDirectoriesForType = PluginSqlUtils.class.getDeclaredMethod("getPluginDirectoriesForType",
-                PluginDirectoryType.class);
-        getPluginDirectoriesForType.setAccessible(true);
-        Object directoryList = getPluginDirectoriesForType.invoke(PluginSqlUtils.class, directoryType);
-        Assert.assertTrue(directoryList instanceof List);
-        Assert.assertEquals(1, ((List) directoryList).size());
-        PluginDirectoryModel insertedDirectoryModel = (PluginDirectoryModel) ((List) directoryList).get(0);
-        Assert.assertEquals(insertedDirectoryModel.getPage(), page);
+        List<PluginDirectoryModel> directoryList = getPluginDirectoriesForType(directoryType);
+        Assert.assertEquals(1, directoryList.size());
+        Assert.assertEquals(directoryList.get(0).getPage(), page);
     }
 
     @Test
@@ -167,6 +154,18 @@ public class PluginDirectorySqlUtilsTest {
             WPOrgPluginModel wpOrgPluginModel = insertedPopularPlugins.get(i);
             Assert.assertEquals(wpOrgPluginModel.getSlug(), slug);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // Use reflection to assert PluginSqlUtils.getPluginDirectoriesForType
+        Method getPluginDirectoriesForType = PluginSqlUtils.class.getDeclaredMethod("getPluginDirectoriesForType",
+                PluginDirectoryType.class);
+        getPluginDirectoriesForType.setAccessible(true);
+        Object directoryList = getPluginDirectoriesForType.invoke(PluginSqlUtils.class, directoryType);
+        Assert.assertTrue(directoryList instanceof List);
+        return (List<PluginDirectoryModel>) directoryList;
     }
 
     private String randomString(String prefix) {

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
@@ -50,7 +50,7 @@ public class PluginDirectorySqlUtilsTest {
             directoryModel.setPage(1);
             pluginDirectoryList.add(directoryModel);
         }
-        Assert.assertEquals(numberOfDirectories, PluginSqlUtils.insertOrUpdatePluginDirectoryList(pluginDirectoryList));
+        PluginSqlUtils.insertPluginDirectoryList(pluginDirectoryList);
 
         // Use reflection to assert PluginSqlUtils.getPluginDirectoriesForType
         Method getPluginDirectoriesForType = PluginSqlUtils.class.getDeclaredMethod("getPluginDirectoriesForType",
@@ -67,62 +67,23 @@ public class PluginDirectorySqlUtilsTest {
         String slug = randomString("slug");
         int page = 5;
         List<PluginDirectoryModel> pluginDirectoryList = new ArrayList<>();
-        String directoryType = PluginDirectoryType.NEW.toString();
+        PluginDirectoryType directoryType = PluginDirectoryType.NEW;
         PluginDirectoryModel directoryModel = new PluginDirectoryModel();
         directoryModel.setSlug(slug);
-        directoryModel.setDirectoryType(directoryType);
+        directoryModel.setDirectoryType(directoryType.toString());
         directoryModel.setPage(page);
         pluginDirectoryList.add(directoryModel);
-        Assert.assertEquals(1, PluginSqlUtils.insertOrUpdatePluginDirectoryList(pluginDirectoryList));
+        PluginSqlUtils.insertPluginDirectoryList(pluginDirectoryList);
 
         // Use reflection to assert PluginSqlUtils.getPluginDirectoriesForType
-        Method getPluginDirectoryModel = PluginSqlUtils.class.getDeclaredMethod("getPluginDirectoryModel",
-                String.class, String.class);
-        getPluginDirectoryModel.setAccessible(true);
-        Object object = getPluginDirectoryModel.invoke(PluginSqlUtils.class, directoryType, slug);
-        Assert.assertNotNull(object);
-        Assert.assertTrue(object instanceof PluginDirectoryModel);
-        PluginDirectoryModel insertedDirectoryModel = (PluginDirectoryModel) object;
+        Method getPluginDirectoriesForType = PluginSqlUtils.class.getDeclaredMethod("getPluginDirectoriesForType",
+                PluginDirectoryType.class);
+        getPluginDirectoriesForType.setAccessible(true);
+        Object directoryList = getPluginDirectoriesForType.invoke(PluginSqlUtils.class, directoryType);
+        Assert.assertTrue(directoryList instanceof List);
+        Assert.assertEquals(1, ((List) directoryList).size());
+        PluginDirectoryModel insertedDirectoryModel = (PluginDirectoryModel) ((List) directoryList).get(0);
         Assert.assertEquals(insertedDirectoryModel.getPage(), page);
-    }
-
-    @Test
-    public void testUpdatePluginDirectoryModel() throws NoSuchMethodException,
-            InvocationTargetException, IllegalAccessException {
-        String slug = randomString("slug");
-        int oldPage = 1;
-        String directoryType = PluginDirectoryType.NEW.toString();
-        PluginDirectoryModel directoryModel = new PluginDirectoryModel();
-        directoryModel.setSlug(slug);
-        directoryModel.setDirectoryType(directoryType);
-        directoryModel.setPage(oldPage);
-
-        Method insertOrUpdatePluginDirectoryModel =
-                PluginSqlUtils.class.getDeclaredMethod("insertOrUpdatePluginDirectoryModel",
-                        PluginDirectoryModel.class);
-        insertOrUpdatePluginDirectoryModel.setAccessible(true);
-        Assert.assertEquals(1, insertOrUpdatePluginDirectoryModel.invoke(PluginSqlUtils.class, directoryModel));
-
-        // Use reflection to assert PluginSqlUtils.getPluginDirectoriesForType
-        Method getPluginDirectoryModel = PluginSqlUtils.class.getDeclaredMethod("getPluginDirectoryModel",
-                String.class, String.class);
-        getPluginDirectoryModel.setAccessible(true);
-        Object firstObject = getPluginDirectoryModel.invoke(PluginSqlUtils.class, directoryType, slug);
-        Assert.assertNotNull(firstObject);
-        Assert.assertTrue(firstObject instanceof PluginDirectoryModel);
-        PluginDirectoryModel insertedDirectoryModel = (PluginDirectoryModel) firstObject;
-        Assert.assertEquals(insertedDirectoryModel.getPage(), oldPage);
-
-        int newPage = 2;
-        directoryModel.setPage(newPage);
-        Assert.assertEquals(1, insertOrUpdatePluginDirectoryModel.invoke(PluginSqlUtils.class, directoryModel));
-
-        Object secondObject = getPluginDirectoryModel.invoke(PluginSqlUtils.class, directoryType, slug);
-        Assert.assertNotNull(secondObject);
-        Assert.assertTrue(secondObject instanceof PluginDirectoryModel);
-        PluginDirectoryModel updatedDirectoryModel = (PluginDirectoryModel) secondObject;
-        Assert.assertEquals(updatedDirectoryModel.getPage(), newPage);
-        Assert.assertEquals(insertedDirectoryModel.getSlug(), updatedDirectoryModel.getSlug());
     }
 
     @Test
@@ -142,7 +103,7 @@ public class PluginDirectorySqlUtilsTest {
             // Add PluginDirectoryModels one by one
             List<PluginDirectoryModel> pluginDirectoryList = new ArrayList<>();
             pluginDirectoryList.add(directoryModel);
-            Assert.assertEquals(1, PluginSqlUtils.insertOrUpdatePluginDirectoryList(pluginDirectoryList));
+            PluginSqlUtils.insertPluginDirectoryList(pluginDirectoryList);
             // Last requested page is the max value of the `page` column for that directory type
             lastRequestedPage = Math.max(lastRequestedPage, page);
             Assert.assertEquals(lastRequestedPage, PluginSqlUtils.getLastRequestedPageForDirectoryType(directoryType));
@@ -173,8 +134,7 @@ public class PluginDirectorySqlUtilsTest {
             directoryModel.setDirectoryType(PluginDirectoryType.NEW.toString());
             directoryListForNewPlugins.add(directoryModel);
         }
-        Assert.assertEquals(numberOfNewPlugins,
-                PluginSqlUtils.insertOrUpdatePluginDirectoryList(directoryListForNewPlugins));
+        PluginSqlUtils.insertPluginDirectoryList(directoryListForNewPlugins);
 
         // Add plugin directory models for POPULAR type
         final List<String> slugListForPopularPlugins = randomSlugsFromList(slugList, numberOfPopularPlugins);
@@ -185,8 +145,7 @@ public class PluginDirectorySqlUtilsTest {
             directoryModel.setDirectoryType(PluginDirectoryType.POPULAR.toString());
             directoryListForPopularPlugins.add(directoryModel);
         }
-        Assert.assertEquals(numberOfPopularPlugins,
-                PluginSqlUtils.insertOrUpdatePluginDirectoryList(directoryListForPopularPlugins));
+        PluginSqlUtils.insertPluginDirectoryList(directoryListForPopularPlugins);
 
         // Assert that getWPOrgPluginsForDirectory return the correct items
 

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
@@ -112,6 +112,10 @@ public class PluginDirectorySqlUtilsTest {
         int numberOfNewPlugins = 30;
         int numberOfPopularPlugins = 40;
 
+        // Assert empty state - SQLite's WHERE IN query could crash if the empty list is not handled properly
+        Assert.assertEquals(0, PluginSqlUtils.getWPOrgPluginsForDirectory(PluginDirectoryType.NEW).size());
+        Assert.assertEquals(0, PluginSqlUtils.getWPOrgPluginsForDirectory(PluginDirectoryType.POPULAR).size());
+
         // Add plugin directory models for NEW type
         final List<String> slugListForNewPlugins = randomSlugsFromList(slugList, numberOfNewPlugins);
         List<PluginDirectoryModel> directoryListForNewPlugins = new ArrayList<>();

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/WPOrgPluginSqlUtilsTest.java
@@ -42,7 +42,7 @@ public class WPOrgPluginSqlUtilsTest {
     @Test
     public void testInsertWPOrgPlugin() {
         String slug = randomString("slug");
-        String name = randomString("name");
+        String displayName = randomString("displayName");
 
         // Assert no plugin exist with the slug
         Assert.assertNull(PluginSqlUtils.getWPOrgPluginBySlug(slug));
@@ -50,39 +50,39 @@ public class WPOrgPluginSqlUtilsTest {
         // Create wporg plugin
         WPOrgPluginModel plugin = new WPOrgPluginModel();
         plugin.setSlug(slug);
-        plugin.setName(name);
+        plugin.setDisplayName(displayName);
 
         // Insert the plugin and assert that it was successful
         Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateWPOrgPlugin(plugin));
         WPOrgPluginModel insertedPlugin = PluginSqlUtils.getWPOrgPluginBySlug(slug);
         Assert.assertNotNull(insertedPlugin);
-        Assert.assertEquals(insertedPlugin.getName(), name);
+        Assert.assertEquals(insertedPlugin.getDisplayName(), displayName);
     }
 
     @Test
     public void testUpdateWPOrgPlugin() {
         String slug = randomString("slug");
-        String name = randomString("name");
+        String displayName = randomString("displayName");
 
         WPOrgPluginModel plugin = new WPOrgPluginModel();
         plugin.setSlug(slug);
-        plugin.setName(name);
+        plugin.setDisplayName(displayName);
 
         // Insert a wporg plugin and assert the state
         Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateWPOrgPlugin(plugin));
         WPOrgPluginModel insertedPlugin = PluginSqlUtils.getWPOrgPluginBySlug(slug);
         Assert.assertNotNull(insertedPlugin);
-        Assert.assertEquals(insertedPlugin.getName(), name);
+        Assert.assertEquals(insertedPlugin.getDisplayName(), displayName);
 
         // Update the name of the plugin and try insertOrUpdate and make sure the plugin is updated
-        String name2 = randomString("name2");
-        Assert.assertTrue(!name.equals(name2));
-        insertedPlugin.setName(name2);
+        String displayName2 = randomString("displayName2-");
+        Assert.assertTrue(!displayName.equals(displayName2));
+        insertedPlugin.setDisplayName(displayName2);
         Assert.assertEquals(1, PluginSqlUtils.insertOrUpdateWPOrgPlugin(insertedPlugin));
         WPOrgPluginModel updatedPlugin = PluginSqlUtils.getWPOrgPluginBySlug(slug);
         Assert.assertNotNull(updatedPlugin);
         Assert.assertEquals(insertedPlugin.getSlug(), updatedPlugin.getSlug());
-        Assert.assertEquals(updatedPlugin.getName(), name2);
+        Assert.assertEquals(updatedPlugin.getDisplayName(), displayName2);
     }
 
     @Test
@@ -110,15 +110,15 @@ public class WPOrgPluginSqlUtilsTest {
         int numberOfPlugins = 2;
         List<WPOrgPluginModel> plugins = new ArrayList<>();
         List<String> slugList = new ArrayList<>();
-        List<String> nameList = new ArrayList<>();
+        List<String> displayNameList = new ArrayList<>();
         for (int i = 0; i < numberOfPlugins; i++) {
             String slug = randomString("slug") + i;
-            String name = randomString("name") + i;
+            String displayName = randomString("name") + i;
             slugList.add(slug);
-            nameList.add(name);
+            displayNameList.add(displayName);
             WPOrgPluginModel wpOrgPluginModel = new WPOrgPluginModel();
             wpOrgPluginModel.setSlug(slug);
-            wpOrgPluginModel.setName(name);
+            wpOrgPluginModel.setDisplayName(displayName);
             plugins.add(wpOrgPluginModel);
         }
         // Insert plugins
@@ -128,12 +128,12 @@ public class WPOrgPluginSqlUtilsTest {
         List<WPOrgPluginModel> updatedPlugins = new ArrayList<>();
         for (int i = 0; i < slugList.size(); i++) {
             String slug = slugList.get(i);
-            String newName = randomString("newName") + i;
-            updatedNameList.add(newName);
+            String newDisplayName = randomString("newDisplayName" + i + "-");
+            updatedNameList.add(newDisplayName);
             WPOrgPluginModel wpOrgPluginModel = PluginSqlUtils.getWPOrgPluginBySlug(slug);
             Assert.assertNotNull(wpOrgPluginModel);
             // Update plugin name
-            wpOrgPluginModel.setName(newName);
+            wpOrgPluginModel.setDisplayName(newDisplayName);
             updatedPlugins.add(wpOrgPluginModel);
         }
         // Update plugins
@@ -142,12 +142,12 @@ public class WPOrgPluginSqlUtilsTest {
         // Assert the plugins are updated
         for (int i = 0; i < numberOfPlugins; i++) {
             String slug = slugList.get(i);
-            String previousName = nameList.get(i);
+            String previousName = displayNameList.get(i);
             String expectedName = updatedNameList.get(i);
             WPOrgPluginModel wpOrgPluginModel = PluginSqlUtils.getWPOrgPluginBySlug(slug);
             Assert.assertNotNull(wpOrgPluginModel);
-            Assert.assertFalse(StringUtils.equals(wpOrgPluginModel.getName(), previousName));
-            Assert.assertTrue(StringUtils.equals(wpOrgPluginModel.getName(), expectedName));
+            Assert.assertFalse(StringUtils.equals(wpOrgPluginModel.getDisplayName(), previousName));
+            Assert.assertTrue(StringUtils.equals(wpOrgPluginModel.getDisplayName(), expectedName));
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/ImmutablePluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/ImmutablePluginModel.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.model.plugin;
 import android.support.annotation.Nullable;
 
 import org.wordpress.android.util.HtmlUtils;
+import org.wordpress.android.util.StringUtils;
 
 @SuppressWarnings("unused")
 public class ImmutablePluginModel {
@@ -38,6 +39,14 @@ public class ImmutablePluginModel {
             return mWPOrgPlugin.getSlug();
         }
         return null;
+    }
+
+    public int getAverageStarRating() {
+        if (mWPOrgPlugin == null) {
+            return 0;
+        }
+        int rating = StringUtils.stringToInt(mWPOrgPlugin.getRating(), 1);
+        return Math.round(rating / 20f);
     }
 
     public @Nullable String getAuthorAsHtml() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/ImmutablePluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/ImmutablePluginModel.java
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.model.plugin;
 
 import android.support.annotation.Nullable;
 
-import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.StringUtils;
 
 @SuppressWarnings("unused")
@@ -61,8 +60,7 @@ public class ImmutablePluginModel {
             return mSitePlugin.getAuthorName();
         }
         if (mWPOrgPlugin != null) {
-            // TODO: Save authorName in WPOrgPluginModel
-            return HtmlUtils.fastStripHtml(mWPOrgPlugin.getAuthorAsHtml());
+            return mWPOrgPlugin.getAuthorName();
         }
         return null;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/ImmutablePluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/ImmutablePluginModel.java
@@ -97,7 +97,7 @@ public class ImmutablePluginModel {
         if (mSitePlugin != null) {
             return mSitePlugin.getDisplayName();
         } else if (mWPOrgPlugin != null) {
-            return mWPOrgPlugin.getName();
+            return mWPOrgPlugin.getDisplayName();
         }
         return null;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/SitePluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/SitePluginModel.java
@@ -3,11 +3,13 @@ package org.wordpress.android.fluxc.model.plugin;
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.RawConstraints;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import java.io.Serializable;
 
 @Table
+@RawConstraints({"UNIQUE (SLUG, LOCAL_SITE_ID)"})
 public class SitePluginModel implements Identifiable, Serializable {
     @PrimaryKey @Column private int mId;
     @Column private int mLocalSiteId;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/WPOrgPluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/WPOrgPluginModel.java
@@ -16,12 +16,12 @@ public class WPOrgPluginModel implements Identifiable, Serializable {
     @Column private String mAuthorName;
     @Column private String mBanner;
     @Column private String mDescriptionAsHtml;
+    @Column private String mDisplayName;
     @Column private String mFaqAsHtml;
     @Column private String mHomepageUrl;
     @Column private String mIcon;
     @Column private String mInstallationInstructionsAsHtml;
     @Column private String mLastUpdated;
-    @Column private String mName;
     @Column private String mRating;
     @Column private String mRequiredWordPressVersion;
     @Column private String mSlug;
@@ -77,6 +77,14 @@ public class WPOrgPluginModel implements Identifiable, Serializable {
         mDescriptionAsHtml = descriptionAsHtml;
     }
 
+    public String getDisplayName() {
+        return mDisplayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        mDisplayName = displayName;
+    }
+
     public String getFaqAsHtml() {
         return mFaqAsHtml;
     }
@@ -115,14 +123,6 @@ public class WPOrgPluginModel implements Identifiable, Serializable {
 
     public void setLastUpdated(String lastUpdated) {
         mLastUpdated = lastUpdated;
-    }
-
-    public String getName() {
-        return mName;
-    }
-
-    public void setName(String name) {
-        mName = name;
     }
 
     public String getRating() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/WPOrgPluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/WPOrgPluginModel.java
@@ -3,11 +3,13 @@ package org.wordpress.android.fluxc.model.plugin;
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.RawConstraints;
 import com.yarolegovich.wellsql.core.annotation.Table;
 
 import java.io.Serializable;
 
 @Table
+@RawConstraints({"UNIQUE (SLUG)"})
 public class WPOrgPluginModel implements Identifiable, Serializable {
     @PrimaryKey @Column private int mId;
     @Column private String mAuthorAsHtml;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/WPOrgPluginModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plugin/WPOrgPluginModel.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 public class WPOrgPluginModel implements Identifiable, Serializable {
     @PrimaryKey @Column private int mId;
     @Column private String mAuthorAsHtml;
+    @Column private String mAuthorName;
     @Column private String mBanner;
     @Column private String mDescriptionAsHtml;
     @Column private String mFaqAsHtml;
@@ -48,6 +49,14 @@ public class WPOrgPluginModel implements Identifiable, Serializable {
 
     public void setAuthorAsHtml(String authorAsHtml) {
         mAuthorAsHtml = authorAsHtml;
+    }
+
+    public String getAuthorName() {
+        return mAuthorName;
+    }
+
+    public void setAuthorName(String authorName) {
+        mAuthorName = authorName;
     }
 
     public String getBanner() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -198,7 +198,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
         wpOrgPluginModel.setIcon(response.icon);
         wpOrgPluginModel.setInstallationInstructionsAsHtml(response.installationInstructionsAsHtml);
         wpOrgPluginModel.setLastUpdated(response.lastUpdated);
-        wpOrgPluginModel.setName(StringEscapeUtils.unescapeHtml4(response.name));
+        wpOrgPluginModel.setDisplayName(StringEscapeUtils.unescapeHtml4(response.name));
         wpOrgPluginModel.setRating(response.rating);
         wpOrgPluginModel.setRequiredWordPressVersion(response.requiredWordPressVersion);
         wpOrgPluginModel.setSlug(response.slug);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -104,6 +104,10 @@ public class PluginSqlUtils {
 
     public static @NonNull List<WPOrgPluginModel> getWPOrgPluginsForDirectory(PluginDirectoryType directoryType) {
         List<PluginDirectoryModel> directoryModels = getPluginDirectoriesForType(directoryType);
+        if (directoryModels.size() == 0) {
+            // No directories found, return an empty list
+            return new ArrayList<>();
+        }
         List<String> slugList = new ArrayList<>(directoryModels.size());
         final HashMap<String, Integer> orderMap = new HashMap<>();
         for (int i = 0; i < directoryModels.size(); i++) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -163,16 +163,12 @@ public class PluginSqlUtils {
                 .endWhere().execute();
     }
 
-    public static int insertOrUpdatePluginDirectoryList(List<PluginDirectoryModel> pluginDirectories) {
+    public static void insertPluginDirectoryList(@Nullable List<PluginDirectoryModel> pluginDirectories) {
         if (pluginDirectories == null) {
-            return 0;
+            return;
         }
 
-        int result = 0;
-        for (PluginDirectoryModel pluginDirectory : pluginDirectories) {
-            result += insertOrUpdatePluginDirectoryModel(pluginDirectory);
-        }
-        return result;
+        WellSql.insert(pluginDirectories).asSingleTransaction(true).execute();
     }
 
     public static int getLastRequestedPageForDirectoryType(PluginDirectoryType directoryType) {
@@ -190,31 +186,5 @@ public class PluginSqlUtils {
                 .equals(PluginDirectoryModelTable.DIRECTORY_TYPE, directoryType)
                 .endWhere()
                 .getAsModel();
-    }
-
-    private static @Nullable PluginDirectoryModel getPluginDirectoryModel(String directoryType, String slug) {
-        List<PluginDirectoryModel> result = WellSql.select(PluginDirectoryModel.class)
-                .where()
-                .equals(PluginDirectoryModelTable.SLUG, slug)
-                .equals(PluginDirectoryModelTable.DIRECTORY_TYPE, directoryType)
-                .endWhere()
-                .getAsModel();
-        return result.isEmpty() ? null : result.get(0);
-    }
-
-    private static int insertOrUpdatePluginDirectoryModel(PluginDirectoryModel pluginDirectory) {
-        if (pluginDirectory == null) {
-            return 0;
-        }
-
-        PluginDirectoryModel existing = getPluginDirectoryModel(pluginDirectory.getDirectoryType(),
-                pluginDirectory.getSlug());
-        if (existing == null) {
-            WellSql.insert(pluginDirectory).execute();
-            return 1;
-        } else {
-            return WellSql.update(PluginDirectoryModel.class).whereId(existing.getId())
-                    .put(pluginDirectory, new UpdateAllExceptId<>(PluginDirectoryModel.class)).execute();
-        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -60,7 +60,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 24;
+        return 25;
     }
 
     @Override
@@ -208,6 +208,28 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE PluginDirectoryModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                         + "SLUG TEXT,DIRECTORY_TYPE TEXT,PAGE INTEGER)");
+                oldVersion++;
+            case 24:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                // Start with a clean slate for Plugins. This migration adds unique constraints for SitePluginModel
+                // and WPOrgPluginModel tables. Adds `authorName` column and renames `name` column to `displayName` in
+                // WPOrgPluginModel table. Since these records are only used as cache and would & should be refreshed
+                // often, there is no real harm to do this other than a slightly longer loading time for the first usage
+                // after the migration. This migration would be much more complicated otherwise.
+                db.execSQL("DELETE FROM PluginDirectoryModel");
+                db.execSQL("DROP TABLE IF EXISTS SitePluginModel");
+                db.execSQL("DROP TABLE IF EXISTS WPOrgPluginModel");
+                db.execSQL("CREATE TABLE SitePluginModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "NAME TEXT,DISPLAY_NAME TEXT,PLUGIN_URL TEXT,VERSION TEXT,SLUG TEXT,DESCRIPTION TEXT,"
+                        + "AUTHOR_NAME TEXT,AUTHOR_URL TEXT,SETTINGS_URL TEXT,IS_ACTIVE INTEGER,"
+                        + "IS_AUTO_UPDATE_ENABLED INTEGER,UNIQUE (SLUG, LOCAL_SITE_ID))");
+                db.execSQL("CREATE TABLE WPOrgPluginModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,AUTHOR_AS_HTML TEXT,"
+                        + "AUTHOR_NAME TEXT,BANNER TEXT,DESCRIPTION_AS_HTML TEXT,DISPLAY_NAME TEXT,FAQ_AS_HTML TEXT,"
+                        + "HOMEPAGE_URL TEXT,ICON TEXT,INSTALLATION_INSTRUCTIONS_AS_HTML TEXT,LAST_UPDATED TEXT,"
+                        + "RATING TEXT,REQUIRED_WORD_PRESS_VERSION TEXT,SLUG TEXT,VERSION TEXT,WHATS_NEW_AS_HTML TEXT,"
+                        + "DOWNLOAD_COUNT INTEGER,NUMBER_OF_RATINGS INTEGER,NUMBER_OF_RATINGS_OF_ONE INTEGER,"
+                        + "NUMBER_OF_RATINGS_OF_TWO INTEGER,NUMBER_OF_RATINGS_OF_THREE INTEGER,"
+                        + "NUMBER_OF_RATINGS_OF_FOUR INTEGER,NUMBER_OF_RATINGS_OF_FIVE INTEGER,UNIQUE (SLUG))");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -770,7 +770,7 @@ public class PluginStore extends Store {
                     // multiple sources. We fetch different directory types (same plugin can be in both new and popular)
                     // as well as do standalone fetches for plugins with `FETCH_WPORG_PLUGIN` action. We also need to
                     // keep track of the page the plugin belongs to, because the `per_page` parameter is unreliable.
-                    PluginSqlUtils.insertOrUpdatePluginDirectoryList(
+                    PluginSqlUtils.insertPluginDirectoryList(
                             pluginDirectoryListFromWPOrgPlugins(payload.wpOrgPlugins, payload.type, payload.page));
                     PluginSqlUtils.insertOrUpdateWPOrgPluginList(payload.wpOrgPlugins);
                 }


### PR DESCRIPTION
This PR aims to make the final minor adjustments to Plugins that mainly focuses on performance.

**Unique Columns**
`WPOrgPluginModel`s `slug` field and `SitePluginModel`s combination of `localSiteId` & `slug` fields are now unique. This will create indexes for us which will make retrieving a plugin by it's slug much faster.

**Model Changes**
I've added an `authorName` property/column to `WPOrgPluginModel` to avoid stripping the html each time it's needed. I've also changed the `name` field to `displayName` in the same model as discussed before. This makes both plugin model's `getDisplayName` properties inline and helps us avoid any confusion about what the name of a wporg plugin is.

**Query Improvements**
* `PluginSqlUtils.getWPOrgPluginsForDirectory` has been greatly improved. We used to query each `WPOrgPluginModel` for each plugin directory separately, which on average started with 51 queries and could easily become thousands of queries if the user scrolled enough pages. With these changes, we only make 1 query to get the plugin directories and another 1 query to get the `WPOrgPluginModel`s for those directories. We also need to manually sort them, but that shouldn't be too expensive of an operation especially since we cache their position.
* Removed `insertOrUpdatePluginDirectoryModel` and `insertPluginDirectoryList`. We really shouldn't be updating plugin directory lists and we shouldn't need to. I tried to explain this a bit in the commit message of 8bbc6144c59ccfb9d665466d29a52aba2042c340. With this change we can make the whole insert in a single transaction. It's worth noting that we make the same assumption in other sql methods elsewhere in the app (not having to update models because they are already removed).

**Migration decision**
Unfortunately there is no way to update a single column in Sqlite, with this many changes, it'd mean that we'd require a pretty long and somewhat complicated migration to move the data. Considering that we treat all this data as a cache and no local changes are ever saved AND the plugin directory feature hasn't even been released, I thought it'd be much easier to just start from a clean slate. Having said that, I am open to writing this migration if anyone else feels strongly about doing so.

Assuming that WPAndroid plays nicely with all these changes (which it looks like it does from a quick testing), this concludes the changes I had in mind for plugins before we start working on `FEATURED` plugins and Automated Transfers.

/cc @nbradbury 