### PR TITLE
Return WPComGsonNetworkError directly from WPComGsonRequests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
@@ -9,13 +9,12 @@ import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener
 import org.wordpress.android.fluxc.network.Response
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import java.util.concurrent.CountDownLatch
@@ -48,10 +47,10 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
                 { _: RootWPAPIRestResponse? ->
                     throw AssertionError("Unexpected success!")
                 },
-                BaseErrorListener {
+                WPComErrorListener {
                     error -> run {
                         // Verify that the error response is correctly parsed
-                        assertEquals("rest_no_route", (error as WPComGsonNetworkError).apiError)
+                        assertEquals("rest_no_route", error.apiError)
                         assertEquals("No route was found matching the URL and request method", error.message)
                         countDownLatch.countDown()
                     }
@@ -77,10 +76,10 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
                         countDownLatch.countDown()
                     }
                 },
-                BaseErrorListener {
+                WPComErrorListener {
                     error -> run {
                         throw AssertionError("Unexpected BaseNetworkError: " +
-                                (error as WPComGsonNetworkError).apiError + " - " + error.message)
+                                error.apiError + " - " + error.message)
                     }
                 })
 
@@ -107,10 +106,10 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
                         countDownLatch.countDown()
                     }
                 },
-                BaseErrorListener {
+                WPComErrorListener {
                     error -> run {
                         throw AssertionError("Unexpected BaseNetworkError: " +
-                                (error as WPComGsonNetworkError).apiError + " - " + error.message)
+                                error.apiError + " - " + error.message)
                     }
                 })
 

--- a/example/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.util.UrlUtils
 import kotlin.test.assertEquals
@@ -24,7 +24,7 @@ class JetpackTunnelGsonRequestTest {
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, 567, params,
                 Any::class.java,
                 { _: Any? -> },
-                BaseErrorListener { _ -> }
+                WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected
@@ -49,7 +49,7 @@ class JetpackTunnelGsonRequestTest {
         val request = JetpackTunnelGsonRequest.buildPostRequest(url, 567, requestBody,
                 Any::class.java,
                 { _: Any? -> },
-                BaseErrorListener { _ -> }
+                WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected
@@ -73,7 +73,7 @@ class JetpackTunnelGsonRequestTest {
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, 567, requestBody,
                 Any::class.java,
                 { _: Any? -> },
-                BaseErrorListener { _ -> }
+                WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected
@@ -97,7 +97,7 @@ class JetpackTunnelGsonRequestTest {
         val request = JetpackTunnelGsonRequest.buildPatchRequest(url, 567, requestBody,
                 Any::class.java,
                 { _: Any? -> },
-                BaseErrorListener { _ -> }
+                WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected
@@ -120,7 +120,7 @@ class JetpackTunnelGsonRequestTest {
         val request = JetpackTunnelGsonRequest.buildDeleteRequest(url, 567, params,
                 Any::class.java,
                 { _: Any? -> },
-                BaseErrorListener { _ -> }
+                WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -22,9 +22,11 @@ import org.wordpress.android.fluxc.action.ActivityLogAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
-import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.activity.ActivityLogRestClient.ActivitiesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.activity.ActivityLogRestClient.ActivitiesResponse.Page
@@ -50,7 +52,7 @@ class ActivityLogRestClientTest {
     private lateinit var activitySuccessMethodCaptor: KArgumentCaptor<(ActivitiesResponse) -> Unit>
     private lateinit var rewindStatusSuccessMethodCaptor: KArgumentCaptor<(RewindStatusResponse) -> Unit>
     private lateinit var rewindSuccessMethodCaptor: KArgumentCaptor<(RewindResponse) -> Unit>
-    private lateinit var errorMethodCaptor: KArgumentCaptor<(BaseRequest.BaseNetworkError) -> Unit>
+    private lateinit var errorMethodCaptor: KArgumentCaptor<(WPComGsonNetworkError) -> Unit>
     private lateinit var activityActionCaptor: KArgumentCaptor<Action<FetchedActivityLogPayload>>
     private lateinit var rewindStatusActionCaptor: KArgumentCaptor<Action<FetchedRewindStatePayload>>
     private lateinit var mRewindActionCaptor: KArgumentCaptor<Action<ActivityLogStore.RewindResultPayload>>
@@ -196,7 +198,7 @@ class ActivityLogRestClientTest {
 
         verify(requestQueue).add(any<WPComGsonRequest<ActivitiesResponse>>())
 
-        errorMethodCaptor.firstValue(BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.NETWORK_ERROR))
+        errorMethodCaptor.firstValue(WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR)))
 
         assertEmittedActivityError(ActivityLogErrorType.GENERIC_ERROR)
     }
@@ -243,7 +245,7 @@ class ActivityLogRestClientTest {
 
         verify(requestQueue).add(any<WPComGsonRequest<RewindStatusResponse>>())
 
-        errorMethodCaptor.firstValue(BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.NETWORK_ERROR))
+        errorMethodCaptor.firstValue(WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR)))
 
         assertEmittedRewindStatusError(RewindStatusErrorType.GENERIC_ERROR)
     }
@@ -341,7 +343,7 @@ class ActivityLogRestClientTest {
 
         verify(requestQueue).add(any<WPComGsonRequest<RewindResponse>>())
 
-        errorMethodCaptor.firstValue.invoke(BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.NETWORK_ERROR))
+        errorMethodCaptor.firstValue.invoke(WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR)))
 
         verify(dispatcher).dispatch(mRewindActionCaptor.capture())
         assertTrue(mRewindActionCaptor.firstValue.payload.isError)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -18,6 +18,10 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 public class WPComGsonRequest<T> extends GsonRequest<T> {
+    public interface WPComErrorListener {
+        void onErrorResponse(@NonNull WPComGsonNetworkError error);
+    }
+
     public static final String REST_AUTHORIZATION_HEADER = "Authorization";
     public static final String REST_AUTHORIZATION_FORMAT = "Bearer %s";
 
@@ -47,13 +51,15 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
      * @param errorListener the error listener
      */
     public static <T> WPComGsonRequest<T> buildGetRequest(String url, Map<String, String> params, Class<T> clazz,
-                                                          Listener<T> listener, BaseErrorListener errorListener) {
-        return new WPComGsonRequest<>(Method.GET, url, params, null, clazz, null, listener, errorListener);
+                                                          Listener<T> listener, WPComErrorListener errorListener) {
+        return new WPComGsonRequest<>(Method.GET, url, params, null, clazz, null, listener,
+                wrapInBaseListener(errorListener));
     }
 
     public static <T> WPComGsonRequest<T> buildGetRequest(String url, Map<String, String> params, Type type,
-                                                          Listener<T> listener, BaseErrorListener errorListener) {
-        return new WPComGsonRequest<>(Method.GET, url, params, null, null, type, listener, errorListener);
+                                                          Listener<T> listener, WPComErrorListener errorListener) {
+        return new WPComGsonRequest<>(Method.GET, url, params, null, null, type, listener,
+                wrapInBaseListener(errorListener));
     }
 
     /**
@@ -65,13 +71,24 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
      * @param errorListener the error listener
      */
     public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, Object> body, Class<T> clazz,
-                                                           Listener<T> listener, BaseErrorListener errorListener) {
-        return new WPComGsonRequest<>(Method.POST, url, null, body, clazz, null, listener, errorListener);
+                                                           Listener<T> listener, WPComErrorListener errorListener) {
+        return new WPComGsonRequest<>(Method.POST, url, null, body, clazz, null, listener,
+                wrapInBaseListener(errorListener));
     }
 
     public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, Object> body, Type type,
-                                                           Listener<T> listener, BaseErrorListener errorListener) {
-        return new WPComGsonRequest<>(Method.POST, url, null, body, null, type, listener, errorListener);
+                                                           Listener<T> listener, WPComErrorListener errorListener) {
+        return new WPComGsonRequest<>(Method.POST, url, null, body, null, type, listener,
+                wrapInBaseListener(errorListener));
+    }
+
+    private static BaseErrorListener wrapInBaseListener(final WPComErrorListener wpComErrorListener) {
+        return new BaseErrorListener() {
+            @Override
+            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                wpComErrorListener.onErrorResponse((WPComGsonNetworkError) error);
+            }
+        };
     }
 
     private String addDefaultParameters(String url) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -86,7 +86,9 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         return new BaseErrorListener() {
             @Override
             public void onErrorResponse(@NonNull BaseNetworkError error) {
-                wpComErrorListener.onErrorResponse((WPComGsonNetworkError) error);
+                if (wpComErrorListener != null) {
+                    wpComErrorListener.onErrorResponse((WPComGsonNetworkError) error);
+                }
             }
         };
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -140,7 +140,8 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
             if (apiError.equals("authorization_required") || apiError.equals("invalid_token")
                     || apiError.equals("access_denied") || apiError.equals("needs_2fa")) {
                 AuthenticationError authError = new AuthenticationError(
-                        Authenticator.jsonErrorToAuthenticationError(jsonObject), apiMessage);
+                        Authenticator.wpComApiErrorToAuthenticationError(apiError, returnedError.message),
+                        returnedError.message);
                 AuthenticateErrorPayload payload = new AuthenticateErrorPayload(authError);
                 mOnAuthFailedListener.onAuthFailed(payload);
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom
 
