### PR TITLE
Activity store - part 6 - move pagination to store

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.fluxc.release
 
 import org.greenrobot.eventbus.Subscribe
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.ActivityLogAction
@@ -14,7 +17,9 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.AccountStore.*
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
 import org.wordpress.android.fluxc.store.SiteStore
@@ -23,7 +28,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.Store
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import java.util.*
+import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -1,10 +1,7 @@
 package org.wordpress.android.fluxc.release
 
 import org.greenrobot.eventbus.Subscribe
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.ActivityLogAction
@@ -17,9 +14,7 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
-import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
-import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
+import org.wordpress.android.fluxc.store.AccountStore.*
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
 import org.wordpress.android.fluxc.store.SiteStore
@@ -28,7 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.Store
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import java.util.Date
+import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -69,8 +64,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         this.mCountDownLatch = CountDownLatch(1)
-        val numOfActivitiesRequested = 1
-        val payload = ActivityLogStore.FetchActivityLogPayload(site, numOfActivitiesRequested, 0)
+        val payload = ActivityLogStore.FetchActivityLogPayload(site)
         activityLogStore.onAction(ActivityLogActionBuilder.newFetchActivitiesAction(payload))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
         assertTrue(incomingActions.size == 1)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -104,7 +104,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         val secondActivity = activityLogModel(2)
         val thirdActivity = activityLogModel(3)
         val activityModels = listOf(firstActivity, secondActivity, thirdActivity)
-        val payload = FetchedActivityLogPayload(activityModels, site, 3, 0)
+        val payload = FetchedActivityLogPayload(activityModels, site, 3, 3, 0)
 
         activityLogStore.onAction(ActivityLogActionBuilder.newFetchedActivitiesAction(payload))
 
@@ -123,7 +123,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         this.mCountDownLatch = CountDownLatch(1)
 
         val activity = activityLogModel(1)
-        val payload = FetchedActivityLogPayload(listOf(activity), site, 1, 0)
+        val payload = FetchedActivityLogPayload(listOf(activity), site, 1, 1, 0)
 
         activityLogStore.onAction(ActivityLogActionBuilder.newFetchedActivitiesAction(payload))
 
@@ -133,7 +133,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         assertEquals(activityLogForSite[0], activity)
 
         val updatedName = "updatedName"
-        val updatedPayload = FetchedActivityLogPayload(listOf(activity.copy(name = updatedName)), site, 1, 0)
+        val updatedPayload = FetchedActivityLogPayload(listOf(activity.copy(name = updatedName)), site, 1, 1, 0)
 
         activityLogStore.onAction(ActivityLogActionBuilder.newFetchedActivitiesAction(updatedPayload))
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
@@ -22,8 +22,7 @@ val ACTIVITY_RESPONSE = ActivityLogRestClient.ActivitiesResponse.ActivityRespons
         "10.0",
         "gridicon.jpg",
         "OK",
