### PR TITLE
Feature/stock photos media model

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -6,6 +6,7 @@
         <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:FluxC Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
+        <entry key="last-active-plugin-version" value="5.16.3" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
         <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:FluxC Style" />

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -6,7 +6,6 @@
         <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:FluxC Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
-        <entry key="last-active-plugin-version" value="5.16.3" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
         <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:FluxC Style" />

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/StockMediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/StockMediaModel.java
@@ -1,0 +1,155 @@
+package org.wordpress.android.fluxc.model;
+
+import org.wordpress.android.fluxc.Payload;
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
+import org.wordpress.android.util.StringUtils;
+
+public class StockMediaModel extends Payload<BaseNetworkError> {
+    private String mId;
+    private String mExtension;
+    private String mFile;
+    private String mGuid;
+    private String mName;
+    private String mTitle;
+    private String mType;
+    private String mUrl;
+    private String mDate;
+
+    private String mLargeThumbnail;
+    private String mMediumThumbnail;
+    private String mPostThumbnail;
+    private String mThumbnail;
+
+    private int mHeight;
+    private int mWidth;
+
+    public String getId() {
+        return mId;
+    }
+
+    public void setId(String id) {
+        this.mId = id;
+    }
+
+    public String getExtension() {
+        return mExtension;
+    }
+
+    public void setExtension(String extension) {
+        this.mExtension = extension;
+    }
+
+    public String getFile() {
+        return mFile;
+    }
+
+    public void setFile(String file) {
+        this.mFile = file;
+    }
+
+    public String getGuid() {
+        return mGuid;
+    }
+
+    public void setGuid(String guid) {
+        this.mGuid = guid;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public void setName(String name) {
+        this.mName = name;
+    }
+
+    public String getTitle() {
+        return mTitle;
+    }
+
+    public void setTitle(String title) {
+        this.mTitle = title;
+    }
+
+    public String getType() {
+        return mType;
+    }
+
+    public void setType(String type) {
+        this.mType = type;
+    }
+
+    public String getUrl() {
+        return mUrl;
+    }
+
+    public void setUrl(String url) {
+        this.mUrl = url;
+    }
+
+    public String getDate() {
+        return mDate;
+    }
+
+    public void setDate(String date) {
+        this.mDate = date;
+    }
+
+    public String getLargeThumbnail() {
+        return mLargeThumbnail;
+    }
+
+    public void setLargeThumbnail(String largeThumbnail) {
+        this.mLargeThumbnail = largeThumbnail;
+    }
+
+    public String getMediumThumbnail() {
+        return mMediumThumbnail;
+    }
+
+    public void setMediumThumbnail(String mediumThumbnail) {
+        this.mMediumThumbnail = mediumThumbnail;
+    }
+
+    public String getPostThumbnail() {
+        return mPostThumbnail;
+    }
+
+    public void setPostThumbnail(String postThumbnail) {
+        this.mPostThumbnail = postThumbnail;
+    }
+
+    public String getThumbnail() {
+        return mThumbnail;
+    }
+
+    public void setThumbnail(String thumbnail) {
+        this.mThumbnail = thumbnail;
+    }
+
+    public int getHeight() {
+        return mHeight;
+    }
+
+    public void setHeight(int height) {
+        this.mHeight = height;
+    }
+
+    public int getWidth() {
+        return mWidth;
+    }
+
+    public void setWidth(int width) {
+        this.mWidth = width;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || !(other instanceof StockMediaModel)) return false;
+
+        StockMediaModel otherMedia = (StockMediaModel) other;
+
+        return StringUtils.equals(this.getId(), otherMedia.getId());
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/StockMediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/StockMediaRestClient.java
@@ -13,16 +13,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 
 import javax.inject.Singleton;
 
-import okhttp3.OkHttpClient;
-
 @Singleton
 public class StockMediaRestClient extends BaseWPComRestClient {
-    private OkHttpClient mOkHttpClient;
-
     public StockMediaRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
-                                OkHttpClient okHttpClient, AccessToken accessToken, UserAgent userAgent) {
+                                AccessToken accessToken, UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
-        mOkHttpClient = okHttpClient;
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/StockMediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/StockMediaRestClient.java
@@ -1,0 +1,58 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.media;
+
+import android.content.Context;
+
+import com.android.volley.RequestQueue;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.model.StockMediaModel;
+import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
+
+import javax.inject.Singleton;
+
+import okhttp3.OkHttpClient;
+
+@Singleton
+public class StockMediaRestClient extends BaseWPComRestClient {
+    private OkHttpClient mOkHttpClient;
+
+    public StockMediaRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
+                                OkHttpClient okHttpClient, AccessToken accessToken, UserAgent userAgent) {
+        super(appContext, dispatcher, requestQueue, accessToken, userAgent);
+        mOkHttpClient = okHttpClient;
+    }
+
+    /**
+     * Creates a {@link StockMediaModel} from a WP.com REST response to a fetch request.
+     */
+    private StockMediaModel getStockMediaFromRestResponse(final StockMediaWPComRestResponse from) {
+        if (from == null) return null;
+
+        final StockMediaModel media = new StockMediaModel();
+
+        media.setId(from.ID);
+        media.setDate(from.date);
+        media.setExtension(from.extension);
+        media.setUrl(from.URL);
+        media.setGuid(from.guid);
+        media.setFile(from.file);
+        media.setTitle(StringEscapeUtils.unescapeHtml4(from.title));
+        media.setName(StringEscapeUtils.unescapeHtml4(from.name));
+        media.setType(from.type);
+
+        media.setHeight(from.height);
+        media.setWidth(from.width);
+
+        if (from.thumbnails != null) {
+            media.setThumbnail(from.thumbnails.thumbnail);
+            media.setLargeThumbnail(from.thumbnails.large);
+            media.setMediumThumbnail(from.thumbnails.medium);
+            media.setPostThumbnail(from.thumbnails.post_thumbnail);
+        }
+
+        return media;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/StockMediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/StockMediaWPComRestResponse.java
@@ -6,6 +6,13 @@ import org.wordpress.android.fluxc.network.Response;
  * Response to GET request for stock media items
  */
 public class StockMediaWPComRestResponse implements Response {
+    public class Thumbnails {
+        public String thumbnail;
+        public String medium;
+        public String large;
+        public String post_thumbnail;
+    }
+
     public String ID;
     public String date;
     public String extension;
@@ -19,5 +26,5 @@ public class StockMediaWPComRestResponse implements Response {
     public int height;
     public int width;
 
-    public MediaWPComRestResponse.Thumbnails thumbnails;
+    public Thumbnails thumbnails;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/StockMediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/StockMediaWPComRestResponse.java
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.media;
+
+import org.wordpress.android.fluxc.network.Response;
+
+/**
+ * Response to GET request for stock media items
+ */
+public class StockMediaWPComRestResponse implements Response {
+    public String ID;
+    public String date;
+    public String extension;
+    public String URL;
+    public String guid;
+    public String file;
+    public String title;
+    public String name;
+    public String type;
+
+    public int height;
+    public int width;
+
+    public MediaWPComRestResponse.Thumbnails thumbnails;
+}


### PR DESCRIPTION
Addresses #724 - this simple first step to adding support for stock photos merely adds a new `StockMediaModel` and a skeleton for `StockMediaRestClient` (which currently has nothing except the code to parse the response from a request for stock photos).

Note that unlike the other models, `StockMediaModel` will not be persisted because there's no reason to store the search results in SQlite.

See [the issue](https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/724) for an example response.