-import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,7 +20,7 @@ class WPComGsonRequestBuilder
         params: Map<String, String>,
         clazz: Class<T>,
         listener: (T) -> Unit,
-        errorListener: (BaseRequest.BaseNetworkError) -> Unit
+        errorListener: (WPComGsonNetworkError) -> Unit
     ): WPComGsonRequest<T> {
         return WPComGsonRequest.buildGetRequest(url, params, clazz, listener, errorListener)
     }
@@ -38,7 +38,7 @@ class WPComGsonRequestBuilder
         body: Map<String, Any>,
         clazz: Class<T>,
         listener: (T) -> Unit,
-        errorListener: (BaseRequest.BaseNetworkError) -> Unit
+        errorListener: (WPComGsonNetworkError) -> Unit
     ): WPComGsonRequest<T> {
         return WPComGsonRequest.buildPostRequest(url, body, clazz, listener, errorListener)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.SubscriptionRestResponse.SubscriptionsResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
@@ -204,9 +205,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedAccountAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AccountRestPayload payload = new AccountRestPayload(null, error);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedAccountAction(payload));
                     }
@@ -231,9 +232,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedSettingsAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AccountRestPayload payload = new AccountRestPayload(null, error);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedSettingsAction(payload));
                     }
@@ -267,13 +268,12 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedUsernameSuggestionsAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AccountFetchUsernameSuggestionsResponsePayload payload =
                                 new AccountFetchUsernameSuggestionsResponsePayload();
