### PR TITLE
Have /domains/suggestions/ call be authenticated

### DIFF
--- a/example/src/main/res/layout/fragment_signed_out_actions.xml
+++ b/example/src/main/res/layout/fragment_signed_out_actions.xml
@@ -39,7 +39,7 @@
         android:id="@+id/domain_suggestions"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Domain suggestions" />
+        android:text="Domain suggestions (results differ if authenticated)" />
 
     <Button
         android:id="@+id/connect_site_info"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -343,7 +343,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                         new Listener<ArrayList<DomainSuggestionResponse>>() {
                             @Override
                             public void onResponse(ArrayList<DomainSuggestionResponse> response) {
-                                SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query, response);
+                                SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query,
+                                        response);
                                 mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
                             }
                         },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -327,6 +327,37 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void suggestDomains(@NonNull final String query, final boolean onlyWordpressCom,
+                               final boolean includeWordpressCom, final boolean includeDotBlogSubdomain,
+                               final int quantity) {
+        String url = WPCOMREST.domains.suggestions.getUrlV1_1();
+        Map<String, String> params = new HashMap<>(4);
+        params.put("query", query);
+        params.put("only_wordpressdotcom", String.valueOf(onlyWordpressCom)); // CHECKSTYLE IGNORE
+        params.put("include_wordpressdotcom", String.valueOf(includeWordpressCom)); // CHECKSTYLE IGNORE
+        params.put("include_dotblogsubdomain", String.valueOf(includeDotBlogSubdomain));
+        params.put("quantity", String.valueOf(quantity));
+        final WPComGsonRequest<ArrayList<DomainSuggestionResponse>> request =
+                WPComGsonRequest.buildGetRequest(url, params,
+                        new TypeToken<ArrayList<DomainSuggestionResponse>>(){}.getType(),
+                        new Listener<ArrayList<DomainSuggestionResponse>>() {
+                            @Override
+                            public void onResponse(ArrayList<DomainSuggestionResponse> response) {
+                                SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query, response);
+                                mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
+                            }
+                        },
+                        new BaseErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                                SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query, error);
+                                mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
+                            }
+                        }
+                );
+        add(request);
+    }
+
     //
     // Unauthenticated network calls
     //
@@ -454,37 +485,6 @@ public class SiteRestClient extends BaseWPComRestClient {
                             payload.error = error;
                         }
                         mDispatcher.dispatch(SiteActionBuilder.newCheckedIsWpcomUrlAction(payload));
-                    }
-                }
-        );
-        addUnauthedRequest(request);
-    }
-
-    public void suggestDomains(@NonNull final String query, final boolean onlyWordpressCom,
-                               final boolean includeWordpressCom, final boolean includeDotBlogSubdomain,
-                               final int quantity) {
-        String url = WPCOMREST.domains.suggestions.getUrlV1_1();
-        Map<String, String> params = new HashMap<>(4);
-        params.put("query", query);
-        params.put("only_wordpressdotcom", String.valueOf(onlyWordpressCom)); // CHECKSTYLE IGNORE
-        params.put("include_wordpressdotcom", String.valueOf(includeWordpressCom)); // CHECKSTYLE IGNORE
-        params.put("include_dotblogsubdomain", String.valueOf(includeDotBlogSubdomain));
-        params.put("quantity", String.valueOf(quantity));
-        final WPComGsonRequest<ArrayList<DomainSuggestionResponse>> request =
-                WPComGsonRequest.buildGetRequest(url, params,
-                        new TypeToken<ArrayList<DomainSuggestionResponse>>(){}.getType(),
-                new Listener<ArrayList<DomainSuggestionResponse>>() {
-                    @Override
-                    public void onResponse(ArrayList<DomainSuggestionResponse> response) {
-                        SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query, response);
-                        mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
-                    }
-                },
-                new BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query, error);
-                        mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
                     }
                 }
         );


### PR DESCRIPTION
Fixes #730 

* Have `suggestDomains()` do its call authenticated
* Move the `suggestDomains()` call up in the module to be closer to the rest of the authenticated calls source code