### PR TITLE
Automated Transfer v1

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
@@ -33,8 +33,10 @@ import static org.junit.Assert.assertTrue;
 public class MockedStack_SiteTest extends MockedStack_Base {
     // from "initiate-automated-transfer-response-success.json"
     private static final int TEST_INITIATE_AUTOMATED_TRANSFER_ID = 197364;
-    public static final int TEST_SITE_ID_TRANSFER_COMPLETE = 84;
-    public static final int TEST_SITE_ID_TRANSFER_INCOMPLETE = 87;
+
+    // Used in ResponseMockingInterceptor
+    public static final int TEST_SITE_ID_TRANSFER_COMPLETE = 123;
+    public static final int TEST_SITE_ID_TRANSFER_INCOMPLETE = 124;
 
     @Inject Dispatcher mDispatcher;
     @Inject SiteStore mSiteStore;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
@@ -1,13 +1,20 @@
 package org.wordpress.android.fluxc.mocked;
 
+import android.support.annotation.NonNull;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnAutomatedTransferEligibilityChecked;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -21,10 +28,13 @@ import static org.junit.Assert.assertTrue;
 public class MockedStack_SiteTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
     @Inject SiteStore mSiteStore;
+    @Inject AccountStore mAccountStore;
 
     enum TestEvents {
         NONE,
-        ELIGIBLE_FOR_AUTOMATED_TRANSFER
+        ACCOUNT_CHANGED,
+        ELIGIBLE_FOR_AUTOMATED_TRANSFER,
+        UPDATE_SITE
     }
 
     private TestEvents mNextEvent;
@@ -43,12 +53,23 @@ public class MockedStack_SiteTest extends MockedStack_Base {
 
     @Test
     public void testEligibleForAutomatedTransfer() throws InterruptedException {
-        SiteModel site = new SiteModel();
-        site.setSiteId(322);
+        // Create dummy site
+        SiteModel site = createAccountAndLocalTestSite();
+
         mNextEvent = TestEvents.ELIGIBLE_FOR_AUTOMATED_TRANSFER;
         mDispatcher.dispatch(SiteActionBuilder.newCheckAutomatedTransferEligibilityAction(site));
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onAccountChanged(OnAccountChanged event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(mNextEvent, TestEvents.ACCOUNT_CHANGED);
+        mCountDownLatch.countDown();
     }
 
     @SuppressWarnings("unused")
@@ -61,5 +82,37 @@ public class MockedStack_SiteTest extends MockedStack_Base {
         assertNotNull(event.site);
         assertTrue(event.site.isEligibleForAutomatedTransfer());
         mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onSiteChanged(OnSiteChanged event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(mNextEvent, TestEvents.UPDATE_SITE);
+        assertEquals(event.rowsAffected, 1);
+        mCountDownLatch.countDown();
+    }
+
+    private @NonNull SiteModel createAccountAndLocalTestSite() throws InterruptedException {
+        AccountModel account = new AccountModel();
+        account.setUserId(478);
+        mNextEvent = TestEvents.ACCOUNT_CHANGED;
+        mDispatcher.dispatch(AccountActionBuilder.newUpdateAccountAction(account));
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        SiteModel site = new SiteModel();
+        site.setSiteId(322);
+        site.setIsWPCom(true);
+        mNextEvent = TestEvents.UPDATE_SITE;
+        mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(site));
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        SiteModel siteFromStore = mSiteStore.getSiteBySiteId(site.getSiteId());
+        assertNotNull(siteFromStore);
+        return siteFromStore;
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
@@ -60,7 +60,7 @@ public class MockedStack_SiteTest extends MockedStack_Base {
 
     @Test
     public void testEligibleForAutomatedTransfer() throws InterruptedException {
-        SiteModel site = createAccountAndLocalTestSite();
+        SiteModel site = createAccountAndLocalTestSite(false);
 
         mNextEvent = TestEvents.ELIGIBLE_FOR_AUTOMATED_TRANSFER;
         mDispatcher.dispatch(SiteActionBuilder.newCheckAutomatedTransferEligibilityAction(site));
@@ -75,7 +75,7 @@ public class MockedStack_SiteTest extends MockedStack_Base {
 
     @Test
     public void testInitiateAutomatedTransferSuccessfully() throws InterruptedException {
-        SiteModel site = createAccountAndLocalTestSite();
+        SiteModel site = createAccountAndLocalTestSite(true);
 
         mNextEvent = TestEvents.INITIATE_AUTOMATED_TRANSFER;
         InitiateAutomatedTransferPayload payload = new InitiateAutomatedTransferPayload(site, "react");
@@ -143,7 +143,7 @@ public class MockedStack_SiteTest extends MockedStack_Base {
         mCountDownLatch.countDown();
     }
 
-    private @NonNull SiteModel createAccountAndLocalTestSite() throws InterruptedException {
+    private @NonNull SiteModel createAccountAndLocalTestSite(boolean isEligible) throws InterruptedException {
         AccountModel account = new AccountModel();
         account.setUserId(478);
         mNextEvent = TestEvents.ACCOUNT_CHANGED;
@@ -154,6 +154,7 @@ public class MockedStack_SiteTest extends MockedStack_Base {
         SiteModel site = new SiteModel();
         site.setSiteId(322);
         site.setIsWPCom(true);
+        site.setIsEligibleForAutomatedTransfer(isEligible);
         mNextEvent = TestEvents.UPDATE_SITE;
         mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(site));
         mCountDownLatch = new CountDownLatch(1);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_SiteTest.java
@@ -1,11 +1,34 @@
 package org.wordpress.android.fluxc.mocked;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.junit.Test;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnAutomatedTransferEligibilityChecked;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class MockedStack_SiteTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
+    @Inject SiteStore mSiteStore;
+
+    enum TestEvents {
+        NONE,
+        ELIGIBLE_FOR_AUTOMATED_TRANSFER
+    }
+
+    private TestEvents mNextEvent;
+    private CountDownLatch mCountDownLatch;
 
     @Override
     public void setUp() throws Exception {
@@ -14,5 +37,29 @@ public class MockedStack_SiteTest extends MockedStack_Base {
         mMockedNetworkAppComponent.inject(this);
         // Register
         mDispatcher.register(this);
+        // Reset expected test event
+        mNextEvent = TestEvents.NONE;
+    }
+
+    @Test
+    public void testEligibleForAutomatedTransfer() throws InterruptedException {
+        SiteModel site = new SiteModel();
+        site.setSiteId(322);
+        mNextEvent = TestEvents.ELIGIBLE_FOR_AUTOMATED_TRANSFER;
+        mDispatcher.dispatch(SiteActionBuilder.newCheckAutomatedTransferEligibilityAction(site));
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onAutomatedTransferEligibilityChecked(OnAutomatedTransferEligibilityChecked event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(mNextEvent, TestEvents.ELIGIBLE_FOR_AUTOMATED_TRANSFER);
+        assertNotNull(event.site);
+        assertTrue(event.site.isEligibleForAutomatedTransfer());
+        mCountDownLatch.countDown();
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -49,15 +49,14 @@ public class MockedNetworkModule {
     @Singleton
     @Provides
     public OkHttpClient.Builder provideOkHttpClientBuilder() {
-        return new OkHttpClient.Builder();
+        return new OkHttpClient.Builder()
+                .addInterceptor(new ResponseMockingInterceptor());
     }
 
     @Singleton
     @Provides
     public OkHttpClient provideOkHttpClientInstance(OkHttpClient.Builder builder) {
-        return builder
-                .addInterceptor(new ResponseMockingInterceptor())
-                .build();
+        return builder.build();
     }
 
     @Singleton

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
@@ -49,6 +49,8 @@ class ResponseMockingInterceptor implements Interceptor {
             return buildPostSuccessResponse(request);
         } else if (requestUrl.contains("automated-transfers/eligibility")) {
             return buildEligibleForAutomatedTransferResponse(request);
+        } else if (requestUrl.contains("automated-transfers/initiate")) {
+            return buildInitiateAutomatedTransferResponse(request);
         } else {
             throw new IllegalStateException("Interceptor was given a request with no mocks - URL: " + requestUrl);
         }
@@ -71,6 +73,11 @@ class ResponseMockingInterceptor implements Interceptor {
 
     private Response buildEligibleForAutomatedTransferResponse(Request request) {
         String responseJson = getStringFromResourceFile("eligible-for-automated-transfer-response-success.json");
+        return buildResponse(request, responseJson, 200);
+    }
+
+    private Response buildInitiateAutomatedTransferResponse(Request request) {
+        String responseJson = getStringFromResourceFile("initiate-automated-transfer-response-success.json");
         return buildResponse(request, responseJson, 200);
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
@@ -25,6 +25,9 @@ import okhttp3.ResponseBody;
 import okio.BufferedSource;
 import okio.Okio;
 
+import static org.wordpress.android.fluxc.mocked.MockedStack_SiteTest.TEST_SITE_ID_TRANSFER_COMPLETE;
+import static org.wordpress.android.fluxc.mocked.MockedStack_SiteTest.TEST_SITE_ID_TRANSFER_INCOMPLETE;
+
 class ResponseMockingInterceptor implements Interceptor {
     @Override
     public Response intercept(@NonNull Interceptor.Chain chain) throws IOException {
@@ -52,10 +55,13 @@ class ResponseMockingInterceptor implements Interceptor {
         } else if (requestUrl.contains("automated-transfers/initiate")) {
             return buildInitiateAutomatedTransferResponse(request);
         } else if (requestUrl.contains("automated-transfers/status")) {
-            return buildCheckAutomatedTransferStatusResponse(request);
-        } else {
-            throw new IllegalStateException("Interceptor was given a request with no mocks - URL: " + requestUrl);
+            if (requestUrl.contains("sites/" + TEST_SITE_ID_TRANSFER_COMPLETE)) {
+                return buildCheckAutomatedTransferCompleteResponse(request);
+            } else if (requestUrl.contains("sites/" + TEST_SITE_ID_TRANSFER_INCOMPLETE)) {
+                return buildCheckAutomatedTransferIncompleteResponse(request);
+            }
         }
+        throw new IllegalStateException("Interceptor was given a request with no mocks - URL: " + requestUrl);
     }
 
     private Response buildMediaErrorResponse(Request request) {
@@ -83,7 +89,12 @@ class ResponseMockingInterceptor implements Interceptor {
         return buildResponse(request, responseJson, 200);
     }
 
-    private Response buildCheckAutomatedTransferStatusResponse(Request request) {
+    private Response buildCheckAutomatedTransferCompleteResponse(Request request) {
+        String responseJson = getStringFromResourceFile("automated-transfer-status-complete-response-success.json");
+        return buildResponse(request, responseJson, 200);
+    }
+
+    private Response buildCheckAutomatedTransferIncompleteResponse(Request request) {
         String responseJson = getStringFromResourceFile("automated-transfer-status-incomplete-response-success.json");
         return buildResponse(request, responseJson, 200);
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
@@ -47,6 +47,8 @@ class ResponseMockingInterceptor implements Interceptor {
         } else if (requestUrl.contains("posts/new")) {
             // WP.com post upload request
             return buildPostSuccessResponse(request);
+        } else if (requestUrl.contains("automated-transfers/eligibility")) {
+            return buildEligibleForAutomatedTransferResponse(request);
         } else {
             throw new IllegalStateException("Interceptor was given a request with no mocks - URL: " + requestUrl);
         }
@@ -64,6 +66,11 @@ class ResponseMockingInterceptor implements Interceptor {
 
     private Response buildPostSuccessResponse(Request request) {
         String responseJson = getStringFromResourceFile("post-upload-response-success.json");
+        return buildResponse(request, responseJson, 200);
+    }
+
+    private Response buildEligibleForAutomatedTransferResponse(Request request) {
+        String responseJson = getStringFromResourceFile("eligible-for-automated-transfer-response-success.json");
         return buildResponse(request, responseJson, 200);
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
@@ -51,6 +51,8 @@ class ResponseMockingInterceptor implements Interceptor {
             return buildEligibleForAutomatedTransferResponse(request);
         } else if (requestUrl.contains("automated-transfers/initiate")) {
             return buildInitiateAutomatedTransferResponse(request);
+        } else if (requestUrl.contains("automated-transfers/status")) {
+            return buildCheckAutomatedTransferStatusResponse(request);
         } else {
             throw new IllegalStateException("Interceptor was given a request with no mocks - URL: " + requestUrl);
         }
@@ -78,6 +80,11 @@ class ResponseMockingInterceptor implements Interceptor {
 
     private Response buildInitiateAutomatedTransferResponse(Request request) {
         String responseJson = getStringFromResourceFile("initiate-automated-transfer-response-success.json");
+        return buildResponse(request, responseJson, 200);
+    }
+
+    private Response buildCheckAutomatedTransferStatusResponse(Request request) {
+        String responseJson = getStringFromResourceFile("automated-transfer-status-incomplete-response-success.json");
         return buildResponse(request, responseJson, 200);
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -59,7 +59,6 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         FETCHED_WPCOM_SUBDOMAIN_SUGGESTIONS,
         ERROR_INVALID_SITE,
         ERROR_UNKNOWN_SITE,
-        ELIGIBLE_FOR_AUTOMATED_TRANSFER,
         INELIGIBLE_FOR_AUTOMATED_TRANSFER
     }
 
@@ -223,11 +222,6 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     }
 
     @Test
-    public void testEligibleForAutomatedTransfer() throws InterruptedException {
-        // TODO
-    }
-
-    @Test
     public void testIneligibleForAutomatedTransfer() throws InterruptedException {
         authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         SiteModel firstSite = mSiteStore.getSites().get(0);
@@ -361,14 +355,9 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
+        assertEquals(mNextEvent, TestEvents.INELIGIBLE_FOR_AUTOMATED_TRANSFER);
         assertNotNull(event.site);
-        if (mNextEvent.equals(TestEvents.ELIGIBLE_FOR_AUTOMATED_TRANSFER)) {
-            assertTrue(event.site.isEligibleForAutomatedTransfer());
-        } else if (mNextEvent.equals(TestEvents.INELIGIBLE_FOR_AUTOMATED_TRANSFER)){
-            assertFalse(event.site.isEligibleForAutomatedTransfer());
-        } else {
-            throw new AssertionError("Unexpected next event: " + mNextEvent);
-        }
+        assertFalse(event.site.isEligibleForAutomatedTransfer());
         mCountDownLatch.countDown();
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
-import org.wordpress.android.fluxc.store.SiteStore.OnAutomatedTransferAvailabilityChecked;
+import org.wordpress.android.fluxc.store.SiteStore.OnAutomatedTransferEligibilityChecked;
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
@@ -357,7 +357,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onAutomatedTransferAvailabilityChecked(OnAutomatedTransferAvailabilityChecked event) {
+    public void onAutomatedTransferEligibilityChecked(OnAutomatedTransferEligibilityChecked event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnAutomatedTransferAvailabilityChecked;
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
@@ -36,6 +37,7 @@ import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
@@ -56,7 +58,9 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         FETCHED_WPCOM_SITE_BY_URL,
         FETCHED_WPCOM_SUBDOMAIN_SUGGESTIONS,
         ERROR_INVALID_SITE,
-        ERROR_UNKNOWN_SITE
+        ERROR_UNKNOWN_SITE,
+        ELIGIBLE_FOR_AUTOMATED_TRANSFER,
+        INELIGIBLE_FOR_AUTOMATED_TRANSFER
     }
 
     private TestEvents mNextEvent;
@@ -218,6 +222,21 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertEquals(firstSite.getSpaceAllowed(), 3L * 1024 * 1024 * 1024);
     }
 
+    @Test
+    public void testEligibleForAutomatedTransfer() throws InterruptedException {
+        // TODO
+    }
+
+    @Test
+    public void testIneligibleForAutomatedTransfer() throws InterruptedException {
+        authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        SiteModel firstSite = mSiteStore.getSites().get(0);
+        mNextEvent = TestEvents.INELIGIBLE_FOR_AUTOMATED_TRANSFER;
+        mDispatcher.dispatch(SiteActionBuilder.newCheckAutomatedTransferEligibilityAction(firstSite));
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
@@ -333,6 +352,23 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
             assertTrue("Was expecting the domain to end in " + suffix, suggestionResponse.domain_name.endsWith(suffix));
         }
 
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onAutomatedTransferAvailabilityChecked(OnAutomatedTransferAvailabilityChecked event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertNotNull(event.site);
+        if (mNextEvent.equals(TestEvents.ELIGIBLE_FOR_AUTOMATED_TRANSFER)) {
+            assertTrue(event.site.isEligibleForAutomatedTransfer());
+        } else if (mNextEvent.equals(TestEvents.INELIGIBLE_FOR_AUTOMATED_TRANSFER)){
+            assertFalse(event.site.isEligibleForAutomatedTransfer());
+        } else {
+            throw new AssertionError("Unexpected next event: " + mNextEvent);
+        }
         mCountDownLatch.countDown();
     }
 

--- a/example/src/androidTest/resources/automated-transfer-status-complete-response-success.json
+++ b/example/src/androidTest/resources/automated-transfer-status-complete-response-success.json
@@ -1,0 +1,4 @@
+{
+  "status":"complete",
+  "transfer_id":197364
+}

--- a/example/src/androidTest/resources/automated-transfer-status-incomplete-response-success.json
+++ b/example/src/androidTest/resources/automated-transfer-status-incomplete-response-success.json
@@ -1,0 +1,4 @@
+{
+  "status":"active",
+  "transfer_id":197364
+}

--- a/example/src/androidTest/resources/eligible-for-automated-transfer-response-success.json
+++ b/example/src/androidTest/resources/eligible-for-automated-transfer-response-success.json
@@ -1,0 +1,3 @@
+{
+  "is_eligible":true
+}

--- a/example/src/androidTest/resources/initiate-automated-transfer-response-success.json
+++ b/example/src/androidTest/resources/initiate-automated-transfer-response-success.json
@@ -1,0 +1,8 @@
+{
+  "plugin_url":"https://downloads.wordpress.org/plugin/react.zip",
+  "status":"active",
+  "success":true,
+  "active_theme_slug":"pub\/independent-publisher-2",
+  "theme_url":"",
+  "transfer_id":197364
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -11,11 +11,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.FetchW
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPComResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferStatusResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
-import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferPayload;
+import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
@@ -82,6 +83,8 @@ public enum SiteAction implements IAction {
     CHECKED_AUTOMATED_TRANSFER_ELIGIBILITY,
     @Action(payloadType = InitiateAutomatedTransferResponsePayload.class)
     INITIATED_AUTOMATED_TRANSFER,
+    @Action(payloadType = AutomatedTransferStatusResponsePayload.class)
+    CHECKED_AUTOMATED_TRANSFER_STATUS,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityR
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
+import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferPayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
@@ -79,6 +80,8 @@ public enum SiteAction implements IAction {
     FETCHED_WPCOM_SITE_BY_URL,
     @Action(payloadType = AutomatedTransferEligibilityResponsePayload.class)
     CHECKED_AUTOMATED_TRANSFER_ELIGIBILITY,
+    @Action(payloadType = InitiateAutomatedTransferResponsePayload.class)
+    INITIATED_AUTOMATED_TRANSFER,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -47,6 +47,12 @@ public enum SiteAction implements IAction {
     FETCH_CONNECT_SITE_INFO,
     @Action(payloadType = String.class)
     FETCH_WPCOM_SITE_BY_URL,
+    @Action(payloadType = SiteModel.class)
+    CHECK_AUTOMATED_TRANSFER_ELIGIBILITY,
+    @Action(payloadType = SiteModel.class)
+    INITIATE_AUTOMATED_TRANSFER,
+    @Action(payloadType = SiteModel.class)
+    CHECK_AUTOMATED_TRANSFER_STATUS,
 
     // Remote responses
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.Export
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.FetchWPComSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPComResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
@@ -75,6 +76,8 @@ public enum SiteAction implements IAction {
     FETCHED_CONNECT_SITE_INFO,
     @Action(payloadType = FetchWPComSiteResponsePayload.class)
     FETCHED_WPCOM_SITE_BY_URL,
+    @Action(payloadType = AutomatedTransferEligibilityResponsePayload.class)
+    CHECKED_AUTOMATED_TRANSFER_ELIGIBILITY,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityR
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
+import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferPayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
@@ -50,7 +51,7 @@ public enum SiteAction implements IAction {
     FETCH_WPCOM_SITE_BY_URL,
     @Action(payloadType = SiteModel.class)
     CHECK_AUTOMATED_TRANSFER_ELIGIBILITY,
-    @Action(payloadType = SiteModel.class)
+    @Action(payloadType = InitiateAutomatedTransferPayload.class)
     INITIATE_AUTOMATED_TRANSFER,
     @Action(payloadType = SiteModel.class)
     CHECK_AUTOMATED_TRANSFER_STATUS,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -69,7 +69,6 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private boolean mIsJetpackInstalled;
     // mIsJetpackConnected is true if Jetpack is installed, activated and connected to a WordPress.com account.
     @Column private boolean mIsJetpackConnected;
-    @Column private boolean mIsAutomatedTransfer;
     @Column private String mJetpackVersion;
 
     // WPCom specifics
@@ -81,6 +80,11 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private String mIconUrl;
     @Column private boolean mHasFreePlan;
     @Column private String mUnmappedUrl;
+
+    // Automated Transfer
+    @Column private boolean mIsAutomatedTransfer;
+    @Column private boolean mIsEligibleForAutomatedTransfer;
+    @Column private String mAutomatedTransferId;
 
     // WPCom capabilities
     @Column private boolean mHasCapabilityEditPages;
@@ -511,6 +515,30 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mUnmappedUrl = unMappedUrl;
     }
 
+    public boolean isAutomatedTransfer() {
+        return mIsAutomatedTransfer;
+    }
+
+    public void setIsAutomatedTransfer(boolean automatedTransfer) {
+        mIsAutomatedTransfer = automatedTransfer;
+    }
+
+    public boolean isEligibleForAutomatedTransfer() {
+        return mIsEligibleForAutomatedTransfer;
+    }
+
+    public void setIsEligibleForAutomatedTransfer(boolean eligibleForAutomatedTransfer) {
+        mIsEligibleForAutomatedTransfer = eligibleForAutomatedTransfer;
+    }
+
+    public String getAutomatedTransferId() {
+        return mAutomatedTransferId;
+    }
+
+    public void setAutomatedTransferId(String automatedTransferId) {
+        mAutomatedTransferId = automatedTransferId;
+    }
+
     public boolean isJetpackInstalled() {
         return mIsJetpackInstalled;
     }
@@ -525,14 +553,6 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setIsJetpackConnected(boolean jetpackConnected) {
         mIsJetpackConnected = jetpackConnected;
-    }
-
-    public boolean isAutomatedTransfer() {
-        return mIsAutomatedTransfer;
-    }
-
-    public void setIsAutomatedTransfer(boolean automatedTransfer) {
-        mIsAutomatedTransfer = automatedTransfer;
     }
 
     public String getJetpackVersion() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -84,7 +84,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     // Automated Transfer
     @Column private boolean mIsAutomatedTransfer;
     @Column private boolean mIsEligibleForAutomatedTransfer;
-    @Column private String mAutomatedTransferId;
+    @Column private int mAutomatedTransferId;
 
     // WPCom capabilities
     @Column private boolean mHasCapabilityEditPages;
@@ -531,11 +531,11 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mIsEligibleForAutomatedTransfer = eligibleForAutomatedTransfer;
     }
 
-    public String getAutomatedTransferId() {
+    public int getAutomatedTransferId() {
         return mAutomatedTransferId;
     }
 
-    public void setAutomatedTransferId(String automatedTransferId) {
+    public void setAutomatedTransferId(int automatedTransferId) {
         mAutomatedTransferId = automatedTransferId;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AutomatedTransferEligibilityCheckResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AutomatedTransferEligibilityCheckResponse.java
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AutomatedTransferEligibilityCheckResponse {
+    @SerializedName("is_eligible")
+    public boolean isEligible;
+    public EligibilityError[] errors;
+
+    class EligibilityError {
+        public String code;
+        public String message;
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AutomatedTransferStatusResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AutomatedTransferStatusResponse.java
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AutomatedTransferStatusResponse {
+    public String status;
+    @SerializedName("transfer_id")
+    public String transferId;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/InitiateAutomatedTransferResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/InitiateAutomatedTransferResponse.java
@@ -6,5 +6,5 @@ public class InitiateAutomatedTransferResponse {
     public String status;
     public boolean success;
     @SerializedName("transfer_id")
-    public String transferId;
+    public int transferId;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/InitiateAutomatedTransferResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/InitiateAutomatedTransferResponse.java
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import com.google.gson.annotations.SerializedName;
+
+public class InitiateAutomatedTransferResponse {
+    public String status;
+    public boolean success;
+    @SerializedName("transfer_id")
+    public String transferId;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -663,10 +663,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                 site.setXmlRpcUrl(from.meta.links.xmlrpc);
             }
         }
-        // Only set the isWPCom flag for "pure" WPCom sites
-        if (!from.jetpack) {
-            site.setIsWPCom(true);
-        }
+        // Only set the isWPCom flag for "pure" WPCom sites - A site might become atomic, so always update to latest
+        site.setIsWPCom(!from.jetpack);
         site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         return site;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -31,11 +31,13 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteWPComRestResponse.SitesResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.UserRoleWPComRestResponse.UserRolesResponse;
+import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
+import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.PostFormatsError;
@@ -523,11 +525,21 @@ public class SiteRestClient extends BaseWPComRestClient {
                         new Listener<InitiateAutomatedTransferResponse>() {
                             @Override
                             public void onResponse(InitiateAutomatedTransferResponse response) {
+                                InitiateAutomatedTransferResponsePayload payload =
+                                        new InitiateAutomatedTransferResponsePayload(site, pluginSlugToInstall);
+                                payload.status = response.status;
+                                payload.success = response.success;
+                                payload.transferId = response.transferId;
+                                mDispatcher.dispatch(SiteActionBuilder.newInitiatedAutomatedTransferAction(payload));
                             }
                         },
                         new BaseErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull BaseNetworkError error) {
+                                InitiateAutomatedTransferResponsePayload payload =
+                                        new InitiateAutomatedTransferResponsePayload(site, pluginSlugToInstall);
+                                payload.error = error;
+                                mDispatcher.dispatch(SiteActionBuilder.newInitiatedAutomatedTransferAction(payload));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -663,8 +663,10 @@ public class SiteRestClient extends BaseWPComRestClient {
                 site.setXmlRpcUrl(from.meta.links.xmlrpc);
             }
         }
-        // Only set the isWPCom flag for "pure" WPCom sites - A site might become atomic, so always update to latest
-        site.setIsWPCom(!from.jetpack);
+        // Only set the isWPCom flag for "pure" WPCom sites
+        if (!from.jetpack) {
+            site.setIsWPCom(true);
+        }
         site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         return site;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -514,8 +514,23 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void initiateAutomatedTransfer(final SiteModel site) {
-        // TODO
+    public void initiateAutomatedTransfer(final SiteModel site, final String pluginSlugToInstall) {
+        String url = WPCOMREST.sites.site(site.getSiteId()).automated_transfers.initiate.getUrlV1_1();
+        Map<String, String> params = new HashMap<>();
+        params.put("plugin", pluginSlugToInstall);
+        final WPComGsonRequest<InitiateAutomatedTransferResponse> request = WPComGsonRequest
+                .buildGetRequest(url, params, InitiateAutomatedTransferResponse.class,
+                        new Listener<InitiateAutomatedTransferResponse>() {
+                            @Override
+                            public void onResponse(InitiateAutomatedTransferResponse response) {
+                            }
+                        },
+                        new BaseErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                            }
+                        });
+        add(request);
     }
 
     public void checkAutomatedTransferStatus(final SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -31,7 +31,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteWPComRestResponse.SitesResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.UserRoleWPComRestResponse.UserRolesResponse;
-import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteError;
@@ -518,10 +517,10 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void initiateAutomatedTransfer(final SiteModel site, final String pluginSlugToInstall) {
         String url = WPCOMREST.sites.site(site.getSiteId()).automated_transfers.initiate.getUrlV1_1();
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("plugin", pluginSlugToInstall);
         final WPComGsonRequest<InitiateAutomatedTransferResponse> request = WPComGsonRequest
-                .buildGetRequest(url, params, InitiateAutomatedTransferResponse.class,
+                .buildPostRequest(url, params, InitiateAutomatedTransferResponse.class,
                         new Listener<InitiateAutomatedTransferResponse>() {
                             @Override
                             public void onResponse(InitiateAutomatedTransferResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -490,6 +490,22 @@ public class SiteRestClient extends BaseWPComRestClient {
         addUnauthedRequest(request);
     }
 
+    // Automated Transfers
+
+    public void checkAutomatedTransferEligibility(final SiteModel site) {
+        // TODO
+    }
+
+    public void initiateAutomatedTransfer(final SiteModel site) {
+        // TODO
+    }
+
+    public void checkAutomatedTransferStatus(final SiteModel site) {
+        // TODO
+    }
+
+    // Utils
+
     private SiteModel siteResponseToSiteModel(SiteWPComRestResponse from) {
         SiteModel site = new SiteModel();
         site.setSiteId(from.ID);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -203,6 +203,38 @@ public class SiteSqlUtils {
                 }).execute();
     }
 
+    public static int setAutomatedTransferEligibility(SiteModel site, boolean isEligible) {
+        if (site == null) {
+            return 0;
+        }
+        return WellSql.update(SiteModel.class)
+                      .whereId(site.getId())
+                      .put(isEligible, new InsertMapper<Boolean>() {
+                          @Override
+                          public ContentValues toCv(Boolean item) {
+                              ContentValues cv = new ContentValues();
+                              cv.put(SiteModelTable.IS_ELIGIBLE_FOR_AUTOMATED_TRANSFER, item);
+                              return cv;
+                          }
+                      }).execute();
+    }
+
+    public static int setAutomatedTransferId(SiteModel site, String transferId) {
+        if (site == null) {
+            return 0;
+        }
+        return WellSql.update(SiteModel.class)
+                      .whereId(site.getId())
+                      .put(transferId, new InsertMapper<String>() {
+                          @Override
+                          public ContentValues toCv(String item) {
+                              ContentValues cv = new ContentValues();
+                              cv.put(SiteModelTable.AUTOMATED_TRANSFER_ID, item);
+                              return cv;
+                          }
+                      }).execute();
+    }
+
     public static SelectQuery<SiteModel> getWPComSites() {
         return WellSql.select(SiteModel.class)
                 .where().beginGroup()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -219,15 +219,15 @@ public class SiteSqlUtils {
                       }).execute();
     }
 
-    public static int setAutomatedTransferId(SiteModel site, String transferId) {
+    public static int setAutomatedTransferId(SiteModel site, int transferId) {
         if (site == null) {
             return 0;
         }
         return WellSql.update(SiteModel.class)
                       .whereId(site.getId())
-                      .put(transferId, new InsertMapper<String>() {
+                      .put(transferId, new InsertMapper<Integer>() {
                           @Override
-                          public ContentValues toCv(String item) {
+                          public ContentValues toCv(Integer item) {
                               ContentValues cv = new ContentValues();
                               cv.put(SiteModelTable.AUTOMATED_TRANSFER_ID, item);
                               return cv;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -241,7 +241,7 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 26:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add IS_ELIGIBLE_FOR_AUTOMATED_TRANSFER INTEGER");
-                db.execSQL("alter table SiteModel add AUTOMATED_TRANSFER_ID STRING");
+                db.execSQL("alter table SiteModel add AUTOMATED_TRANSFER_ID INTEGER");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -60,7 +60,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 26;
+        return 27;
     }
 
     @Override
@@ -237,6 +237,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("alter table SiteModel add SPACE_ALLOWED INTEGER");
                 db.execSQL("alter table SiteModel add SPACE_USED INTEGER");
                 db.execSQL("alter table SiteModel add SPACE_PERCENT_USED REAL");
+                oldVersion++;
+            case 26:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SiteModel add IS_ELIGIBLE_FOR_AUTOMATED_TRANSFER INTEGER");
+                db.execSQL("alter table SiteModel add AUTOMATED_TRANSFER_ID STRING");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -380,9 +380,9 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class OnAutomatedTransferAvailabilityChecked extends OnChanged<AutomatedTransferError> {
+    public static class OnAutomatedTransferEligibilityChecked extends OnChanged<AutomatedTransferError> {
         public SiteModel site;
-        public OnAutomatedTransferAvailabilityChecked(SiteModel site, AutomatedTransferError error) {
+        public OnAutomatedTransferEligibilityChecked(SiteModel site, AutomatedTransferError error) {
             this.site = site;
             this.error = error;
         }
@@ -1230,7 +1230,7 @@ public class SiteStore extends Store {
         }
         // Refresh the site from DB
         SiteModel updatedSite = getSiteByLocalId(payload.site.getId());
-        emitChange(new OnAutomatedTransferAvailabilityChecked(updatedSite, payload.error));
+        emitChange(new OnAutomatedTransferEligibilityChecked(updatedSite, payload.error));
     }
 
     private void initiateAutomatedTransfer(InitiateAutomatedTransferPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -823,6 +823,16 @@ public class SiteStore extends Store {
             case SUGGESTED_DOMAINS:
                 handleSuggestedDomains((SuggestDomainsResponsePayload) action.getPayload());
                 break;
+            // Automated Transfer
+            case CHECK_AUTOMATED_TRANSFER_ELIGIBILITY:
+                checkAutomatedTransferEligibility((SiteModel) action.getPayload());
+                break;
+            case INITIATE_AUTOMATED_TRANSFER:
+                initiateAutomatedTransfer((SiteModel) action.getPayload());
+                break;
+            case CHECK_AUTOMATED_TRANSFER_STATUS:
+                checkAutomatedTransferStatus((SiteModel) action.getPayload());
+                break;
         }
     }
 
@@ -1086,5 +1096,19 @@ public class SiteStore extends Store {
             }
         }
         emitChange(event);
+    }
+
+    // Automated Transfers
+
+    private void checkAutomatedTransferEligibility(SiteModel site) {
+        mSiteRestClient.checkAutomatedTransferEligibility(site);
+    }
+
+    private void initiateAutomatedTransfer(SiteModel site) {
+        mSiteRestClient.initiateAutomatedTransfer(site);
+    }
+
+    private void checkAutomatedTransferStatus(SiteModel site) {
+        mSiteRestClient.checkAutomatedTransferStatus(site);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -180,6 +180,22 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class AutomatedTransferStatusResponsePayload extends Payload<AutomatedTransferError> {
+        public SiteModel site;
+        public String status;
+        public String transferId;
+
+        public AutomatedTransferStatusResponsePayload(SiteModel site, String status, String transferId) {
+            this.site = site;
+            this.status = status;
+            this.transferId = transferId;
+        }
+        public AutomatedTransferStatusResponsePayload(SiteModel site, AutomatedTransferError error) {
+            this.site = site;
+            this.error = error;
+        }
+    }
+
     public static class SiteError implements OnChangedError {
         public SiteErrorType type;
         public String message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -173,7 +173,7 @@ public class SiteStore extends Store {
         public String pluginSlugToInstall;
         public String status;
         public boolean success;
-        public String transferId;
+        public int transferId;
 
         public InitiateAutomatedTransferResponsePayload(SiteModel site, String pluginSlugToInstall) {
             this.site = site;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -166,6 +166,19 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class InitiateAutomatedTransferResponsePayload extends Payload<BaseNetworkError> {
+        public SiteModel site;
+        public String pluginSlugToInstall;
+        public String status;
+        public boolean success;
+        public String transferId;
+
+        public InitiateAutomatedTransferResponsePayload(SiteModel site, String pluginSlugToInstall) {
+            this.site = site;
+            this.pluginSlugToInstall = pluginSlugToInstall;
+        }
+    }
+
     public static class SiteError implements OnChangedError {
         public SiteErrorType type;
         public String message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1265,13 +1265,7 @@ public class SiteStore extends Store {
         boolean isTransferCompleted = false;
         if (!payload.isError()) {
             isTransferCompleted = payload.status.equalsIgnoreCase("complete");
-
-            if (isTransferCompleted) {
-                // We need to fetch the site after AT is completed since it'll become a Jetpack site
-                mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(payload.site));
-            }
         }
-
         emitChange(new OnAutomatedTransferStatusChecked(payload.site, isTransferCompleted, payload.error));
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store;
 
 import android.database.Cursor;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.wellsql.generated.SiteModelTable;
@@ -141,7 +142,7 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class InitiateAutomatedTransferPayload extends Payload<BaseNetworkError> {
+    public static class InitiateAutomatedTransferPayload extends Payload<AutomatedTransferError> {
         public SiteModel site;
         public String pluginSlugToInstall;
 
@@ -151,7 +152,7 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class AutomatedTransferEligibilityResponsePayload extends Payload<BaseNetworkError> {
+    public static class AutomatedTransferEligibilityResponsePayload extends Payload<AutomatedTransferError> {
         public SiteModel site;
         public boolean isEligible;
 
@@ -160,13 +161,13 @@ public class SiteStore extends Store {
             this.isEligible = isEligible;
         }
 
-        public AutomatedTransferEligibilityResponsePayload(SiteModel site, BaseNetworkError error) {
+        public AutomatedTransferEligibilityResponsePayload(SiteModel site, AutomatedTransferError error) {
             this.site = site;
             this.error = error;
         }
     }
 
-    public static class InitiateAutomatedTransferResponsePayload extends Payload<BaseNetworkError> {
+    public static class InitiateAutomatedTransferResponsePayload extends Payload<AutomatedTransferError> {
         public SiteModel site;
         public String pluginSlugToInstall;
         public String status;
@@ -248,6 +249,16 @@ public class SiteStore extends Store {
 
         public ExportSiteError(ExportSiteErrorType type) {
             this.type = type;
+        }
+    }
+
+    public static class AutomatedTransferError implements OnChangedError {
+        public final @NonNull AutomatedTransferErrorType type;
+        public final @Nullable String message;
+
+        public AutomatedTransferError(@Nullable String type, @Nullable String message) {
+            this.type = AutomatedTransferErrorType.fromString(type);
+            this.message = message;
         }
     }
 
@@ -352,18 +363,18 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class OnAutomatedTransferAvailabilityChecked extends OnChanged<SiteError> {
+    public static class OnAutomatedTransferAvailabilityChecked extends OnChanged<AutomatedTransferError> {
         public SiteModel site;
-        public OnAutomatedTransferAvailabilityChecked(SiteModel site, SiteError siteError) {
+        public OnAutomatedTransferAvailabilityChecked(SiteModel site, AutomatedTransferError error) {
             this.site = site;
-            this.error = siteError;
+            this.error = error;
         }
     }
 
-    public static class OnAutomatedTransferInitiated extends OnChanged<SiteError> {
+    public static class OnAutomatedTransferInitiated extends OnChanged<AutomatedTransferError> {
         public SiteModel site;
         public String pluginSlugToInstall;
-        public OnAutomatedTransferInitiated(SiteModel site, String pluginSlugToInstall, SiteError error) {
+        public OnAutomatedTransferInitiated(SiteModel site, String pluginSlugToInstall, AutomatedTransferError error) {
             this.site = site;
             this.pluginSlugToInstall = pluginSlugToInstall;
             this.error = error;
@@ -462,6 +473,21 @@ public class SiteStore extends Store {
                 String siteString = string.toUpperCase(Locale.US).replace(BLOG, SITE);
                 for (NewSiteErrorType v : NewSiteErrorType.values()) {
                     if (siteString.equalsIgnoreCase(v.name())) {
+                        return v;
+                    }
+                }
+            }
+            return GENERIC_ERROR;
+        }
+    }
+
+    public enum AutomatedTransferErrorType {
+        GENERIC_ERROR;
+
+        public static AutomatedTransferErrorType fromString(String type) {
+            if (!TextUtils.isEmpty(type)) {
+                for (AutomatedTransferErrorType v : AutomatedTransferErrorType.values()) {
+                    if (type.equalsIgnoreCase(v.name())) {
                         return v;
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -141,6 +141,21 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class AutomatedTransferEligibilityResponsePayload extends Payload<BaseNetworkError> {
+        public SiteModel site;
+        public boolean isEligible;
+
+        public AutomatedTransferEligibilityResponsePayload(SiteModel site, boolean isEligible) {
+            this.site = site;
+            this.isEligible = isEligible;
+        }
+
+        public AutomatedTransferEligibilityResponsePayload(SiteModel site, BaseNetworkError error) {
+            this.site = site;
+            this.error = error;
+        }
+    }
+
     public static class SiteError implements OnChangedError {
         public SiteErrorType type;
         public String message;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -141,6 +141,16 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class InitiateAutomatedTransferPayload extends Payload<BaseNetworkError> {
+        public SiteModel site;
+        public String pluginSlugToInstall;
+
+        public InitiateAutomatedTransferPayload(SiteModel site, String pluginSlugToInstall) {
+            this.site = site;
+            this.pluginSlugToInstall = pluginSlugToInstall;
+        }
+    }
+
     public static class AutomatedTransferEligibilityResponsePayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public boolean isEligible;
@@ -851,7 +861,7 @@ public class SiteStore extends Store {
                 checkAutomatedTransferEligibility((SiteModel) action.getPayload());
                 break;
             case INITIATE_AUTOMATED_TRANSFER:
-                initiateAutomatedTransfer((SiteModel) action.getPayload());
+                initiateAutomatedTransfer((InitiateAutomatedTransferPayload) action.getPayload());
                 break;
             case CHECK_AUTOMATED_TRANSFER_STATUS:
                 checkAutomatedTransferStatus((SiteModel) action.getPayload());
@@ -1156,8 +1166,8 @@ public class SiteStore extends Store {
         emitChange(event);
     }
 
-    private void initiateAutomatedTransfer(SiteModel site) {
-        mSiteRestClient.initiateAutomatedTransfer(site);
+    private void initiateAutomatedTransfer(InitiateAutomatedTransferPayload payload) {
+        mSiteRestClient.initiateAutomatedTransfer(payload.site, payload.pluginSlugToInstall);
     }
 
     private void checkAutomatedTransferStatus(SiteModel site) {

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -28,7 +28,7 @@
 
 /sites/$site/automated-transfers/eligibility
 /sites/$site/automated-transfers/initiate
-/sites/$site/automated-transfers/status/$transfer_id
+/sites/$site/automated-transfers/status
 
 /sites/$site/comments/
 /sites/$site/comments/$comment_ID

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -26,6 +26,10 @@
 /sites/$site/roles
 /sites/new/
 
+/sites/$site/automated-transfers/eligibility
+/sites/$site/automated-transfers/initiate
+/sites/$site/automated-transfers/status/$transfer_id
+
 /sites/$site/comments/
 /sites/$site/comments/$comment_ID
 /sites/$site/comments/$comment_ID/delete


### PR DESCRIPTION
This PR adds the Automated Transfer endpoints and their implementation. The reason I am calling it v1 is that due to its complicated nature, we might end up adding more things or change some small things.

Please don't let the changeset scare you as most of it is just tests. I personally prefer to have the tests so I can better understand what's going on and have something to debug with, but I am more than happy to separate it into its own PR if the reviewer prefers it.

Please ping me for the API documentation and related P2 posts before reviewing this PR. Unfortunately they are not public.

Quick note about `MockedStack_SiteTest`: Since AT is a destructive & irrecoverable action, I opted to use mocked tests. We didn't have some things setup in that class, so this PR adds helper methods for both site and account creation as well as cleaning them up after the test.

I will add a couple line comments in the PR which I think will be more useful than explaining it here.
