### PR TITLE
Import checkstyle and code style config changes from WPAndroid

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:FluxC Style" />
+        <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:FluxC Style" />
+        <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -10,7 +10,7 @@
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
         <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
-        <entry key="scanscope" value="JavaOnlyWithTests" />
+        <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />
       </map>
     </option>

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -10,7 +10,7 @@
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
         <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
-        <entry key="scanscope" value="AllSourcesWithTests" />
+        <entry key="scanscope" value="JavaOnlyWithTests" />
         <entry key="suppress-errors" value="false" />
       </map>
     </option>

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -3,6 +3,7 @@
   <component name="ProjectCodeStyleSettingsManager">
     <option name="PER_PROJECT_SETTINGS">
       <value>
+        <option name="FIELD_NAME_PREFIX" value="m" />
         <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
         <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
         <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -30,10 +30,14 @@
             <emptyLine />
           </value>
         </option>
+        <option name="ENABLE_JAVADOC_FORMATTING" value="false" />
         <option name="RIGHT_MARGIN" value="120" />
         <AndroidXmlCodeStyleSettings>
           <option name="USE_CUSTOM_SETTINGS" value="true" />
         </AndroidXmlCodeStyleSettings>
+        <JavaCodeStyleSettings>
+          <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+        </JavaCodeStyleSettings>
         <JetCodeStyleSettings>
           <option name="PACKAGES_TO_USE_STAR_IMPORTS">
             <value>
@@ -44,9 +48,6 @@
           <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
         </JetCodeStyleSettings>
         <Objective-C-extensions>
-          <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
-          <option name="RELEASE_STYLE" value="IVAR" />
-          <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
           <file>
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
@@ -72,11 +73,35 @@
           </extensions>
         </Objective-C-extensions>
         <XML>
-          <option name="XML_KEEP_LINE_BREAKS" value="false" />
-          <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-          <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
         <codeStyleSettings language="JAVA">
+          <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+          <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+          <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+          <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />
+          <option name="CALL_PARAMETERS_WRAP" value="1" />
+          <option name="METHOD_PARAMETERS_WRAP" value="1" />
+          <option name="RESOURCE_LIST_WRAP" value="1" />
+          <option name="EXTENDS_LIST_WRAP" value="1" />
+          <option name="THROWS_LIST_WRAP" value="1" />
+          <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+          <option name="THROWS_KEYWORD_WRAP" value="1" />
+          <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+          <option name="BINARY_OPERATION_WRAP" value="1" />
+          <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+          <option name="TERNARY_OPERATION_WRAP" value="1" />
+          <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+          <option name="FOR_STATEMENT_WRAP" value="1" />
+          <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+          <option name="ASSIGNMENT_WRAP" value="1" />
+          <option name="ASSERT_STATEMENT_WRAP" value="1" />
+          <option name="IF_BRACE_FORCE" value="3" />
+          <option name="DOWHILE_BRACE_FORCE" value="1" />
+          <option name="WHILE_BRACE_FORCE" value="1" />
+          <option name="FOR_BRACE_FORCE" value="3" />
+          <option name="WRAP_LONG_LINES" value="true" />
+          <option name="METHOD_ANNOTATION_WRAP" value="1" />
           <option name="FIELD_ANNOTATION_WRAP" value="1" />
         </codeStyleSettings>
         <codeStyleSettings language="XML">

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -32,7 +32,6 @@
             <emptyLine />
           </value>
         </option>
-        <option name="ENABLE_JAVADOC_FORMATTING" value="false" />
         <option name="RIGHT_MARGIN" value="120" />
         <AndroidXmlCodeStyleSettings>
           <option name="USE_CUSTOM_SETTINGS" value="true" />

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -78,7 +78,6 @@
         </XML>
         <codeStyleSettings language="JAVA">
           <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
-          <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
           <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
           <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />
           <option name="CALL_PARAMETERS_WRAP" value="1" />

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -4,6 +4,7 @@
     <option name="PER_PROJECT_SETTINGS">
       <value>
         <option name="FIELD_NAME_PREFIX" value="m" />
+        <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
         <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
         <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
         <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -5,6 +5,9 @@
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="ignoreSwitchStatementsWithDefault" value="false" />
     </inspection_tool>