-                        payload.error = new AccountFetchUsernameSuggestionsError(
-                                ((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new AccountFetchUsernameSuggestionsError(error.apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedUsernameSuggestionsAction(payload));
                     }
                 }
@@ -290,9 +290,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newSentVerificationEmailAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         NewAccountResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
                         mDispatcher.dispatch(AccountActionBuilder.newSentVerificationEmailAction(payload));
                     }
@@ -322,9 +322,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newPushedSettingsAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AccountPushSettingsResponsePayload payload = new AccountPushSettingsResponsePayload(error);
                         mDispatcher.dispatch(AccountActionBuilder.newPushedSettingsAction(payload));
                     }
@@ -429,11 +429,11 @@ public class AccountRestClient extends BaseWPComRestClient {
                         }
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AccountPushSocialResponsePayload payload = new AccountPushSocialResponsePayload();
-                        payload.error = new AccountSocialError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new AccountSocialError(error.apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newPushedSocialAction(payload));
                     }
                 }
@@ -532,11 +532,11 @@ public class AccountRestClient extends BaseWPComRestClient {
                         }
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AccountPushSocialResponsePayload payload = new AccountPushSocialResponsePayload();
-                        payload.error = new AccountSocialError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new AccountSocialError(error.apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newPushedSocialAction(payload));
                     }
                 }
@@ -625,13 +625,12 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newPushedUsernameAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AccountPushUsernameResponsePayload payload = new AccountPushUsernameResponsePayload(username,
                                 actionType);
-                        payload.error = new AccountUsernameError(((WPComGsonNetworkError) error).apiError,
-                                error.message);
+                        payload.error = new AccountUsernameError(error.apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newPushedUsernameAction(payload));
                     }
                 }
@@ -663,9 +662,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newCreatedNewAccountAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         NewAccountResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
                         payload.dryRun = dryRun;
                         mDispatcher.dispatch(AccountActionBuilder.newCreatedNewAccountAction(payload));
@@ -710,9 +709,9 @@ public class AccountRestClient extends BaseWPComRestClient {
                         }
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         SubscriptionsModel payload = new SubscriptionsModel();
                         payload.error = error;
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedSubscriptionsAction(payload));
@@ -745,12 +744,11 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         SubscriptionResponsePayload payload = new SubscriptionResponsePayload();
-                        payload.error = new SubscriptionError(((WPComGsonNetworkError) error).apiError,
-                                error.message);
+                        payload.error = new SubscriptionError(error.apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 }
@@ -781,12 +779,11 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         SubscriptionResponsePayload payload = new SubscriptionResponsePayload();
-                        payload.error = new SubscriptionError(((WPComGsonNetworkError) error).apiError,
-                                error.message);
+                        payload.error = new SubscriptionError(error.apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 }
@@ -819,12 +816,11 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         SubscriptionResponsePayload payload = new SubscriptionResponsePayload();
-                        payload.error = new SubscriptionError(((WPComGsonNetworkError) error).apiError,
-                                error.message);
+                        payload.error = new SubscriptionError(error.apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 }
@@ -856,14 +852,12 @@ public class AccountRestClient extends BaseWPComRestClient {
                                 payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         SubscriptionResponsePayload payload = new SubscriptionResponsePayload();
-                        payload.error = new SubscriptionError(((WPComGsonNetworkError) error).apiError,
-                                error.message);
-                        mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(
-                                payload));
+                        payload.error = new SubscriptionError(error.apiError, error.message);
+                        mDispatcher.dispatch(AccountActionBuilder.newUpdatedSubscriptionAction(payload));
                     }
                 }
         );
@@ -973,16 +967,16 @@ public class AccountRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(AccountActionBuilder.newCheckedIsAvailableAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // We don't expect anything but server errors here - the API itself returns errors with a
                         // 200 status code, which will appear under Listener.onResponse instead
                         IsAvailableResponsePayload payload = new IsAvailableResponsePayload();
                         payload.value = value;
                         payload.type = type;
 
-                        payload.error = new IsAvailableError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new IsAvailableError(error.apiError, error.message);
                         mDispatcher.dispatch(AccountActionBuilder.newCheckedIsAvailableAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.model.activity.RewindStatusModel
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.ActivityLogStore
@@ -195,7 +195,7 @@ constructor(
             FetchedRewindStatePayload(RewindStatusError(errorType), site)
 
     private fun <T> genericToError(
-        error: BaseRequest.BaseNetworkError,
+        error: WPComGsonNetworkError,
         genericError: T,
         invalidResponse: T,
         authorizationRequired: T
@@ -204,10 +204,8 @@ constructor(
         if (error.isGeneric && error.type == BaseRequest.GenericErrorType.INVALID_RESPONSE) {
             errorType = invalidResponse
         }
-        if (error is WPComGsonRequest.WPComGsonNetworkError) {
-            if ("unauthorized" == error.apiError) {
-                errorType = authorizationRequired
-            }
+        if ("unauthorized" == error.apiError) {
+            errorType = authorizationRequired
         }
         return errorType
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -18,9 +18,8 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailError;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailErrorType;
@@ -231,12 +230,11 @@ public class Authenticator {
                         }
                         mDispatcher.dispatch(AuthenticationActionBuilder.newSentAuthEmailAction(responsePayload));
                     }
-                }, new BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AuthEmailResponsePayload responsePayload = new AuthEmailResponsePayload(payload.isSignup);
-                        responsePayload.error = new AuthEmailError(((WPComGsonNetworkError) error).apiError,
-                                error.message);
+                        responsePayload.error = new AuthEmailError(error.apiError, error.message);
                         mDispatcher.dispatch(AuthenticationActionBuilder.newSentAuthEmailAction(responsePayload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -275,13 +275,18 @@ public class Authenticator {
         if (jsonObject != null) {
             String errorType = jsonObject.optString("error", "");
             String errorMessage = jsonObject.optString("error_description", "");
-            error = AuthenticationErrorType.fromString(errorType);
-            // Special cases for vague error types
-            if (error == AuthenticationErrorType.INVALID_REQUEST) {
-                // Try to parse the error message to specify the error
-                if (errorMessage.contains("Incorrect username or password.")) {
-                    return AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD;
-                }
+            error = wpComApiErrorToAuthenticationError(errorType, errorMessage);
+        }
+        return error;
+    }
+
+    public static AuthenticationErrorType wpComApiErrorToAuthenticationError(String errorType, String errorMessage) {
+        AuthenticationErrorType error = AuthenticationErrorType.fromString(errorType);
+        // Special cases for vague error types
+        if (error == AuthenticationErrorType.INVALID_REQUEST) {
+            // Try to parse the error message to specify the error
+            if (errorMessage.contains("Incorrect username or password.")) {
+                return AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD;
             }
         }
         return error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -15,11 +15,11 @@ import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.CommentsWPComRestResponse;
 import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsResponsePayload;
@@ -59,9 +59,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                     }
                 },
 
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentsAction(
                                 CommentErrorUtils.commentErrorToFetchCommentsPayload(error, site)));
                     }
@@ -88,9 +88,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                     }
                 },
 
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         mDispatcher.dispatch(CommentActionBuilder.newPushedCommentAction(
                                 CommentErrorUtils.commentErrorToPushCommentPayload(error, comment)));
                     }
@@ -117,9 +117,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                     }
                 },
 
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
@@ -150,9 +150,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                     }
                 },
 
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         mDispatcher.dispatch(CommentActionBuilder.newDeletedCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
@@ -178,9 +178,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                     }
                 },
 
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         mDispatcher.dispatch(CommentActionBuilder.newCreatedNewCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, reply)));
                     }
