### PR TITLE
WooCommerce: Add customer_note mapping to WCOrderModel

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -72,6 +72,11 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals(40.0, getOrderSubtotal(), 0.01)
         }
 
+        // Customer note
+        with(payload.orders[1]) {
+            assertEquals("test checkout field editor note", customerNote)
+        }
+
         // Refunded order
         with(payload.orders[2]) {
             assertEquals(85.0, getOrderSubtotal(), 0.01)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -27,6 +27,8 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var paymentMethodTitle = "" // Displayable payment method, e.g. 'Cash on delivery', 'Credit Card (Stripe)'
     @Column var pricesIncludeTax = false
 
+    @Column var customerNote = "" // Note left by the customer during order submission
+
     @Column var discountTotal = ""
     @Column var discountCodes = ""
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -51,6 +51,8 @@ class OrderApiResponse : Response {
     val payment_method_title: String? = null
     val prices_include_tax: Boolean = false
 
+    val customer_note: String? = null
+
     val discount_total: String? = null
     val coupon_lines: List<CouponLine>? = null
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -72,6 +72,8 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
             paymentMethodTitle = response.payment_method_title ?: ""
             pricesIncludeTax = response.prices_include_tax
 
+            customerNote = response.customer_note ?: ""
+
             discountTotal = response.discount_total ?: ""
             response.coupon_lines?.let { couponLines ->
                 // Extract the discount codes from the coupon_lines list and store them as a comma-delimited String


### PR DESCRIPTION
Adds the new `WCOrderModel.customerNote` field mapped from the order api response element `customer_note`.

Tests have also been updated where applicable.

cc: @aforcier 