### PR TITLE
Update to ktlint 0.21.0

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -47,6 +47,7 @@
           </option>
           <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
           <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+          <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
         </JetCodeStyleSettings>
         <Objective-C-extensions>
           <file>
@@ -264,6 +265,7 @@
         <codeStyleSettings language="kotlin">
           <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
           <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+          <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
         </codeStyleSettings>
       </value>
     </option>

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     }
 
     dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.19.0'
+        ktlint 'com.github.shyiko:ktlint:0.21.0'
     }
 
     task ktlint(type: JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     }
 
     dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.14.0'
+        ktlint 'com.github.shyiko:ktlint:0.19.0'
     }
 
     task ktlint(type: JavaExec) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
@@ -76,8 +76,8 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
                 },
                 BaseErrorListener {
                     error -> run {
-                        throw AssertionError("Unexpected BaseNetworkError: "
-                                + (error as WPComGsonNetworkError).apiError + " - " + error.message)
+                        throw AssertionError("Unexpected BaseNetworkError: " +
+                                (error as WPComGsonNetworkError).apiError + " - " + error.message)
                     }
                 })
 
@@ -105,8 +105,8 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
                 },
                 BaseErrorListener {
                     error -> run {
-                        throw AssertionError("Unexpected BaseNetworkError: "
-                                + (error as WPComGsonNetworkError).apiError + " - " + error.message)
+                        throw AssertionError("Unexpected BaseNetworkError: " +
+                                (error as WPComGsonNetworkError).apiError + " - " + error.message)
                     }
                 })
 
@@ -115,9 +115,12 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
     }
 
     @Singleton
