### PR TITLE
Add connected tests for WooCommerce addon

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
+import org.wordpress.android.fluxc.module.ReleaseWCNetworkModule;
 
 import javax.inject.Singleton;
 
@@ -20,6 +21,7 @@ import dagger.Component;
         ReleaseOkHttpClientModule.class,
         ReleaseBaseModule.class,
         ReleaseNetworkModule.class,
+        ReleaseWCNetworkModule.class,
         ReleaseToolsModule.class,
         MockedToolsModule.class
 })

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -48,4 +48,5 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_ThemeTestWPCom test);
     void inject(ReleaseStack_UploadTest test);
     void inject(ReleaseStack_WCBaseStoreTest test);
+    void inject(ReleaseStack_WCOrderTest test);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -47,4 +47,5 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_ThemeTestJetpack test);
     void inject(ReleaseStack_ThemeTestWPCom test);
     void inject(ReleaseStack_UploadTest test);
+    void inject(ReleaseStack_WCBaseStoreTest test);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
@@ -43,7 +43,7 @@ public class ReleaseStack_Base {
         mReleaseStackAppComponent = DaggerReleaseStack_AppComponent.builder()
                 .appContextModule(new AppContextModule(mAppContext))
                 .build();
-        WellSqlConfig config = new WellSqlConfig(mAppContext);
+        WellSqlConfig config = new WellSqlConfig(mAppContext, WellSqlConfig.ADDON_WOOCOMMERCE);
         WellSql.init(config);
         config.reset();
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCBase.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCBase.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.release
+
+import com.wellsql.generated.SiteModelTable
+import org.wordpress.android.fluxc.example.BuildConfig
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
+
+open class ReleaseStack_WCBase : ReleaseStack_WPComBase() {
+    private val authenticatePayload by lazy {
+        AuthenticatePayload(BuildConfig.TEST_WPCOM_USERNAME_WOO_JETPACK,
+                BuildConfig.TEST_WPCOM_PASSWORD_WOO_JETPACK)
+    }
+
+    override fun getSiteFromDb(): SiteModel {
+        val wcSites = SiteSqlUtils.getSitesWith(SiteModelTable.HAS_WOO_COMMERCE, true).asModel
+        if (wcSites.isEmpty()) {
+            throw AssertionError("This test account doesn't seem to have any WooCommerce sites!")
+        } else {
+            return wcSites[0]
+        }
+    }
+
+    override fun buildAuthenticatePayload() = authenticatePayload
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCBaseStoreTest.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.fluxc.release
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class ReleaseStack_WCBaseStoreTest : ReleaseStack_WCBase() {
+    internal enum class TestEvent {
+        NONE
+    }
+
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    private var nextEvent: TestEvent = TestEvent.NONE
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mReleaseStackAppComponent.inject(this)
+        // Register
+        init()
+        // Reset expected test event
+        nextEvent = TestEvent.NONE
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testGetSites() {
+        assertTrue(wooCommerceStore.getWooCommerceSites().isNotEmpty())
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.fluxc.release
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.action.WCOrderAction
+import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
+    internal enum class TestEvent {
+        NONE,
+        FETCHED_ORDERS
+    }
+
+    @Inject internal lateinit var orderStore: WCOrderStore
+
+    private var nextEvent: TestEvent = TestEvent.NONE
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mReleaseStackAppComponent.inject(this)
+        // Register
+        init()
+        // Reset expected test event
+        nextEvent = TestEvent.NONE
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchOrders() {
+        nextEvent = TestEvent.FETCHED_ORDERS
+        mCountDownLatch = CountDownLatch(1)
+
+        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, false)))
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val firstFetchOrders = orderStore.getOrdersForSite(sSite).size
+
+        assertTrue(firstFetchOrders > 0 && firstFetchOrders <= WCOrderStore.NUM_ORDERS_PER_FETCH)
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onOrderChanged(event: OnOrderChanged) {
+        event.error?.let {
+            throw AssertionError("OnOrderChanged has error: " + it.type)
+        }
+
+        when (event.causeOfChange) {
+            WCOrderAction.FETCH_ORDERS -> {
+                assertEquals(TestEvent.FETCHED_ORDERS, nextEvent)
+                mCountDownLatch.countDown()
+            }
+            else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
+        }
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -1,6 +1,10 @@
 package org.wordpress.android.fluxc.release;
 
+import android.content.Context;
+import android.preference.PreferenceManager;
+
 import org.greenrobot.eventbus.Subscribe;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -22,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -43,8 +48,17 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
     private AuthenticatePayload mAuthenticatePayload;
 
     @BeforeClass
-    public static void setup() {
+    public static void beforeClass() {
         sSite = null;
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        // Clear the token after the entire class finishes
+        // This ensures that the token is not re-used by other tests that don't extend this class,
+        // and are supposed to use a different WordPress.com account
+        Context context = getInstrumentation().getTargetContext().getApplicationContext();
+        PreferenceManager.getDefaultSharedPreferences(context).edit().putString("ACCOUNT_TOKEN_PREF_KEY", null).apply();
     }
 
     @Override

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -40,6 +40,7 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
     }
 
     private TestEvents mNextEvent;
+    private AuthenticatePayload mAuthenticatePayload;
 
     @BeforeClass
     public static void setup() {
@@ -62,14 +63,25 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
 
         if (sSite == null) {
             fetchSites();
-            sSite = mSiteStore.getSites().get(0);
+            sSite = getSiteFromDb();
         }
+    }
+
+    protected SiteModel getSiteFromDb() {
+        return mSiteStore.getSites().get(0);
+    }
+
+    protected AuthenticatePayload buildAuthenticatePayload() {
+        if (mAuthenticatePayload == null) {
+            mAuthenticatePayload = new AuthenticatePayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
+                    BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        }
+        return mAuthenticatePayload;
     }
 
     private void authenticate() throws InterruptedException {
         // Authenticate a test user (actual credentials declared in gradle.properties)
-        AuthenticatePayload payload = new AuthenticatePayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
-                BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        AuthenticatePayload payload = buildAuthenticatePayload();
 
         // Correct user we should get an OnAuthenticationChanged message
         mCountDownLatch = new CountDownLatch(1);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -131,7 +131,7 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
             throw new AssertionError("event error type: " + event.error.type);
         }
         assertTrue(mSiteStore.hasSite());
-        assertTrue(mSiteStore.hasWPComSite());
+        assertTrue(mSiteStore.hasSitesAccessedViaWPComRest());
         assertEquals(TestEvents.SITE_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }

--- a/example/tests.properties-example
+++ b/example/tests.properties-example
@@ -186,6 +186,12 @@ TEST_WPORG_URL_JETPACK_SUBFOLDER_ENDPOINT = FIXME
 TEST_WPCOM_USERNAME_JETPACK_BETA_SITE = FIXME
 TEST_WPCOM_PASSWORD_JETPACK_BETA_SITE = FIXME
 
+## Woo
+
+# WP.com - Account with only one site: a Jetpack site with WooCommerce set up: http://do.wpmt.co/woo-jetpack
+TEST_WPCOM_USERNAME_WOO_JETPACK = FIXME
+TEST_WPCOM_PASSWORD_WOO_JETPACK = FIXME
+
 # Local files to override default samples. Keep the empty string to use default samples.
 # These files should be at least 500KB, otherwise they may cause cancellation tests to fail on fast enough connections.
 # Path (on device) to a test image for uploading, e.g. /sdcard/Pictures/flux-capacitor-schematics.png


### PR DESCRIPTION
Closes #751, adding a basic pair of connected tests for the WooCommerce store and order fetching, along with some scaffolding.

I modified `ReleaseStack_WPComBase` a little, so it can be extended and reused for tests requiring specific types of WordPress.com accounts (and not the default 'agnostic' `TEST_WPCOM_USERNAME_TEST1`/`TEST_WPCOM_PASSWORD_TEST1` pair).

Based on that, I set up `ReleaseStack_WCBase` for tests requiring an account with a Jetpack-connected WooCommerce site. We may want to also, separately, add a `ReleaseStack_JetpackBase`, for tests requiring a Jetpack site specifically.

I'll update the test credentials in the usual place - in the meantime please ping me for the new test credentials.

cc @maxme since we discussed this a bit and it builds a bit on our connected test overhaul