### PR TITLE
Set `locale` in body too for the /users/new/ call

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -18,9 +18,9 @@ import org.wordpress.android.util.LanguageUtils;
 
 public abstract class BaseWPComRestClient {
     private AccessToken mAccessToken;
-    private final Context mAppContext;
     private final RequestQueue mRequestQueue;
 
+    protected final Context mAppContext;
     protected final Dispatcher mDispatcher;
     protected UserAgent mUserAgent;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -38,6 +38,7 @@ import org.wordpress.android.fluxc.store.AccountStore.NewUserError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.LanguageUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -593,6 +594,10 @@ public class AccountRestClient extends BaseWPComRestClient {
         body.put("validate", dryRun ? "1" : "0");
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());
+
+        // backend needs locale set both the POST body _and_ the query param to fully set up the user's locale settings
+        //  (messages language, followed blogs initialization)
+        body.put("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
 
         WPComGsonRequest<AccountBoolResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 AccountBoolResponse.class,


### PR DESCRIPTION
Addresses the locale issue in #609 for the `/users/new` endpoint call.

After some coordination with our WPCOM backend fellows, it is now understood that the endpoint expects the `locale` param to be passed both via the http query args and via the POST body. It then performs separate operations based on those. So, we need to pass the locale with both means. Internal ref: p2-p5T066-Bj/#comment-1658

Note: To try creating a new user with the example app, [the dryRun param](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/84190f747dc83efc2a3028f13277ba00bc7a428a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java#L117-L117) of the NewAccountPayload needs to be set to `false`.