### PR TITLE
GDPR - Add Tracks Opt Out field to Account Settings

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
@@ -37,10 +37,12 @@ public class AccountModelTest {
         copyAccount.setVisibleSiteCount(testAccount.getVisibleSiteCount() + 1);
         copyAccount.setEmail("copyEmail");
         copyAccount.setPendingEmailChange(!testAccount.getPendingEmailChange());
+        copyAccount.setTracksOptOut(!testAccount.getTracksOptOut());
         Assert.assertFalse(copyAccount.equals(testAccount));
         testAccount.copyAccountAttributes(copyAccount);
         Assert.assertFalse(copyAccount.equals(testAccount));
         copyAccount.setPendingEmailChange(testAccount.getPendingEmailChange());
+        copyAccount.setTracksOptOut(testAccount.getTracksOptOut());
         Assert.assertTrue(copyAccount.equals(testAccount));
     }
 
@@ -56,6 +58,7 @@ public class AccountModelTest {
         copyAccount.setDate("copyDate");
         copyAccount.setNewEmail("copyNewEmail");
         copyAccount.setPendingEmailChange(!testAccount.getPendingEmailChange());
+        copyAccount.setTracksOptOut(!testAccount.getTracksOptOut());
         copyAccount.setWebAddress("copyWebAddress");
         copyAccount.setUserId(testAccount.getUserId() + 1);
         Assert.assertFalse(copyAccount.equals(testAccount));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -35,6 +35,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
     @Column private String mNewEmail;
     @Column private boolean mPendingEmailChange;
     @Column private String mWebAddress; // WPCom rest API: user_URL
+    @Column private boolean mTracksOptOut;
 
     public AccountModel() {
         init();
@@ -74,7 +75,8 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
                && StringUtils.equals(getNewEmail(), otherAccount.getNewEmail())
                && getPendingEmailChange() == otherAccount.getPendingEmailChange()
                && StringUtils.equals(getWebAddress(), otherAccount.getWebAddress())
-               && getHasUnseenNotes() == otherAccount.getHasUnseenNotes();
+               && getHasUnseenNotes() == otherAccount.getHasUnseenNotes()
+               && getTracksOptOut() == otherAccount.getTracksOptOut();
     }
 
     public void init() {
@@ -95,6 +97,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
         mNewEmail = "";
         mPendingEmailChange = false;
         mWebAddress = "";
+        mTracksOptOut = false;
     }
 
     /**
@@ -128,6 +131,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
         setDate(other.getDate());
         setNewEmail(other.getNewEmail());
         setPendingEmailChange(other.getPendingEmailChange());
+        setTracksOptOut(other.getTracksOptOut());
         setWebAddress(other.getWebAddress());
         setDisplayName(other.getDisplayName());
     }
@@ -274,5 +278,13 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
 
     public void setHasUnseenNotes(boolean hasUnseenNotes) {
         mHasUnseenNotes = hasUnseenNotes;
+    }
+
+    public boolean getTracksOptOut() {
+        return mTracksOptOut;
+    }
+
+    public void setTracksOptOut(boolean tracksOptOut) {
+        mTracksOptOut = tracksOptOut;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -808,6 +808,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         account.setNewEmail(from.new_user_email);
         account.setAvatarUrl(from.avatar_URL);
         account.setPendingEmailChange(from.user_email_change_pending);
+        account.setTracksOptOut(from.tracks_opt_out);
         account.setWebAddress(from.user_URL);
         account.setPrimarySiteId(from.primary_site_ID);
         return account;
@@ -834,6 +835,9 @@ public class AccountRestClient extends BaseWPComRestClient {
         if (from.containsKey("user_email")) accountModel.setEmail((String) from.get("user_email"));
         if (from.containsKey("user_email_change_pending")) {
             accountModel.setPendingEmailChange((Boolean) from.get("user_email_change_pending"));
+        }
+        if (from.containsKey("tracks_opt_out")) {
+            accountModel.setTracksOptOut((Boolean) from.get("tracks_opt_out"));
         }
         if (from.containsKey("new_user_email")) accountModel.setEmail((String) from.get("new_user_email"));
         if (from.containsKey("user_URL")) accountModel.setWebAddress((String) from.get("user_URL"));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSettingsResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSettingsResponse.java
@@ -19,4 +19,5 @@ public class AccountSettingsResponse implements Response {
     public String user_URL;
     public String avatar_URL;
     public long primary_site_ID;
+    public boolean tracks_opt_out;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -41,7 +41,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 27;
+        return 28;
     }
 
     @Override
@@ -223,6 +223,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("ALTER TABLE SiteModel ADD IS_WP_COM_STORE INTEGER");
                 db.execSQL("ALTER TABLE SiteModel ADD HAS_WOO_COMMERCE INTEGER");
+                oldVersion++;
+            case 27:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table AccountModel add TRACKS_OPT_OUT boolean;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
As part of the GDPR efforts, WordPress.com recently introduced a new setting to opt-out. We want to sync the opt-out in the apps with that value whenever the user is signed in.

The setting is stored as tracks_opt_out in me/settings.


Once this PR is merged I will take care of implementing the opt-out in wp-android as soon as possible.