### PR TITLE
Issue/jetpack connect signup

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -326,94 +326,31 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
 
     @Test
     public void testSendAuthEmail() throws InterruptedException {
-        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
-                null, null));
-    }
-
-    @Test
-    public void testSendAuthEmailWithFlow() throws InterruptedException {
-        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, null));
-    }
-
-    @Test
-    public void testSendAuthEmailWithSource() throws InterruptedException {
-        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
-                null, AuthEmailPayloadSource.STATS));
-    }
-
-    @Test
-    public void testSendAuthEmailWithFlowAndSource() throws InterruptedException {
-        testSendAuthEmailWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-    }
-
-    private void testSendAuthEmailWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, false,
+                null, null);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void testSendAuthEmailViaUsername() throws InterruptedException {
-        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
-                null, null));
-    }
-
-    @Test
-    public void testSendAuthEmailViaUsernameWithFlow() throws InterruptedException {
-        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, null));
-    }
-
-    @Test
-    public void testSendAuthEmailViaUsernameWithSource() throws InterruptedException {
-        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
-                null, AuthEmailPayloadSource.STATS));
-    }
-
-    @Test
-    public void testSendAuthEmailViaUsernameWithFlowAndSource() throws InterruptedException {
-        testSendAuthEmailViaUsernameWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-    }
-
-    private void testSendAuthEmailViaUsernameWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_USERNAME_TEST1, false,
+                AuthEmailPayloadFlow.JETPACK, null);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void testSendAuthEmailInvalid() throws InterruptedException {
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
-                null, null));
-    }
-
-    @Test
-    public void testSendAuthEmailInvalidWithFlow() throws InterruptedException {
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
-                AuthEmailPayloadFlow.JETPACK, null));
-    }
-
-    @Test
-    public void testSendAuthEmailInvalidWithSource() throws InterruptedException {
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
-                null, AuthEmailPayloadSource.STATS));
-    }
-
-    @Test
-    public void testSendAuthEmailInvalidWithFlowAndSource() throws InterruptedException {
-        testSendAuthEmailInvalidWithPayload(new AuthEmailPayload("email@domain", false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-    }
-
-    private void testSendAuthEmailInvalidWithPayload(AuthEmailPayload payload) throws InterruptedException {
         // even for an invalid email address, the v1.3 /auth/send-login-email endpoint returns "User does not exist"
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         mCountDownLatch = new CountDownLatch(1);
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", false,
+                null, AuthEmailPayloadSource.NOTIFICATIONS);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -421,34 +358,10 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testSendAuthEmailNoSuchUser() throws InterruptedException {
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        testSendAuthEmailNoSuchUserWithPayload(new AuthEmailPayload(unknownEmail, false,
-                null, null));
-    }
-
-    @Test
-    public void testSendAuthEmailNoSuchUserWithFlow() throws InterruptedException {
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        testSendAuthEmailNoSuchUserWithPayload(new AuthEmailPayload(unknownEmail, false,
-                AuthEmailPayloadFlow.JETPACK, null));
-    }
-
-    @Test
-    public void testSendAuthEmailNoSuchUserWithSource() throws InterruptedException {
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        testSendAuthEmailNoSuchUserWithPayload(new AuthEmailPayload(unknownEmail, false,
-                null, AuthEmailPayloadSource.STATS));
-    }
-
-    @Test
-    public void testSendAuthEmailNoSuchUserWithFlowAndSource() throws InterruptedException {
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        testSendAuthEmailNoSuchUserWithPayload(new AuthEmailPayload(unknownEmail, false,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-    }
-
-    private void testSendAuthEmailNoSuchUserWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_NO_SUCH_USER;
         mCountDownLatch = new CountDownLatch(1);
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, false,
+                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.STATS);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -456,96 +369,28 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testSendAuthEmailSignup() throws InterruptedException {
         String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        testSendAuthEmailSignupWithPayload(new AuthEmailPayload(unknownEmail, true,
-                null, null));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupWithFlow() throws InterruptedException {
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        testSendAuthEmailSignupWithPayload(new AuthEmailPayload(unknownEmail, true,
-                AuthEmailPayloadFlow.JETPACK, null));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupWithSource() throws InterruptedException {
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        testSendAuthEmailSignupWithPayload(new AuthEmailPayload(unknownEmail, true,
-                null, AuthEmailPayloadSource.STATS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupWithFlowAndSource() throws InterruptedException {
-        String unknownEmail = "marty" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + "@themacflys.com";
-        testSendAuthEmailSignupWithPayload(new AuthEmailPayload(unknownEmail, true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-    }
-
-    private void testSendAuthEmailSignupWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.SENT_AUTH_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
+        AuthEmailPayload payload = new AuthEmailPayload(unknownEmail, true, null, null);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void testSendAuthEmailSignupInvalid() throws InterruptedException {
-        testSendAuthEmailSignupInvalidWithPayload(new AuthEmailPayload("email@domain", true,
-                null, null));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupInvalidWithFlow() throws InterruptedException {
-        testSendAuthEmailSignupInvalidWithPayload(new AuthEmailPayload("email@domain", true,
-                AuthEmailPayloadFlow.JETPACK, null));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupInvalidWithSource() throws InterruptedException {
-        testSendAuthEmailSignupInvalidWithPayload(new AuthEmailPayload("email@domain", true,
-                null, AuthEmailPayloadSource.STATS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupInvalidWithFlowAndSource() throws InterruptedException {
-        testSendAuthEmailSignupInvalidWithPayload(new AuthEmailPayload("email@domain", true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-    }
-
-    private void testSendAuthEmailSignupInvalidWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_INVALID;
         mCountDownLatch = new CountDownLatch(1);
+        AuthEmailPayload payload = new AuthEmailPayload("email@domain", true, AuthEmailPayloadFlow.JETPACK, null);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void testSendAuthEmailSignupUserExists() throws InterruptedException {
-        testSendAuthEmailSignupUserExistsWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
-                null, null));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupUserExistsWithFlow() throws InterruptedException {
-        testSendAuthEmailSignupUserExistsWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
-                AuthEmailPayloadFlow.JETPACK, null));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupUserExistsWithSource() throws InterruptedException {
-        testSendAuthEmailSignupUserExistsWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
-                null, AuthEmailPayloadSource.STATS));
-    }
-
-    @Test
-    public void testSendAuthEmailSignupUserExistsWithFlowAndSource() throws InterruptedException {
-        testSendAuthEmailSignupUserExistsWithPayload(new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
-                AuthEmailPayloadFlow.JETPACK, AuthEmailPayloadSource.NOTIFICATIONS));
-    }
-
-    private void testSendAuthEmailSignupUserExistsWithPayload(AuthEmailPayload payload) throws InterruptedException {
         mNextEvent = TestEvents.AUTH_EMAIL_ERROR_USER_EXISTS;
         mCountDownLatch = new CountDownLatch(1);
+        AuthEmailPayload payload = new AuthEmailPayload(BuildConfig.TEST_WPCOM_EMAIL_TEST1, true,
+                null, AuthEmailPayloadSource.NOTIFICATIONS);
         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }


### PR DESCRIPTION
### Fix
Remove the tests added in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/783 to avoid exceeding the login/signup rate limit.  The number of tests will be the same as the previous amount.  The `null` values in those tests were replaced with `flow` and `source` values in various ways to ensure the parameters do not alter the results of the previous tests.