@@ -206,9 +206,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                     }
                 },
 
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         mDispatcher.dispatch(CommentActionBuilder.newCreatedNewCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
@@ -245,9 +245,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                     }
                 },
 
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         mDispatcher.dispatch(CommentActionBuilder.newLikedCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -4,8 +4,8 @@ import com.android.volley.Response
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
 import java.lang.reflect.Type
 import java.net.URLEncoder
 
@@ -107,7 +107,7 @@ object JetpackTunnelGsonRequest {
         params: Map<String, String>,
         type: Type,
         listener: (T?) -> Unit,
-        errorListener: BaseErrorListener
+        errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedParams = createTunnelParams(params, wpApiEndpoint)
 
@@ -137,7 +137,7 @@ object JetpackTunnelGsonRequest {
         body: Map<String, Any>,
         type: Type,
         listener: (T?) -> Unit,
-        errorListener: BaseErrorListener
+        errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "post", body = body, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
@@ -161,7 +161,7 @@ object JetpackTunnelGsonRequest {
         body: Map<String, Any>,
         type: Type,
         listener: (T?) -> Unit,
-        errorListener: BaseErrorListener
+        errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "patch", body = body, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
@@ -185,7 +185,7 @@ object JetpackTunnelGsonRequest {
         body: Map<String, Any>,
         type: Type,
         listener: (T?) -> Unit,
-        errorListener: BaseErrorListener
+        errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "put", body = body, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
@@ -209,7 +209,7 @@ object JetpackTunnelGsonRequest {
         params: Map<String, String>,
         type: Type,
         listener: (T?) -> Unit,
-        errorListener: BaseErrorListener
+        errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "delete", params = params, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
@@ -220,7 +220,7 @@ object JetpackTunnelGsonRequest {
         wrappedBody: Map<String, Any>,
         type: Type,
         listener: (T?) -> Unit,
-        errorListener: BaseErrorListener
+        errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val tunnelRequestUrl = getTunnelApiUrl(siteId)
         val wrappedType = TypeToken.getParameterized(JetpackTunnelResponse::class.java, type).type

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -23,13 +23,12 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.StockMediaModel;
-import org.wordpress.android.fluxc.network.BaseRequest;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.BaseUploadRequestBody.ProgressListener;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaWPComRestResponse.MultipleMediaResponse;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload;
@@ -121,9 +120,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                             notifyMediaPushed(site, media, error);
                         }
                     }
-                }, new BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(T.MEDIA, "error editing remote media: " + error);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         notifyMediaPushed(site, media, mediaError);
@@ -275,9 +274,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                             notifyMediaListFetched(site, error, mimeType);
                         }
                     }
-                }, new BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(T.MEDIA, "VolleyError Fetching media: " + error);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         notifyMediaListFetched(site, mediaError, mimeType);
@@ -313,9 +312,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                             notifyMediaFetched(site, media, error);
                         }
                     }
-                }, new BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(T.MEDIA, "VolleyError Fetching media: " + error);
                         MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                         notifyMediaFetched(site, media, mediaError);
@@ -350,9 +349,9 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                             notifyMediaDeleted(site, media, error);
                         }
                     }
-                }, new BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(T.MEDIA, "VolleyError deleting media (ID=" + media.getMediaId() + "): " + error);
                         MediaErrorType mediaError = MediaErrorType.fromBaseNetworkError(error);
                         if (mediaError == MediaErrorType.NOT_FOUND) {
@@ -415,17 +414,16 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         UploadedStockMediaPayload payload = new UploadedStockMediaPayload(site, mediaList);
                         mDispatcher.dispatch(MediaActionBuilder.newUploadedStockMediaAction(payload));
                     }
