### PR TITLE
Bump minSdk to 15 and fix connected tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   global:
     - MALLOC_ARENA_MAX=2
     - GRADLE_OPTS="-Xmx768m -Xms256m -Xss1m"
-    - ANDROID_SDKS=android-14
-    - ANDROID_TARGET=android-14
+    - ANDROID_SDKS=android-15
+    - ANDROID_TARGET=android-15
 
 before_install:
   # TODO: Remove the following line when Travis' platform-tools are updated to v24+

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -102,9 +102,11 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.8.9'
     testImplementation 'org.robolectric:robolectric:3.6.1'
     testImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
+
     androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestImplementation 'org.mockito:mockito-core:1.10.19'
+    androidTestImplementation 'org.apache.commons:commons-lang3:3.5'
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
     androidTestCompileOnly 'org.glassfish:javax.annotation:10.0-b28'
     // Test orchestrator

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -26,7 +26,7 @@ android {
     defaultConfig {
         versionCode 4
         versionName "0.1"
-        minSdkVersion 14
+        minSdkVersion 15
         targetSdkVersion 25
     }
     buildTypes {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         versionCode 1
         versionName "0.1"
-        minSdkVersion 14
+        minSdkVersion 15
         targetSdkVersion 25
     }
     buildTypes {


### PR DESCRIPTION
It looks like with the update to version `1.20.0` of the utils library in #769, connected tests no longer run, with the error:

>>>
> Manifest merger failed : uses-sdk:minSdkVersion 14 cannot be smaller than version 15 declared in library [org.wordpress:utils:1.20.0] /Users/alex/.gradle/caches/transforms-1/files-1.1/utils-1.20.0.aar/2e2ed7b162ae38291e3a15d01dcb32af/AndroidManifest.xml as the library might be using APIs not available in 14
        Suggestion: use a compatible library with a minSdk of at most 14,
                or increase this project's minSdk version to at least 15,
                or use tools:overrideLibrary="org.wordpress.android.util" to force usage (may lead to runtime failures)

This bumps the minSdk of FluxC to `15`, and also adds an import for a library the connected tests need that's no longer exposed through the `util` lib.

I seem to remember running the connected tests successfully for #769, I wonder if I ran into a caching issue or if I'm just losing it 🙃