### PR TITLE
Reset the site object for each WP.com connected test class

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.BeforeClass;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -39,6 +40,11 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
     }
 
     private TestEvents mNextEvent;
+
+    @BeforeClass
+    public static void setup() {
+        sSite = null;
+    }
 
     @Override
     protected void init() throws Exception {


### PR DESCRIPTION
Prevents an issue when running all connected tests, where the Jetpack media tests log into a different account, but then the WP.com media tests attempt to use the same account and the existing `sSite`, which was set from the last WP.com tests, causing an auth error. This is a clean way to ensure each test class starts with a fresh WP.com session (but doesn't log out and back in for each individual test).

cc @maxme 