### PR TITLE
Issue/add notification subscriptions

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -43,6 +43,7 @@ import org.wordpress.android.fluxc.store.AccountStore.NewUserError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.SubscriptionError;
 import org.wordpress.android.fluxc.store.AccountStore.SubscriptionResponsePayload;
+import org.wordpress.android.fluxc.store.AccountStore.SubscriptionType;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateSubscriptionPayload.SubscriptionFrequency;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -696,6 +697,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(SubscriptionResponse response) {
                         SubscriptionResponsePayload payload = new SubscriptionResponsePayload(response.subscribed);
+                        payload.type = SubscriptionType.EMAIL_COMMENT;
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 },
@@ -731,6 +733,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(SubscriptionResponse response) {
                         SubscriptionResponsePayload payload = new SubscriptionResponsePayload(response.subscribed);
+                        payload.type = SubscriptionType.EMAIL_POST;
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 },
@@ -768,6 +771,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(SubscriptionResponse response) {
                         SubscriptionResponsePayload payload = new SubscriptionResponsePayload(response.subscribed);
+                        payload.type = SubscriptionType.EMAIL_POST_FREQUENCY;
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 },
@@ -803,6 +807,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(SubscriptionResponse response) {
                         SubscriptionResponsePayload payload = new SubscriptionResponsePayload(response.subscribed);
+                        payload.type = SubscriptionType.NOTIFICATION_POST;
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(
                                 payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -369,6 +369,7 @@ public class AccountStore extends Store {
     }
 
     public static class OnSubscriptionUpdated extends OnChanged<SubscriptionError> {
+        public SubscriptionType type;
         public boolean subscribed;
         public OnSubscriptionUpdated() {
         }
@@ -1158,6 +1159,7 @@ public class AccountStore extends Store {
             event.error = new SubscriptionError(event.error.toString(), event.error.message);
         } else {
             event.subscribed = payload.isSubscribed;
+            event.type = payload.type;
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -207,12 +207,20 @@ public class AccountStore extends Store {
     }
 
     public static class SubscriptionResponsePayload extends Payload<SubscriptionError> {
-        public boolean subscribed;
+        public SubscriptionType type;
+        public boolean isSubscribed;
         public SubscriptionResponsePayload() {
         }
-        public SubscriptionResponsePayload(boolean subscribed) {
-            this.subscribed = subscribed;
+        public SubscriptionResponsePayload(boolean isSubscribed) {
+            this.isSubscribed = isSubscribed;
         }
+    }
+
+    public enum SubscriptionType {
+        EMAIL_COMMENT,
+        EMAIL_POST,
+        EMAIL_POST_FREQUENCY,
+        NOTIFICATION_POST
     }
 
     /**
@@ -1149,7 +1157,7 @@ public class AccountStore extends Store {
         if (payload.isError()) {
             event.error = new SubscriptionError(event.error.toString(), event.error.message);
         } else {
-            event.subscribed = payload.subscribed;
+            event.subscribed = payload.isSubscribed;
         }
         emitChange(event);
     }


### PR DESCRIPTION
Update the `SubscriptionResponsePayload` class to include the new `SubscriptionType` in order to differentiate between subscriptions in the `onSubscriptionUpdated` callback used in https://github.com/wordpress-mobile/WordPress-Android/issues/7540.