### PR TITLE
Replace InstrumentationTestCase by JUnit tests and use the test orchestrator 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ allprojects {
 
     repositories {
         jcenter()
+        google()
     }
 
     task checkstyle(type: Checkstyle) {
@@ -69,5 +70,5 @@ subprojects {
 
 ext {
     daggerVersion = '2.11'
-    supportLibraryVersion = '25.3.1'
+    supportLibraryVersion = '25.4.0'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -80,7 +80,8 @@ dependencies {
     // WordPress libs
     implementation ('org.wordpress:utils:1.16.0') {
         // Using official volley package
-        exclude group: "com.mcxiaoke.volley";
+        exclude group: "com.mcxiaoke.volley"
+        exclude group: "com.android.support"
     }
 
     // Dagger

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -100,12 +100,11 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-core:1.10.19'
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
     androidTestCompileOnly 'org.glassfish:javax.annotation:10.0-b28'
+    // Test orchestrator
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestUtil 'com.android.support.test:orchestrator:1.0.1'
 
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'
     debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
-
-    // Test orchestrator
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestUtil 'com.android.support.test:orchestrator:1.0.1'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -41,7 +41,10 @@ android {
     }
 
     testOptions {
-        execution 'ANDROID_TEST_ORCHESTRATOR'
+        // Don't use the test orchestrator yet, some of our connected testsare sharing state to reduce network
+        // pressure on the API (authentication/fetch profile/fetch sites).
+        // Uncomment the next line to enable the Orchestrator.
+        // execution 'ANDROID_TEST_ORCHESTRATOR'
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,10 +7,6 @@ buildscript {
     }
 }
 
-repositories {
-    jcenter()
-}
-
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -29,6 +25,8 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -37,8 +35,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
     lintOptions {
         warning 'InvalidPackage'
+    }
+
+    testOptions {
+        execution 'ANDROID_TEST_ORCHESTRATOR'
     }
 }
 
@@ -100,4 +103,8 @@ dependencies {
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'
     debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
+
+    // Test orchestrator
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestUtil 'com.android.support.test:orchestrator:1.0.1'
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
@@ -1,6 +1,11 @@
 package org.wordpress.android.fluxc.mocked;
 
+import android.support.test.runner.AndroidJUnit4;
+
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -9,9 +14,12 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * Tests using a Mocked Network app component. Test the Store itself and not the underlying network component(s).
  */
+@RunWith(AndroidJUnit4.class)
 public class MockedStack_AccountTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
@@ -19,7 +27,8 @@ public class MockedStack_AccountTest extends MockedStack_Base {
     public boolean mIsError;
 
     @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         super.setUp();
         // Inject
         mMockedNetworkAppComponent.inject(this);
@@ -27,6 +36,7 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         mDispatcher.register(this);
     }
 
+    @Test
     public void testAuthenticationOK() {
         AuthenticatePayload payload = new AuthenticatePayload("test", "test");
         mIsError = false;
@@ -34,6 +44,7 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
     }
 
+    @Test
     public void testAuthenticationKO() {
         AuthenticatePayload payload = new AuthenticatePayload("error", "error");
         mIsError = true;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
@@ -1,21 +1,22 @@
 package org.wordpress.android.fluxc.mocked;
 
 import android.content.Context;
-import android.test.InstrumentationTestCase;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import org.junit.Before;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 
-public class MockedStack_Base extends InstrumentationTestCase {
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+
+public class MockedStack_Base {
     Context mAppContext;
     MockedNetworkAppComponent mMockedNetworkAppComponent;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         // Needed for Mockito
         System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
         mAppContext = getInstrumentation().getTargetContext().getApplicationContext();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
@@ -8,7 +8,7 @@ public class MockedStack_SiteTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         // Inject
         mMockedNetworkAppComponent.inject(this);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
@@ -23,6 +24,7 @@ import javax.inject.Inject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 /**
  * Tests using a Mocked Network app component. Test the Store itself and not the underlying network component(s).
  *
@@ -52,6 +54,7 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testUploadMedia() throws InterruptedException {
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
         startSuccessfulMediaUpload(testMedia, getTestSite());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
@@ -20,6 +20,9 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 /**
  * Tests using a Mocked Network app component. Test the Store itself and not the underlying network component(s).
  *
@@ -40,7 +43,7 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
     private CountDownLatch mCountDownLatch;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         // Inject
         mMockedNetworkAppComponent.inject(this);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.UploadAction;
@@ -37,6 +38,12 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
 /**
  * Tests using a Mocked Network app component. Test the Store itself and not the underlying network component(s).
  */
@@ -64,7 +71,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
     private CountDownLatch mCountDownLatch;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         // Inject
         mMockedNetworkAppComponent.inject(this);
@@ -73,6 +80,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testUploadMedia() throws InterruptedException {
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
         startSuccessfulMediaUpload(testMedia, getTestSite());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -93,6 +93,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
     }
 
+    @Test
     public void testUploadMediaError() throws InterruptedException {
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
         startFailingMediaUpload(testMedia, getTestSite());
@@ -108,6 +109,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
     }
 
+    @Test
     public void testRegisterPostAndUploadMediaWithError() throws InterruptedException {
         SiteModel site = getTestSite();
 
@@ -203,6 +205,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         assertFalse(mUploadStore.isPendingPost(mPost));
     }
 
+    @Test
     public void testRegisterPostAndUploadMediaWithPostCancellation() throws InterruptedException {
         SiteModel site = getTestSite();
 
@@ -272,6 +275,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         assertEquals(0, mUploadStore.getFailedMediaForPost(mPost).size());
     }
 
+    @Test
     public void testUploadMediaInCancelledPost() throws InterruptedException {
         SiteModel site = getTestSite();
 
@@ -328,6 +332,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         assertNull(getPostUploadModelForPostModel(mPost));
     }
 
+    @Test
     public void testUpdateMediaModelState() throws InterruptedException {
         SiteModel site = getTestSite();
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -89,7 +89,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         // Confirm that the corresponding MediaUploadModel's state has been updated automatically
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
         assertNotNull(mediaUploadModel);
-        assertEquals(1F, mUploadStore.getUploadProgressForMedia(testMedia));
+        assertEquals(1F, mUploadStore.getUploadProgressForMedia(testMedia), 0.1);
         assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
     }
 
@@ -105,7 +105,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         // Confirm that the corresponding MediaUploadModel's state has been updated automatically
         MediaUploadModel mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
         assertNotNull(mediaUploadModel);
-        assertEquals(0F, mUploadStore.getUploadProgressForMedia(testMedia));
+        assertEquals(0F, mUploadStore.getUploadProgressForMedia(testMedia), 0.1);
         assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
     }
 
@@ -374,7 +374,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
         assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
         assertNotNull(mediaUploadModel.getMediaError());
-        assertEquals(0F, mUploadStore.getUploadProgressForMedia(testMedia));
+        assertEquals(0F, mUploadStore.getUploadProgressForMedia(testMedia), 0.1);
 
         // The PostUploadModel should have been set to CANCELLED automatically via the UPDATE_MEDIA action
         PostUploadModel postUploadModel = getPostUploadModelForPostModel(mPost);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -14,6 +15,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests on real servers using the full release stack (no mock)
@@ -34,7 +40,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
     private OnAvailabilityChecked mLastEvent;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -43,6 +49,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testIsAvailableBlog() throws InterruptedException {
         mNextEvent = TestEvents.IS_AVAILABLE_BLOG;
         mCountDownLatch = new CountDownLatch(1);
@@ -64,6 +71,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         assertTrue(mLastEvent.isAvailable);
     }
 
+    @Test
     public void testIsAvailableBlogInvalid() throws InterruptedException {
         mNextEvent = TestEvents.ERROR_INVALID;
         mCountDownLatch = new CountDownLatch(1);
@@ -75,6 +83,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         assertFalse(mLastEvent.isAvailable);
     }
 
+    @Test
     public void testIsAvailableDomain() throws InterruptedException {
         mNextEvent = TestEvents.IS_AVAILABLE_DOMAIN;
         mCountDownLatch = new CountDownLatch(1);
@@ -98,6 +107,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         assertNull(mLastEvent.suggestions);
     }
 
+    @Test
     public void testIsAvailableDomainInvalid() throws InterruptedException {
         mNextEvent = TestEvents.ERROR_INVALID;
         mCountDownLatch = new CountDownLatch(1);
@@ -109,6 +119,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         assertFalse(mLastEvent.isAvailable);
     }
 
+    @Test
     public void testIsAvailableEmail() throws InterruptedException {
         mNextEvent = TestEvents.IS_AVAILABLE_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
@@ -130,6 +141,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         assertTrue(mLastEvent.isAvailable);
     }
 
+    @Test
     public void testIsAvailableEmailInvalid() throws InterruptedException {
         mNextEvent = TestEvents.ERROR_INVALID;
         mCountDownLatch = new CountDownLatch(1);
@@ -141,6 +153,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         assertFalse(mLastEvent.isAvailable);
     }
 
+    @Test
     public void testIsAvailableUsername() throws InterruptedException {
         mNextEvent = TestEvents.IS_AVAILABLE_USERNAME;
         mCountDownLatch = new CountDownLatch(1);
@@ -162,6 +175,7 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         assertTrue(mLastEvent.isAvailable);
     }
 
+    @Test
     public void testIsAvailableUsernameInvalid() throws InterruptedException {
         mNextEvent = TestEvents.ERROR_INVALID;
         mCountDownLatch = new CountDownLatch(1);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -28,6 +29,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests with real credentials on real servers using the full release stack (no mock)
@@ -56,7 +61,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     private boolean mExpectAccountInfosChanged;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -65,21 +70,25 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testWPComAuthenticationOK() throws InterruptedException {
         mNextEvent = TestEvents.AUTHENTICATE;
         authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
     }
 
+    @Test
     public void testWPComAuthenticationIncorrectUsernameOrPassword() throws InterruptedException {
         mNextEvent = TestEvents.INCORRECT_USERNAME_OR_PASSWORD_ERROR;
         authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_BAD_PASSWORD);
     }
 
+    @Test
     public void testWPCom2faAuthentication() throws InterruptedException {
         mNextEvent = TestEvents.AUTHENTICATE_2FA_ERROR;
         authenticate(BuildConfig.TEST_WPCOM_USERNAME_2FA, BuildConfig.TEST_WPCOM_PASSWORD_2FA);
     }
 
+    @Test
     public void testWPComFetch() throws InterruptedException {
         if (!mAccountStore.hasAccessToken()) {
             mNextEvent = TestEvents.AUTHENTICATE;
@@ -92,6 +101,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testWPComPost() throws InterruptedException {
         if (!mAccountStore.hasAccessToken()) {
             mNextEvent = TestEvents.AUTHENTICATE;
@@ -110,6 +120,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
     }
 
+    @Test
     public void testWPComPostNoChange() throws InterruptedException {
         if (!mAccountStore.hasAccessToken()) {
             mNextEvent = TestEvents.AUTHENTICATE;
@@ -136,6 +147,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertEquals(newValue, mAccountStore.getAccount().getAboutMe());
     }
 
+    @Test
     public void testWPComPostPrimarySiteIdNoChange() throws InterruptedException {
         if (!mAccountStore.hasAccessToken()) {
             mNextEvent = TestEvents.AUTHENTICATE;
@@ -162,6 +174,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertEquals(newValue, String.valueOf(mAccountStore.getAccount().getPrimarySiteId()));
     }
 
+    @Test
     public void testChangeWPComUsernameInvalidInputError() throws InterruptedException {
         if (!mAccountStore.hasAccessToken()) {
             mNextEvent = TestEvents.AUTHENTICATE;
@@ -183,6 +196,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertEquals(address, String.valueOf(mAccountStore.getAccount().getWebAddress()));
     }
 
+    @Test
     public void testFetchWPComUsernameSuggestionsNoNameError() throws InterruptedException {
         mNextEvent = TestEvents.FETCH_USERNAME_SUGGESTIONS_ERROR_NO_NAME;
 
@@ -193,6 +207,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testFetchWPComUsernameSuggestionsSuccess() throws InterruptedException {
         mNextEvent = TestEvents.FETCH_USERNAME_SUGGESTIONS_SUCCESS;
 
@@ -203,6 +218,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testWPComSignOut() throws InterruptedException {
         mNextEvent = TestEvents.AUTHENTICATE;
         authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
@@ -216,6 +232,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertEquals(0, mAccountStore.getAccount().getUserId());
     }
 
+    @Test
     public void testWPComSignOutCollision() throws InterruptedException {
         mNextEvent = TestEvents.AUTHENTICATE;
         authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
@@ -235,6 +252,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertEquals(0, mAccountStore.getAccount().getUserId());
     }
 
+    @Test
     public void testSendAuthEmail() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false);
@@ -243,6 +261,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testSendAuthEmailViaUsername() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false);
@@ -251,6 +270,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testSendAuthEmailInvalid() throws InterruptedException {
         // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
@@ -260,6 +280,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testSendAuthEmailNoSuchUser() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
@@ -269,6 +290,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testSendAuthEmailSignup() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
@@ -278,6 +300,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testSendAuthEmailSignupInvalid() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
         AuthEmailPayload payload = new AuthEmailPayload("email@domain", true);
@@ -286,6 +309,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testSendAuthEmailSignupUserExists() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.fluxc.release;
 
 import android.content.Context;
-import android.test.InstrumentationTestCase;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import org.junit.Before;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.module.AppContextModule;
@@ -13,6 +13,8 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import java.util.concurrent.CountDownLatch;
 
 import javax.inject.Inject;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
 /**
  * NOTE:
@@ -25,16 +27,15 @@ import javax.inject.Inject;
  *  Therefore the test class must provide an injected AccountStore member, even though
  *  methods/properties from the AccountStore are never explicitly invoked.
  */
-public class ReleaseStack_Base extends InstrumentationTestCase {
+public class ReleaseStack_Base {
     @Inject Dispatcher mDispatcher;
 
     Context mAppContext;
     ReleaseStack_AppComponent mReleaseStackAppComponent;
     CountDownLatch mCountDownLatch;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         // Needed for Mockito
         System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
         mAppContext = getInstrumentation().getTargetContext().getApplicationContext();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.release;
 import com.yarolegovich.wellsql.SelectQuery;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.CommentActionBuilder;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
@@ -31,6 +32,12 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
 public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     @Inject CommentStore mCommentStore;
     @Inject PostStore mPostStore;
@@ -51,7 +58,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     private PostModel mFirstPost;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -64,6 +71,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     }
 
     // Note: This test is not specific to WPCOM (local changes only)
+    @Test
     public void testInstantiateComment() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -75,6 +83,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     }
 
     // Note: This test is not specific to WPCOM (local changes only)
+    @Test
     public void testInstantiateUpdateAndRemoveComment() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -105,6 +114,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         }
     }
 
+    @Test
     public void testRemoveAllComments() throws InterruptedException {
         fetchFirstComments();
 
@@ -120,6 +130,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(0, count);
     }
 
+    @Test
     public void testInstantiateAndCreateNewComment() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -139,6 +150,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
     }
 
+    @Test
     public void testLikeAndUnlikeComment() throws InterruptedException {
         // Fetch existing comments and get first comment
         fetchFirstComments();
@@ -167,6 +179,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertFalse(comment.getILike());
     }
 
+    @Test
     public void testDeleteCommentOnce() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -197,6 +210,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(CommentStatus.TRASH.toString(), comment.getStatus());
     }
 
+    @Test
     public void testDeleteCommentTwice() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -232,6 +246,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(comment, null);
     }
 
+    @Test
     public void testErrorDuplicatedComment() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -253,6 +268,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testNewCommentToAnUnknownPost() throws InterruptedException {
         CommentModel newComment = new CommentModel();
 
@@ -266,6 +282,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testReplyToAnUnknownComment() throws InterruptedException {
         CommentModel fakeComment = new CommentModel();
         CommentModel newComment = new CommentModel();
@@ -277,6 +294,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testInstantiateAndCreateReplyComment() throws InterruptedException {
         // Fetch existing comments and get first comment
         fetchFirstComments();
@@ -304,6 +322,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(mNewComment.getRemoteSiteId(), comment.getRemoteSiteId());
     }
 
+    @Test
     public void testFetchComments() throws InterruptedException {
         FetchCommentsPayload payload = new FetchCommentsPayload(sSite, 10, 0);
         mNextEvent = TestEvents.COMMENT_CHANGED;
@@ -313,6 +332,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testFetchComment() throws InterruptedException {
         fetchFirstComments();
         CommentModel firstComment = mComments.get(0);
@@ -325,6 +345,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testEditValidComment() throws InterruptedException {
         fetchFirstComments();
 
@@ -354,6 +375,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(updatedComment.getContent().contains(firstComment.getContent()));
     }
 
+    @Test
     public void testEditInvalidComment() throws InterruptedException {
         CommentModel comment = new CommentModel();
         comment.setContent("");

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.CommentActionBuilder;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
@@ -26,6 +27,10 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Inject CommentStore mCommentStore;
     @Inject PostStore mPostStore;
@@ -44,7 +49,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private CommentModel mNewComment;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -55,6 +60,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testFetchComments() throws InterruptedException {
         FetchCommentsPayload payload = new FetchCommentsPayload(sSite, 10, 0);
         mNextEvent = TestEvents.COMMENT_CHANGED;
@@ -64,6 +70,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testFetchComment() throws InterruptedException {
         fetchFirstComments();
         // Get first comment
@@ -75,6 +82,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testInstantiateAndCreateNewComment() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -94,6 +102,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
     }
 
+    @Test
     public void testInstantiateAndCreateNewCommentDuplicate() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -115,6 +124,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testReplyToAnUnknownComment() throws InterruptedException {
         CommentModel fakeComment = new CommentModel();
         CommentModel newComment = new CommentModel();
@@ -131,6 +141,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testInstantiateAndCreateReplyComment() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -155,6 +166,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(comment.getRemoteParentCommentId(), firstComment.getRemoteCommentId());
     }
 
+    @Test
     public void testEditValidComment() throws InterruptedException {
         fetchFirstComments();
 
@@ -176,6 +188,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(comment.getContent(), firstComment.getContent());
     }
 
+    @Test
     public void testEditInvalidComment() throws InterruptedException {
         fetchFirstComments();
 
@@ -194,6 +207,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testDeleteCommentOnce() throws InterruptedException {
         // New Comment
         createNewComment();
@@ -224,6 +238,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(CommentStatus.TRASH.toString(), comment.getStatus());
     }
 
+    @Test
     public void testDeleteCommentTwice() throws InterruptedException {
         // New Comment
         createNewComment();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
@@ -23,6 +24,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests with real credentials on real servers using the full release stack (no mock)
@@ -56,7 +61,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
     private String mPassword;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -65,6 +70,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testNoUrlFetchSites() throws InterruptedException {
         mUrl = "";
         mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE;
@@ -79,6 +85,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testInvalidUrlFetchSites() throws InterruptedException {
         mUrl = "notaurl&*@";
         mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE;
@@ -93,6 +100,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testNonWordPressFetchSites() throws InterruptedException {
         mUrl = "example.com";
         mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE;
@@ -107,6 +115,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testWPComUrlFetchSites() throws InterruptedException {
         mUrl = "mysite.wordpress.com";
         mUsername = BuildConfig.TEST_WPCOM_USERNAME_TEST1;
@@ -121,6 +130,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testXMLRPCSimpleFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
@@ -128,6 +138,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCSimpleHTTPSFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_VALID_SSL,
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL,
@@ -135,6 +146,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPRedirectFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTP_TO_HTTP_REDIRECT,
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_HTTP_TO_HTTP_REDIRECT,
@@ -142,6 +154,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPSRedirectFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTP_TO_HTTPS_REDIRECT,
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_HTTP_TO_HTTPS_REDIRECT,
@@ -149,6 +162,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPSToHTTPSRedirectFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTPS_TO_HTTPS_REDIRECT,
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_HTTPS_TO_HTTPS_REDIRECT,
@@ -156,6 +170,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPSToHTTPRedirectFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTPS_TO_HTTP_REDIRECT,
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_HTTPS_TO_HTTP_REDIRECT,
@@ -163,6 +178,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPSSameDomainRedirectFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_VALID_SSL_REDIRECT,
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL_REDIRECT,
@@ -170,6 +186,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCSelfSignedSSLFetchSites() throws InterruptedException {
         checkSelfHostedSelfSignedSSLFetchForSite(BuildConfig.TEST_WPORG_URL_SH_SELFSIGNED_SSL,
                 BuildConfig.TEST_WPORG_USERNAME_SH_SELFSIGNED_SSL,
@@ -177,6 +194,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPAuthFetchSites() throws InterruptedException {
         checkSelfHostedHTTPAuthFetchForSite(BuildConfig.TEST_WPORG_URL_SH_HTTPAUTH,
                 BuildConfig.TEST_WPORG_USERNAME_SH_HTTPAUTH,
@@ -186,6 +204,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPSRedirectWithEndpointSameDomainFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_VALID_SSL_REDIRECT_ENDPOINT,
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL_REDIRECT,
@@ -195,6 +214,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
 
     // No protocol in URL tests
 
+    @Test
     public void testXMLRPCSimpleNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_SIMPLE),
                 BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
@@ -202,6 +222,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCSimpleHTTPSNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_VALID_SSL),
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL,
@@ -209,6 +230,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(
                 UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTP_TO_HTTP_REDIRECT),
@@ -217,6 +239,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPSNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(
                 UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTP_TO_HTTPS_REDIRECT),
@@ -225,6 +248,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPSToHTTPSNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(
                 UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTPS_TO_HTTPS_REDIRECT),
@@ -233,6 +257,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPSToHTTPNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(
                 UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTPS_TO_HTTP_REDIRECT),
@@ -241,6 +266,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPSSameDomainNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_VALID_SSL_REDIRECT),
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL_REDIRECT,
@@ -248,6 +274,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCSelfSignedSSLNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSelfSignedSSLFetchForSite(UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_SELFSIGNED_SSL),
                 BuildConfig.TEST_WPORG_USERNAME_SH_SELFSIGNED_SSL,
@@ -255,6 +282,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPAuthNoProtocolFetchSites() throws InterruptedException {
         checkSelfHostedHTTPAuthFetchForSite(UrlUtils.removeScheme(BuildConfig.TEST_WPORG_URL_SH_HTTPAUTH),
                 BuildConfig.TEST_WPORG_USERNAME_SH_HTTPAUTH,
@@ -266,6 +294,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
 
     // Bad protocol tests
 
+    @Test
     public void testXMLRPCSimpleBadProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_SIMPLE),
                 BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
@@ -273,6 +302,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCSimpleHTTPSBadProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_VALID_SSL),
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL,
@@ -280,6 +310,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPBadProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(
                 addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTP_TO_HTTP_REDIRECT),
@@ -288,6 +319,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPSBadProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(
                 addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTP_TO_HTTPS_REDIRECT),
@@ -296,6 +328,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPSToHTTPSBadProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(
                 addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTPS_TO_HTTPS_REDIRECT),
@@ -304,6 +337,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPSToHTTPBadProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(
                 addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_VALID_HTTPS_TO_HTTP_REDIRECT),
@@ -312,6 +346,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPToHTTPSSameDomainBadProtocolRedirectFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_VALID_SSL_REDIRECT),
                 BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL_REDIRECT,
@@ -319,6 +354,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCSelfSignedSSLBadProtocolFetchSites() throws InterruptedException {
         checkSelfHostedSelfSignedSSLFetchForSite(addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_SELFSIGNED_SSL),
                 BuildConfig.TEST_WPORG_USERNAME_SH_SELFSIGNED_SSL,
@@ -326,6 +362,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCHTTPAuthBadProtocolFetchSites() throws InterruptedException {
         checkSelfHostedHTTPAuthFetchForSite(addBadProtocolToUrl(BuildConfig.TEST_WPORG_URL_SH_HTTPAUTH),
                 BuildConfig.TEST_WPORG_USERNAME_SH_HTTPAUTH,
@@ -335,6 +372,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCRsdFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_RSD,
                 BuildConfig.TEST_WPORG_USERNAME_SH_RSD,
@@ -342,6 +380,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCNoRsdFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_NO_RSD,
                 BuildConfig.TEST_WPORG_USERNAME_SH_NO_RSD,
@@ -349,6 +388,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testIDNEmojiFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_IDN_EMOJI,
                 BuildConfig.TEST_WPORG_USERNAME_SH_IDN_EMOJI,
@@ -356,6 +396,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testIDNJapaneseFetchSites() throws InterruptedException {
         checkSelfHostedSimpleFetchForSite(BuildConfig.TEST_WPORG_URL_SH_IDN_JAPANESE,
                 BuildConfig.TEST_WPORG_USERNAME_SH_IDN_JAPANESE,
@@ -363,6 +404,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
                 TestEvents.DISCOVERY_SUCCEEDED_XMLRPC);
     }
 
+    @Test
     public void testXMLRPCBlockedDiscovery() throws InterruptedException {
         mUrl = BuildConfig.TEST_WPORG_URL_SH_BLOCKED;
         mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_BLOCKED;
@@ -377,6 +419,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testXMLRPCForbiddenDiscovery() throws InterruptedException {
         mUrl = BuildConfig.TEST_WPORG_URL_SH_FORBIDDEN;
         mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_FORBIDDEN;
@@ -391,6 +434,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testXMLRPCMissingMethodDiscovery() throws InterruptedException {
         mUrl = BuildConfig.TEST_WPORG_URL_SH_MISSING_METHODS;
         mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_MISSING_METHODS;
@@ -405,6 +449,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testWPAPISimpleFetchSites() throws InterruptedException {
         if (org.wordpress.android.fluxc.BuildConfig.ENABLE_WPAPI) {
             mUrl = BuildConfig.TEST_WPORG_URL_SH_WPAPI_SIMPLE;
@@ -423,6 +468,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
         }
     }
 
+    @Test
     public void testWPAPIMissingV2SimpleFetchSites() throws InterruptedException {
         // If the wp/v2 namespace is unsupported, we don't expect a WP-API endpoint to be discovered
         // (but an XML-RPC endpoint should be found)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
@@ -4,6 +4,7 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
@@ -24,6 +25,13 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
     @Inject SiteStore mSiteStore;
     @Inject MediaStore mMediaStore;
@@ -39,7 +47,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
     private TestEvents mNextEvent;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -48,6 +56,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testLoadImageFromHTTPAuthSite() throws Throwable {
         signInToHTTPAuthSite();
 
@@ -84,8 +93,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
                 );
             }
         };
-
-        runTestOnUiThread(loadImageTask);
+        getInstrumentation().runOnMainSync(loadImageTask);
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -29,6 +30,9 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
     @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;
@@ -46,7 +50,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
     private TestEvents mNextEvent;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -55,6 +59,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testUploadMediaLowFilesizeLimit() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_JETPACK_UPLOAD_LIMIT,
                 BuildConfig.TEST_WPCOM_PASSWORD_JETPACK_UPLOAD_LIMIT);
@@ -73,6 +78,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testUploadMediaLowMemoryLimit() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -31,6 +32,12 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 @SuppressLint("UseSparseArrays")
 public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     @Inject MediaStore mMediaStore;
@@ -56,7 +63,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     private Map<Integer, MediaModel> mUploadedMediaModels = new HashMap<>();
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -64,6 +71,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         init();
     }
 
+    @Test
     public void testDeleteMedia() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -81,6 +89,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         assertNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
     }
 
+    @Test
     public void testFetchMediaList() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -119,6 +128,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testFetchMedia() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -145,6 +155,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testEditMedia() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -171,6 +182,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testEditNonexistentMedia() throws InterruptedException {
         // create media with invalid ID
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -182,6 +194,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         assertNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
     }
 
+    @Test
     public void testUploadImage() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -198,6 +211,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testUploadImageAttachedToPost() throws InterruptedException {
         // Upload media attached to remotely saved post
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -231,6 +245,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testCancelImageUpload() throws InterruptedException {
         // First, try canceling an image with the default behavior (canceled image is deleted from the store)
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -269,6 +284,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
     }
 
+    @Test
     public void testUploadMultipleImages() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
@@ -306,6 +322,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         }
     }
 
+    @Test
     public void testUploadMultipleImagesAndCancel() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
@@ -349,6 +366,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         }
     }
 
+    @Test
     public void testUploadMultipleImagesAndCancelWithoutDeleting() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
@@ -394,6 +412,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         }
     }
 
+    @Test
     public void testUploadVideo() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleVideoPath(), MediaUtils.MIME_TYPE_VIDEO);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -34,6 +35,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @SuppressLint("UseSparseArrays")
 public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
@@ -69,7 +76,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private Map<Integer, MediaModel> mUploadedMediaModels = new HashMap<>();
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -78,6 +85,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testDeleteMedia() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -95,6 +103,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNull(mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId()));
     }
 
+    @Test
     public void testDeleteMediaThatDoesNotExist() throws InterruptedException {
         MediaModel testMedia = new MediaModel();
         testMedia.setMediaId(9999999L);
@@ -102,6 +111,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testFetchMediaList() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -140,6 +150,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testFetchMediaThatDoesNotExist() throws InterruptedException {
         List<Long> mediaIds = new ArrayList<>();
         mediaIds.add(9999999L);
@@ -152,6 +163,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
     }
 
+    @Test
     public void testFetchMediaThatExists() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -178,6 +190,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testEditMedia() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -204,6 +217,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testUploadImage() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -220,6 +234,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testUploadImageAttachedToPost() throws InterruptedException {
         // Upload media attached to remotely saved post
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -253,6 +268,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testCancelImageUpload() throws InterruptedException {
         // First, try canceling an image with the default behavior (canceled image is deleted from the store)
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -291,6 +307,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
     }
 
+    @Test
     public void testUploadMultipleImages() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
@@ -328,6 +345,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
     }
 
+    @Test
     public void testUploadMultipleImagesAndCancel() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
@@ -371,6 +389,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
     }
 
+    @Test
     public void testUploadMultipleImagesAndCancelWithoutDeleting() throws InterruptedException {
         // upload media to guarantee media exists
         mUploadedIds = new ArrayList<>();
@@ -416,6 +435,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         }
     }
 
+    @Test
     public void testUploadVideo() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleVideoPath(), MediaUtils.MIME_TYPE_VIDEO);
@@ -432,6 +452,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         deleteMedia(testMedia);
     }
 
+    @Test
     public void testUploadImageOlderWordPress() throws InterruptedException {
         // Before WordPress 4.4, a separate call to wp.getMediaItem was necessary after wp.uploadFile completed.
         // This is a regression test making sure we're falling back to that behaviour when expected field are missing
@@ -465,6 +486,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testUploadVideoOlderWordPress() throws InterruptedException {
         // Before WordPress 4.4, a separate call to wp.getMediaItem was necessary after wp.uploadFile completed.
         // This is a regression test making sure we're falling back to that behaviour when expected field are missing

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -1,20 +1,23 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
-import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.PluginStore;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginErrorType;
+import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType;
@@ -24,8 +27,6 @@ import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginsFetched;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginsRemoved;
-import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginErrorType;
-import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
@@ -37,6 +38,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     @Inject SiteStore mSiteStore;
@@ -61,7 +68,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     private SitePluginModel mInstalledPlugin;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -71,6 +78,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mInstalledPlugin = null;
     }
 
+    @Test
     public void testFetchSitePlugins() throws InterruptedException {
         SiteModel site = fetchSingleJetpackSitePlugins();
 
@@ -80,6 +88,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testConfigureSitePlugin() throws InterruptedException {
         // In order to have a reliable test, let's first fetch the list of plugins, pick the first plugin
         // and change it's active status, so we can make sure when we run the test multiple times, each time
@@ -109,6 +118,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
     // It's both easier and more efficient to combine install & delete tests since we need to make sure we have the
     // plugin installed for the delete test and the plugin is not installed for the install test
+    @Test
     public void testInstallAndDeleteSitePlugin() throws InterruptedException {
         String pluginSlugToInstall = "react";
         // Fetch the list of installed plugins to make sure `React` is not installed
@@ -149,6 +159,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testConfigureUnknownPluginError() throws InterruptedException {
         SiteModel site = authenticateAndRetrieveSingleJetpackSite();
 
@@ -166,6 +177,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testDeleteActivePluginError() throws InterruptedException {
         SiteModel site = fetchSingleJetpackSitePlugins();
 
@@ -186,6 +198,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     }
 
     // Trying to remove a plugin that doesn't exist in remote should remove the plugin from DB
+    @Test
     public void testDeleteUnknownPlugin() throws InterruptedException {
         SiteModel site = fetchSingleJetpackSitePlugins();
 
@@ -212,6 +225,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testInstallPluginNoPackageError() throws InterruptedException {
         SiteModel site = fetchSingleJetpackSitePlugins();
         installSitePlugin(site, "this-plugin-does-not-exist", TestEvents.INSTALL_SITE_PLUGIN_ERROR_NO_PACKAGE);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
@@ -28,6 +29,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
     @Inject PostStore mPostStore;
@@ -56,7 +63,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
     private boolean mCanLoadMorePosts;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -70,6 +77,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
     }
 
     // Note: This test is not specific to WPCOM (local changes only)
+    @Test
     public void testRemoveLocalDraft() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -82,6 +90,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(0, PostSqlUtils.getPostsForSite(sSite, false).size());
     }
 
+    @Test
     public void testUploadNewPost() throws InterruptedException {
         // Instantiate new post
         createNewPost();
@@ -102,6 +111,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertFalse(uploadedPost.getCategoryIdList().isEmpty());
     }
 
+    @Test
     public void testEditRemotePost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -133,6 +143,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(dateCreated, finalPost.getDateCreated());
     }
 
+    @Test
     public void testRevertLocallyChangedPost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -157,6 +168,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertFalse(latestPost.isLocallyChanged());
     }
 
+    @Test
     public void testChangeLocalDraft() throws InterruptedException {
         createNewPost();
 
@@ -213,6 +225,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mPost.isLocalDraft());
     }
 
+    @Test
     public void testMultipleLocalChangesToUploadedPost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -250,6 +263,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertFalse(mPost.isLocalDraft());
     }
 
+    @Test
     public void testChangePublishedPostToScheduled() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -275,6 +289,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
     }
 
+    @Test
     public void testFetchPosts() throws InterruptedException {
         mNextEvent = TestEvents.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -305,6 +320,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
     }
 
+    @Test
     public void testFetchPages() throws InterruptedException {
         mNextEvent = TestEvents.PAGES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -320,6 +336,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
     }
 
+    @Test
     public void testFullFeaturedPostUpload() throws InterruptedException {
         createNewPost();
 
@@ -362,6 +379,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(featuredImageId, newPost.getFeaturedImageId());
     }
 
+    @Test
     public void testUploadAndEditPage() throws InterruptedException {
         createNewPost();
         mPost.setIsPage(true);
@@ -388,6 +406,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(0, mPostStore.getPostsCountForSite(sSite));
     }
 
+    @Test
     public void testFullFeaturedPageUpload() throws InterruptedException {
         createNewPost();
 
@@ -427,6 +446,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(0, newPage.getFeaturedImageId()); // The page should upload, but have the featured image stripped
     }
 
+    @Test
     public void testClearTagsFromPost() throws InterruptedException {
         createNewPost();
 
@@ -460,6 +480,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(finalPost.getTagNameList().isEmpty());
     }
 
+    @Test
     public void testClearFeaturedImageFromPost() throws InterruptedException {
         createNewPost();
 
@@ -493,6 +514,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertFalse(finalPost.hasFeaturedImage());
     }
 
+    @Test
     public void testAddLocationToRemotePost() throws InterruptedException {
         // 1. Upload a post with no location data
         createNewPost();
@@ -529,6 +551,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
     }
 
+    @Test
     public void testUploadPostWithLocation() throws InterruptedException {
         // 1. Upload a post with location data
         createNewPost();
@@ -583,6 +606,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertFalse(mPost.hasLocation());
     }
 
+    @Test
     public void testDeleteRemotePost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -606,6 +630,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
     // Error handling tests
 
+    @Test
     public void testFetchInvalidPost() throws InterruptedException {
         PostModel post = new PostModel();
         post.setRemotePostId(6420328);
@@ -619,6 +644,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testEditInvalidPost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -659,6 +685,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(dateCreated, persistedPost.getDateCreated());
     }
 
+    @Test
     public void testDeleteInvalidRemotePost() throws InterruptedException {
         PostModel invalidPost = new PostModel();
         invalidPost.setRemotePostId(6420328);
@@ -672,6 +699,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testFetchPostFromInvalidSite() throws InterruptedException {
         PostModel post = new PostModel();
         post.setRemotePostId(6420328);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -547,8 +547,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         // The set location should be stored in the remote post
         assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude(), 0.1);
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude(), 0.1);
     }
 
     @Test
@@ -574,8 +574,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         // The set location should be stored in the remote post
         assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude(), 0.1);
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude(), 0.1);
 
         // 2. Modify the post without changing the location data and update
         mPost.setTitle("A new title");
@@ -590,8 +590,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         // The location data should not have been altered
         assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude(), 0.1);
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude(), 0.1);
 
         // 3. Clear location data from the post and update
         mPost.clearLocation();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
@@ -28,6 +29,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Inject PostStore mPostStore;
@@ -58,7 +65,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private boolean mCanLoadMorePosts;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -74,6 +81,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mLastPostError = null;
     }
 
+    @Test
     public void testUploadNewPost() throws InterruptedException {
         // Instantiate new post
         createNewPost();
@@ -94,6 +102,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertFalse(uploadedPost.getCategoryIdList().isEmpty());
     }
 
+    @Test
     public void testEditRemotePost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -125,6 +134,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(dateCreated, finalPost.getDateCreated());
     }
 
+    @Test
     public void testRevertLocallyChangedPost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -149,6 +159,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertFalse(latestPost.isLocallyChanged());
     }
 
+    @Test
     public void testChangeLocalDraft() throws InterruptedException {
         createNewPost();
 
@@ -205,6 +216,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mPost.isLocalDraft());
     }
 
+    @Test
     public void testMultipleLocalChangesToUploadedPost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -242,6 +254,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertFalse(mPost.isLocalDraft());
     }
 
+    @Test
     public void testChangePublishedPostToScheduled() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -267,6 +280,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
     }
 
+    @Test
     public void testFetchPosts() throws InterruptedException {
         mNextEvent = TestEvents.POSTS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -297,6 +311,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
     }
 
+    @Test
     public void testFetchPages() throws InterruptedException {
         mNextEvent = TestEvents.PAGES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -312,6 +327,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(mCanLoadMorePosts, firstFetchPosts == PostStore.NUM_POSTS_PER_FETCH);
     }
 
+    @Test
     public void testFullFeaturedPostUpload() throws InterruptedException {
         createNewPost();
 
@@ -354,6 +370,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(featuredImageId, newPost.getFeaturedImageId());
     }
 
+    @Test
     public void testUploadAndEditPage() throws InterruptedException {
         createNewPost();
         mPost.setIsPage(true);
@@ -380,6 +397,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(0, mPostStore.getPostsCountForSite(sSite));
     }
 
+    @Test
     public void testFullFeaturedPageUpload() throws InterruptedException {
         createNewPost();
 
@@ -414,6 +432,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(date, newPage.getDateCreated());
     }
 
+    @Test
     public void testClearTagsFromPost() throws InterruptedException {
         createNewPost();
 
@@ -447,6 +466,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(finalPost.getTagNameList().isEmpty());
     }
 
+    @Test
     public void testClearFeaturedImageFromPost() throws InterruptedException {
         createNewPost();
 
@@ -480,6 +500,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertFalse(finalPost.hasFeaturedImage());
     }
 
+    @Test
     public void testAddLocationToRemotePost() throws InterruptedException {
         // 1. Upload a post with no location data
         createNewPost();
@@ -516,6 +537,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
     }
 
+    @Test
     public void testUploadPostWithLocation() throws InterruptedException {
         // 1. Upload a post with location data
         createNewPost();
@@ -570,6 +592,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertFalse(mPost.hasLocation());
     }
 
+    @Test
     public void testDeleteRemotePost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -593,6 +616,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     // Error handling tests
 
+    @Test
     public void testFetchInvalidPost() throws InterruptedException {
         PostModel post = new PostModel();
         post.setRemotePostId(6420328);
@@ -609,6 +633,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid post ID.", mLastPostError.message);
     }
 
+    @Test
     public void testEditInvalidPost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -653,6 +678,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid post ID.", mLastPostError.message);
     }
 
