### PR TITLE
WooCommerce: Update order status

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
@@ -46,13 +46,11 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
                 { _: RootWPAPIRestResponse? ->
                     throw AssertionError("Unexpected success!")
                 },
-                BaseErrorListener {
-                    error -> run {
-                        // Verify that the error response is correctly parsed
-                        assertEquals("rest_no_route", (error as WPComGsonNetworkError).apiError)
-                        assertEquals("No route was found matching the URL and request method", error.message)
-                        countDownLatch.countDown()
-                    }
+                BaseErrorListener { error ->
+                    // Verify that the error response is correctly parsed
+                    assertEquals("rest_no_route", (error as WPComGsonNetworkError).apiError)
+                    assertEquals("No route was found matching the URL and request method", error.message)
+                    countDownLatch.countDown()
                 })
 
         jetpackTunnelClient.exposedAdd(request)
@@ -68,17 +66,13 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, 567, params,
                 RootWPAPIRestResponse::class.java,
                 { response: RootWPAPIRestResponse? ->
-                    run {
-                        // Verify that the successful response is correctly parsed
-                        assertTrue(response?.namespaces?.contains("wp/v2")!!)
-                        countDownLatch.countDown()
-                    }
+                    // Verify that the successful response is correctly parsed
+                    assertTrue(response?.namespaces?.contains("wp/v2")!!)
+                    countDownLatch.countDown()
                 },
-                BaseErrorListener {
-                    error -> run {
-                        throw AssertionError("Unexpected BaseNetworkError: "
-                                + (error as WPComGsonNetworkError).apiError + " - " + error.message)
-                    }
+                BaseErrorListener { error ->
+                    throw AssertionError("Unexpected BaseNetworkError: "
+                            + (error as WPComGsonNetworkError).apiError + " - " + error.message)
                 })
 
         jetpackTunnelClient.exposedAdd(request)
