### PR TITLE
Add slug to all site plugin events

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -102,8 +102,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.CONFIGURED_SITE_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
 
-        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, immutablePlugin.getName(), isActive,
-                immutablePlugin.isAutoUpdateEnabled());
+        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, immutablePlugin.getName(),
+                immutablePlugin.getSlug(), isActive, immutablePlugin.isAutoUpdateEnabled());
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -163,12 +163,13 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
     public void testConfigureUnknownPluginError() throws InterruptedException {
         SiteModel site = authenticateAndRetrieveSingleJetpackSite();
-        String pluginName = "this-plugin-does-not-exist";
+        String pluginName = "this-plugin-does-not-exist-name";
+        String pluginSlug = "this-plugin-does-not-exist-slug";
 
         mNextEvent = TestEvents.UNKNOWN_SITE_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
 
-        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, pluginName, false, false);
+        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, pluginName, pluginSlug, false, false);
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -458,8 +459,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.CONFIGURED_SITE_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
 
-        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin.getName(), false,
-                plugin.isAutoUpdateEnabled());
+        ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin.getName(), plugin.getSlug(),
+                false, plugin.isAutoUpdateEnabled());
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -218,8 +218,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         mNextEvent = TestEvents.DELETED_SITE_PLUGIN;
         mCountDownLatch = new CountDownLatch(1);
 
-        DeleteSitePluginPayload payload = new DeleteSitePluginPayload(site, immutablePlugin.getSlug(),
-                immutablePlugin.getName());
+        DeleteSitePluginPayload payload = new DeleteSitePluginPayload(site, immutablePlugin.getName(),
+                immutablePlugin.getSlug());
         mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(payload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -436,7 +436,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         Assert.assertTrue(!TextUtils.isEmpty(plugin.getName()));
         Assert.assertTrue(!TextUtils.isEmpty(plugin.getSlug()));
         mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(
-                new DeleteSitePluginPayload(site, plugin.getSlug(), plugin.getName())));
+                new DeleteSitePluginPayload(site, plugin.getName(), plugin.getSlug())));
         mNextEvent = testEvent;
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -82,8 +82,8 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void configureSitePlugin(@NonNull final SiteModel site, @NonNull final String pluginName, boolean isActive,
-                                    boolean isAutoUpdatesEnabled) {
+    public void configureSitePlugin(@NonNull final SiteModel site, @NonNull final String pluginName,
+                                    @NonNull final String slug, boolean isActive, boolean isAutoUpdatesEnabled) {
         String url = WPCOMREST.sites.site(site.getSiteId()).plugins.name(getEncodedPluginName(pluginName)).getUrlV1_2();
         Map<String, Object> params = new HashMap<>();
         params.put("active", isActive);
@@ -104,7 +104,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         ConfigureSitePluginError configurePluginError = new ConfigureSitePluginError(((
                                 WPComGsonNetworkError) networkError).apiError, networkError.message);
                         ConfiguredSitePluginPayload payload =
-                                new ConfiguredSitePluginPayload(site, pluginName, configurePluginError);
+                                new ConfiguredSitePluginPayload(site, pluginName, slug, configurePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload));
                     }
                 }
