### PR TITLE
Activate plugin after it's installed

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -816,6 +816,14 @@ public class PluginStore extends Store {
             PluginSqlUtils.insertOrUpdateSitePlugin(payload.site, payload.plugin);
         }
         emitChange(event);
+
+        // Once the plugin is installed activate it and enable autoupdates
+        // This is only a temporary solution as we are trying to get this implemented on the server side
+        if (!payload.isError() && payload.plugin != null) {
+            ConfigureSitePluginPayload configurePayload = new ConfigureSitePluginPayload(payload.site,
+                    payload.plugin.getName(), payload.plugin.getSlug(), true, true);
+            mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(configurePayload));
+        }
     }
 
     private void searchedPluginDirectory(SearchedPluginDirectoryPayload payload) {


### PR DESCRIPTION
As discussed in https://github.com/wordpress-mobile/WordPress-Android/pull/7293 we are activating the plugin once it's installed in FluxC. I pinged @elibud for help to get this implemented on the server side, but until that's done we kind of have to live with this ugliness.

With this change it means WPAndroid will get both `onSitePluginInstalled` and `onSitePluginConfigured` events after an action is dispatched to install a new plugin. It also means that even if the user leaves the plugin detail page, the activation will happen and its result will be reflected in the plugin directory and plugin list pages.

The only thing to keep in mind is that, if the install is successful but the configuration fails, we'll end up showing an error to the user for an action they didn't initiate. However, there is not much we can do about that without complicating the code unnecessarily. So, hopefully server side folks will come through for us 🤞 

/cc @theck13 