-    class JetpackTunnelClientForTests @Inject constructor(appContext: Context, dispatcher: Dispatcher,
-                                                          requestQueue: RequestQueue, accessToken: AccessToken,
-                                                          userAgent: UserAgent
+    class JetpackTunnelClientForTests @Inject constructor(
+        appContext: Context,
+        dispatcher: Dispatcher,
+        requestQueue: RequestQueue,
+        accessToken: AccessToken,
+        userAgent: UserAgent
     ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
         /**
          * Wraps and exposes the protected [add] method so that tests can add requests directly.

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -312,8 +312,8 @@ class MainFragment : Fragment() {
         }
         if (siteStore.hasSite()) {
             val firstSite = siteStore.sites[0]
-            prependToLog("First site name: " + firstSite.name + " - Total sites: " + siteStore.sitesCount
-                    + " - rowsAffected: " + event.rowsAffected)
+            prependToLog("First site name: " + firstSite.name + " - Total sites: " + siteStore.sitesCount +
+                    " - rowsAffected: " + event.rowsAffected)
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThreeEditTextDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThreeEditTextDialog.kt
@@ -56,7 +56,11 @@ class ThreeEditTextDialog : DialogFragment() {
 
     companion object {
         @JvmStatic
-        fun newInstance(onClickListener: Listener, text1Hint: String, text2Hint: String, text3Hint: String
+        fun newInstance(
+            onClickListener: Listener,
+            text1Hint: String,
+            text2Hint: String,
+            text3Hint: String
         ): ThreeEditTextDialog {
             val fragment = ThreeEditTextDialog()
             fragment.setListener(onClickListener)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -101,8 +101,13 @@ object JetpackTunnelGsonRequest {
      *
      * @param T the expected response object from the WP-API endpoint
      */
-    fun <T : Any> buildGetRequest(wpApiEndpoint: String, siteId: Long, params: Map<String, String>,
-                                  type: Type, listener: (T?) -> Unit, errorListener: BaseErrorListener
+    fun <T : Any> buildGetRequest(
+        wpApiEndpoint: String,
+        siteId: Long,
+        params: Map<String, String>,
+        type: Type,
+        listener: (T?) -> Unit,
+        errorListener: BaseErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedParams = createTunnelParams(params, wpApiEndpoint)
 
@@ -126,8 +131,13 @@ object JetpackTunnelGsonRequest {
      *
      * @param T the expected response object from the WP-API endpoint
      */
-    fun <T : Any> buildPostRequest(wpApiEndpoint: String, siteId: Long, body: Map<String, Any>,
-                                   type: Type, listener: (T?) -> Unit, errorListener: BaseErrorListener
+    fun <T : Any> buildPostRequest(
+        wpApiEndpoint: String,
+        siteId: Long,
+        body: Map<String, Any>,
+        type: Type,
+        listener: (T?) -> Unit,
+        errorListener: BaseErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "post", body = body, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
@@ -145,8 +155,13 @@ object JetpackTunnelGsonRequest {
      *
      * @param T the expected response object from the WP-API endpoint
      */
-    fun <T : Any> buildPatchRequest(wpApiEndpoint: String, siteId: Long, body: Map<String, Any>,
-                                    type: Type, listener: (T?) -> Unit, errorListener: BaseErrorListener
+    fun <T : Any> buildPatchRequest(
+        wpApiEndpoint: String,
+        siteId: Long,
+        body: Map<String, Any>,
+        type: Type,
+        listener: (T?) -> Unit,
+        errorListener: BaseErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "patch", body = body, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
@@ -164,8 +179,13 @@ object JetpackTunnelGsonRequest {
      *
      * @param T the expected response object from the WP-API endpoint
      */
-    fun <T : Any> buildPutRequest(wpApiEndpoint: String, siteId: Long, body: Map<String, Any>,
-                                  type: Type, listener: (T?) -> Unit, errorListener: BaseErrorListener
+    fun <T : Any> buildPutRequest(
+        wpApiEndpoint: String,
+        siteId: Long,
+        body: Map<String, Any>,
+        type: Type,
+        listener: (T?) -> Unit,
+        errorListener: BaseErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "put", body = body, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
@@ -183,15 +203,24 @@ object JetpackTunnelGsonRequest {
      *
      * @param T the expected response object from the WP-API endpoint
      */
-    fun <T : Any> buildDeleteRequest(wpApiEndpoint: String, siteId: Long, params: Map<String, String>,
-                                     type: Type, listener: (T?) -> Unit, errorListener: BaseErrorListener
+    fun <T : Any> buildDeleteRequest(
+        wpApiEndpoint: String,
+        siteId: Long,
+        params: Map<String, String>,
+        type: Type,
+        listener: (T?) -> Unit,
+        errorListener: BaseErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "delete", params = params, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
     }
 
-    private fun <T : Any> buildWrappedPostRequest(siteId: Long, wrappedBody: Map<String, Any>, type: Type,
-                                                  listener: (T?) -> Unit, errorListener: BaseErrorListener
+    private fun <T : Any> buildWrappedPostRequest(
+        siteId: Long,
+        wrappedBody: Map<String, Any>,
+        type: Type,
+        listener: (T?) -> Unit,
+        errorListener: BaseErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val tunnelRequestUrl = getTunnelApiUrl(siteId)
         val wrappedType = TypeToken.getParameterized(JetpackTunnelResponse::class.java, type).type
@@ -212,8 +241,12 @@ object JetpackTunnelGsonRequest {
         return finalParams
     }
 
-    private fun createTunnelBody(method: String, body: Map<String, Any> = mapOf(),
-                                 params: Map<String, String> = mapOf(), path: String): MutableMap<String, Any> {
+    private fun createTunnelBody(
+        method: String,
+        body: Map<String, Any> = mapOf(),
+        params: Map<String, String> = mapOf(),
+        path: String
+    ): MutableMap<String, Any> {
         val finalBody = mutableMapOf<String, Any>()
         with(finalBody) {
             put("path", buildRestApiPath(path, params, method))
@@ -226,7 +259,7 @@ object JetpackTunnelGsonRequest {
     }
 
     private fun buildRestApiPath(path: String, params: Map<String, String>, method: String): String {
-        var result = path + "&_method=" + method
+        var result = "$path&_method=$method"
         if (params.isNotEmpty()) {
             for (param in params) {
                 result += "&" + URLEncoder.encode(param.key, "UTF-8") + "=" + URLEncoder.encode(param.value, "UTF-8")


### PR DESCRIPTION
Updates `ktlint` to `0.21.0` and fixes new style violations introduced.

### Main changes:

1. Functions that can't fit on a single line must have each of their parameters on a separate line, indented with normal (4 space) indentation:

```
fun newInstance(
    onClickListener: Listener,
    text1Hint: String,
    text2Hint: String,
    text3Hint: String
): ThreeEditTextDialog {
    ...
}
```

This one is also enforced in the AS formatter via changes to the shared IDEA config file.

2. Operators need to appear before a wrapped line, not after:

```
prependToLog("error: " + event.error.type + "Some more text here: " +
        event.error.message)
```

This is, sadly, the opposite of our rule for Java (which is a checkstyle default), which forces the operators to appear at the beginning of the new line. There's some hope that this may be addressed in the future, but for now we'll have to live with the inconsistency.

cc @maxme