### PR TITLE
issue/766-increase_stock_media_fetch_count

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.java
@@ -27,7 +27,8 @@ import javax.inject.Singleton;
 
 @Singleton
 public class StockMediaRestClient extends BaseWPComRestClient {
-    public static final int DEFAULT_NUM_STOCK_MEDIA_PER_FETCH = 20;
+    // this should be a multiple of both 3 and 4 since WPAndroid shows either 3 or 4 pics per row
+    public static final int DEFAULT_NUM_STOCK_MEDIA_PER_FETCH = 36;
 
     public StockMediaRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
                                 AccessToken accessToken, UserAgent userAgent) {


### PR DESCRIPTION
Resolves #766 - Increases `DEFAULT_NUM_STOCK_MEDIA_PER_FETCH` from 20 to 36 so we don't page so quickly when the user scrolls. Note that this is a multiple of both 3 and 4 to match the grid row count in WPAndroid (3 in portrait, 4 in landscape).

You can test this by using [this](https://github.com/wordpress-mobile/WordPress-Android/pull/7547) WPAndroid branch.