-        "activity123",
-        false)
+        "activity123")
 val ACTIVITY_RESPONSE_PAGE = ActivityLogRestClient.ActivitiesResponse.Page(listOf(ACTIVITY_RESPONSE))
 val RESTORE_RESPONSE = ActivityLogRestClient.RewindStatusResponse.RestoreStatusResponse(rewind_id = "123",
         status = RewindStatusModel.RestoreStatus.Status.RUNNING.value,

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -106,6 +106,7 @@ class ActivityLogRestClientTest {
             assertEquals(this.type, ActivityLogAction.FETCHED_ACTIVITIES)
             assertEquals(this.payload.number, number)
             assertEquals(this.payload.offset, offset)
+            assertEquals(this.payload.totalItems, 1)
             assertEquals(this.payload.site, site)
             assertEquals(this.payload.activityLogModels.size, 1)
             assertNull(this.payload.error)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -113,7 +113,6 @@ class ActivityLogRestClientTest {
             with(this.payload.activityLogModels[0]) {
                 assertEquals(this.activityID, ACTIVITY_RESPONSE.activity_id)
                 assertEquals(this.gridicon, ACTIVITY_RESPONSE.gridicon)
-                assertEquals(this.discarded, ACTIVITY_RESPONSE.is_discarded)
                 assertEquals(this.name, ACTIVITY_RESPONSE.name)
                 assertEquals(this.published, ACTIVITY_RESPONSE.published)
                 assertEquals(this.rewindID, ACTIVITY_RESPONSE.rewind_id)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -89,6 +89,20 @@ class ActivityLogStoreTest {
     }
 
     @Test
+    fun cannotLoadMoreWhenResponseEmpty() {
+        val activityModels = listOf<ActivityLogModel>()
+        val payload = ActivityLogStore.FetchedActivityLogPayload(activityModels, siteModel, 100, 10, 0)
+        val action = ActivityLogActionBuilder.newFetchedActivitiesAction(payload)
+
+        activityLogStore.onAction(action)
+
+        val expectedChangeEvent = ActivityLogStore.OnActivityLogFetched(0,
+                false,
+                ActivityLogAction.FETCHED_ACTIVITIES)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
+    @Test
     fun setsLoadMoreToTrueOnMoreItems() {
         val activityModels = listOf<ActivityLogModel>(mock())
         val payload = ActivityLogStore.FetchedActivityLogPayload(activityModels, siteModel, 15, 10, 0)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -1,6 +1,10 @@
 package org.wordpress.android.fluxc.store
 
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
 import com.yarolegovich.wellsql.SelectQuery
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/ActivityLogModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/ActivityLogModel.kt
@@ -13,7 +13,6 @@ data class ActivityLogModel(
     val rewindable: Boolean?,
     val rewindID: String?,
     val published: Date,
-    val discarded: Boolean?,
     val actor: ActivityActor? = null
 ) {
     enum class Status(value: String) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -122,7 +122,6 @@ class ActivityLogRestClient
                             rewindable = it.is_rewindable,
                             rewindID = it.rewind_id,
                             published = it.published,
-                            discarded = it.is_discarded,
                             actor = it.actor?.let {
                                 ActivityLogModel.ActivityActor(
                                         it.name,
@@ -211,8 +210,7 @@ class ActivityLogRestClient
             val rewind_id: String?,
             val gridicon: String?,
             val status: String?,
-            val activity_id: String?,
-            val is_discarded: Boolean?
+            val activity_id: String?
         )
 
         class Content(val text: String?)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -53,7 +53,7 @@ class ActivityLogRestClient
                             ActivityLogErrorType.GENERIC_ERROR,
                             ActivityLogErrorType.INVALID_RESPONSE,
                             ActivityLogErrorType.AUTHORIZATION_REQUIRED
-                    ),
+                    )
                     val error = ActivityError(errorType, networkError.message)
                     val payload = FetchedActivityLogPayload(error, site, number = number, offset = offset)
                     dispatcher.dispatch(ActivityLogActionBuilder.newFetchedActivitiesAction(payload))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -124,7 +124,7 @@ class ActivityLogRestClient
             }
         }
         error?.let {
-            return FetchedActivityLogPayload(ActivityError(it), site, number, totalItems, offset)
+            return FetchedActivityLogPayload(ActivityError(it), site, totalItems, number, offset)
         }
         return FetchedActivityLogPayload(activities, site, totalItems, number, offset)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -51,6 +51,10 @@ class ActivityLogSqlUtils
                 .map { it.build() }
     }
 
+    fun deleteActivityLog(): Int {
+        return WellSql.delete(ActivityLogBuilder::class.java).execute()
+    }
+
     fun insertOrUpdateRewindStatus(site: SiteModel, rewindStatusModel: RewindStatusModel) {
         val existingRewindStatus = getRewindStatusBuilder(site)
         val rewindStatusBuilder = rewindStatusModel.toBuilder(site)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -11,7 +11,7 @@ import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -97,7 +97,6 @@ class ActivityLogSqlUtils
                 rewindable = this.rewindable,
                 rewindID = this.rewindID,
                 published = this.published.time,
-                discarded = this.discarded,
                 displayName = this.actor?.displayName,
                 actorType = this.actor?.type,
                 wpcomUserID = this.actor?.wpcomUserID,
@@ -153,10 +152,13 @@ class ActivityLogSqlUtils
         override fun getId() = mId
 
         fun build(): ActivityLogModel {
-            var actor: ActivityLogModel.ActivityActor? = null
-            if (actorType != null || displayName != null || wpcomUserID != null || avatarURL != null || role != null) {
-                actor = ActivityLogModel.ActivityActor(displayName, type, wpcomUserID, avatarURL, role)
-            }
+            val actor = if (actorType != null ||
+                    displayName != null ||
+                    wpcomUserID != null ||
+                    avatarURL != null ||
+                    role != null) {
+                ActivityLogModel.ActivityActor(displayName, type, wpcomUserID, avatarURL, role)
+            } else null
             return ActivityLogModel(activityID,
                     summary,
                     text,
@@ -167,7 +169,6 @@ class ActivityLogSqlUtils
                     rewindable,
                     rewindID,
                     Date(published),
-                    discarded,
                     actor)
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -69,7 +69,8 @@ class ActivityLogStore
             val rowsAffected = if (payload.activityLogModels.isNotEmpty())
                 activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
             else 0
-            emitChange(OnActivityLogFetched(rowsAffected, action))
+            val canLoadMore = (payload.offset + payload.number) < payload.totalItems
+            emitChange(OnActivityLogFetched(rowsAffected, canLoadMore, action))
         }
     }
 
@@ -90,9 +91,10 @@ class ActivityLogStore
 
     // Actions
     data class OnActivityLogFetched(val rowsAffected: Int,
+                                    val canLoadMore: Boolean,
                                     var causeOfChange: ActivityLogAction) : Store.OnChanged<ActivityError>() {
         constructor(error: ActivityError, causeOfChange: ActivityLogAction) :
-                this(rowsAffected = 0, causeOfChange = causeOfChange) {
+                this(rowsAffected = 0, canLoadMore = true, causeOfChange = causeOfChange) {
             this.error = error
         }
     }
@@ -112,12 +114,14 @@ class ActivityLogStore
 
     class FetchedActivityLogPayload(val activityLogModels: List<ActivityLogModel> = listOf(),
                                     val site: SiteModel,
+                                    val totalItems: Int,
                                     val number: Int,
                                     val offset: Int) : Payload<ActivityError>() {
         constructor(error: ActivityError,
                     site: SiteModel,
+                    totalItems: Int = 0,
                     number: Int,
-                    offset: Int) : this(site = site, number = number, offset = offset) {
+                    offset: Int) : this(site = site, totalItems = totalItems, number = number, offset = offset) {
             this.error = error
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -31,11 +31,10 @@ class ActivityLogStore
         when (actionType) {
             ActivityLogAction.FETCH_ACTIVITIES -> fetchActivities(action.payload as FetchActivityLogPayload)
             ActivityLogAction.FETCHED_ACTIVITIES ->
-                storeActivityLog(action.payload as FetchedActivityLogPayload,
-                                 actionType)
+                storeActivityLog(action.payload as FetchedActivityLogPayload, actionType)
             ActivityLogAction.FETCH_REWIND_STATE -> fetchActivitiesRewind(action.payload as FetchRewindStatePayload)
-            ActivityLogAction.FETCHED_REWIND_STATE -> storeRewindState(action.payload as FetchedRewindStatePayload,
-                                                                       actionType)
+            ActivityLogAction.FETCHED_REWIND_STATE ->
+                storeRewindState(action.payload as FetchedRewindStatePayload, actionType)
         }
     }
 
@@ -56,7 +55,7 @@ class ActivityLogStore
         var offset = 0
         if (fetchActivityLogPayload.loadMore) {
             offset = activityLogSqlUtils.getActivitiesForSite(fetchActivityLogPayload.site,
-                                                                             SelectQuery.ORDER_ASCENDING).size
+                    SelectQuery.ORDER_ASCENDING).size
         } else {
             activityLogSqlUtils.deleteActivityLog()
         }
@@ -65,8 +64,7 @@ class ActivityLogStore
 
     private fun storeActivityLog(payload: FetchedActivityLogPayload, action: ActivityLogAction) {
         if (payload.activityLogModels.isNotEmpty()) {
-            val rowsAffected = activityLogSqlUtils.insertOrUpdateActivities(payload.site,
-                                                                            payload.activityLogModels)
+            val rowsAffected = activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
             emitChange(OnActivityLogFetched(rowsAffected, action))
         } else if (payload.error != null) {
             emitChange(OnActivityLogFetched(payload.error, action))
@@ -75,8 +73,7 @@ class ActivityLogStore
 
     private fun storeRewindState(payload: FetchedRewindStatePayload, action: ActivityLogAction) {
         if (payload.rewindStatusModelResponse != null) {
-            activityLogSqlUtils.insertOrUpdateRewindStatus(payload.site,
-                                                           payload.rewindStatusModelResponse)
+            activityLogSqlUtils.insertOrUpdateRewindStatus(payload.site, payload.rewindStatusModelResponse)
             emitChange(OnRewindStatusFetched(action))
         } else if (payload.error != null) {
             emitChange(OnRewindStatusFetched(payload.error, action))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -73,7 +73,8 @@ class ActivityLogStore
             val rowsAffected = if (payload.activityLogModels.isNotEmpty())
                 activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
             else 0
-            val canLoadMore = (payload.offset + payload.number) < payload.totalItems
+            val canLoadMore = payload.activityLogModels.isNotEmpty()
+                    && (payload.offset + payload.number) < payload.totalItems
             emitChange(OnActivityLogFetched(rowsAffected, canLoadMore, action))
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -73,8 +73,8 @@ class ActivityLogStore
             val rowsAffected = if (payload.activityLogModels.isNotEmpty())
                 activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
             else 0
-            val canLoadMore = payload.activityLogModels.isNotEmpty()
-                    && (payload.offset + payload.number) < payload.totalItems
+            val canLoadMore = payload.activityLogModels.isNotEmpty() &&
+                    (payload.offset + payload.number) < payload.totalItems
             emitChange(OnActivityLogFetched(rowsAffected, canLoadMore, action))
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -158,8 +158,7 @@ class ActivityLogStore
         MISSING_PUBLISHED_DATE
     }
 
-    class ActivityError(var type: ActivityLogErrorType,
-                        var message: String? = null) : Store.OnChangedError
+    class ActivityError(var type: ActivityLogErrorType, var message: String? = null) : Store.OnChangedError
 
     enum class RewindStatusErrorType {
         GENERIC_ERROR,
@@ -172,6 +171,5 @@ class ActivityLogStore
         INVALID_RESTORE_STATUS
     }
 
-    class RewindStatusError(var type: RewindStatusErrorType,
-                            var message: String? = null) : Store.OnChangedError
+    class RewindStatusError(var type: RewindStatusErrorType, var message: String? = null) : Store.OnChangedError
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -63,20 +63,24 @@ class ActivityLogStore
     }
 
     private fun storeActivityLog(payload: FetchedActivityLogPayload, action: ActivityLogAction) {
-        if (payload.activityLogModels.isNotEmpty()) {
-            val rowsAffected = activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
-            emitChange(OnActivityLogFetched(rowsAffected, action))
-        } else if (payload.error != null) {
+        if (payload.error != null) {
             emitChange(OnActivityLogFetched(payload.error, action))
+        } else {
+            val rowsAffected = if (payload.activityLogModels.isNotEmpty())
+                activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
+            else 0
+            emitChange(OnActivityLogFetched(rowsAffected, action))
         }
     }
 
     private fun storeRewindState(payload: FetchedRewindStatePayload, action: ActivityLogAction) {
-        if (payload.rewindStatusModelResponse != null) {
-            activityLogSqlUtils.insertOrUpdateRewindStatus(payload.site, payload.rewindStatusModelResponse)
-            emitChange(OnRewindStatusFetched(action))
-        } else if (payload.error != null) {
+        if (payload.error != null) {
             emitChange(OnRewindStatusFetched(payload.error, action))
+        } else {
+            if (payload.rewindStatusModelResponse != null) {
+                activityLogSqlUtils.insertOrUpdateRewindStatus(payload.site, payload.rewindStatusModelResponse)
+            }
+            emitChange(OnRewindStatusFetched(action))
         }
     }
 


### PR DESCRIPTION
- change logic so the client doesn't need to know what page it's on. It requests either the first or a next page. On first the store cleans up the DB, on next page it reads size of activity log in DB and loads the next page