-                }, new BaseRequest.BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseRequest.BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(AppLog.T.MEDIA, "VolleyError uploading stock media: " + error);
                         UploadStockMediaError mediaError = new UploadStockMediaError(
                                 UploadStockMediaErrorType.fromBaseNetworkError(error), error.message);
                         UploadedStockMediaPayload payload = new UploadedStockMediaPayload(site, mediaError);
                         mDispatcher.dispatch(MediaActionBuilder.newUploadedStockMediaAction(payload));
                     }
-                }
-                                                                    );
+                });
 
         add(request);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -419,7 +419,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                     public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(AppLog.T.MEDIA, "VolleyError uploading stock media: " + error);
                         UploadStockMediaError mediaError = new UploadStockMediaError(
-                                UploadStockMediaErrorType.fromBaseNetworkError(error), error.message);
+                                UploadStockMediaErrorType.fromNetworkError(error), error.message);
                         UploadedStockMediaPayload payload = new UploadedStockMediaPayload(site, mediaError);
                         mDispatcher.dispatch(MediaActionBuilder.newUploadedStockMediaAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -13,11 +13,10 @@ import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType;
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginWPComRestResponse.FetchPluginsResponse;
@@ -66,11 +65,11 @@ public class PluginRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginDirectoryAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        PluginDirectoryError directoryError = new PluginDirectoryError(((WPComGsonNetworkError)
-                                networkError).apiError, networkError.message);
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
+                        PluginDirectoryError directoryError = new PluginDirectoryError(
+                                networkError.apiError, networkError.message);
                         FetchedPluginDirectoryPayload payload =
                                 new FetchedPluginDirectoryPayload(PluginDirectoryType.SITE, false, directoryError);
                         mDispatcher.dispatch(PluginActionBuilder.newFetchedPluginDirectoryAction(payload));
@@ -96,11 +95,11 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 new ConfiguredSitePluginPayload(site, pluginFromResponse)));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        ConfigureSitePluginError configurePluginError = new ConfigureSitePluginError(((
-                                WPComGsonNetworkError) networkError).apiError, networkError.message);
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
+                        ConfigureSitePluginError configurePluginError = new ConfigureSitePluginError(
+                                networkError.apiError, networkError.message);
                         ConfiguredSitePluginPayload payload =
                                 new ConfiguredSitePluginPayload(site, pluginName, slug, configurePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload));
@@ -123,13 +122,11 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 new DeletedSitePluginPayload(site, slug, pluginName)));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        DeletedSitePluginPayload payload =
-                                new DeletedSitePluginPayload(site, slug, pluginName);
-                        payload.error = new DeleteSitePluginError(((WPComGsonNetworkError)
-                                networkError).apiError, networkError.message);
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
+                        DeletedSitePluginPayload payload = new DeletedSitePluginPayload(site, slug, pluginName);
+                        payload.error = new DeleteSitePluginError(networkError.apiError, networkError.message);
                         mDispatcher.dispatch(PluginActionBuilder.newDeletedSitePluginAction(payload));
                     }
                 }
@@ -149,11 +146,11 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 new InstalledSitePluginPayload(site, pluginFromResponse)));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        InstallSitePluginError installPluginError = new InstallSitePluginError(((WPComGsonNetworkError)
-                                networkError).apiError, networkError.message);
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
+                        InstallSitePluginError installPluginError = new InstallSitePluginError(
+                                networkError.apiError, networkError.message);
                         InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, pluginSlug,
                                 installPluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(payload));
@@ -177,12 +174,11 @@ public class PluginRestClient extends BaseWPComRestClient {
                                 new UpdatedSitePluginPayload(site, pluginFromResponse)));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError networkError) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
                         UpdateSitePluginError updatePluginError
-                                = new UpdateSitePluginError(((WPComGsonNetworkError) networkError).apiError,
-                                networkError.message);
+                                = new UpdateSitePluginError(networkError.apiError, networkError.message);
                         UpdatedSitePluginPayload payload = new UpdatedSitePluginPayload(site, pluginName, slug,
                                 updatePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newUpdatedSitePluginAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -16,11 +16,10 @@ import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostLocation;
 import org.wordpress.android.fluxc.model.post.PostStatus;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostsResponse;
@@ -69,12 +68,12 @@ public class PostRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 404 unknown_post (invalid post ID)
                         FetchPostResponsePayload payload = new FetchPostResponsePayload(post, site);
-                        payload.error = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new PostError(error.apiError, error.message);
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostAction(payload));
                     }
                 }
@@ -123,11 +122,11 @@ public class PostRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostsAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 404 unknown_post_type (invalid post type, shouldn't happen)
-                        PostError postError = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
+                        PostError postError = new PostError(error.apiError, error.message);
                         FetchPostsResponsePayload payload = new FetchPostsResponsePayload(postError);
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostsAction(payload));
                     }
@@ -163,14 +162,14 @@ public class PostRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(UploadActionBuilder.newPushedPostAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 404 unknown_post (invalid post ID)
                         // Note: Unlike XML-RPC, if an invalid term (category or tag) ID is specified, the server just
                         // ignores it and creates/updates the post normally
                         RemotePostPayload payload = new RemotePostPayload(post, site);
-                        payload.error = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new PostError(error.apiError, error.message);
                         mDispatcher.dispatch(UploadActionBuilder.newPushedPostAction(payload));
                     }
                 }
