### PR TITLE
Checkstyle rule enforcing fully qualified imports for Store nested classes

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,7 @@
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
       <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+      <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
       <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
@@ -43,6 +44,7 @@
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="IMPORT_NESTED_CLASSES" value="true" />
     </JetCodeStyleSettings>
     <Objective-C-extensions>
       <file>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -67,6 +67,12 @@
         <property name="severity" value="error"/>
     </module>
 
+    <module name="RegexpSingleline">
+        <property name="format" value="^(?!.*\bimport\b).*Store\.[A-Z][A-Za-z0-9]*[ );]"/>
+        <property name="message" value="Specific imports should be used for FluxC Store inner classes"/>
+        <property name="severity" value="error"/>
+    </module>
+
     <module name="RegexpMultiline">
         <property name="format" value="@Inject(\n|\r\n).*[^{,(]$"/>
         <property name="message" value="Inject annotation should be in-line with the annotated field or property"/>

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_FluxCImageLoaderTest.java
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
@@ -112,7 +113,7 @@ public class ReleaseStack_FluxCImageLoaderTest extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onMediaListFetched(MediaStore.OnMediaListFetched event) {
+    public void onMediaListFetched(OnMediaListFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -22,6 +22,8 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
+import org.wordpress.android.fluxc.store.MediaStore.OnStockMediaUploaded;
+import org.wordpress.android.fluxc.store.MediaStore.UploadStockMediaPayload;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
 
@@ -549,7 +551,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onStockMediaUploaded(MediaStore.OnStockMediaUploaded event) {
+    public void onStockMediaUploaded(OnStockMediaUploaded event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: "
                                      + event.error.type);
@@ -702,8 +704,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     }
 
     private void uploadStockMedia(@NonNull List<StockMediaModel> stockMediaList) throws InterruptedException {
-        MediaStore.UploadStockMediaPayload uploadPayload =
-                new MediaStore.UploadStockMediaPayload(sSite, stockMediaList);
+        UploadStockMediaPayload uploadPayload = new UploadStockMediaPayload(sSite, stockMediaList);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadStockMediaAction(uploadPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_StockMediaTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_StockMediaTest.java
@@ -8,6 +8,8 @@ import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.StockMediaActionBuilder;
 import org.wordpress.android.fluxc.model.StockMediaModel;
 import org.wordpress.android.fluxc.store.StockMediaStore;
+import org.wordpress.android.fluxc.store.StockMediaStore.FetchStockMediaListPayload;
+import org.wordpress.android.fluxc.store.StockMediaStore.OnStockMediaListFetched;
 import org.wordpress.android.util.AppLog;
 
 import java.util.List;
@@ -57,8 +59,7 @@ public class ReleaseStack_StockMediaTest extends ReleaseStack_WPComBase {
     }
 
     private void fetchStockMediaList(@NonNull String searchTerm, int page) throws InterruptedException {
-        StockMediaStore.FetchStockMediaListPayload fetchPayload =
-                new StockMediaStore.FetchStockMediaListPayload(searchTerm, page);
+        FetchStockMediaListPayload fetchPayload = new FetchStockMediaListPayload(searchTerm, page);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(StockMediaActionBuilder.newFetchStockMediaAction(fetchPayload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -77,7 +78,7 @@ public class ReleaseStack_StockMediaTest extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onStockMediaListFetched(StockMediaStore.OnStockMediaListFetched event) {
+    public void onStockMediaListFetched(OnStockMediaListFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: "
                     + event.error.type);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -15,8 +15,20 @@ import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched;
+import org.wordpress.android.fluxc.store.ThemeStore.OnSiteThemesChanged;
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated;
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeDeleted;
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeInstalled;
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeRemoved;
+import org.wordpress.android.fluxc.store.ThemeStore.OnWpComThemesChanged;
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
 import java.util.List;
@@ -207,7 +219,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onSiteThemesChanged(ThemeStore.OnSiteThemesChanged event) {
+    public void onSiteThemesChanged(OnSiteThemesChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -224,7 +236,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onWpComThemesChanged(ThemeStore.OnWpComThemesChanged event) {
+    public void onWpComThemesChanged(OnWpComThemesChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -234,7 +246,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onCurrentThemeFetched(ThemeStore.OnCurrentThemeFetched event) {
+    public void onCurrentThemeFetched(OnCurrentThemeFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -246,7 +258,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onThemeActivated(ThemeStore.OnThemeActivated event) {
+    public void onThemeActivated(OnThemeActivated event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -256,7 +268,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onThemeInstalled(ThemeStore.OnThemeInstalled event) {
+    public void onThemeInstalled(OnThemeInstalled event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -266,7 +278,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onThemeDeleted(ThemeStore.OnThemeDeleted event) {
+    public void onThemeDeleted(OnThemeDeleted event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -276,7 +288,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onThemeRemoved(ThemeStore.OnThemeRemoved event) {
+    public void onThemeRemoved(OnThemeRemoved event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -286,7 +298,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onAuthenticationChanged(AccountStore.OnAuthenticationChanged event) {
+    public void onAuthenticationChanged(OnAuthenticationChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -295,7 +307,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onAccountChanged(AccountStore.OnAccountChanged event) {
+    public void onAccountChanged(OnAccountChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -304,7 +316,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSiteChanged(SiteStore.OnSiteChanged event) {
+    public void onSiteChanged(OnSiteChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -313,7 +325,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onSiteRemoved(SiteStore.OnSiteRemoved event) {
+    public void onSiteRemoved(OnSiteRemoved event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -334,7 +346,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     private void authenticateWPComAndFetchSites(String username, String password) throws InterruptedException {
         // Authenticate a test user (actual credentials declared in gradle.properties)
-        AccountStore.AuthenticatePayload payload = new AccountStore.AuthenticatePayload(username, password);
+        AuthenticatePayload payload = new AuthenticatePayload(username, password);
         mCountDownLatch = new CountDownLatch(1);
 
         // Correct user we should get an OnAuthenticationChanged message

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -6,9 +6,13 @@ import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.model.ThemeModel;
-import org.wordpress.android.fluxc.store.AccountStore;
-import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched;
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated;
+import org.wordpress.android.fluxc.store.ThemeStore.OnWpComThemesChanged;
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
 import java.util.List;
@@ -92,7 +96,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onThemeActivated(ThemeStore.OnThemeActivated event) {
+    public void onThemeActivated(OnThemeActivated event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -102,7 +106,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onWpComThemesChanged(ThemeStore.OnWpComThemesChanged event) {
+    public void onWpComThemesChanged(OnWpComThemesChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -112,7 +116,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onCurrentThemeFetched(ThemeStore.OnCurrentThemeFetched event) {
+    public void onCurrentThemeFetched(OnCurrentThemeFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -123,7 +127,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onAuthenticationChanged(AccountStore.OnAuthenticationChanged event) {
+    public void onAuthenticationChanged(OnAuthenticationChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -132,7 +136,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onAccountChanged(AccountStore.OnAccountChanged event) {
+    public void onAccountChanged(OnAccountChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
@@ -141,7 +145,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSiteChanged(SiteStore.OnSiteChanged event) {
+    public void onSiteChanged(OnSiteChanged event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -18,6 +18,12 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.ThemeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.ThemeStore
+import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched
+import org.wordpress.android.fluxc.store.ThemeStore.OnSiteThemesChanged
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeDeleted
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeInstalled
+import org.wordpress.android.fluxc.store.ThemeStore.OnWpComThemesChanged
 import javax.inject.Inject
 
 class ThemeFragment : Fragment() {
@@ -149,7 +155,7 @@ class ThemeFragment : Fragment() {
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onThemeInstalled(event: ThemeStore.OnThemeInstalled) {
+    fun onThemeInstalled(event: OnThemeInstalled) {
         prependToLog("onThemeInstalled: ")
         if (event.isError) {
             prependToLog("error: " + event.error.message)
@@ -160,7 +166,7 @@ class ThemeFragment : Fragment() {
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onThemeDeleted(event: ThemeStore.OnThemeDeleted) {
+    fun onThemeDeleted(event: OnThemeDeleted) {
         prependToLog("onThemeDeleted: ")
         if (event.isError) {
             prependToLog("error: " + event.error.message)
@@ -171,7 +177,7 @@ class ThemeFragment : Fragment() {
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onThemeActivated(event: ThemeStore.OnThemeActivated) {
+    fun onThemeActivated(event: OnThemeActivated) {
         prependToLog("onThemeActivated: ")
         if (event.isError) {
             prependToLog("error: " + event.error.message)
@@ -182,7 +188,7 @@ class ThemeFragment : Fragment() {
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onCurrentThemeFetched(event: ThemeStore.OnCurrentThemeFetched) {
+    fun onCurrentThemeFetched(event: OnCurrentThemeFetched) {
         prependToLog("onCurrentThemeFetched: ")
         if (event.isError) {
             prependToLog("error: " + event.error.message)
@@ -193,7 +199,7 @@ class ThemeFragment : Fragment() {
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onSiteThemesChanged(event: ThemeStore.OnSiteThemesChanged) {
+    fun onSiteThemesChanged(event: OnSiteThemesChanged) {
         prependToLog("onSiteThemesChanged: ")
         if (event.isError) {
             prependToLog("error: " + event.error.message)
@@ -208,7 +214,7 @@ class ThemeFragment : Fragment() {
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onWpComThemesChanged(event: ThemeStore.OnWpComThemesChanged) {
+    fun onWpComThemesChanged(event: OnWpComThemesChanged) {
         prependToLog("onWpComThemesChanged: ")
         if (event.isError) {
             prependToLog("error: " + event.error.message)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.java
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
-import org.wordpress.android.fluxc.store.StockMediaStore;
+import org.wordpress.android.fluxc.store.StockMediaStore.FetchedStockMediaListPayload;
 import org.wordpress.android.fluxc.store.StockMediaStore.StockMediaError;
 import org.wordpress.android.fluxc.store.StockMediaStore.StockMediaErrorType;
 import org.wordpress.android.util.AppLog;
@@ -51,8 +51,8 @@ public class StockMediaRestClient extends BaseWPComRestClient {
                 new Response.Listener<SearchStockMediaResponse>() {
                     @Override
                     public void onResponse(SearchStockMediaResponse response) {
-                        StockMediaStore.FetchedStockMediaListPayload payload =
-                                new StockMediaStore.FetchedStockMediaListPayload(
+                        FetchedStockMediaListPayload payload =
+                                new FetchedStockMediaListPayload(
                                         response.media,
                                         searchTerm,
                                         response.nextPage,
@@ -65,8 +65,7 @@ public class StockMediaRestClient extends BaseWPComRestClient {
                         AppLog.e(AppLog.T.MEDIA, "VolleyError Fetching stock media: " + error);
                         StockMediaError mediaError = new StockMediaError(
                                 StockMediaErrorType.fromBaseNetworkError(error), error.message);
-                        StockMediaStore.FetchedStockMediaListPayload payload =
-                                new StockMediaStore.FetchedStockMediaListPayload(mediaError, searchTerm);
+                        FetchedStockMediaListPayload payload = new FetchedStockMediaListPayload(mediaError, searchTerm);
                         mDispatcher.dispatch(StockMediaActionBuilder.newFetchedStockMediaAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.java
@@ -136,11 +136,11 @@ public class StockMediaStore extends Store {
         AppLog.d(AppLog.T.MEDIA, "StockMediaStore onRegister");
     }
 
-    private void performFetchStockMediaList(StockMediaStore.FetchStockMediaListPayload payload) {
+    private void performFetchStockMediaList(FetchStockMediaListPayload payload) {
         mStockMediaRestClient.searchStockMedia(payload.searchTerm, payload.page);
     }
 
-    private void handleStockMediaListFetched(@NonNull StockMediaStore.FetchedStockMediaListPayload payload) {
+    private void handleStockMediaListFetched(@NonNull FetchedStockMediaListPayload payload) {
         OnStockMediaListFetched onStockMediaListFetched;
 
         if (payload.isError()) {

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/PostActivity.java
@@ -37,8 +37,10 @@ import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
+import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
+import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.utils.MediaUtils;
@@ -199,7 +201,7 @@ public class PostActivity extends AppCompatActivity {
                              + "\" height=\"" + mMedia.getHeight() + "\" />";
         post.setContent(postContent);
 
-        PostStore.RemotePostPayload payload = new PostStore.RemotePostPayload(post, mSite);
+        RemotePostPayload payload = new RemotePostPayload(post, mSite);
         mDispatcher.dispatch(PostActionBuilder.newPushPostAction(payload));
         AppLog.i(AppLog.T.API, "Create a new media post for " + mMedia.getUrl());
     }
@@ -289,7 +291,7 @@ public class PostActivity extends AppCompatActivity {
     }
 
     private void fetchPosts() {
-        PostStore.FetchPostsPayload payload = new PostStore.FetchPostsPayload(mSite);
+        FetchPostsPayload payload = new FetchPostsPayload(mSite);
         mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(payload));
     }
 


### PR DESCRIPTION
We've been favoring using fully qualified imports for inner classes of `Store`s (e.g, `FetchPostsPayload` instead of `PostStore.FetchPostsPayload`), but there's no checkstyle rule and AS's default behavior is not to add the fully qualified import.

This PR adds a checkstyle rule that flags any case of inner/nested classes being used without a fully qualified import, in an effort to keep things consistent and avoid having to point it out in PR reviews.

Initially I had also added a setting in the shared configs that would make AS use specific imports by default. But, while this works well for FluxC, I'm not sure if it's behaviour we want to use everywhere. The reason this makes sense for stores is that the inner classes tend to be errors, error types, payloads, and `OnChanged` events, all of which have pretty standard and clear naming. Some non-FluxC things though, like `LinearLayout.LayoutParams params`, are less clear when a specific import is used (several classes define `LayoutParams`).

So **my proposal is to add the checkstyle rule to keep inner store imports clear, but not modify the default behavior**. This might be a little annoying though. It depends how strongly we feel about keeping the style consistent (to me, it's automatic to hit Alt+Enter to use the more specific import, but the immediate checkstyle violation may be a slight nuisance when first using FluxC).

Would love some thoughts on this - @maxme, @oguzkocer in particular.

(Just for reference, the auto-import settings that can be enabled are in `Preferences` > `Editor` > `Code Style` > (`Java` > `Imports` > `Insert imports for inner classes` AND `Kotlin` > `Imports` > `Other` > `Insert imports for nested classes`).)