### PR TITLE
WooCommerce: Store order details

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.mocked;
 import org.wordpress.android.fluxc.example.di.AppSecretsModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.MockedNetworkModule;
+import org.wordpress.android.fluxc.module.MockedWCNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 
 import javax.inject.Singleton;
@@ -15,6 +16,7 @@ import dagger.Component;
         AppSecretsModule.class,
         ReleaseBaseModule.class,
         MockedNetworkModule.class, // Mocked module
+        MockedWCNetworkModule.class // Mocked module
 })
 public interface MockedNetworkAppComponent {
     void inject(MockedStack_AccountTest object);
@@ -22,4 +24,5 @@ public interface MockedNetworkAppComponent {
     void inject(MockedStack_SiteTest object);
     void inject(MockedStack_UploadStoreTest object);
     void inject(MockedStack_UploadTest object);
+    void inject(MockedStack_WCOrdersTest object);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
@@ -24,7 +24,7 @@ public class MockedStack_Base {
         mMockedNetworkAppComponent = DaggerMockedNetworkAppComponent.builder()
                 .appContextModule(new AppContextModule(mAppContext))
                 .build();
-        WellSqlConfig config = new WellSqlConfig(mAppContext);
+        WellSqlConfig config = new WellSqlConfig(mAppContext, WellSqlConfig.ADDON_WOOCOMMERCE);
         WellSql.init(config);
         config.reset();
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -58,6 +58,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         with(payload.orders[0]) {
             assertEquals(5, localSiteId)
             assertEquals(949, remoteOrderId)
+            assertEquals("949", number)
             assertEquals(OrderStatus.PROCESSING, status)
             assertEquals("USD", currency)
             assertEquals("2018-04-02T14:57:39Z", dateCreated)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -1,0 +1,110 @@
+package org.wordpress.android.fluxc.mocked
+
+import org.greenrobot.eventbus.Subscribe
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.action.WCOrderAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.module.MockedNetworkModule
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatus
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlin.properties.Delegates.notNull
+
+/**
+ * Tests using a Mocked Network app component. Test the network client itself and not the underlying
+ * network component(s).
+ */
+class MockedStack_WCOrdersTest : MockedStack_Base() {
+    @Inject internal lateinit var orderRestClient: OrderRestClient
+    @Inject internal lateinit var dispatcher: Dispatcher
+
+    private var lastAction: Action<*>? = null
+    private var countDownLatch: CountDownLatch by notNull()
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mMockedNetworkAppComponent.inject(this)
+        dispatcher.register(this)
+        lastAction = null
+    }
+
+    @Test
+    fun testSuccessfulOrderFetch() {
+        orderRestClient.fetchOrders(SiteModel().apply {
+            id = 5
+            siteId = 567
+        }, 0)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_ORDERS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchOrdersResponsePayload
+        assertNull(payload.error)
+        assertEquals(4, payload.orders.size)
+
+        with(payload.orders[0]) {
+            assertEquals(5, localSiteId)
+            assertEquals(949, remoteOrderId)
+            assertEquals(OrderStatus.PROCESSING, status)
+            assertEquals("USD", currency)
+            assertEquals("2018-04-02T14:57:39Z", dateCreated)
+            assertEquals("44.00", total)
+            assertEquals("0.00", totalTax)
+            assertEquals("4.00", shippingTotal)
+            assertEquals("stripe", paymentMethod)
+            assertEquals("Credit Card (Stripe)", paymentMethodTitle)
+            assertFalse(pricesIncludeTax)
+            assertEquals(2, getLineItemList().size)
+            assertEquals(40.0, getOrderSubtotal(), 0.01)
+        }
+
+        // Refunded order
+        with(payload.orders[2]) {
+            assertEquals(85.0, getOrderSubtotal(), 0.01)
+            assertEquals("7.00", shippingTotal)
+            assertEquals("92.00", total)
+            assertEquals(-92.0, refundTotal, 0.01)
+        }
+
+        // Order with coupons
+        with(payload.orders[3]) {
+            assertEquals(60.0, getOrderSubtotal(), 0.01)
+            assertEquals("7.59", shippingTotal)
+            assertEquals("7.59", total)
+            assertEquals("60.00", discountTotal)
+            assertEquals("20\$off, 40\$off", discountCodes)
+        }
+    }
+
+    @Test
+    fun testOrderFetchErrorResponse() {
+        orderRestClient.fetchOrders(SiteModel().apply { siteId = MockedNetworkModule.FAILURE_SITE_ID }, 0)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_ORDERS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchOrdersResponsePayload
+        assertNotNull(payload.error)
+    }
+
+    @Suppress("unused")
+    @Subscribe
+    fun onAction(action: Action<*>) {
+        lastAction = action
+        countDownLatch.countDown()
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.module
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import dagger.Module
+import dagger.Provides
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import javax.inject.Singleton
+
+@Module
+class MockedWCNetworkModule {
+    @Singleton
+    @Provides
+    fun provideOrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue: RequestQueue,
+                               token: AccessToken, userAgent: UserAgent) =
+            OrderRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
@@ -75,6 +75,12 @@ class ResponseMockingInterceptor implements Interceptor {
                     }
                 case "/wp/v2/settings/":
                     return buildJetpackTunnelWPV2SettingsSuccessResponse(request);
+                case "/wc/v2/orders/":
+                    if (requestUrl.contains(String.valueOf(MockedNetworkModule.FAILURE_SITE_ID))) {
+                        return buildJetpackTunnelRootFailureResponse(request);
+                    } else {
+                        return buildWCOrdersSuccessResponse(request);
+                    }
             }
         }
         throw new IllegalStateException("Interceptor was given a request with no mocks - URL: " + requestUrl);
@@ -102,6 +108,10 @@ class ResponseMockingInterceptor implements Interceptor {
 
     private Response buildJetpackTunnelWPV2SettingsSuccessResponse(Request request) {
         return buildSuccessResponse(request, "jetpack-tunnel-wp-v2-settings-response-success.json");
+    }
+
+    private Response buildWCOrdersSuccessResponse(Request request) {
+        return buildSuccessResponse(request, "wc-orders-response-success.json");
     }
 
     private Response buildSuccessResponse(Request request, String resourceFileName) {

--- a/example/src/androidTest/resources/wc-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-orders-response-success.json
@@ -386,7 +386,7 @@
     {
       "id": 786,
       "parent_id": 0,
-      "number": "786",
+      "number": "56AQ",
       "order_key": "wc_order_5a7cd18fc8e37",
       "created_via": "checkout",
       "version": "3.3.1",

--- a/example/src/androidTest/resources/wc-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-orders-response-success.json
@@ -1,0 +1,615 @@
+{
+  "data": [
+    {
+      "id": 949,
+      "parent_id": 0,
+      "number": "949",
+      "order_key": "wc_order_5ac244e370297",
+      "created_via": "checkout",
+      "version": "3.3.4",
+      "status": "processing",
+      "currency": "USD",
+      "date_created": "2018-04-02T10:57:39",
+      "date_created_gmt": "2018-04-02T14:57:39",
+      "date_modified": "2018-04-02T10:57:43",
+      "date_modified_gmt": "2018-04-02T14:57:43",
+      "discount_total": "0.00",
+      "discount_tax": "0.00",
+      "shipping_total": "4.00",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "44.00",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 1,
+      "customer_ip_address": "100.2.138.170",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10_13_3) applewebkit\/537.36 (khtml, like gecko) chrome\/65.0.3325.162 safari\/537.36",
+      "customer_note": "",
+      "billing": {
+        "first_name": "Jake",
+        "last_name": "Jakeson",
+        "company": "The DeLorean Shop",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Hill Valley",
+        "state": "CA",
+        "postcode": "95420",
+        "country": "US",
+        "email": "jake.jakeson@totallyrealemail.com",
+        "phone": "333-333-3333"
+      },
+      "shipping": {
+        "first_name": "Jake",
+        "last_name": "Jakeson",
+        "company": "The DeLorean Shop",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Hill Valley",
+        "state": "CA",
+        "postcode": "95420",
+        "country": "US"
+      },
+      "payment_method": "stripe",
+      "payment_method_title": "Credit Card (Stripe)",
+      "transaction_id": "ch_abcdef123456",
+      "date_paid": "2018-04-02T10:57:43",
+      "date_paid_gmt": "2018-04-02T14:57:43",
+      "date_completed": null,
+      "date_completed_gmt": null,
+      "cart_hash": "437b930db84b8079c2dd804a71936b5f",
+      "meta_data": [],
+      "line_items": [
+        {
+          "id": 879,
+          "name": "PDF Doc (Downloadable Product)",
+          "product_id": 290,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "10.00",
+          "subtotal_tax": "0.00",
+          "total": "10.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "",
+          "price": 10
+        },
+        {
+          "id": 880,
+          "name": "Black T-shirt (H&M)",
+          "product_id": 373,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "30.00",
+          "subtotal_tax": "0.00",
+          "total": "30.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "111-111-111",
+          "price": 30
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 881,
+          "method_title": "Flat rate",
+          "method_id": "flat_rate:31",
+          "total": "4.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 6426,
+              "key": "Items",
+              "value": "Black T-shirt (H&M) &times; 1"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [],
+      "refunds": [],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders\/949"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders"
+          }
+        ],
+        "customer": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/customers\/1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 939,
+      "parent_id": 0,
+      "number": "939",
+      "order_key": "wc_order_5abff457cc653",
+      "created_via": "checkout",
+      "version": "3.3.4",
+      "status": "processing",
+      "currency": "USD",
+      "date_created": "2018-03-31T16:49:27",
+      "date_created_gmt": "2018-03-31T20:49:27",
+      "date_modified": "2018-03-31T16:49:28",
+      "date_modified_gmt": "2018-03-31T20:49:28",
+      "discount_total": "0.00",
+      "discount_tax": "0.00",
+      "shipping_total": "4.00",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "64.00",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 1,
+      "customer_ip_address": "100.2.138.170",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10_13_3) applewebkit\/537.36 (khtml, like gecko) chrome\/65.0.3325.162 safari\/537.36",
+      "customer_note": "test checkout field editor note",
+      "billing": {
+        "first_name": "Jake",
+        "last_name": "Jakeson",
+        "company": "The DeLorean Shop",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Hill Valley",
+        "state": "CA",
+        "postcode": "95420",
+        "country": "US",
+        "email": "jake.jakeson@totallyrealemail.com",
+        "phone": "333-333-3333"
+      },
+      "shipping": {
+        "first_name": "Jake",
+        "last_name": "Jakeson",
+        "company": "The DeLorean Shop",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Hill Valley",
+        "state": "CA",
+        "postcode": "95420",
+        "country": "US"
+      },
+      "payment_method": "cod",
+      "payment_method_title": "Cash on delivery",
+      "transaction_id": "",
+      "date_paid": null,
+      "date_paid_gmt": null,
+      "date_completed": null,
+      "date_completed_gmt": null,
+      "cart_hash": "437b930db84b8079c2dd804a71936b5f",
+      "meta_data": [],
+      "line_items": [
+        {
+          "id": 877,
+          "name": "Blue T-shirt (Zara)",
+          "product_id": 371,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "60.00",
+          "subtotal_tax": "0.00",
+          "total": "60.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "",
+          "price": 60
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 878,
+          "method_title": "Flat rate",
+          "method_id": "flat_rate:31",
+          "total": "4.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 6403,
+              "key": "Items",
+              "value": "Blue T-shirt (Zara) &times; 1"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [],
+      "refunds": [],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders\/939"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders"
+          }
+        ],
+        "customer": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/customers\/1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 937,
+      "parent_id": 0,
+      "number": "937",
+      "order_key": "wc_order_5abfef9ba073e",
+      "created_via": "checkout",
+      "version": "3.3.4",
+      "status": "refunded",
+      "currency": "USD",
+      "date_created": "2018-03-31T16:29:15",
+      "date_created_gmt": "2018-03-31T20:29:15",
+      "date_modified": "2018-03-31T16:52:05",
+      "date_modified_gmt": "2018-03-31T20:52:05",
+      "discount_total": "0.00",
+      "discount_tax": "0.00",
+      "shipping_total": "7.00",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "92.00",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 1,
+      "customer_ip_address": "100.2.138.170",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10_13_3) applewebkit\/537.36 (khtml, like gecko) chrome\/65.0.3325.162 safari\/537.36",
+      "customer_note": "",
+      "billing": {
+        "first_name": "Jake",
+        "last_name": "Jakeson",
+        "company": "The DeLorean Shop",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Hill Valley",
+        "state": "CA",
+        "postcode": "95420",
+        "country": "US",
+        "email": "jake.jakeson@totallyrealemail.com",
+        "phone": "333-333-3333"
+      },
+      "shipping": {
+        "first_name": "Jake",
+        "last_name": "Jakeson",
+        "company": "The DeLorean Shop",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Hill Valley",
+        "state": "CA",
+        "postcode": "95420",
+        "country": "US"
+      },
+      "payment_method": "cod",
+      "payment_method_title": "Cash on delivery",
+      "transaction_id": "",
+      "date_paid": null,
+      "date_paid_gmt": null,
+      "date_completed": null,
+      "date_completed_gmt": null,
+      "cart_hash": "437b930db84b8079c2dd804a71936b5f",
+      "meta_data": [],
+      "line_items": [
+        {
+          "id": 874,
+          "name": "Twin Peaks T-Shirt (Product Add-On)",
+          "product_id": 348,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "25.00",
+          "subtotal_tax": "0.00",
+          "total": "25.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "",
+          "price": 25
+        },
+        {
+          "id": 875,
+          "name": "Black T-shirt (H&M)",
+          "product_id": 373,
+          "variation_id": 0,
+          "quantity": 2,
+          "tax_class": "",
+          "subtotal": "60.00",
+          "subtotal_tax": "0.00",
+          "total": "60.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "111-111-111",
+          "price": 30
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 876,
+          "method_title": "Flat rate",
+          "method_id": "flat_rate:31",
+          "total": "7.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 6389,
+              "key": "Items",
+              "value": "Twin Peaks T-Shirt (Product Add-On) &times; 1, Black T-shirt (H&M) &times; 2"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [],
+      "refunds": [
+        {
+          "id": 940,
+          "refund": "Order fully refunded",
+          "total": "-92.00"
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders\/937"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders"
+          }
+        ],
+        "customer": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/customers\/1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 786,
+      "parent_id": 0,
+      "number": "786",
+      "order_key": "wc_order_5a7cd18fc8e37",
+      "created_via": "checkout",
+      "version": "3.3.1",
+      "status": "completed",
+      "currency": "USD",
+      "date_created": "2018-02-08T17:39:11",
+      "date_created_gmt": "2018-02-08T22:39:11",
+      "date_modified": "2018-02-19T18:19:03",
+      "date_modified_gmt": "2018-02-19T23:19:03",
+      "discount_total": "60.00",
+      "discount_tax": "0.00",
+      "shipping_total": "7.59",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "7.59",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 1,
+      "customer_ip_address": "108.30.4.3",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10_12_6) applewebkit\/537.36 (khtml, like gecko) chrome\/63.0.3239.132 safari\/537.36",
+      "customer_note": "",
+      "billing": {
+        "first_name": "John",
+        "last_name": "Song",
+        "company": "",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Miami",
+        "state": "CA",
+        "postcode": "33131",
+        "country": "US",
+        "email": "jake.jakeson@totallyrealemail.com",
+        "phone": "333-333-3333"
+      },
+      "shipping": {
+        "first_name": "John",
+        "last_name": "Song",
+        "company": "",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Miami",
+        "state": "CA",
+        "postcode": "33131",
+        "country": "US"
+      },
+      "payment_method": "stripe",
+      "payment_method_title": "Credit Card (Stripe)",
+      "transaction_id": "ch_abcdef123456",
+      "date_paid": "2018-02-08T17:39:13",
+      "date_paid_gmt": "2018-02-08T22:39:13",
+      "date_completed": "2018-02-19T18:19:03",
+      "date_completed_gmt": "2018-02-19T23:19:03",
+      "cart_hash": "437b930db84b8079c2dd804a71936b5f",
+      "meta_data": [],
+      "line_items": [
+        {
+          "id": 822,
+          "name": "Fruits Basket (Mix & Match Product)",
+          "product_id": 52,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "50.00",
+          "subtotal_tax": "0.00",
+          "total": "0.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "",
+          "price": 0
+        },
+        {
+          "id": 823,
+          "name": "Book a Co-Working Desk (Bookable Product)",
+          "product_id": 760,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "10.00",
+          "subtotal_tax": "0.00",
+          "total": "0.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "LE272-A8",
+          "price": 0
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 824,
+          "method_title": "Retail Ground&#8482;",
+          "method_id": "usps:D_STANDARD_POST",
+          "total": "7.59",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 6019,
+              "key": "Package 1",
+              "value": "1 \u00d7 1 \u00d7 1 (in) 1lbs"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [
+        {
+          "id": 825,
+          "code": "20$off",
+          "discount": "20",
+          "discount_tax": "0",
+          "meta_data": [
+            {
+              "id": 6022,
+              "key": "coupon_data",
+              "value": {
+                "id": 672,
+                "code": "20$off",
+                "amount": "20",
+                "date_created": {
+                  "date": "2017-10-29 18:19:18.000000",
+                  "timezone_type": 3,
+                  "timezone": "America\/New_York"
+                },
+                "date_modified": {
+                  "date": "2017-10-29 18:19:18.000000",
+                  "timezone_type": 3,
+                  "timezone": "America\/New_York"
+                },
+                "date_expires": null,
+                "discount_type": "fixed_cart",
+                "description": "",
+                "usage_count": 1,
+                "individual_use": false,
+                "product_ids": [],
+                "excluded_product_ids": [],
+                "usage_limit": 0,
+                "usage_limit_per_user": 0,
+                "limit_usage_to_x_items": null,
+                "free_shipping": false,
+                "product_categories": [],
+                "excluded_product_categories": [],
+                "exclude_sale_items": false,
+                "minimum_amount": "",
+                "maximum_amount": "",
+                "email_restrictions": [],
+                "used_by": [
+                  "1"
+                ],
+                "virtual": false,
+                "meta_data": []
+              }
+            }
+          ]
+        },
+        {
+          "id": 826,
+          "code": "40$off",
+          "discount": "40",
+          "discount_tax": "0",
+          "meta_data": [
+            {
+              "id": 6025,
+              "key": "coupon_data",
+              "value": {
+                "id": 671,
+                "code": "40$off",
+                "amount": "40",
+                "date_created": {
+                  "date": "2017-10-29 18:16:37.000000",
+                  "timezone_type": 3,
+                  "timezone": "America\/New_York"
+                },
+                "date_modified": {
+                  "date": "2017-10-29 18:30:07.000000",
+                  "timezone_type": 3,
+                  "timezone": "America\/New_York"
+                },
+                "date_expires": null,
+                "discount_type": "fixed_cart",
+                "description": "",
+                "usage_count": 0,
+                "individual_use": false,
+                "product_ids": [],
+                "excluded_product_ids": [],
+                "usage_limit": 0,
+                "usage_limit_per_user": 0,
+                "limit_usage_to_x_items": null,
+                "free_shipping": false,
+                "product_categories": [],
+                "excluded_product_categories": [],
+                "exclude_sale_items": false,
+                "minimum_amount": "",
+                "maximum_amount": "",
+                "email_restrictions": [],
+                "used_by": [],
+                "virtual": false,
+                "meta_data": []
+              }
+            }
+          ]
+        }
+      ],
+      "refunds": [],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders\/786"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders"
+          }
+        ],
+        "customer": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/customers\/1"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/UnitTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/UnitTestUtils.java
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
-public class TestUtils {
+public class UnitTestUtils {
     public static final int DEFAULT_TIMEOUT_MS = 30000;
 
     public static void waitFor(long milliseconds) {

--- a/example/src/test/java/org/wordpress/android/fluxc/UnitTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/UnitTestUtils.java
@@ -3,6 +3,11 @@ package org.wordpress.android.fluxc;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
 public class UnitTestUtils {
     public static final int DEFAULT_TIMEOUT_MS = 30000;
 
@@ -16,6 +21,26 @@ public class UnitTestUtils {
 
     public static void waitForNetworkCall() {
         waitFor(DEFAULT_TIMEOUT_MS);
+    }
+
+    public static String getStringFromResourceFile(Class clazz, String filename) {
+        try {
+            InputStream is = clazz.getClassLoader().getResourceAsStream(filename);
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+
+            StringBuilder buffer = new StringBuilder();
+            String lineString;
+
+            while ((lineString = bufferedReader.readLine()) != null) {
+                buffer.append(lineString);
+            }
+
+            bufferedReader.close();
+            return buffer.toString();
+        } catch (IOException e) {
+            AppLog.e(T.TESTS, "Could not load response JSON file.");
+            return null;
+        }
     }
 }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteXMLRPCClientTest.java
@@ -17,7 +17,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowLog;
 import org.wordpress.android.fluxc.Dispatcher;
-import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.UnitTestUtils;
 import org.wordpress.android.fluxc.action.SiteAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -139,7 +139,7 @@ public class SiteXMLRPCClientTest {
                           + "  </struct>\n"
                           + "</value></param></params></methodResponse>";
         mSiteXMLRPCClient.fetchSite(site);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(UnitTestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -186,7 +186,7 @@ public class SiteXMLRPCClientTest {
 
         mCountDownLatch = new CountDownLatch(3);
         mSiteXMLRPCClient.fetchSite(site);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(UnitTestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -208,7 +208,7 @@ public class SiteXMLRPCClientTest {
 
         mCountDownLatch = new CountDownLatch(1);
         mSiteXMLRPCClient.fetchSites(xmlrpcUrl, "thedoc", "gr3@tsc0tt");
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(UnitTestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -251,6 +251,6 @@ public class SiteXMLRPCClientTest {
 
         mCountDownLatch = new CountDownLatch(3);
         mSiteXMLRPCClient.fetchSites(xmlrpcUrl, "thedoc", "gr3@tsc0tt");
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch.await(UnitTestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -6,10 +6,14 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatus
 object OrderTestUtils {
     fun generateSampleOrder(remoteId: Long): WCOrderModel = generateSampleOrder(remoteId, OrderStatus.PROCESSING)
 
-    fun generateSampleOrder(remoteId: Long, status: String): WCOrderModel {
-        val example = WCOrderModel().apply { remoteOrderId = remoteId }
-        example.localSiteId = 6
-        example.status = status
-        return example
+    fun generateSampleOrder(remoteId: Long, orderStatus: String): WCOrderModel {
+        return WCOrderModel().apply {
+            remoteOrderId = remoteId
+            localSiteId = 6
+            status = orderStatus
+            dateCreated = "1955-11-05T14:15:00Z"
+            currency = "USD"
+            total = "10.0"
+        }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.fluxc.wc.order
+
+import org.junit.Test
+import org.wordpress.android.fluxc.UnitTestUtils
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WCOrderModelTest {
+    @Test
+    fun testGetShippingAddress() {
+        val model = OrderTestUtils.generateSampleOrder(61).apply {
+            shippingAddress1 = "Some place"
+        }
+
+        assertEquals("Some place", model.getShippingAddress().address1)
+        model.shippingAddress1 = "something else"
+        assertEquals("something else", model.getShippingAddress().address1)
+    }
+
+    @Test
+    fun testGetShippingVSBillingAddress() {
+        val model = OrderTestUtils.generateSampleOrder(61).apply {
+            billingAddress1 = "Some place"
+            billingCountry = "Canada"
+            shippingAddress1 = "A different place"
+            shippingCountry = "Canada"
+        }
+
+        assertTrue(model.hasSeparateShippingDetails())
+        assertEquals("Some place", model.getBillingAddress().address1)
+        assertEquals("A different place", model.getShippingAddress().address1)
+        model.billingAddress1 = "something else"
+        assertEquals("something else", model.getBillingAddress().address1)
+    }
+
+    @Test
+    fun testGetLineItems() {
+        val model = OrderTestUtils.generateSampleOrder(61).apply {
+            lineItems = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/lineitems.json")
+        }
+        val renderedLineItems = model.getLineItemList()
+        assertEquals(2, renderedLineItems.size)
+
+        with(renderedLineItems[0]) {
+            assertEquals("A test", name)
+            assertEquals(15, productId)
+            assertNull(variationId)
+            assertEquals("10.00", total)
+            assertNull(sku)
+        }
+
+        with(renderedLineItems[1]) {
+            assertEquals("A second test", name)
+            assertEquals(65, productId)
+            assertEquals(3, variationId)
+            assertEquals("20.00", total)
+            assertEquals("blabla", sku)
+        }
+    }
+
+    @Test
+    fun testGetSubtotal() {
+        val model = OrderTestUtils.generateSampleOrder(61).apply {
+            lineItems = "[{\"subtotal\": \"12.26\"},{\"subtotal\": \"15.39\"}]"
+        }
+
+        assertEquals(27.65, model.getOrderSubtotal())
+
+        model.lineItems = "[{\"total\": \"12.26\"},{\"total\": \"15.39\"}]"
+        assertEquals(0.0, model.getOrderSubtotal())
+    }
+}

--- a/example/src/test/resources/wc/lineitems.json
+++ b/example/src/test/resources/wc/lineitems.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id":1,
+    "name":"A test",
+    "product_id":15,
+    "quantity":1,
+    "tax_class":"",
+    "subtotal":"10.00",
+    "subtotal_tax":"0.00",
+    "total":"10.00",
+    "total_tax":"0.00",
+    "taxes":[],
+    "meta_data":[],
+    "sku":null,
+    "price":10
+  },
+  {
+    "id":2,
+    "name":"A second test",
+    "product_id":65,
+    "variation_id":3,
+    "quantity":2,
+    "tax_class":"",
+    "subtotal":"20.00",
+    "subtotal_tax":"0.00",
+    "total":"20.00",
+    "total_tax":"0.00",
+    "taxes":[],
+    "meta_data":[],
+    "sku":"blabla",
+    "price":20
+  }
+]

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -18,7 +18,13 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var status = ""
     @Column var currency = ""
     @Column var dateCreated = "" // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
-    @Column var total = ""
+    @Column var total = "" // Complete total, including taxes
+
+    @Column var totalTax = ""// The total amount of tax (from products, shipping, discounts, etc.)
+    @Column var shippingTotal = "" // The total shipping cost (excluding tax)
+    @Column var paymentMethod = "" // Payment method code, e.g. 'cod', 'stripe'
+    @Column var paymentMethodTitle = "" // Displayable payment method, e.g. 'Cash on delivery', 'Credit Card (Stripe)'
+    @Column var pricesIncludeTax = false
 
     @Column var billingFirstName = ""
     @Column var billingLastName = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -62,6 +62,7 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         @SerializedName("variation_id")
         val variationId: Long? = null
         val quantity: Int? = null
+        val subtotal: String? = null
         val total: String? = null // Price x quantity
         @SerializedName("total_tax")
         val totalTax: String? = null
@@ -100,5 +101,12 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     fun getLineItemList(): List<LineItem> {
         val responseType = object : TypeToken<List<LineItem>>() {}.type
         return gson.fromJson(lineItems, responseType) as? List<LineItem> ?: emptyList()
+    }
+
+    /**
+     * Returns the order subtotal (the sum of the subtotals of each line item in the order).
+     */
+    fun getOrderSubtotal(): Double {
+        return getLineItemList().sumByDouble { it.subtotal?.toDoubleOrNull() ?: 0.0 }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -4,6 +4,8 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.order.OrderAddress
+import org.wordpress.android.fluxc.model.order.OrderAddress.AddressType
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
@@ -14,6 +16,7 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var currency = ""
     @Column var dateCreated = "" // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @Column var total = ""
+
     @Column var billingFirstName = ""
     @Column var billingLastName = ""
     @Column var billingCompany = ""
@@ -51,4 +54,14 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
      * as the shippingX properties will be empty.
      */
     fun hasSeparateShippingDetails() = shippingCountry.isNotEmpty()
+
+    /**
+     * Returns the billing details wrapped in a [OrderAddress].
+     */
+    fun getBillingAddress() = OrderAddress(this, AddressType.BILLING)
+
+    /**
+     * Returns the shipping details wrapped in a [OrderAddress].
+     */
+    fun getShippingAddress() = OrderAddress(this, AddressType.SHIPPING)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -14,7 +14,8 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var localSiteId = 0
-    @Column var remoteOrderId = 0L
+    @Column var remoteOrderId = 0L // The unique identifier for this order on the server
+    @Column var number = "" // The order number to display to the user
     @Column var status = ""
     @Column var currency = ""
     @Column var dateCreated = "" // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -56,11 +56,11 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         @SerializedName("variation_id")
         val variationId: Long? = null
         val quantity: Int? = null
-        val total: Float? = null // Price x quantity
+        val total: String? = null // Price x quantity
         @SerializedName("total_tax")
-        val totalTax: Float? = null
+        val totalTax: String? = null
         val sku: String? = null
-        val price: Float? = null // The per-item price
+        val price: String? = null // The per-item price
     }
 
     override fun getId() = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -16,10 +16,39 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var total = ""
     @Column var billingFirstName = ""
     @Column var billingLastName = ""
+    @Column var billingCompany = ""
+    @Column var billingAddress1 = ""
+    @Column var billingAddress2 = ""
+    @Column var billingCity = ""
+    @Column var billingState = ""
+    @Column var billingPostcode = ""
+    @Column var billingCountry = ""
+    @Column var billingEmail = ""
+    @Column var billingPhone = ""
+
+    @Column var shippingFirstName = ""
+    @Column var shippingLastName = ""
+    @Column var shippingCompany = ""
+    @Column var shippingAddress1 = ""
+    @Column var shippingAddress2 = ""
+    @Column var shippingCity = ""
+    @Column var shippingState = ""
+    @Column var shippingPostcode = ""
+    @Column var shippingCountry = ""
+
 
     override fun getId() = id
 
     override fun setId(id: Int) {
         this.id = id
     }
+
+    /**
+     * Returns true if there are shipping details defined for this order,
+     * which are different from the billing details.
+     *
+     * If no separate shipping details are defined, the billing details should be used instead,
+     * as the shippingX properties will be empty.
+     */
+    fun hasSeparateShippingDetails() = shippingCountry.isNotEmpty()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.model
 
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
@@ -39,6 +42,26 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var shippingPostcode = ""
     @Column var shippingCountry = ""
 
+    @Column var lineItems = ""
+
+    companion object {
+        private val gson by lazy { Gson() }
+    }
+
+    class LineItem {
+        val id: Long? = null
+        val name: String? = null
+        @SerializedName("product_id")
+        val productId: Long? = null
+        @SerializedName("variation_id")
+        val variationId: Long? = null
+        val quantity: Int? = null
+        val total: Float? = null // Price x quantity
+        @SerializedName("total_tax")
+        val totalTax: Float? = null
+        val sku: String? = null
+        val price: Float? = null // The per-item price
+    }
 
     override fun getId() = id
 
@@ -64,4 +87,12 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
      * Returns the shipping details wrapped in a [OrderAddress].
      */
     fun getShippingAddress() = OrderAddress(this, AddressType.SHIPPING)
+
+    /**
+     * Deserializes the JSON contained in [lineItems] into a list of [LineItem] objects.
+     */
+    fun getLineItemList(): List<LineItem> {
+        val responseType = object : TypeToken<List<LineItem>>() {}.type
+        return gson.fromJson(lineItems, responseType) as? List<LineItem> ?: emptyList()
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -29,6 +29,8 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var discountTotal = ""
     @Column var discountCodes = ""
 
+    @Column var refundTotal = 0.0 // The total refund value for this order (usually a negative number)
+
     @Column var billingFirstName = ""
     @Column var billingLastName = ""
     @Column var billingCompany = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -26,6 +26,9 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var paymentMethodTitle = "" // Displayable payment method, e.g. 'Cash on delivery', 'Credit Card (Stripe)'
     @Column var pricesIncludeTax = false
 
+    @Column var discountTotal = ""
+    @Column var discountCodes = ""
+
     @Column var billingFirstName = ""
     @Column var billingLastName = ""
     @Column var billingCompany = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderAddress.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderAddress.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.fluxc.model.order
+
+import org.wordpress.android.fluxc.model.WCOrderModel
+
+class OrderAddress(orderModel: WCOrderModel, type: AddressType) {
+    enum class AddressType {
+        SHIPPING, BILLING
+    }
+
+    val firstName: String
+    val lastName: String
+    val company: String
+    val address1: String
+    val address2: String
+    val city: String
+    val state: String
+    val postcode: String
+    val country: String
+
+    init {
+        when (type) {
+            AddressType.BILLING -> {
+                firstName = orderModel.billingFirstName
+                lastName = orderModel.billingLastName
+                company = orderModel.billingCompany
+                address1 = orderModel.billingAddress1
+                address2 = orderModel.billingAddress2
+                city = orderModel.billingCity
+                state = orderModel.billingState
+                postcode = orderModel.billingPostcode
+                country = orderModel.billingCountry
+            }
+            AddressType.SHIPPING -> {
+                firstName = orderModel.shippingFirstName
+                lastName = orderModel.shippingLastName
+                company = orderModel.shippingCompany
+                address1 = orderModel.shippingAddress1
+                address2 = orderModel.shippingAddress2
+                city = orderModel.shippingCity
+                state = orderModel.shippingState
+                postcode = orderModel.shippingPostcode
+                country = orderModel.shippingCountry
+            }
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
+import com.google.gson.JsonElement
 import org.wordpress.android.fluxc.network.Response
 
 @Suppress("PropertyName")
@@ -38,4 +39,8 @@ class OrderApiResponse : Response {
 
     val billing: Billing? = null
     val shipping: Shipping? = null
+
+    // This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand.
+    // See WCOrderModel.LineItem
+    val line_items: JsonElement? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -35,6 +35,10 @@ class OrderApiResponse : Response {
         val code: String? = null
     }
 
+    class Refund {
+        val total: String? = null
+    }
+
     val number: Long? = null
     val status: String? = null
     val currency: String? = null
@@ -55,4 +59,6 @@ class OrderApiResponse : Response {
     // This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand.
     // See WCOrderModel.LineItem
     val line_items: JsonElement? = null
+
+    val refunds: List<Refund>? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -31,6 +31,10 @@ class OrderApiResponse : Response {
         val country: String? = null
     }
 
+    class CouponLine {
+        val code: String? = null
+    }
+
     val number: Long? = null
     val status: String? = null
     val currency: String? = null
@@ -41,6 +45,9 @@ class OrderApiResponse : Response {
     val payment_method: String? = null
     val payment_method_title: String? = null
     val prices_include_tax: Boolean = false
+
+    val discount_total: String? = null
+    val coupon_lines: List<CouponLine>? = null
 
     val billing: Billing? = null
     val shipping: Shipping? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -4,15 +4,38 @@ import org.wordpress.android.fluxc.network.Response
 
 @Suppress("PropertyName")
 class OrderApiResponse : Response {
+    class Billing {
+        val first_name: String? = null
+        val last_name: String? = null
+        val company: String? = null
+        val address_1: String? = null
+        val address_2: String? = null
+        val city: String? = null
+        val state: String? = null
+        val postcode: String? = null
+        val country: String? = null
+        val email: String? = null
+        val phone: String? = null
+    }
+
+    class Shipping {
+        val first_name: String? = null
+        val last_name: String? = null
+        val company: String? = null
+        val address_1: String? = null
+        val address_2: String? = null
+        val city: String? = null
+        val state: String? = null
+        val postcode: String? = null
+        val country: String? = null
+    }
+
     val number: Long? = null
     val status: String? = null
     val currency: String? = null
     val date_created_gmt: String? = null
     val total: String? = null
-    val billing: Billing? = null
 
-    class Billing {
-        val first_name: String? = null
-        val last_name: String? = null
-    }
+    val billing: Billing? = null
+    val shipping: Shipping? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -39,7 +39,8 @@ class OrderApiResponse : Response {
         val total: String? = null
     }
 
-    val number: Long? = null
+    val id: Long? = null
+    val number: String? = null
     val status: String? = null
     val currency: String? = null
     val date_created_gmt: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -36,6 +36,11 @@ class OrderApiResponse : Response {
     val currency: String? = null
     val date_created_gmt: String? = null
     val total: String? = null
+    val total_tax: String? = null
+    val shipping_total: String? = null
+    val payment_method: String? = null
+    val payment_method_title: String? = null
+    val prices_include_tax: Boolean = false
 
     val billing: Billing? = null
     val shipping: Shipping? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -60,7 +60,8 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
 
     private fun orderResponseToOrderModel(response: OrderApiResponse): WCOrderModel {
         return WCOrderModel().apply {
-            remoteOrderId = response.number ?: 0
+            remoteOrderId = response.id ?: 0
+            number = response.number ?: remoteOrderId.toString()
             status = response.status ?: ""
             currency = response.currency ?: ""
             dateCreated = "${response.date_created_gmt}Z" // Store the date in UTC format

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -71,6 +71,14 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
             paymentMethodTitle = response.payment_method_title ?: ""
             pricesIncludeTax = response.prices_include_tax
 
+            discountTotal = response.discount_total ?: ""
+            response.coupon_lines?.let { couponLines ->
+                // Extract the discount codes from the coupon_lines list and store them as a comma-delimited String
+                discountCodes = couponLines
+                        .filter { !it.code.isNullOrEmpty() }
+                        .joinToString { it.code!! }
+            }
+
             billingFirstName = response.billing?.first_name ?: ""
             billingLastName = response.billing?.last_name ?: ""
             billingCompany = response.billing?.company ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -65,6 +65,11 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
             currency = response.currency ?: ""
             dateCreated = "${response.date_created_gmt}Z" // Store the date in UTC format
             total = response.total ?: ""
+            totalTax = response.total_tax ?: ""
+            shippingTotal = response.shipping_total ?: ""
+            paymentMethod = response.payment_method ?: ""
+            paymentMethodTitle = response.payment_method_title ?: ""
+            pricesIncludeTax = response.prices_include_tax
 
             billingFirstName = response.billing?.first_name ?: ""
             billingLastName = response.billing?.last_name ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -79,6 +79,11 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
                         .joinToString { it.code!! }
             }
 
+            response.refunds?.let { refunds ->
+                // Extract the individual refund totals from the refunds list and store their sum as a Double
+                refundTotal = refunds.sumByDouble { it.total?.toDoubleOrNull() ?: 0.0 }
+            }
+
             billingFirstName = response.billing?.first_name ?: ""
             billingLastName = response.billing?.last_name ?: ""
             billingCompany = response.billing?.company ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -65,6 +65,7 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
             currency = response.currency ?: ""
             dateCreated = "${response.date_created_gmt}Z" // Store the date in UTC format
             total = response.total ?: ""
+
             billingFirstName = response.billing?.first_name ?: ""
             billingLastName = response.billing?.last_name ?: ""
             billingCompany = response.billing?.company ?: ""
@@ -86,6 +87,8 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
             shippingState = response.shipping?.state ?: ""
             shippingPostcode = response.shipping?.postcode ?: ""
             shippingCountry = response.shipping?.country ?: ""
+
+            lineItems = response.line_items.toString()
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -67,6 +67,25 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
             total = response.total ?: ""
             billingFirstName = response.billing?.first_name ?: ""
             billingLastName = response.billing?.last_name ?: ""
+            billingCompany = response.billing?.company ?: ""
+            billingAddress1 = response.billing?.address_1 ?: ""
+            billingAddress2 = response.billing?.address_2 ?: ""
+            billingCity = response.billing?.city ?: ""
+            billingState = response.billing?.state ?: ""
+            billingPostcode = response.billing?.postcode ?: ""
+            billingCountry = response.billing?.country ?: ""
+            billingEmail = response.billing?.email ?: ""
+            billingPhone = response.billing?.phone ?: ""
+
+            shippingFirstName = response.shipping?.first_name ?: ""
+            shippingLastName = response.shipping?.last_name ?: ""
+            shippingCompany = response.shipping?.company ?: ""
+            shippingAddress1 = response.shipping?.address_1 ?: ""
+            shippingAddress2 = response.shipping?.address_2 ?: ""
+            shippingCity = response.shipping?.city ?: ""
+            shippingState = response.shipping?.state ?: ""
+            shippingPostcode = response.shipping?.postcode ?: ""
+            shippingCountry = response.shipping?.country ?: ""
         }
     }
 }


### PR DESCRIPTION
Adds more fields to the `WCOrderModel`, mainly customer details, payment information, and the product list. Also adds some some unit and mocked network tests.

cc @AmandaRiu 