@@ -95,19 +89,15 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
         val request = JetpackTunnelGsonRequest.buildPostRequest(url, 567, requestBody,
                 SettingsAPIResponse::class.java,
                 { response: SettingsAPIResponse? ->
-                    run {
-                        // Verify that the successful response is correctly parsed
-                        assertEquals("New Title", response?.title)
-                        assertEquals("New Description", response?.description)
-                        assertNull(response?.language)
-                        countDownLatch.countDown()
-                    }
+                    // Verify that the successful response is correctly parsed
+                    assertEquals("New Title", response?.title)
+                    assertEquals("New Description", response?.description)
+                    assertNull(response?.language)
+                    countDownLatch.countDown()
                 },
-                BaseErrorListener {
-                    error -> run {
-                        throw AssertionError("Unexpected BaseNetworkError: "
-                                + (error as WPComGsonNetworkError).apiError + " - " + error.message)
-                    }
+                BaseErrorListener { error ->
+                    throw AssertionError("Unexpected BaseNetworkError: "
+                            + (error as WPComGsonNetworkError).apiError + " - " + error.message)
                 })
 
         jetpackTunnelClient.exposedAdd(request)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.java
@@ -31,6 +31,8 @@ import okio.Buffer;
 import okio.BufferedSource;
 import okio.Okio;
 
+import static org.wordpress.android.fluxc.mocked.MockedStack_WCOrdersTest.TEST_UPDATE_ORDER_ID;
+
 class ResponseMockingInterceptor implements Interceptor {
     @Override
     public Response intercept(@NonNull Interceptor.Chain chain) throws IOException {
@@ -81,6 +83,12 @@ class ResponseMockingInterceptor implements Interceptor {
                     } else {
                         return buildWCOrdersSuccessResponse(request);
                     }
+                case "/wc/v2/orders/" + TEST_UPDATE_ORDER_ID + "/":
+                    if (requestUrl.contains(String.valueOf(MockedNetworkModule.FAILURE_SITE_ID))) {
+                        return buildWCOrderUpdateFailureResponse(request);
+                    } else {
+                        return buildWCOrderUpdateSuccessResponse(request);
+                    }
             }
         }
         throw new IllegalStateException("Interceptor was given a request with no mocks - URL: " + requestUrl);
@@ -112,6 +120,14 @@ class ResponseMockingInterceptor implements Interceptor {
 
     private Response buildWCOrdersSuccessResponse(Request request) {
         return buildSuccessResponse(request, "wc-orders-response-success.json");
+    }
+
+    private Response buildWCOrderUpdateSuccessResponse(Request request) {
+        return buildSuccessResponse(request, "wc-order-update-response-success.json");
+    }
+
+    private Response buildWCOrderUpdateFailureResponse(Request request) {
+        return buildErrorResponse(request, "wc-order-update-response-failure-invalid-id.json", 400);
     }
 
     private Response buildSuccessResponse(Request request, String resourceFileName) {

--- a/example/src/androidTest/resources/wc-order-update-response-failure-invalid-id.json
+++ b/example/src/androidTest/resources/wc-order-update-response-failure-invalid-id.json
@@ -1,0 +1,4 @@
+{
+  "error": "woocommerce_rest_shop_order_invalid_id",
+  "message": "Invalid ID."
+}

--- a/example/src/androidTest/resources/wc-order-update-response-success.json
+++ b/example/src/androidTest/resources/wc-order-update-response-success.json
@@ -1,0 +1,123 @@
+{
+  "data": {
+    "id": 88,
+    "parent_id": 0,
+    "number": "88",
+    "order_key": "wc_order_5a77766b88986",
+    "created_via": "checkout",
+    "version": "3.3.5",
+    "status": "refunded",
+    "currency": "USD",
+    "date_created": "2018-02-04T21:08:59",
+    "date_created_gmt": "2018-02-04T21:08:59",
+    "date_modified": "2018-04-11T18:58:54",
+    "date_modified_gmt": "2018-04-11T18:58:54",
+    "discount_total": "0.00",
+    "discount_tax": "0.00",
+    "shipping_total": "0.00",
+    "shipping_tax": "0.00",
+    "cart_tax": "0.00",
+    "total": "15.00",
+    "total_tax": "0.00",
+    "prices_include_tax": false,
+    "customer_id": 0,
+    "customer_ip_address": "101.164.14.22",
+    "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10.13; rv:58.0) gecko\/20100101 firefox\/58.0",
+    "customer_note": "",
+    "billing": {
+      "first_name": "John",
+      "last_name": "Quail",
+      "company": "",
+      "address_1": "Somewhere 55",
+      "address_2": "",
+      "city": "Place",
+      "state": "AK",
+      "postcode": "42532",
+      "country": "US",
+      "email": "place2153216321532152@thing.com",
+      "phone": "2332532"
+    },
+    "shipping": {
+      "first_name": "John",
+      "last_name": "Quail",
+      "company": "",
+      "address_1": "Somewhere 55",
+      "address_2": "",
+      "city": "Place",
+      "state": "AK",
+      "postcode": "42532",
+      "country": "US"
+    },
+    "payment_method": "cheque",
+    "payment_method_title": "Check payments",
+    "transaction_id": "",
+    "date_paid": "2018-04-11T18:58:54",
+    "date_paid_gmt": "2018-04-11T18:58:54",
+    "date_completed": null,
+    "date_completed_gmt": null,
+    "cart_hash": "3bc7aa78f62c9f30f8852fba6914694d",
+    "meta_data": [
+      {
+        "id": 671,
+        "key": "mailchimp_woocommerce_is_subscribed",
+        "value": "0"
+      },
+      {
+        "id": 677,
+        "key": "_shipping_phone",
+        "value": "2332532"
+      }
+    ],
+    "line_items": [
+      {
+        "id": 3,
+        "name": "Product",
+        "product_id": 58,
+        "variation_id": 0,
+        "quantity": 1,
+        "tax_class": "",
+        "subtotal": "15.00",
+        "subtotal_tax": "0.00",
+        "total": "15.00",
+        "total_tax": "0.00",
+        "taxes": [],
+        "meta_data": [],
+        "sku": "",
+        "price": 15
+      }
+    ],
+    "tax_lines": [],
+    "shipping_lines": [
+      {
+        "id": 4,
+        "method_title": "Free shipping",
+        "method_id": "free_shipping:1",
+        "total": "0.00",
+        "total_tax": "0.00",
+        "taxes": [],
+        "meta_data": [
+          {
+            "id": 28,
+            "key": "Items",
+            "value": "Product &times; 1"
+          }
+        ]
+      }
+    ],
+    "fee_lines": [],
+    "coupon_lines": [],
+    "refunds": [],
+    "_links": {
+      "self": [
+        {
+          "href": "https:\/\/alexforcier-test-store-1.blog\/wp-json\/wc\/v2\/orders\/88"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https:\/\/alexforcier-test-store-1.blog\/wp-json\/wc\/v2\/orders"
+        }
+      ]
+    }
+  }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.example.utils
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.widget.EditText
+
+typealias AlertTextListener = (EditText) -> Unit
+
+fun showSingleLineDialog(activity: Activity, message: String, alertTextListener: AlertTextListener) {
+    val alert = AlertDialog.Builder(activity)
+    val editText = EditText(activity)
+    editText.setSingleLine()
+    alert.setMessage(message)
+    alert.setView(editText)
+    alert.setPositiveButton(android.R.string.ok, { _, _ -> alertTextListener(editText) })
+    alert.show()
+}

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -18,4 +18,10 @@
         android:layout_height="wrap_content"
         android:text="Fetch Orders" />
 
+    <Button
+        android:id="@+id/update_latest_order_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Update Latest Order Status" />
+
 </LinearLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -124,8 +124,8 @@ class WCOrderStoreTest {
 
     @Test
     fun testOrderErrorType() {
-        assertEquals(OrderErrorType.REST_INVALID_PARAM, OrderErrorType.fromString("rest_invalid_param"))
-        assertEquals(OrderErrorType.REST_INVALID_PARAM, OrderErrorType.fromString("REST_INVALID_PARAM"))
+        assertEquals(OrderErrorType.INVALID_PARAM, OrderErrorType.fromString("invalid_param"))
+        assertEquals(OrderErrorType.INVALID_PARAM, OrderErrorType.fromString("INVALID_PARAM"))
         assertEquals(OrderErrorType.GENERIC_ERROR, OrderErrorType.fromString(""))
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -10,6 +10,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatus
@@ -17,6 +18,7 @@ import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
+import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -100,6 +102,24 @@ class WCOrderStoreTest {
 
         val fullOrderList = orderStore.getOrdersForSite(site)
         assertEquals(1, fullOrderList.size)
+    }
+
+    @Test
+    fun testUpdateOrderStatus() {
+        val orderModel = OrderTestUtils.generateSampleOrder(42)
+        val site = SiteModel().apply { id = orderModel.localSiteId }
+        OrderSqlUtils.insertOrUpdateOrder(orderModel)
+
+        // Simulate incoming action with updated order model
+        val payload = RemoteOrderPayload(orderModel.apply { status = OrderStatus.REFUNDED }, site)
+        orderStore.onAction(WCOrderActionBuilder.newUpdatedOrderStatusAction(payload))
+
+        with (orderStore.getOrderByLocalOrderId(orderModel.id)!!) {
+            // The version of the order model in the database should have the updated status
+            assertEquals(OrderStatus.REFUNDED, status)
+            // Other fields should not be altered by the update
+            assertEquals(orderModel.currency, currency)
+        }
     }
 
     @Test

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -5,14 +5,20 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload;
 
 @ActionEnum
 public enum WCOrderAction implements IAction {
     // Remote actions
     @Action(payloadType = FetchOrdersPayload.class)
     FETCH_ORDERS,
+    @Action(payloadType = UpdateOrderStatusPayload.class)
+    UPDATE_ORDER_STATUS,
 
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
-    FETCHED_ORDERS
+    FETCHED_ORDERS,
+    @Action(payloadType = RemoteOrderPayload.class)
+    UPDATED_ORDER_STATUS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.android.volley.RequestQueue
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
@@ -17,6 +18,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
+import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import javax.inject.Singleton
 
 @Singleton
@@ -29,6 +31,8 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
      *
      * The number of orders fetched is defined in [WCOrderStore.NUM_ORDERS_PER_FETCH], and retrieving older
      * orders is done by passing an [offset].
+     *
+     * Dispatches a [WCOrderAction.FETCHED_ORDERS] action with the resulting list of orders.
      */
     fun fetchOrders(site: SiteModel, offset: Int) {
         val url = WOOCOMMERCE.orders.pathV2
@@ -38,22 +42,46 @@ class OrderRestClient(appContext: Context, dispatcher: Dispatcher, requestQueue:
                 "offset" to offset.toString())
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderApiResponse>? ->
-                    run {
-                        val orderModels = response?.map {
-                            orderResponseToOrderModel(it).apply { localSiteId = site.id }
-                        }.orEmpty()
+                    val orderModels = response?.map {
+                        orderResponseToOrderModel(it).apply { localSiteId = site.id }
+                    }.orEmpty()
 
-                        val canLoadMore = orderModels.size == WCOrderStore.NUM_ORDERS_PER_FETCH
-                        val payload = FetchOrdersResponsePayload(site, orderModels, offset > 0, canLoadMore)
-                        mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
+                    val canLoadMore = orderModels.size == WCOrderStore.NUM_ORDERS_PER_FETCH
+                    val payload = FetchOrdersResponsePayload(site, orderModels, offset > 0, canLoadMore)
+                    mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
+                },
+                BaseErrorListener { networkError ->
+                    val orderError = OrderError((networkError as WPComGsonNetworkError).apiError, networkError.message)
+                    val payload = FetchOrdersResponsePayload(orderError, site)
+                    mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
+                })
+        add(request)
+    }
+
+    /**
+     * Makes a PUT call to `/wc/v2/orders/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
+     * updating the status for the given [order] to [status].
+     *
+     * Dispatches a [WCOrderAction.UPDATED_ORDER_STATUS] with the updated [WCOrderModel].
+     */
+    fun updateOrderStatus(order: WCOrderModel, site: SiteModel, status: String) {
+        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).pathV2
+        val params = mapOf("status" to status)
+        val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, params, OrderApiResponse::class.java,
+                { response: OrderApiResponse? ->
+                    response?.let {
+                        val newModel = orderResponseToOrderModel(it).apply {
+                            id = order.id
+                            localSiteId = site.id
+                        }
+                        val payload = RemoteOrderPayload(newModel, site)
+                        mDispatcher.dispatch(WCOrderActionBuilder.newUpdatedOrderStatusAction(payload))
                     }
                 },
-                BaseErrorListener { error ->
-                    run {
-                        val orderError = OrderError((error as WPComGsonNetworkError).apiError, error.message)
-                        val payload = FetchOrdersResponsePayload(orderError, site)
-                        mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
-                    }
+                BaseErrorListener { networkError ->
+                    val orderError = OrderError((networkError as WPComGsonNetworkError).apiError, networkError.message)
+                    val payload = RemoteOrderPayload(orderError, order, site)
+                    mDispatcher.dispatch(WCOrderActionBuilder.newUpdatedOrderStatusAction(payload))
                 })
         add(request)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatus
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Locale
@@ -54,12 +55,11 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         constructor(error: OrderError, order: WCOrderModel, site: SiteModel) : this(order, site) { this.error = error }
     }
 
-    class OrderError(val type: OrderErrorType? = null, val message: String = "") : OnChangedError {
-        constructor(type: String, message: String): this(OrderErrorType.fromString(type), message)
-    }
+    class OrderError(val type: OrderErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
 
     enum class OrderErrorType {
-        REST_INVALID_PARAM,
+        INVALID_PARAM,
+        INVALID_ID,
         GENERIC_ERROR;
 
         companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -41,6 +41,19 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         constructor(error: OrderError, site: SiteModel) : this(site) { this.error = error }
     }
 
+    class UpdateOrderStatusPayload(
+            val order: WCOrderModel,
+            val site: SiteModel,
+            val status: String
+    ) : Payload<BaseNetworkError>()
+
+    class RemoteOrderPayload(
+            val order: WCOrderModel,
+            val site: SiteModel
+    ) : Payload<OrderError>() {
+        constructor(error: OrderError, order: WCOrderModel, site: SiteModel) : this(order, site) { this.error = error }
+    }
+
     class OrderError(val type: OrderErrorType? = null, val message: String = "") : OnChangedError {
         constructor(type: String, message: String): this(OrderErrorType.fromString(type), message)
     }
@@ -85,7 +98,9 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         val actionType = action.type as? WCOrderAction ?: return
         when (actionType) {
             WCOrderAction.FETCH_ORDERS -> fetchOrders(action.payload as FetchOrdersPayload)
-            WCOrderAction.FETCHED_ORDERS -> handledFetchOrdersCompleted(action.payload as FetchOrdersResponsePayload)
+            WCOrderAction.UPDATE_ORDER_STATUS -> updateOrderStatus(action.payload as UpdateOrderStatusPayload)
+            WCOrderAction.FETCHED_ORDERS -> handleFetchOrdersCompleted(action.payload as FetchOrdersResponsePayload)
+            WCOrderAction.UPDATED_ORDER_STATUS -> handleUpdateOrderStatusCompleted(action.payload as RemoteOrderPayload)
         }
     }
 
@@ -98,7 +113,11 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         wcOrderRestClient.fetchOrders(payload.site, offset)
     }
 
-    private fun handledFetchOrdersCompleted(payload: FetchOrdersResponsePayload) {
+    private fun updateOrderStatus(payload: UpdateOrderStatusPayload) {
+        with(payload) { wcOrderRestClient.updateOrderStatus(order, site, status) }
+    }
+
+    private fun handleFetchOrdersCompleted(payload: FetchOrdersResponsePayload) {
         val onOrderChanged: OnOrderChanged
 
         if (payload.isError) {
@@ -117,6 +136,21 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         }
 
         onOrderChanged.causeOfChange = WCOrderAction.FETCH_ORDERS
+
+        emitChange(onOrderChanged)
+    }
+
+    private fun handleUpdateOrderStatusCompleted(payload: RemoteOrderPayload) {
+        val onOrderChanged: OnOrderChanged
+
+        if (payload.isError) {
+            onOrderChanged = OnOrderChanged(0).also { it.error = payload.error }
+        } else {
+            val rowsAffected = OrderSqlUtils.insertOrUpdateOrder(payload.order)
+            onOrderChanged = OnOrderChanged(rowsAffected)
+        }
+
+        onOrderChanged.causeOfChange = WCOrderAction.UPDATE_ORDER_STATUS
 
         emitChange(onOrderChanged)
     }

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -1,1 +1,2 @@
 /orders/
+/orders/<id>/


### PR DESCRIPTION
Adds support for changing an order's status on the server.

### TODO:
* [x] Add 'update status' button to example app
* [x] Mocked network tests