+    <inspection_tool class="IllegalIdentifier" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="Tests" level="ERROR" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,6 @@ allprojects {
 
     task checkstyle(type: Checkstyle) {
         source 'src'
-        include '**/*.java'
-        include '**/*.kt'
-        include '**/*.xml'
-        exclude '**/gen/**'
 
         classpath = files()
     }

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -82,7 +82,7 @@
 
     <!-- Specific to FluxC -->
     <module name="RegexpMultiline">
-        <property name="format" value="(?&lt;!^@Singleton)\n.*extends \w.*Client[\s{]"/>
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends (BaseWPComRestClient|BaseXMLRPCClient|BaseWPAPIRestClient|BaseWPOrgAPIClient)[\s{]"/>
         <property name="message" value="Network clients must be annotated with @Singleton"/>
     </module>
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -4,6 +4,10 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+    <!-- Restricts scan to specific extensions.           -->
+    <!-- See http://checkstyle.sf.net/config.html#Checker -->
+    <property name="fileExtensions" value="java, kt, xml"/>
+
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
     <module name="NewlineAtEndOfFile"/>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -8,6 +8,12 @@
     <!-- See http://checkstyle.sf.net/config.html#Checker -->
     <property name="fileExtensions" value="java, kt, xml"/>
 
+    <!-- Excludes given file patterns from scan.              -->
+    <!-- See http://checkstyle.sf.net/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="[/\\]gen[/\\]"/>
+    </module>
+
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
     <module name="NewlineAtEndOfFile"/>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -82,7 +82,7 @@
 
     <!-- Specific to FluxC -->
     <module name="RegexpMultiline">
-        <property name="format" value="(?&lt;!^@Singleton)\n.*extends (BaseWPComRestClient|BaseXMLRPCClient|BaseWPAPIRestClient|BaseWPOrgAPIClient)[\s{]"/>
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Base[\w]*Client[\s{]"/>
         <property name="message" value="Network clients must be annotated with @Singleton"/>
     </module>
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -52,7 +52,7 @@
     </module>
 
     <module name="RegexpSingleline">
-        <property name="format" value="@[\S]*(\([{]?\&quot;.*\&quot;[}]?\)++|\([^\&quot;]*\)++)[^ \t]"/>
+        <property name="format" value="[^\S\r\n]@[\S]*(\([{]?\&quot;.*\&quot;[}]?\)++|\([^\&quot;]*\)++)[^ \t]"/>
         <property name="message" value="In-line annotations must be followed by one whitespace"/>
         <property name="severity" value="error"/>
     </module>
@@ -74,25 +74,27 @@
         <property name="severity" value="error"/>
     </module>
 
+    <!-- Specific to FluxC -->
     <module name="RegexpMultiline">
         <property name="format" value="(?&lt;!^@Singleton)\n.*extends Store[\s{]"/>
         <property name="message" value="Stores must be annotated with @Singleton"/>
     </module>
 
+    <!-- Specific to FluxC -->
     <module name="RegexpMultiline">
         <property name="format" value="(?&lt;!^@Singleton)\n.*extends \w.*Client[\s{]"/>
         <property name="message" value="Network clients must be annotated with @Singleton"/>
     </module>
 
-    <!-- Specific to FluxC / WordPress -->
+    <!-- Specific to WordPress -->
     <module name="RegexpSingleline">
       <property name="format" value=".*dotcom(?!.*checkstyle ignore)"/>
       <property name="ignoreCase" value="true"/>
-      <property name="message" value="Kim is not happy, you should not use _dotcom_, use _wpcom_ instead"/>
+      <property name="message" value="You should not use _dotcom_, use _wpcom_ instead"/>
       <property name="severity" value="error"/>
     </module>
 
-    <!-- Specific to FluxC / WordPress -->
+    <!-- Specific to WordPress -->
     <module name="RegexpSingleline">
       <property name="format" value=".*dotorg(?!.*checkstyle ignore)"/>
       <property name="ignoreCase" value="true"/>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -46,7 +46,7 @@
     </module>
 
     <module name="RegexpSingleline">
-      <property name="format" value=" \/\/[^ \t]"/>
+      <property name="format" value=" \/\/(?!noinspection)[^ \t]"/>
       <property name="message" value="Line comments '//' must be followed by one whitespace"/>
       <property name="severity" value="error"/>
     </module>


### PR DESCRIPTION
Brings in the latest changes from WPAndroid, consolidating new changes here with those we made for the refactor on that side.

Once this is done, we can update https://github.com/Automattic/style-config-android, and import the fetchstyle gradle plugin in both projects 🎉

cc @maxme 