### PR TITLE
Localize account creation

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -68,8 +68,9 @@ public class MockedNetworkModule {
 
     @Singleton
     @Provides
-    public Authenticator provideAuthenticator(Dispatcher dispatcher, AppSecrets appSecrets, RequestQueue requestQueue) {
-        Authenticator authenticator = new Authenticator(dispatcher, requestQueue, appSecrets);
+    public Authenticator provideAuthenticator(Context appContext, Dispatcher dispatcher, AppSecrets appSecrets,
+                                              RequestQueue requestQueue) {
+        Authenticator authenticator = new Authenticator(appContext, dispatcher, requestQueue, appSecrets);
         Authenticator spy = spy(authenticator);
 
         // Mock Authenticator with correct user: test/test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -73,9 +73,9 @@ public class ReleaseNetworkModule {
 
     @Singleton
     @Provides
-    public Authenticator provideAuthenticator(Dispatcher dispatcher, AppSecrets appSecrets,
+    public Authenticator provideAuthenticator(Context appContext, Dispatcher dispatcher, AppSecrets appSecrets,
                                               @Named("regular") RequestQueue requestQueue) {
-        return new Authenticator(dispatcher, requestQueue, appSecrets);
+        return new Authenticator(appContext, dispatcher, requestQueue, appSecrets);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -18,8 +18,9 @@ import org.wordpress.android.util.LanguageUtils;
 
 public abstract class BaseWPComRestClient {
     private AccessToken mAccessToken;
-    private final Context mAppContext;
     private final RequestQueue mRequestQueue;
+
+    protected final Context mAppContext;
     protected final Dispatcher mDispatcher;
     protected UserAgent mUserAgent;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -18,9 +18,9 @@ import org.wordpress.android.util.LanguageUtils;
 
 public abstract class BaseWPComRestClient {
     private AccessToken mAccessToken;
+    private final Context mAppContext;
     private final RequestQueue mRequestQueue;
 
-    protected final Context mAppContext;
     protected final Dispatcher mDispatcher;
     protected UserAgent mUserAgent;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -38,6 +38,7 @@ import org.wordpress.android.fluxc.store.AccountStore.NewUserError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.LanguageUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -595,6 +596,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         body.put("validate", dryRun ? "1" : "0");
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());
+        body.put("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
 
         WPComGsonRequest<AccountBoolResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 AccountBoolResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -38,7 +38,6 @@ import org.wordpress.android.fluxc.store.AccountStore.NewUserError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.LanguageUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -596,8 +595,6 @@ public class AccountRestClient extends BaseWPComRestClient {
         body.put("validate", dryRun ? "1" : "0");
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());
-        body.put("locale", LanguageUtils.patchDeviceLanguageCode(
-                LanguageUtils.getCurrentDeviceLanguage(mAppContext).getLanguage()));
 
         WPComGsonRequest<AccountBoolResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 AccountBoolResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -596,7 +596,8 @@ public class AccountRestClient extends BaseWPComRestClient {
         body.put("validate", dryRun ? "1" : "0");
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());
-        body.put("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
+        body.put("locale", LanguageUtils.patchDeviceLanguageCode(
+                LanguageUtils.getCurrentDeviceLanguage(mAppContext).getLanguage()));
 
         WPComGsonRequest<AccountBoolResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 AccountBoolResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -214,8 +214,6 @@ public class Authenticator {
         params.put("email", payload.emailOrUsername);
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
-        params.put("locale", LanguageUtils.patchDeviceLanguageCode(
-                LanguageUtils.getCurrentDeviceLanguage(mAppContext).getLanguage()));
 
         WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, params, AuthEmailWPComRestResponse.class,
                 new Response.Listener<AuthEmailWPComRestResponse>() {
@@ -238,6 +236,7 @@ public class Authenticator {
                     }
                 }
         );
+        request.addQueryParameter("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
 
         mRequestQueue.add(request);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -214,7 +214,8 @@ public class Authenticator {
         params.put("email", payload.emailOrUsername);
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
-        params.put("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
+        params.put("locale", LanguageUtils.patchDeviceLanguageCode(
+                LanguageUtils.getCurrentDeviceLanguage(mAppContext).getLanguage()));
 
         WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, params, AuthEmailWPComRestResponse.class,
                 new Response.Listener<AuthEmailWPComRestResponse>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.auth;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
@@ -27,6 +28,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.LanguageUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
@@ -57,6 +59,7 @@ public class Authenticator {
     private static final String INVALID_OTP_ERROR = "invalid_otp";
     private static final String INVALID_CREDS_ERROR = "Incorrect username or password.";
 
+    private final Context mAppContext;
     private final Dispatcher mDispatcher;
     private final RequestQueue mRequestQueue;
     private AppSecrets mAppSecrets;
@@ -76,7 +79,8 @@ public class Authenticator {
     }
 
     @Inject
-    public Authenticator(Dispatcher dispatcher, RequestQueue requestQueue, AppSecrets secrets) {
+    public Authenticator(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue, AppSecrets secrets) {
+        mAppContext = appContext;
         mDispatcher = dispatcher;
         mRequestQueue = requestQueue;
         mAppSecrets = secrets;
@@ -210,6 +214,7 @@ public class Authenticator {
         params.put("email", payload.emailOrUsername);
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
+        params.put("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
 
         WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, params, AuthEmailWPComRestResponse.class,
                 new Response.Listener<AuthEmailWPComRestResponse>() {


### PR DESCRIPTION
Addresses the account related part of #609 by setting the `locale` body param of the ~`/users/new` and~ `auth/send-signup-email`.

To test:
1. Put the device on the French language/locale
2. Run the example app and head over to the "Signed out actions" section
3. Tap on "Send magic link sign e-mail" and input an email you have access to but *not* already registered with WPCOM and hit "Next"
4. Access that email account and verify that a new email has arrived and it's in French