### PR TITLE
Issue/jetpack connect signup

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -12,6 +12,8 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AccountUsernameActionType;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
+import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadFlow;
+import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadSource;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.FetchUsernameSuggestionsPayload;
@@ -332,9 +334,69 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     }
 
     @Test
+    public void testSendAuthEmailWithFlow() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailWithFlowAndSource() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailWithSource() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false, null,
+                AuthEmailPayloadSource.STATS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
     public void testSendAuthEmailViaUsername() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false, null, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailViaUsernameWithFlow() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailViaUsernameWithFlowAndSource() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailViaUsernameWithSource() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false, null,
+                AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -351,10 +413,72 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     }
 
     @Test
+    public void testSendAuthEmailInvalidWithFlowAndSource() throws InterruptedException {
+        // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailInvalidWithFlow() throws InterruptedException {
+        // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false, AuthEmailPayloadFlow.JETPACK, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailInvalidWithSource() throws InterruptedException {
+        // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false, null, AuthEmailPayloadSource.STATS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
     public void testSendAuthEmailNoSuchUser() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
         AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false, null, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailNoSuchUserWithFlow() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false, AuthEmailPayloadFlow.JETPACK, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailNoSuchUserWithFlowAndSource() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailNoSuchUserWithSource() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false, null, AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -371,6 +495,37 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     }
 
     @Test
+    public void testSendAuthEmailSignupWithFlow() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true, AuthEmailPayloadFlow.JETPACK, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailSignupWithFlowAndSource() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailSignupWithSource() throws InterruptedException {
+        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true, null, AuthEmailPayloadSource.STATS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
     public void testSendAuthEmailSignupInvalid() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
         AuthEmailPayload payload = new AuthEmailPayload("email@domain", true, null, null);
@@ -380,9 +535,67 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     }
 
     @Test
+    public void testSendAuthEmailSignupInvalidWithFlow() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true, AuthEmailPayloadFlow.JETPACK, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailSignupInvalidWithFlowAndSource() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailSignupInvalidWithSource() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true, null, AuthEmailPayloadSource.STATS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
     public void testSendAuthEmailSignupUserExists() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
         AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true, null, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailSignupUserExistsWithFlow() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+                AuthEmailPayloadFlow.JETPACK, null);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailSignupUserExistsWithFlowAndSource() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSendAuthEmailSignupUserExistsWithSource() throws InterruptedException {
+        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true, null,
+                AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -326,22 +326,29 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmail() throws InterruptedException {
-        // Payload with neither flow nor source
         testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
                 null, null));
-        // Payload with both flow and source
-        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-        // Payload with flow only
+    }
+
+    @Test
+    public void testSendAuthEmailWithFlow() throws InterruptedException {
         testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
                 AuthEmailPayloadFlow.JETPACK, null));
-        // Payload with source only
+    }
+
+    @Test
+    public void testSendAuthEmailWithSource() throws InterruptedException {
         testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
                 null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailWithPayload(AuthEmailPayload payload) throws InterruptedException {
+    public void testSendAuthEmailWithFlowAndSource() throws InterruptedException {
+        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+    }
+
+    private void testSendAuthEmailWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
@@ -350,22 +357,29 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailViaUsername() throws InterruptedException {
-        // Payload with neither flow nor source
         testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
                 null, null));
-        // Payload with both flow and source
-        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-        // Payload with flow only
+    }
+
+    @Test
+    public void testSendAuthEmailViaUsernameWithFlow() throws InterruptedException {
         testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
                 AuthEmailPayloadFlow.JETPACK, null));
-        // Payload with source only
+    }
+
+    @Test
+    public void testSendAuthEmailViaUsernameWithSource() throws InterruptedException {
         testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
                 null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailViaUsernameWithPayload(AuthEmailPayload payload) throws InterruptedException {
+    public void testSendAuthEmailViaUsernameWithFlowAndSource() throws InterruptedException {
+        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+    }
+
+    private void testSendAuthEmailViaUsernameWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
@@ -374,22 +388,29 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailInvalid() throws InterruptedException {
-        // Payload with neither flow nor source
         testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
                 null, null));
-        // Payload with both flow and source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-        // Payload with flow only
+    }
+
+    @Test
+    public void testSendAuthEmailInvalidWithFlow() throws InterruptedException {
         testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
                 AuthEmailPayloadFlow.JETPACK, null));