+    @Test
     public void testDeleteInvalidRemotePost() throws InterruptedException {
         PostModel invalidPost = new PostModel();
         invalidPost.setRemotePostId(6420328);
@@ -669,6 +695,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid post ID.", mLastPostError.message);
     }
 
+    @Test
     public void testCreateNewPostWithInvalidCategory() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -692,6 +719,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid term ID.", mLastPostError.message);
     }
 
+    @Test
     public void testEditPostWithInvalidTerm() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -739,6 +767,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid term ID.", mLastPostError.message);
     }
 
+    @Test
     public void testCreateNewPostWithInvalidFeaturedImage() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -759,6 +788,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid attachment ID.", mLastPostError.message);
     }
 
+    @Test
     public void testEditPostWithInvalidFeaturedImage() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -803,6 +833,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid attachment ID.", mLastPostError.message);
     }
 
+    @Test
     public void testFetchPostBadCredentials() throws InterruptedException {
         PostModel post = new PostModel();
         post.setRemotePostId(10);
@@ -824,6 +855,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Incorrect username or password.", mLastPostError.message);
     }
 
+    @Test
     public void testFetchPostBadUrl() throws InterruptedException {
         PostModel post = new PostModel();
         post.setRemotePostId(10);
@@ -845,6 +877,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     // TODO: Test: Upload a page to a custom site that has pages disabled (should get a 403 'Invalid post type')
 
+    @Test
     public void testFetchPostsAsSubscriber() throws InterruptedException {
         SiteModel site = new SiteModel();
         site.setId(2);
@@ -862,6 +895,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testCreatePostAsSubscriber() throws InterruptedException {
         SiteModel subscriberSite = new SiteModel();
         subscriberSite.setId(2);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -533,8 +533,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // The set location should be stored in the remote post
         assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude(), 0.1);
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude(), 0.1);
     }
 
     @Test
