### PR TITLE
Fixes checkstyle issues on Windows

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -65,12 +65,12 @@
     </module>
 
     <module name="RegexpMultiline">
-        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Store[\s{]"/>
+        <property name="format" value="(?&lt;!^@Singleton)^(\n|\r\n).*extends Store[\s{]"/>
         <property name="message" value="Stores must be annotated with @Singleton"/>
     </module>
 
     <module name="RegexpMultiline">
-        <property name="format" value="(?&lt;!^@Singleton)\n.*extends \w.*Client[\s{]"/>
+        <property name="format" value="(?&lt;!^@Singleton)^(\n|\r\n).*extends \w.*Client[\s{]"/>
         <property name="message" value="Network clients must be annotated with @Singleton"/>
     </module>
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -35,13 +35,13 @@
 
     <module name="RegexpMultiline">
       <property name="format"
-                value="\n[\t ]*\n[\t ]*\}"/>
+                value="(\n|\r\n)[\t ]*(\n|\r\n)[\t ]*\}"/>
       <property name="message" value="Empty line not allowed before brace"/>
     </module>
 
     <module name="RegexpMultiline">
       <property name="format"
-                value="\{[\t ]*\n[\t ]*\n"/>
+                value="\{[\t ]*(\n|\r\n)[\t ]*(\n|\r\n)"/>
       <property name="message" value="Empty line not allowed after brace"/>
     </module>
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -65,12 +65,12 @@
     </module>
 
     <module name="RegexpMultiline">
-        <property name="format" value="(?&lt;!^@Singleton)^(\n|\r\n).*extends Store[\s{]"/>
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Store[\s{]"/>
         <property name="message" value="Stores must be annotated with @Singleton"/>
     </module>
 
     <module name="RegexpMultiline">
-        <property name="format" value="(?&lt;!^@Singleton)^(\n|\r\n).*extends \w.*Client[\s{]"/>
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends \w.*Client[\s{]"/>
         <property name="message" value="Network clients must be annotated with @Singleton"/>
     </module>
 


### PR DESCRIPTION
I've had these false positive and false negative checkstyle issues for a while on Windows. I finally got around to fixing them. I've tested these changes on both Mac and Windows and it looks like everything is working as expected. The only thing I am confused about is why we need that `^` for the `@Singleton` checkstyles.

/cc @aforcier 