### PR TITLE
Use File.separator for file path for endpoint generator

### DIFF
--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -66,7 +66,8 @@ public class EndpointProcessor extends AbstractProcessor {
 
         try {
             String outputPath = mFiler.getResource(StandardLocation.CLASS_OUTPUT, "", "tmp").getName();
-            if (outputPath.contains("/fluxc/build/")) {
+            String fs = File.separator;
+            if (outputPath.contains(fs + "fluxc" + fs + "build")) {
                 generateWPCOMRESTEndpointFile();
                 generateWPCOMV2EndpointFile();
                 generateXMLRPCEndpointFile();


### PR DESCRIPTION
This PR fixes the build for Windows. I've struggled with this issue throughout the week because from our discussion on Slack, I thought the issue was related to the `Gradle` build. The moment I checked out the PR that introduced the issue, which I should have done in the first place, I saw the issue immediately.

Moral of the story:
1. If there is an issue introduced by a specific PR, always check it out before trying out random things 🤦‍♂️ 
2. Don't use platform specific file separators :)

To test:
* Do a clean build and run the example app in both Windows and Mac/Linux. I've already checked both platforms and everything is working for me.

_P.S: This is a pretty frustrating blocker for me and I'd really appreciate it if the PR is merged as soon as possible._