@@ -198,12 +197,12 @@ public class PostRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(PostActionBuilder.newDeletedPostAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 404 unknown_post (invalid post ID)
                         RemotePostPayload payload = new RemotePostPayload(post, site);
-                        payload.error = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new PostError(error.apiError, error.message);
                         mDispatcher.dispatch(PostActionBuilder.newDeletedPostAction(payload));
                     }
                 }
@@ -250,10 +249,10 @@ public class PostRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        PostError postError = new PostError(((WPComGsonNetworkError) error).apiError, error.message);
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                        PostError postError = new PostError(error.apiError, error.message);
                         SearchPostsResponsePayload payload =
                                 new SearchPostsResponsePayload(site, searchTerm, pages, postError);
                         mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -47,6 +47,7 @@ import org.wordpress.android.fluxc.store.SiteStore.PostFormatsErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteError;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
+import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesError;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesErrorType;
@@ -353,7 +354,10 @@ public class SiteRestClient extends BaseWPComRestClient {
                         new WPComErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                                SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query, error);
+                                SuggestDomainError suggestDomainError =
+                                        new SuggestDomainError(error.apiError, error.message);
+                                SuggestDomainsResponsePayload payload =
+                                        new SuggestDomainsResponsePayload(query, suggestDomainError);
                                 mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
                             }
                         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -20,12 +20,12 @@ import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.RoleModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
@@ -127,9 +127,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                         }
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         SitesModel payload = new SitesModel(Collections.<SiteModel>emptyList());
                         payload.error = error;
                         mDispatcher.dispatch(SiteActionBuilder.newFetchedSitesAction(payload));
@@ -157,9 +157,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                         }
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         SiteModel payload = new SiteModel();
                         payload.error = error;
                         mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(payload));
@@ -200,9 +200,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newCreatedNewSiteAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         NewSiteResponsePayload payload = volleyErrorToAccountResponsePayload(error.volleyError);
                         payload.dryRun = dryRun;
                         mDispatcher.dispatch(SiteActionBuilder.newCreatedNewSiteAction(payload));
@@ -235,9 +235,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 FetchedPostFormatsPayload(site, postFormats)));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         FetchedPostFormatsPayload payload = new FetchedPostFormatsPayload(site,
                                 Collections.<PostFormatModel>emptyList());
                         // TODO: what other kind of error could we get here?
@@ -267,9 +267,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 FetchedUserRolesPayload(site, roleArray)));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         FetchedUserRolesPayload payload = new FetchedUserRolesPayload(site,
                                 Collections.<RoleModel>emptyList());
                         // TODO: what other kind of error could we get here?
@@ -293,12 +293,11 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newDeletedSiteAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         DeleteSiteResponsePayload payload = new DeleteSiteResponsePayload();
-                        WPComGsonNetworkError networkError = ((WPComGsonNetworkError) error);
-                        payload.error = new DeleteSiteError(networkError.apiError, networkError.message);
+                        payload.error = new DeleteSiteError(error.apiError, error.message);
                         payload.site = site;
                         mDispatcher.dispatch(SiteActionBuilder.newDeletedSiteAction(payload));
                     }
@@ -318,9 +317,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newExportedSiteAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         ExportSiteResponsePayload payload = new ExportSiteResponsePayload();
                         payload.error = error;
                         mDispatcher.dispatch(SiteActionBuilder.newExportedSiteAction(payload));
@@ -351,9 +350,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
                             }
                         },
-                        new BaseErrorListener() {
+                        new WPComErrorListener() {
                             @Override
-                            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                            public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                                 SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query, error);
                                 mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
                             }
@@ -394,9 +393,9 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newFetchedConnectSiteInfoAction(info));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         SiteError siteError = new SiteError(SiteErrorType.INVALID_SITE);
                         ConnectSiteInfoPayload info = new ConnectSiteInfoPayload(siteUrl, siteError);
                         mDispatcher.dispatch(SiteActionBuilder.newFetchedConnectSiteInfoAction(info));
@@ -435,22 +434,20 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newFetchedWpcomSiteByUrlAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         FetchWPComSiteResponsePayload payload = new FetchWPComSiteResponsePayload();
                         payload.checkedUrl = siteUrl;
 
                         SiteErrorType siteErrorType = SiteErrorType.GENERIC_ERROR;
-                        if (error instanceof WPComGsonNetworkError) {
-                            switch (((WPComGsonNetworkError) error).apiError) {
-                                case "unauthorized":
-                                    siteErrorType = SiteErrorType.UNAUTHORIZED;
-                                    break;
-                                case "unknown_blog":
-                                    siteErrorType = SiteErrorType.UNKNOWN_SITE;
-                                    break;
-                            }
+                        switch (error.apiError) {
+                            case "unauthorized":
+                                siteErrorType = SiteErrorType.UNAUTHORIZED;
+                                break;
+                            case "unknown_blog":
+                                siteErrorType = SiteErrorType.UNKNOWN_SITE;
+                                break;
                         }
                         payload.error = new SiteError(siteErrorType);
 
@@ -474,16 +471,14 @@ public class SiteRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(SiteActionBuilder.newCheckedIsWpcomUrlAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         IsWPComResponsePayload payload = new IsWPComResponsePayload();
                         payload.url = testedUrl;
                         // "unauthorized" and "unknown_blog" errors expected if the site is not accessible via
                         // the WPCom REST API.
-                        if (error instanceof WPComGsonNetworkError
-                                && ("unauthorized".equals(((WPComGsonNetworkError) error).apiError)
-                                || "unknown_blog".equals(((WPComGsonNetworkError) error).apiError))) {
+                        if ("unauthorized".equals(error.apiError) || "unknown_blog".equals(error.apiError)) {
                             payload.isWPCom = false;
                         } else {
                             payload.error = error;
@@ -515,11 +510,11 @@ public class SiteRestClient extends BaseWPComRestClient {
                                         strErrorCodes)));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                        AutomatedTransferError payloadError = new AutomatedTransferError(((WPComGsonNetworkError)
-                                networkError).apiError, networkError.message);
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
+                        AutomatedTransferError payloadError = new AutomatedTransferError(
+                                networkError.apiError, networkError.message);
                         mDispatcher.dispatch(SiteActionBuilder.newCheckedAutomatedTransferEligibilityAction(
                                 new AutomatedTransferEligibilityResponsePayload(site, payloadError)));
                     }
@@ -542,13 +537,12 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 mDispatcher.dispatch(SiteActionBuilder.newInitiatedAutomatedTransferAction(payload));
                             }
                         },
