### PR TITLE
Account for WP V2 API error code naming

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/WPComGsonRequestTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/WPComGsonRequestTest.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.network
+
+import com.android.volley.NetworkResponse
+import com.android.volley.Response.Listener
+import com.android.volley.VolleyError
+import com.nhaarman.mockito_kotlin.mock
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class WPComGsonRequestTest {
+    @Test
+    fun testWPComErrorResponse() {
+        val url = WPCOMREST.sites.site(123).posts.post(456).urlV1_1
+        val request = WPComGsonRequest.buildGetRequest(url, null, Object::class.java,
+                mock<Listener<String>>(), mock())
+
+        val responseJson = "{\"error\":\"unknown_post\",\"message\":\"Unknown post\"}"
+        val baseNetworkError = buildErrorResponseObject(responseJson, 404)
+
+        // Simulate a network response for this request
+        val augmentedError = request.deliverBaseNetworkError(baseNetworkError) as WPComGsonNetworkError
+
+        assertEquals(GenericErrorType.UNKNOWN, augmentedError.type)
+        assertEquals("unknown_post", augmentedError.apiError)
+        assertEquals("Unknown post", augmentedError.message)
+    }
+
+    @Test
+    fun testWPComV2ErrorResponse() {
+        val url = WPCOMV2.users.username.suggestions.url
+        val request = WPComGsonRequest.buildGetRequest(url, null, Object::class.java,
+                mock<Listener<String>>(), mock())
+
+        val responseJson = "{\"code\":\"rest_no_name\"," +
+                "\"message\":\"A name from which to derive username suggestions is required.\"}"
+        val baseNetworkError = buildErrorResponseObject(responseJson, 400)
+
+        // Simulate a network response for this request
+        val augmentedError = request.deliverBaseNetworkError(baseNetworkError) as WPComGsonNetworkError
+
+        assertEquals(GenericErrorType.UNKNOWN, augmentedError.type)
+        assertEquals("rest_no_name", augmentedError.apiError)
+        assertEquals("A name from which to derive username suggestions is required.", augmentedError.message)
+    }
+
+    private fun buildErrorResponseObject(responseJson: String, errorCode: Int): BaseNetworkError {
+        val networkResponse = NetworkResponse(errorCode, responseJson.toByteArray(), mapOf(), true)
+        return BaseNetworkError(VolleyError(networkResponse))
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -105,6 +105,10 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
                 jsonObject = new JSONObject();
             }
             String apiError = jsonObject.optString("error", "");
+            if (TextUtils.isEmpty(apiError)) {
+                // WP V2 endpoints use "code" instead of "error"
+                apiError = jsonObject.optString("code", "");
+            }
             String apiMessage = jsonObject.optString("message", "");
             if (TextUtils.isEmpty(apiMessage)) {
                 // Auth endpoints use "error_description" instead of "message"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -28,7 +28,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.store.AccountStore.AccountFetchUsernameSuggestionsError;
-import org.wordpress.android.fluxc.store.AccountStore.AccountFetchUsernameSuggestionsErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AccountSocialError;
 import org.wordpress.android.fluxc.store.AccountStore.AccountSocialErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AccountUsernameActionType;
@@ -263,7 +262,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         AccountFetchUsernameSuggestionsResponsePayload payload =
-                                volleyErrorToFetchUsernameSuggestionsResponsePayload(error.volleyError);
+                                new AccountFetchUsernameSuggestionsResponsePayload();
+                        payload.error = new AccountFetchUsernameSuggestionsError(
+                                ((WPComGsonNetworkError) error).apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedUsernameSuggestionsAction(payload));
                     }
                 }
@@ -796,28 +797,6 @@ public class AccountRestClient extends BaseWPComRestClient {
                 payload.error.message = errors.getJSONObject(0).getString("message");
             } catch (UnsupportedEncodingException | JSONException exception) {
                 AppLog.e(T.API, "Unable to parse social error response: " + exception.getMessage());
-            }
-        }
-
-        return payload;
-    }
-
-    private AccountFetchUsernameSuggestionsResponsePayload volleyErrorToFetchUsernameSuggestionsResponsePayload(
-            VolleyError error) {
-        AccountFetchUsernameSuggestionsResponsePayload payload = new AccountFetchUsernameSuggestionsResponsePayload();
-        payload.error = new AccountFetchUsernameSuggestionsError(
-                AccountFetchUsernameSuggestionsErrorType.GENERIC_ERROR, "");
-
-        if (error.networkResponse != null && error.networkResponse.data != null) {
-            AppLog.e(T.API, new String(error.networkResponse.data));
-
-            try {
-                String responseBody = new String(error.networkResponse.data, "UTF-8");
-                JSONObject object = new JSONObject(responseBody);
-                payload.error.type = AccountFetchUsernameSuggestionsErrorType.fromString(object.optString("code"));
-                payload.error.message = object.optString("message");
-            } catch (UnsupportedEncodingException | JSONException exception) {
-                AppLog.e(T.API, "Unable to parse username suggestions error response: " + exception.getMessage());
             }
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -454,9 +454,8 @@ public class AccountStore extends Store {
         public AccountFetchUsernameSuggestionsErrorType type;
         public String message;
 
-        public AccountFetchUsernameSuggestionsError(@NonNull AccountFetchUsernameSuggestionsErrorType type,
-                                                    @NonNull String message) {
-            this.type = type;
+        public AccountFetchUsernameSuggestionsError(@NonNull String type, @NonNull String message) {
+            this.type = AccountFetchUsernameSuggestionsErrorType.fromString(type);
             this.message = message;
         }
     }


### PR DESCRIPTION
The V2 wpcom endpoints (`/wpcom/v2/` and `/wp/v2/` are the most relevant to us of those) use `code` instead of `error` in their error Json responses:

```js
{
  "code": "rest_invalid_param",
  "message": "Invalid parameter(s): unit",
}
```

This was handled manually for the username suggestions endpoint (`/wpcom/v2/users/username/suggestions/`), but since it seems fairly standard to the v2 endpoints I moved it to the base error handler in `WPComGsonRequest` and dropped the custom handler for username suggestions.

#### Testing note

There's already a test that relies on a `/wpcom/v2/` error being handled correctly: [`ReleaseStack_AccountTest.testFetchWPComUsernameSuggestionsNoNameError()`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/e3916f37c30ec53fcc7248d6f9c0a35c9f469164/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java#L273).