@@ -560,8 +560,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // The set location should be stored in the remote post
         assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude(), 0.1);
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude(), 0.1);
 
         // 2. Modify the post without changing the location data and update
         mPost.setTitle("A new title");
@@ -576,8 +576,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // The location data should not have been altered
         assertTrue(mPost.hasLocation());
-        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude());
-        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude());
+        assertEquals(EXAMPLE_LATITUDE, mPost.getLocation().getLatitude(), 0.1);
+        assertEquals(EXAMPLE_LONGITUDE, mPost.getLocation().getLongitude(), 0.1);
 
         // 3. Clear location data from the post and update
         mPost.clearLocation();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.release;
 import android.text.TextUtils;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -26,6 +27,12 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+
 /**
  * Tests with real credentials on real servers using the full release stack (no mock)
  */
@@ -43,7 +50,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
     private TestEvents mNextEvent;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -52,6 +59,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testWPComJetpackOnlySiteFetch() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
@@ -72,6 +80,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertFalse(mSiteStore.hasSiteAccessedViaXMLRPC());
     }
 
+    @Test
     public void testWPComSingleJetpackSiteFetch() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_ONE_JETPACK,
                 BuildConfig.TEST_WPCOM_PASSWORD_ONE_JETPACK);
@@ -88,6 +97,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
+    @Test
     public void testWPComMultipleJetpackSiteFetch() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_MULTIPLE_JETPACK,
                 BuildConfig.TEST_WPCOM_PASSWORD_MULTIPLE_JETPACK);