-                        new BaseErrorListener() {
+                        new WPComErrorListener() {
                             @Override
-                            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                            public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
                                 InitiateAutomatedTransferResponsePayload payload =
                                         new InitiateAutomatedTransferResponsePayload(site, pluginSlugToInstall);
-                                payload.error = new AutomatedTransferError(((WPComGsonNetworkError)
-                                        error).apiError, error.message);
+                                payload.error = new AutomatedTransferError(networkError.apiError, networkError.message);
                                 mDispatcher.dispatch(SiteActionBuilder.newInitiatedAutomatedTransferAction(payload));
                             }
                         });
@@ -567,11 +561,11 @@ public class SiteRestClient extends BaseWPComRestClient {
                                                 response.currentStep, response.totalSteps)));
                             }
                         },
-                        new BaseErrorListener() {
+                        new WPComErrorListener() {
                             @Override
-                            public void onErrorResponse(@NonNull BaseNetworkError networkError) {
-                                AutomatedTransferError error = new AutomatedTransferError(((WPComGsonNetworkError)
-                                        networkError).apiError, networkError.message);
+                            public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
+                                AutomatedTransferError error = new AutomatedTransferError(
+                                        networkError.apiError, networkError.message);
                                 mDispatcher.dispatch(SiteActionBuilder.newCheckedAutomatedTransferStatusAction(
                                         new AutomatedTransferStatusResponsePayload(site, error)));
                             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.java
@@ -9,10 +9,11 @@ import com.android.volley.Response;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.StockMediaActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
-import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.store.StockMediaStore.FetchedStockMediaListPayload;
 import org.wordpress.android.fluxc.store.StockMediaStore.StockMediaError;
@@ -59,9 +60,9 @@ public class StockMediaRestClient extends BaseWPComRestClient {
                                         response.canLoadMore);
                         mDispatcher.dispatch(StockMediaActionBuilder.newFetchedStockMediaAction(payload));
                     }
-                }, new BaseRequest.BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseRequest.BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(AppLog.T.MEDIA, "VolleyError Fetching stock media: " + error);
                         StockMediaError mediaError = new StockMediaError(
                                 StockMediaErrorType.fromBaseNetworkError(error), error.message);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -14,11 +14,10 @@ import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST.SitesEndpoint.Si
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.model.TermsModel;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse.TermsResponse;
@@ -61,12 +60,11 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 400 invalid_taxonomy
-                        TaxonomyError taxonomyError = new TaxonomyError(((WPComGsonNetworkError) error).apiError,
-                                error.message);
+                        TaxonomyError taxonomyError = new TaxonomyError(error.apiError, error.message);
                         FetchTermResponsePayload payload = new FetchTermResponsePayload(term, site);
                         payload.error = taxonomyError;
                         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
@@ -101,12 +99,11 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 400 invalid_taxonomy
-                        TaxonomyError taxonomyError = new TaxonomyError(((WPComGsonNetworkError) error).apiError,
-                                error.message);
+                        TaxonomyError taxonomyError = new TaxonomyError(error.apiError, error.message);
                         FetchTermsResponsePayload payload = new FetchTermsResponsePayload(taxonomyError, taxonomyName);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
                     }
@@ -139,12 +136,12 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
                         RemoteTermPayload payload = new RemoteTermPayload(term, site);
-                        payload.error = new TaxonomyError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new TaxonomyError(error.apiError, error.message);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                     }
                 }
@@ -170,12 +167,12 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                     }
                 },
-                new BaseErrorListener() {
+                new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
                         RemoteTermPayload payload = new RemoteTermPayload(term, site);
-                        payload.error = new TaxonomyError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new TaxonomyError(error.apiError, error.message);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -12,11 +12,10 @@ import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
-import org.wordpress.android.fluxc.network.BaseRequest;
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
@@ -61,12 +60,12 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         SiteThemePayload payload = new SiteThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }
-                }, new BaseRequest.BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme deletion request.");
                         SiteThemePayload payload = new SiteThemePayload(site, theme);
-                        payload.error = new ThemesError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new ThemesError(error.apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newDeletedThemeAction(payload));
                     }
                 }));
@@ -85,12 +84,12 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         SiteThemePayload payload = new SiteThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
                     }
-                }, new BaseRequest.BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to Jetpack theme installation request.");
                         SiteThemePayload payload = new SiteThemePayload(site, theme);
-                        payload.error = new ThemesError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new ThemesError(error.apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newInstalledThemeAction(payload));
                     }
                 }));
