### PR TITLE
Use UploadStockMediaError rather than StockMediaError in the MediaStore

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -37,8 +37,9 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
+import org.wordpress.android.fluxc.store.MediaStore.UploadStockMediaError;
+import org.wordpress.android.fluxc.store.MediaStore.UploadStockMediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.UploadedStockMediaPayload;
-import org.wordpress.android.fluxc.store.StockMediaStore;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -418,8 +419,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                     @Override
                     public void onErrorResponse(@NonNull BaseRequest.BaseNetworkError error) {
                         AppLog.e(AppLog.T.MEDIA, "VolleyError uploading stock media: " + error);
-                        StockMediaStore.StockMediaError mediaError = new StockMediaStore.StockMediaError(
-                                StockMediaStore.StockMediaErrorType.fromBaseNetworkError(error), error.message);
+                        UploadStockMediaError mediaError = new UploadStockMediaError(
+                                UploadStockMediaErrorType.fromBaseNetworkError(error), error.message);
                         UploadedStockMediaPayload payload = new UploadedStockMediaPayload(site, mediaError);
                         mDispatcher.dispatch(MediaActionBuilder.newUploadedStockMediaAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -176,7 +176,7 @@ public class MediaStore extends Store {
      * Actions: UPLOADED_STOCK_MEDIA
      */
     @SuppressWarnings("WeakerAccess")
-    public static class UploadedStockMediaPayload extends Payload<StockMediaStore.StockMediaError> {
+    public static class UploadedStockMediaPayload extends Payload<UploadStockMediaError> {
         @NonNull public List<MediaModel> mediaList;
         @NonNull public SiteModel site;
 
@@ -185,7 +185,7 @@ public class MediaStore extends Store {
             this.mediaList = mediaList;
         }
 
-        public UploadedStockMediaPayload(@NonNull SiteModel site, @NonNull StockMediaStore.StockMediaError error) {
+        public UploadedStockMediaPayload(@NonNull SiteModel site, @NonNull UploadStockMediaError error) {
             this.site = site;
             this.error = error;
             this.mediaList = new ArrayList<>();
@@ -230,6 +230,15 @@ public class MediaStore extends Store {
             }
 
             return mediaError;
+        }
+    }
+
+    public static class UploadStockMediaError implements OnChangedError {
+        public UploadStockMediaErrorType type;
+        public String message;
+        public UploadStockMediaError(UploadStockMediaErrorType type, String message) {
+            this.type = type;
+            this.message = message;
         }
     }
 
@@ -282,7 +291,7 @@ public class MediaStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class OnStockMediaUploaded extends OnChanged<StockMediaStore.StockMediaError> {
+    public static class OnStockMediaUploaded extends OnChanged<UploadStockMediaError> {
         @NonNull public List<MediaModel> mediaList;
         @Nullable public SiteModel site;
 
@@ -290,7 +299,7 @@ public class MediaStore extends Store {
             this.site = site;
             this.mediaList = mediaList;
         }
-        public OnStockMediaUploaded(@NonNull SiteModel site, @NonNull StockMediaStore.StockMediaError error) {
+        public OnStockMediaUploaded(@NonNull SiteModel site, @NonNull UploadStockMediaError error) {
             this.site = site;
             this.error = error;
             this.mediaList = new ArrayList<>();


### PR DESCRIPTION
Fixes an oversight in the stock media upload process that used `StockMedia.StockMediaError` for upload-related errors, as per [this comment](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/749#discussion_r176177118).

cc: @oguzkocer 