@@ -112,8 +112,8 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void deleteSitePlugin(@NonNull final SiteModel site, @NonNull final String slug,
-                                 @NonNull final String pluginName) {
+    public void deleteSitePlugin(@NonNull final SiteModel site, @NonNull final String pluginName,
+                                 @NonNull final String slug) {
         String url = WPCOMREST.sites.site(site.getSiteId()).
                 plugins.name(getEncodedPluginName(pluginName)).delete.getUrlV1_2();
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
@@ -165,7 +165,8 @@ public class PluginRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void updateSitePlugin(@NonNull final SiteModel site, @NonNull final String pluginName) {
+    public void updateSitePlugin(@NonNull final SiteModel site, @NonNull final String pluginName,
+                                 @NonNull final String slug) {
         String url = WPCOMREST.sites.site(site.getSiteId()).
                 plugins.name(getEncodedPluginName(pluginName)).update.getUrlV1_2();
         final WPComGsonRequest<PluginWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
@@ -184,7 +185,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                         UpdateSitePluginError updatePluginError
                                 = new UpdateSitePluginError(((WPComGsonNetworkError) networkError).apiError,
                                 networkError.message);
-                        UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, pluginName,
+                        UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, pluginName, slug,
                                 updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -56,10 +56,10 @@ public class PluginStore extends Store {
         public String slug;
         public String pluginName;
 
-        public DeleteSitePluginPayload(SiteModel site, String slug, String pluginName) {
+        public DeleteSitePluginPayload(SiteModel site, String pluginName, String slug) {
             this.site = site;
-            this.slug = slug;
             this.pluginName = pluginName;
+            this.slug = slug;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -36,13 +36,15 @@ public class PluginStore extends Store {
     public static class ConfigureSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public String pluginName;
+        public String slug;
         public boolean isActive;
         public boolean isAutoUpdateEnabled;
 
-        public ConfigureSitePluginPayload(SiteModel site, String pluginName, boolean isActive,
+        public ConfigureSitePluginPayload(SiteModel site, String pluginName, String slug, boolean isActive,
                                           boolean isAutoUpdateEnabled) {
             this.site = site;
             this.pluginName = pluginName;
+            this.slug = slug;
             this.isActive = isActive;
             this.isAutoUpdateEnabled = isAutoUpdateEnabled;
         }
@@ -102,10 +104,12 @@ public class PluginStore extends Store {
     public static class UpdateSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public String pluginName;
+        public String slug;
 
-        public UpdateSitePluginPayload(SiteModel site, String pluginName) {
+        public UpdateSitePluginPayload(SiteModel site, String pluginName, String slug) {
             this.site = site;
             this.pluginName = pluginName;
+            this.slug = slug;
         }
     }
 
@@ -115,17 +119,21 @@ public class PluginStore extends Store {
     public static class ConfiguredSitePluginPayload extends Payload<ConfigureSitePluginError> {
         public SiteModel site;
         public String pluginName;
+        public String slug;
         public SitePluginModel plugin;
 
         public ConfiguredSitePluginPayload(SiteModel site, SitePluginModel plugin) {
             this.site = site;
             this.plugin = plugin;
             this.pluginName = this.plugin.getName();
+            this.slug = this.plugin.getSlug();
         }
 
-        public ConfiguredSitePluginPayload(SiteModel site, String pluginName, ConfigureSitePluginError error) {
+        public ConfiguredSitePluginPayload(SiteModel site, String pluginName, String slug,
+                                           ConfigureSitePluginError error) {
             this.site = site;
             this.pluginName = pluginName;
+            this.slug = slug;
             this.error = error;
         }
     }
@@ -233,17 +241,20 @@ public class PluginStore extends Store {
     public static class UpdatedSitePluginPayload extends Payload<UpdateSitePluginError> {
         public SiteModel site;
         public String pluginName;
+        public String slug;
         public SitePluginModel plugin;
 
         public UpdatedSitePluginPayload(SiteModel site, SitePluginModel plugin) {
             this.site = site;
             this.plugin = plugin;
             this.pluginName = this.plugin.getName();
+            this.slug = this.plugin.getSlug();
         }
 
-        public UpdatedSitePluginPayload(SiteModel site, String pluginName, UpdateSitePluginError error) {
+        public UpdatedSitePluginPayload(SiteModel site, String pluginName, String slug, UpdateSitePluginError error) {
             this.site = site;
             this.pluginName = pluginName;
+            this.slug = slug;
             this.error = error;
         }
     }
@@ -471,9 +482,11 @@ public class PluginStore extends Store {
     public static class OnSitePluginConfigured extends OnChanged<ConfigureSitePluginError> {
         public SiteModel site;
         public String pluginName;
-        public OnSitePluginConfigured(SiteModel site, String pluginName) {
+        public String slug;
+        public OnSitePluginConfigured(SiteModel site, String pluginName, String slug) {
             this.site = site;
             this.pluginName = pluginName;
+            this.slug = slug;
         }
     }
 
@@ -481,9 +494,11 @@ public class PluginStore extends Store {
     public static class OnSitePluginDeleted extends OnChanged<DeleteSitePluginError> {
         public SiteModel site;
         public String pluginName;
-        public OnSitePluginDeleted(SiteModel site, String pluginName) {
+        public String slug;
+        public OnSitePluginDeleted(SiteModel site, String pluginName, String slug) {
             this.site = site;
             this.pluginName = pluginName;
+            this.slug = slug;
         }
     }
 
@@ -501,9 +516,11 @@ public class PluginStore extends Store {
     public static class OnSitePluginUpdated extends OnChanged<UpdateSitePluginError> {
         public SiteModel site;
         public String pluginName;
-        public OnSitePluginUpdated(SiteModel site, String pluginName) {
+        public String slug;
+        public OnSitePluginUpdated(SiteModel site, String pluginName, String slug) {
             this.site = site;
             this.pluginName = pluginName;
+            this.slug = slug;
         }
     }
 
@@ -640,11 +657,11 @@ public class PluginStore extends Store {
 
     private void configureSitePlugin(ConfigureSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.configureSitePlugin(payload.site, payload.pluginName, payload.isActive,
+            mPluginRestClient.configureSitePlugin(payload.site, payload.pluginName, payload.slug, payload.isActive,
                     payload.isAutoUpdateEnabled);
         } else {
             ConfigureSitePluginError error = new ConfigureSitePluginError(ConfigureSitePluginErrorType.NOT_AVAILABLE);
-            ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site,
+            ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site, payload.slug,
                     payload.pluginName, error);
             mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(errorPayload));
         }
@@ -652,7 +669,7 @@ public class PluginStore extends Store {
 
     private void deleteSitePlugin(DeleteSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.deleteSitePlugin(payload.site, payload.slug, payload.pluginName);
+            mPluginRestClient.deleteSitePlugin(payload.site, payload.pluginName, payload.slug);
         } else {
             DeleteSitePluginError error = new DeleteSitePluginError(DeleteSitePluginErrorType.NOT_AVAILABLE);
             DeletedSitePluginPayload errorPayload = new DeletedSitePluginPayload(payload.site, payload.slug,
@@ -706,12 +723,12 @@ public class PluginStore extends Store {
 
     private void updateSitePlugin(UpdateSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
-            mPluginRestClient.updateSitePlugin(payload.site, payload.pluginName);
+            mPluginRestClient.updateSitePlugin(payload.site, payload.pluginName, payload.slug);
         } else {
             UpdateSitePluginError error = new UpdateSitePluginError(
                     UpdateSitePluginErrorType.NOT_AVAILABLE);
             UpdatedSitePluginPayload errorPayload = new UpdatedSitePluginPayload(payload.site,
-                    payload.pluginName, error);
+                    payload.pluginName, payload.slug, error);
             mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(errorPayload));
         }
     }
@@ -728,7 +745,7 @@ public class PluginStore extends Store {
     // Network callbacks
 
     private void configuredSitePlugin(ConfiguredSitePluginPayload payload) {
-        OnSitePluginConfigured event = new OnSitePluginConfigured(payload.site, payload.pluginName);
+        OnSitePluginConfigured event = new OnSitePluginConfigured(payload.site, payload.pluginName, payload.slug);
         if (payload.isError()) {
             event.error = payload.error;
         } else {
@@ -738,7 +755,7 @@ public class PluginStore extends Store {
     }
 
     private void deletedSitePlugin(DeletedSitePluginPayload payload) {
-        OnSitePluginDeleted event = new OnSitePluginDeleted(payload.site, payload.pluginName);
+        OnSitePluginDeleted event = new OnSitePluginDeleted(payload.site, payload.pluginName, payload.slug);
         // If the remote returns `UNKNOWN_PLUGIN` error, it means the plugin is not installed in remote anymore
         // most likely because the plugin is already removed on a different client and it was not synced yet.
         // Since we are trying to remove an already removed plugin, we should just remove it from DB and treat it as a
@@ -819,7 +836,7 @@ public class PluginStore extends Store {
     }
 
     private void updatedSitePlugin(UpdatedSitePluginPayload payload) {
-        OnSitePluginUpdated event = new OnSitePluginUpdated(payload.site, payload.pluginName);
+        OnSitePluginUpdated event = new OnSitePluginUpdated(payload.site, payload.pluginName, payload.slug);
         if (payload.isError()) {
             event.error = payload.error;
         } else {


### PR DESCRIPTION
This is small PR that adds the `slug` field to all the site plugin events (and payloads as a result). I didn't think this was necessary, because in WPAndroid in plugin detail page, we knew the plugin name for these events, so we didn't really need the slug since there was only single plugin. However, now that I am handling these events for plugin lists, I found that I couldn't figure out which plugin the event is about without it's slug.

/cc @theck13 (for the review) @nbradbury (to keep you in the loop for plugin changes)