-        // Payload with source only
+    }
+
+    @Test
+    public void testSendAuthEmailInvalidWithSource() throws InterruptedException {
         testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
                 null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailInvalidWithPayload(AuthEmailPayload payload) throws InterruptedException {
+    public void testSendAuthEmailInvalidWithFlowAndSource() throws InterruptedException {
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+    }
+
+    private void testSendAuthEmailInvalidWithPayload(AuthEmailPayload payload) throws InterruptedException {
         // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         mCountDownLatch = new CountDownLatch(1);
@@ -400,23 +421,32 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testSendAuthEmailNoSuchUser() throws InterruptedException {
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-
-        // Payload with neither flow nor source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, false,
+        testSendAuthEmailNoSuchUserWithPayload(new AuthEmailPayload(unknownEmail, false,
                 null, null));
-        // Payload with both flow and source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-        // Payload with flow only
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, false,
+    }
+
+    @Test
+    public void testSendAuthEmailNoSuchUserWithFlow() throws InterruptedException {
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        testSendAuthEmailNoSuchUserWithPayload(new AuthEmailPayload(unknownEmail, false,
                 AuthEmailPayloadFlow.JETPACK, null));
-        // Payload with source only
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, false,
+    }
+
+    @Test
+    public void testSendAuthEmailNoSuchUserWithSource() throws InterruptedException {
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        testSendAuthEmailNoSuchUserWithPayload(new AuthEmailPayload(unknownEmail, false,
                 null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailNoSuchUserWithPayload(AuthEmailPayload payload) throws InterruptedException {
+    public void testSendAuthEmailNoSuchUserWithFlowAndSource() throws InterruptedException {
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        testSendAuthEmailNoSuchUserWithPayload(new AuthEmailPayload(unknownEmail, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+    }
+
+    private void testSendAuthEmailNoSuchUserWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
@@ -426,23 +456,32 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testSendAuthEmailSignup() throws InterruptedException {
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-
-        // Payload with neither flow nor source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, true,
+        testSendAuthEmailSignupWithPayload(new AuthEmailPayload(unknownEmail, true,
                 null, null));
-        // Payload with both flow and source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-        // Payload with flow only
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, true,
+    }
+
+    @Test
+    public void testSendAuthEmailSignupWithFlow() throws InterruptedException {
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        testSendAuthEmailSignupWithPayload(new AuthEmailPayload(unknownEmail, true,
                 AuthEmailPayloadFlow.JETPACK, null));
-        // Payload with source only
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, true,
+    }
+
+    @Test
+    public void testSendAuthEmailSignupWithSource() throws InterruptedException {
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        testSendAuthEmailSignupWithPayload(new AuthEmailPayload(unknownEmail, true,
                 null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailSignupWithPayload(AuthEmailPayload payload) throws InterruptedException {
+    public void testSendAuthEmailSignupWithFlowAndSource() throws InterruptedException {
+        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
+        testSendAuthEmailSignupWithPayload(new AuthEmailPayload(unknownEmail, true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+    }
+
+    private void testSendAuthEmailSignupWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
@@ -451,22 +490,29 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailSignupInvalid() throws InterruptedException {
-        // Payload with neither flow nor source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", true,
+        testSendAuthEmailSignupInvalidWithPayload(new AuthEmailPayload("email@domain", true,
                 null, null));
-        // Payload with both flow and source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-        // Payload with flow only
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", true,
+    }
+
+    @Test
+    public void testSendAuthEmailSignupInvalidWithFlow() throws InterruptedException {
+        testSendAuthEmailSignupInvalidWithPayload(new AuthEmailPayload("email@domain", true,
                 AuthEmailPayloadFlow.JETPACK, null));
-        // Payload with source only
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", true,
+    }
+
+    @Test
+    public void testSendAuthEmailSignupInvalidWithSource() throws InterruptedException {
+        testSendAuthEmailSignupInvalidWithPayload(new AuthEmailPayload("email@domain", true,
                 null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailSignupInvalidWithPayload(AuthEmailPayload payload) throws InterruptedException {
+    public void testSendAuthEmailSignupInvalidWithFlowAndSource() throws InterruptedException {
+        testSendAuthEmailSignupInvalidWithPayload(new AuthEmailPayload("email@domain", true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+    }
+
+    private void testSendAuthEmailSignupInvalidWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
@@ -475,22 +521,29 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailSignupUserExists() throws InterruptedException {
-        // Payload with neither flow nor source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+        testSendAuthEmailSignupUserExistsWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
                 null, null));
-        // Payload with both flow and source
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-        // Payload with flow only
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+    }
+
+    @Test
+    public void testSendAuthEmailSignupUserExistsWithFlow() throws InterruptedException {
+        testSendAuthEmailSignupUserExistsWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
                 AuthEmailPayloadFlow.JETPACK, null));
-        // Payload with source only
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+    }
+
+    @Test
+    public void testSendAuthEmailSignupUserExistsWithSource() throws InterruptedException {
+        testSendAuthEmailSignupUserExistsWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
                 null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailSignupUserExistsWithPayload(AuthEmailPayload payload) throws InterruptedException {
+    public void testSendAuthEmailSignupUserExistsWithFlowAndSource() throws InterruptedException {
+        testSendAuthEmailSignupUserExistsWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+    }
+
+    private void testSendAuthEmailSignupUserExistsWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -326,38 +326,23 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmail() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false, null, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // Payload with neither flow nor source
+        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
+                null, null));
+        // Payload with both flow and source
+        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+        // Payload with flow only
+        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, null));
+        // Payload with source only
+        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
+                null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailWithFlow() throws InterruptedException {
+    public void testSendAuthEmailWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailWithFlowAndSource() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailWithSource() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false, null,
-                AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -365,38 +350,23 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailViaUsername() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false, null, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // Payload with neither flow nor source
+        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
+                null, null));
+        // Payload with both flow and source
+        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+        // Payload with flow only
+        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, null));
+        // Payload with source only
+        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
+                null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailViaUsernameWithFlow() throws InterruptedException {
+    public void testSendAuthEmailViaUsernameWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailViaUsernameWithFlowAndSource() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailViaUsernameWithSource() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false, null,
-                AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -404,40 +374,24 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailInvalid() throws InterruptedException {
-        // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false, null, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // Payload with neither flow nor source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
+                null, null));
+        // Payload with both flow and source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+        // Payload with flow only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
+                AuthEmailPayloadFlow.JETPACK, null));
+        // Payload with source only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
+                null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailInvalidWithFlowAndSource() throws InterruptedException {
+    public void testSendAuthEmailInvalidWithPayload(AuthEmailPayload payload) throws InterruptedException {
         // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailInvalidWithFlow() throws InterruptedException {
-        // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false, AuthEmailPayloadFlow.JETPACK, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailInvalidWithSource() throws InterruptedException {
-        // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false, null, AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -445,40 +399,25 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailNoSuchUser() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false, null, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Payload with neither flow nor source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, false,
+                null, null));
+        // Payload with both flow and source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+        // Payload with flow only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, false,
+                AuthEmailPayloadFlow.JETPACK, null));
+        // Payload with source only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, false,
+                null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailNoSuchUserWithFlow() throws InterruptedException {
+    public void testSendAuthEmailNoSuchUserWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false, AuthEmailPayloadFlow.JETPACK, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailNoSuchUserWithFlowAndSource() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailNoSuchUserWithSource() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false, null, AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -486,40 +425,25 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailSignup() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true, null, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Payload with neither flow nor source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, true,
+                null, null));
+        // Payload with both flow and source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+        // Payload with flow only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, true,
+                AuthEmailPayloadFlow.JETPACK, null));
+        // Payload with source only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(unknownEmail, true,
+                null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailSignupWithFlow() throws InterruptedException {
+    public void testSendAuthEmailSignupWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true, AuthEmailPayloadFlow.JETPACK, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupWithFlowAndSource() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupWithSource() throws InterruptedException {
-        mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true, null, AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -527,36 +451,23 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailSignupInvalid() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true, null, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // Payload with neither flow nor source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", true,
+                null, null));
+        // Payload with both flow and source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+        // Payload with flow only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", true,
+                AuthEmailPayloadFlow.JETPACK, null));
+        // Payload with source only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", true,
+                null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailSignupInvalidWithFlow() throws InterruptedException {
+    public void testSendAuthEmailSignupInvalidWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true, AuthEmailPayloadFlow.JETPACK, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupInvalidWithFlowAndSource() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupInvalidWithSource() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true, null, AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -564,38 +475,23 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmailSignupUserExists() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true, null, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        // Payload with neither flow nor source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+                null, null));
+        // Payload with both flow and source
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
+        // Payload with flow only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+                AuthEmailPayloadFlow.JETPACK, null));
+        // Payload with source only
+        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+                null, AuthEmailPayloadSource.STATS));
     }
 
     @Test
-    public void testSendAuthEmailSignupUserExistsWithFlow() throws InterruptedException {
+    public void testSendAuthEmailSignupUserExistsWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
-                AuthEmailPayloadFlow.JETPACK, null);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupUserExistsWithFlowAndSource() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS);
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupUserExistsWithSource() throws InterruptedException {
-        mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true, null,
-                AuthEmailPayloadSource.STATS);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -265,7 +265,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testSendAuthEmail() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false);
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false, null, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -274,7 +274,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testSendAuthEmailViaUsername() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false);
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false, null, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -284,7 +284,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     public void testSendAuthEmailInvalid() throws InterruptedException {
         // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false);
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false, null, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -294,7 +294,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     public void testSendAuthEmailNoSuchUser() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false);
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false, null, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -304,7 +304,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     public void testSendAuthEmailSignup() throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true);
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true, null, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -313,7 +313,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testSendAuthEmailSignupInvalid() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
-        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true);
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true, null, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
@@ -322,7 +322,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testSendAuthEmailSignupUserExists() throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
-        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true);
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true, null, null);
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -171,7 +171,7 @@ public class SignedOutActionsFragment extends Fragment {
         alert.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 String emailOrUsername = editText.getText().toString();
-                AuthEmailPayload authEmailPayload = new AuthEmailPayload(emailOrUsername, isSignup);
+                AuthEmailPayload authEmailPayload = new AuthEmailPayload(emailOrUsername, isSignup, null, null);
                 mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(authEmailPayload));
             }
         });

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -209,6 +209,8 @@ public class Authenticator {
 
         Map<String, Object> params = new HashMap<>();
         params.put("email", payload.emailOrUsername);
+        params.put("flow", payload.flow != null ? payload.flow.toString() : "");
+        params.put("source", payload.source != null ? payload.source.toString() : "");
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -209,10 +209,16 @@ public class Authenticator {
 
         Map<String, Object> params = new HashMap<>();
         params.put("email", payload.emailOrUsername);
-        params.put("flow", payload.flow != null ? payload.flow.toString() : "");
-        params.put("source", payload.source != null ? payload.source.toString() : "");
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
+
+        if (payload.flow != null) {
+            params.put("flow", payload.flow.toString());
+        }
+
+        if (payload.source != null) {
+            params.put("source", payload.source.toString());
+        }
 
         WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, params, AuthEmailWPComRestResponse.class,
                 new Response.Listener<AuthEmailWPComRestResponse>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -68,12 +68,48 @@ public class AccountStore extends Store {
     }
 
     public static class AuthEmailPayload extends Payload<BaseNetworkError> {
+        public AuthEmailPayloadFlow flow;
+        public AuthEmailPayloadSource source;
         public String emailOrUsername;
         public boolean isSignup;
 
-        public AuthEmailPayload(String emailOrUsername, boolean isSignup) {
+        public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailPayloadFlow flow,
+                                AuthEmailPayloadSource source) {
             this.emailOrUsername = emailOrUsername;
             this.isSignup = isSignup;
+            this.flow = flow;
+            this.source = source;
+        }
+    }
+
+    public enum AuthEmailPayloadFlow {
+        JETPACK("jetpack");
+
+        private final String mString;
+
+        AuthEmailPayloadFlow(final String s) {
+            mString = s;
+        }
+
+        @Override
+        public String toString() {
+            return mString;
+        }
+    }
+
+    public enum AuthEmailPayloadSource {
+        NOTIFICATIONS("notifications"),
+        STATS("stats");
+
+        private final String mString;
+
+        AuthEmailPayloadSource(final String s) {
+            mString = s;
+        }
+
+        @Override
+        public String toString() {
+            return mString;
         }
     }
 


### PR DESCRIPTION
### Fix
Add the `flow` and `source` fields to the `AuthEmailPayload` with `AuthEmailPayloadFlow` and `AuthEmailPayloadSource` enumerations to differentiate between the origin of magic links.