@@ -104,6 +114,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
+    @Test
     public void testWPComJetpackMultisiteSiteFetch() throws InterruptedException {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_JETPACK_MULTISITE,
                 BuildConfig.TEST_WPCOM_PASSWORD_JETPACK_MULTISITE);
@@ -122,6 +133,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
+    @Test
     public void testXMLRPCNonJetpackSiteFetch() throws InterruptedException {
         // Add a non-Jetpack self-hosted site
         fetchSitesXMLRPC(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
@@ -143,6 +155,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertEquals(0, site.getSiteId());
     }
 
+    @Test
     public void testXMLRPCJetpackConnectedSiteFetch() throws InterruptedException {
         // Add a Jetpack-connected site as self-hosted
         fetchSitesXMLRPC(BuildConfig.TEST_WPORG_USERNAME_SINGLE_JETPACK_ONLY,
@@ -163,6 +176,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertNotSame(0, site.getSiteId());
     }
 
+    @Test
     public void testXMLRPCJetpackDisconnectedSiteFetch() throws InterruptedException {
         // Add a self-hosted site with Jetpack installed and active but not connected to WP.com
         fetchSitesXMLRPC(BuildConfig.TEST_WPORG_USERNAME_JETPACK_DISCONNECTED,
@@ -184,6 +198,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertEquals(0, site.getSiteId());
     }
 
+    @Test
     public void testWPComJetpackToXMLRPCDuplicateSiteFetch() throws InterruptedException {
         // Authenticate as WP.com user with a single site, which is a Jetpack site
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
@@ -221,6 +236,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
+    @Test
     public void testXMLRPCJetpackToWPComDuplicateSiteFetch() throws InterruptedException {
         // Add a Jetpack-connected site as self-hosted
         fetchSitesXMLRPC(BuildConfig.TEST_WPORG_USERNAME_SINGLE_JETPACK_ONLY,
@@ -256,6 +272,7 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         assertFalse(mSiteStore.hasSitesAccessedViaWPComRest());
     }
 
+    @Test
     public void testWPComToXMLRPCJetpackDifferentAccountsSiteFetch() throws InterruptedException {
         // Authenticate as WP.com user
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -17,10 +18,10 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
-import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains;
+import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnWPComSiteFetched;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
@@ -32,6 +33,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests with real credentials on real servers using the full release stack (no mock)
@@ -57,7 +63,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     private int mExpectedRowsAffected;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -67,6 +73,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mExpectedRowsAffected = 0;
     }
 
+    @Test
     public void testWPComSiteFetchAndLogout() throws InterruptedException {
         authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
                 BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
@@ -80,6 +87,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testFetchPostFormats() throws InterruptedException {
         authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
                 BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
@@ -98,6 +106,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertNotSame(0, postFormats.size());
     }
 
+    @Test
     public void testFetchUserRoles() throws InterruptedException {
         authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
                 BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
@@ -116,6 +125,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertNotSame(0, roles.size());
     }
 
+    @Test
     public void testFetchConnectSiteInfo() throws InterruptedException {
         String site = "http://www.example.com";
         mDispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(site));
@@ -130,6 +140,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testFetchWPComSiteByUrl() throws InterruptedException {
         String site = "http://en.blog.wordpress.com";
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(site));
@@ -164,6 +175,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testWPComSiteFetchAndLogoutCollision() throws InterruptedException {
         authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
                 BuildConfig.TEST_WPCOM_PASSWORD_TEST1);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
@@ -27,6 +28,10 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 /**
  * Tests with real credentials on real servers using the full release stack (no mock).
  * Skips self hosted site discovery, directly using the ENDPOINT URLs from tests.properties.
@@ -50,7 +55,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
     private TestEvents mNextEvent;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -59,36 +64,42 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testXMLRPCSimpleFetchProfile() throws InterruptedException {
         fetchProfile(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
     }
 
+    @Test
     public void testXMLRPCSimpleFetchSites() throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
     }
 
+    @Test
     public void testXMLRPCSimpleContributorFetchSites() throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE_CONTRIB,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE_CONTRIB,
                 BuildConfig.TEST_WPORG_URL_SH_SIMPLE_CONTRIB_ENDPOINT);
     }
 
+    @Test
     public void testXMLRPCMultiSiteFetchSites() throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_MULTISITE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_MULTISITE,
                 BuildConfig.TEST_WPORG_URL_SH_MULTISITE_ENDPOINT);
     }
 
+    @Test
     public void testXMLRPCSimpleHTTPSFetchSites() throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_VALID_SSL,
                 BuildConfig.TEST_WPORG_URL_SH_VALID_SSL_ENDPOINT);
     }
 
+    @Test
     public void testXMLRPCSelfSignedSSLFetchSites() throws InterruptedException {
         mMemorizingTrustManager.clearLocalTrustStore();
 
@@ -117,6 +128,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mMemorizingTrustManager.clearLocalTrustStore();
     }
 
+    @Test
     public void testXMLRPCHTTPAuthFetchSites() throws InterruptedException {
         RefreshSitesXMLRPCPayload payload = new RefreshSitesXMLRPCPayload();
         payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_HTTPAUTH;
@@ -143,6 +155,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testXMLRPCHTTPAuthFetchSites2() throws InterruptedException {
         RefreshSitesXMLRPCPayload payload = new RefreshSitesXMLRPCPayload();
         payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_HTTPAUTH;
@@ -161,6 +174,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testXMLRPCFetchAndDeleteSite() throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE,
@@ -174,6 +188,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testXMLRPCFetchMultipleSites() throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE,
@@ -194,6 +209,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         assertEquals(2, mSiteStore.getSitesCount());
     }
 
+    @Test
     public void testFetchPostFormats() throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE,

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
@@ -21,6 +22,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     @Inject TaxonomyStore mTaxonomyStore;
@@ -45,7 +51,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     private TestEvents mNextEvent;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -55,6 +61,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testFetchCategories() throws InterruptedException {
         mNextEvent = TestEvents.CATEGORIES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -67,6 +74,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(categories.size() > 0);
     }
 
+    @Test
     public void testFetchTags() throws InterruptedException {
         mNextEvent = TestEvents.TAGS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -79,6 +87,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(tags.size() > 0);
     }
 
+    @Test
     public void testFetchTermsForInvalidTaxonomy() throws InterruptedException {
         mNextEvent = TestEvents.ERROR_INVALID_TAXONOMY;
         mCountDownLatch = new CountDownLatch(1);
@@ -92,6 +101,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
     public void testFetchSingleCategory() throws InterruptedException {
         mNextEvent = TestEvents.TERM_UPDATED;
         mCountDownLatch = new CountDownLatch(1);
@@ -110,6 +120,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, fetchedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUploadNewCategory() throws InterruptedException {
         // Instantiate new category
         TermModel term = createNewCategory();
@@ -126,11 +137,13 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUpdateExistingCategory() throws InterruptedException {
         TermModel term = createNewCategory();
         testUpdateExistingTerm(term);
     }
 
+    @Test
     public void testUploadNewTag() throws InterruptedException {
         // Instantiate new tag
         TermModel term = createNewTag();
@@ -147,11 +160,13 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUpdateExistingTag() throws InterruptedException {
         TermModel term = createNewTag();
         testUpdateExistingTerm(term);
     }
 
+    @Test
     public void testDeleteTag() throws InterruptedException {
         TermModel term = createNewTag();
         setupTermAttributes(term);
@@ -164,6 +179,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(0, WellSqlUtils.getTotalTermsCount());
     }
 
+    @Test
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
         TaxonomyModel taxonomyModel = new TaxonomyModel();
         taxonomyModel.setName(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
@@ -183,6 +199,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUploadTermForInvalidTaxonomy() throws InterruptedException {
         TaxonomyModel taxonomyModel = new TaxonomyModel();
         taxonomyModel.setName("roads");
@@ -203,6 +220,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(0, failedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUploadNewCategoryDuplicate() throws InterruptedException {
         // Instantiate new category
         TermModel term = createNewCategory();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
@@ -22,6 +23,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Inject TaxonomyStore mTaxonomyStore;
@@ -47,7 +53,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private TaxonomyError mLastTaxonomyError;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -59,6 +65,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mLastTaxonomyError = null;
     }
 
+    @Test
     public void testFetchCategories() throws InterruptedException {
         mNextEvent = TestEvents.CATEGORIES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -71,6 +78,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(categories.size() > 0);
     }
 
+    @Test
     public void testFetchTags() throws InterruptedException {
         mNextEvent = TestEvents.TAGS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -83,6 +91,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(tags.size() > 0);
     }
 
+    @Test
     public void testFetchTermsForInvalidTaxonomy() throws InterruptedException {
         mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
@@ -100,6 +109,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid taxonomy.", mLastTaxonomyError.message);
     }
 
+    @Test
     public void testFetchSingleCategory() throws InterruptedException {
         mNextEvent = TestEvents.TERM_UPDATED;
         mCountDownLatch = new CountDownLatch(1);
@@ -119,6 +129,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, fetchedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUploadNewCategory() throws InterruptedException {
         // Instantiate new category
         TermModel term = createNewCategory();
@@ -135,11 +146,13 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUpdateExistingCategory() throws InterruptedException {
         TermModel term = createNewCategory();
         testUpdateExistingTerm(term);
     }
 
+    @Test
     public void testUploadNewTag() throws InterruptedException {
         // Instantiate new tag
         TermModel term = createNewTag();
@@ -156,11 +169,13 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUpdateExistingTag() throws InterruptedException {
         TermModel term = createNewTag();
         testUpdateExistingTerm(term);
     }
 
+    @Test
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
         TaxonomyModel taxonomyModel = new TaxonomyModel();
         taxonomyModel.setName(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
@@ -180,6 +195,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
     }
 
+    @Test
     public void testUploadTermForInvalidTaxonomy() throws InterruptedException {
         TaxonomyModel taxonomyModel = new TaxonomyModel();
         taxonomyModel.setName("roads");
@@ -204,6 +220,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("Invalid taxonomy.", mLastTaxonomyError.message);
     }
 
+    @Test
     public void testUploadNewCategoryDuplicate() throws InterruptedException {
         // Instantiate new category
         TermModel term = createNewCategory();
@@ -227,6 +244,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals("A term with the name provided already exists with this parent.", mLastTaxonomyError.message);
     }
 
+    @Test
     public void testDeleteTag() throws InterruptedException {
         TermModel term = createNewTag();
         setupTermAttributes(term);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.ThemeAction;
 import org.wordpress.android.fluxc.example.test.BuildConfig;
@@ -23,6 +24,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     enum TestEvents {
@@ -48,7 +55,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     private static final String EDIN_THEME_ID = "edin-wpcom";
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -57,6 +64,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testFetchInstalledThemes() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
@@ -72,6 +80,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testFetchCurrentTheme() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
@@ -85,6 +94,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testActivateTheme() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
@@ -111,6 +121,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testInstallTheme() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
         final String themeId = EDIN_THEME_ID;
@@ -137,6 +148,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testDeleteTheme() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
         final String themeId = EDIN_THEME_ID;
@@ -166,6 +178,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
     public void testRemoveSiteThemes() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.model.ThemeModel;
@@ -16,6 +17,12 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     enum TestEvents {
         NONE,
@@ -29,7 +36,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     private TestEvents mNextEvent;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -38,6 +45,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testFetchCurrentTheme() throws InterruptedException {
         // Make sure no theme is active at first
         assertNull(mThemeStore.getActiveThemeForSite(sSite));
@@ -45,6 +53,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         assertNotNull(currentTheme);
     }
 
+    @Test
     public void testFetchWPComThemes() throws InterruptedException {
         // verify themes don't already exist in store
         assertTrue(mThemeStore.getWpComThemes().isEmpty());
@@ -59,6 +68,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         }
     }
 
+    @Test
     public void testActivateTheme() throws InterruptedException {
         // Make sure no theme is active at first
         assertNull(mThemeStore.getActiveThemeForSite(sSite));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
@@ -107,7 +107,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
 
         // Confirm that the corresponding MediaUploadModel's state has been updated automatically
         mediaUploadModel = getMediaUploadModelForMediaModel(testMedia);
-        assertEquals(1F, mUploadStore.getUploadProgressForMedia(testMedia));
+        assertEquals(1F, mUploadStore.getUploadProgressForMedia(testMedia), 0.1);
         assertEquals(MediaUploadModel.COMPLETED, mediaUploadModel.getUploadState());
 
         // Delete test image

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.action.UploadAction;
@@ -40,6 +41,13 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
     private static final String POST_DEFAULT_TITLE = "UploadTest base post";
     private static final String POST_DEFAULT_DESCRIPTION = "Hi there, I'm a post from FluxC!";
@@ -65,7 +73,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
     private long mLastUploadedId = -1L;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
 
@@ -73,6 +81,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         init();
     }
 
+    @Test
     public void testUploadImage() throws InterruptedException {
         // Start uploading media
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -110,6 +119,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         assertNull(getMediaUploadModelForMediaModel(testMedia));
     }
 
+    @Test
     public void testUploadInvalidMedia() throws InterruptedException {
         // Start uploading media
         MediaModel testMedia = newMediaModel(getSampleImagePath(), "not-even-close/to-an-actual-mime-type");
@@ -137,6 +147,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         assertNull(getMediaUploadModelForMediaModel(testMedia));
     }
 
+    @Test
     public void testCancelImageUpload() throws InterruptedException {
         // First, try canceling an image with the default behavior (canceled image is deleted from the store)
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
@@ -184,6 +195,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         assertEquals(MediaUploadModel.FAILED, mediaUploadModel.getUploadState());
     }
 
+    @Test
     public void testRegisterAndUploadPost() throws InterruptedException {
         // Instantiate new post
         createNewPost();
@@ -212,6 +224,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         assertNull(getPostUploadModelForPostModel(uploadedPost));
     }
 
+    @Test
     public void testRegisterAndUploadInvalidPost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
@@ -247,6 +260,7 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         assertEquals(PostErrorType.UNKNOWN_POST, PostErrorType.fromString(postUploadModel.getErrorType()));
     }
 
+    @Test
     public void testRegisterPostAndUploadMedia() throws InterruptedException {
         // Start uploading media
         MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -21,6 +21,10 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class ReleaseStack_WPComBase extends ReleaseStack_Base {
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.release;
 import junit.framework.Assert;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType;
@@ -20,6 +21,10 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     @Inject PluginStore mPluginStore;
 
@@ -35,7 +40,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
     private int mSearchPage;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         mReleaseStackAppComponent.inject(this);
         // Register
@@ -44,6 +49,7 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         mNextEvent = TestEvents.NONE;
     }
 
+    @Test
     public void testFetchWPOrgPlugin() throws InterruptedException {
         String slug = "akismet";
         mNextEvent = TestEvents.WPORG_PLUGIN_FETCHED;

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -66,7 +66,8 @@ dependencies {
     // WordPress libs
     implementation ('org.wordpress:utils:1.16.0') {
         // Using official volley package
-        exclude group: "com.mcxiaoke.volley";
+        exclude group: "com.mcxiaoke.volley"
+        exclude group: "com.android.support"
     }
 
     // Custom WellSql version

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
@@ -15,7 +15,11 @@ public class UserAgent {
         // E.g.:
         //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
         //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
-        mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
+        try {
+            mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
+        } catch (RuntimeException re) {
+            mDefaultUserAgent = "Mozilla/5.0 (Linux; Android 6.0; default FluxC UA; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36";
+        }
         // User-Agent string when making HTTP connections, for both API traffic and WebViews.
         // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
         // to get the full feature list of the browser and serve content accordingly, e.g.:

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -55,7 +55,8 @@ dependencies {
     // WordPress libs
     implementation ('org.wordpress:utils:1.16.0') {
         // Using official volley package
-        exclude group: "com.mcxiaoke.volley";
+        exclude group: "com.mcxiaoke.volley"
+        exclude group: "com.android.support"
     }
 
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"


### PR DESCRIPTION
Purpose of the PR is to replace InstrumentationTestCase by JUnit tests. Tests will run independently and if one crashes, the test suite will continue.

This PR replaces the previous #702