### PR TITLE
Add gradle fetchstyle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,11 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.automattic.android:fetchstyle:1.0'
     }
 }
+
+apply plugin: 'com.automattic.android.fetchstyle'
 
 allprojects {
     apply plugin: 'checkstyle'


### PR DESCRIPTION
Adds our [gradle fetchstyle plugin](https://github.com/Automattic/style-config-android/tree/develop/fetchstyle-gradle) to the project.

To fetch style files using the fetchstyle plugin:

```
$ ./gradlew downloadConfigs
```

There are also more narrow tasks to only update certain files if necessary, they're defined [here](https://github.com/Automattic/style-config-android/blob/03b0557ea931299fd440de68252e4900e6e9a502/fetchstyle-gradle/src/main/groovy/com/automattic/android/fetchstyle/FetchStylePlugin.groovy).