@@ -114,12 +113,12 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         payload.theme.setActive(StringUtils.equals(theme.getThemeId(), response.id));
                         mDispatcher.dispatch(ThemeActionBuilder.newActivatedThemeAction(payload));
                     }
-                }, new BaseRequest.BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.d(AppLog.T.API, "Received error response to theme activation request.");
                         SiteThemePayload payload = new SiteThemePayload(site, theme);
-                        payload.error = new ThemesError(((WPComGsonNetworkError) error).apiError, error.message);
+                        payload.error = new ThemesError(error.apiError, error.message);
                         mDispatcher.dispatch(ThemeActionBuilder.newActivatedThemeAction(payload));
                     }
                 }));
@@ -140,12 +139,12 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         FetchedWpComThemesPayload payload = new FetchedWpComThemesPayload(themes);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
                     }
-                }, new BaseRequest.BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to WP.com themes fetch request.");
                         ThemesError themeError = new ThemesError(
-                                ((WPComGsonNetworkError) error).apiError, error.message);
+                                error.apiError, error.message);
                         FetchedWpComThemesPayload payload = new FetchedWpComThemesPayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
                     }
@@ -167,12 +166,11 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         FetchedSiteThemesPayload payload = new FetchedSiteThemesPayload(site, themes);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedInstalledThemesAction(payload));
                     }
-                }, new BaseRequest.BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to Jetpack installed themes fetch request.");
-                        ThemesError themeError = new ThemesError(
-                                ((WPComGsonRequest.WPComGsonNetworkError) error).apiError, error.message);
+                        ThemesError themeError = new ThemesError(error.apiError, error.message);
                         FetchedSiteThemesPayload payload = new FetchedSiteThemesPayload(site, themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedInstalledThemesAction(payload));
                     }
@@ -194,12 +192,11 @@ public class ThemeRestClient extends BaseWPComRestClient {
                         FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(site, responseTheme);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedCurrentThemeAction(payload));
                     }
-                }, new BaseRequest.BaseErrorListener() {
+                }, new WPComErrorListener() {
                     @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         AppLog.e(AppLog.T.API, "Received error response to current theme fetch request.");
-                        ThemesError themeError = new ThemesError(
-                                ((WPComGsonNetworkError) error).apiError, error.message);
+                        ThemesError themeError = new ThemesError(error.apiError, error.message);
                         FetchedCurrentThemePayload payload = new FetchedCurrentThemePayload(site, themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedCurrentThemeAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -21,7 +21,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.StockMediaModel;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.MediaSqlUtils;
@@ -387,16 +387,13 @@ public class MediaStore extends Store {
         UNKNOWN,
         GENERIC_ERROR;
 
-        public static UploadStockMediaErrorType fromBaseNetworkError(BaseNetworkError baseError) {
-            if (baseError instanceof WPComGsonRequest.WPComGsonNetworkError) {
-                WPComGsonRequest.WPComGsonNetworkError wpError = (WPComGsonRequest.WPComGsonNetworkError) baseError;
-                // invalid upload request
-                if (wpError.apiError.equalsIgnoreCase("invalid_input")) {
-                    return INVALID_INPUT;
-                }
+        public static UploadStockMediaErrorType fromNetworkError(WPComGsonNetworkError wpError) {
+            // invalid upload request
+            if (wpError.apiError.equalsIgnoreCase("invalid_input")) {
+                return INVALID_INPUT;
             }
             // can happen if invalid pexels image url is passed
-            if (baseError.type == BaseRequest.GenericErrorType.UNKNOWN) {
+            if (wpError.type == BaseRequest.GenericErrorType.UNKNOWN) {
                 return UNKNOWN;
             }
             return GENERIC_ERROR;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -21,8 +21,6 @@ import org.wordpress.android.fluxc.model.RoleModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.DeleteSiteResponsePayload;
@@ -107,10 +105,10 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class SuggestDomainsResponsePayload extends Payload<BaseNetworkError> {
+    public static class SuggestDomainsResponsePayload extends Payload<SuggestDomainError> {
         public String query;
         public List<DomainSuggestionResponse> suggestions;
-        public SuggestDomainsResponsePayload(@NonNull String query, BaseNetworkError error) {
+        public SuggestDomainsResponsePayload(@NonNull String query, SuggestDomainError error) {
             this.query = query;
             this.error = error;
             this.suggestions = new ArrayList<>();
@@ -1234,12 +1232,7 @@ public class SiteStore extends Store {
     private void handleSuggestedDomains(SuggestDomainsResponsePayload payload) {
         OnSuggestedDomains event = new OnSuggestedDomains(payload.query, payload.suggestions);
         if (payload.isError()) {
-            if (payload.error instanceof WPComGsonRequest.WPComGsonNetworkError) {
-                event.error = new SuggestDomainError(((WPComGsonNetworkError) payload.error).apiError,
-                        payload.error.message);
-            } else {
-                event.error = new SuggestDomainError("", payload.error.message);
-            }
+            event.error = payload.error;
         }
         emitChange(event);
     }


### PR DESCRIPTION
[Wraps the error listener in `WPComGsonRequest`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/feature/wpcom-gson-error-refactor?expand=1#diff-8aec461b9ea3f73c8e15c4b4a6231f9b), so that the WordPress.com-based network clients now supply a `WPComErrorListener` instead of a `BaseNetworkListener`, and receive a `WPComGsonNetworkError` in the callback (instead of its `BaseNetworkError` superclass).

This lets us eliminate the `(WPComGsonNetworkError) error` casts that we've had to use all over the place.