### PR TITLE
Update connect/site-info API call

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -378,13 +378,12 @@ public class SiteRestClient extends BaseWPComRestClient {
             return;
         }
 
-        // Sanitize and encode the Url for the API call.
-        String sanitizedURL = UrlUtils.removeScheme(siteUrl);
-        sanitizedURL = sanitizedURL.replace("/", "::");
+        Map<String, String> params = new HashMap<>(1);
+        params.put("url", uri.toString());
 
         // Make the call.
-        String url = WPCOMREST.connect.site_info.protocol(uri.getScheme()).address(sanitizedURL).getUrlV1_1();
-        final WPComGsonRequest<ConnectSiteInfoResponse> request = WPComGsonRequest.buildGetRequest(url, null,
+        String url = WPCOMREST.connect.site_info.getUrlV1_1();
+        final WPComGsonRequest<ConnectSiteInfoResponse> request = WPComGsonRequest.buildGetRequest(url, params,
                 ConnectSiteInfoResponse.class,
                 new Listener<ConnectSiteInfoResponse>() {
                     @Override

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -1,7 +1,7 @@
 /auth/send-login-email/
 /auth/send-signup-email/
 
-/connect/site-info/$protocol#String/$address#String
+/connect/site-info/
 
 /is-available/blog/
 /is-available/domain/


### PR DESCRIPTION
A new site-info endpoint has been added that receives the URL as a query
parameter rather than parts of the path (D11731-code)

This simplifies the API call and is less error-prone.

What was in the path, with `/` -> `::` (slug-style) encoding:

`https://public-api.wordpress.com/rest/v1.1/connect/site-info/https/example.com::site::path`

Is now a query param (no need to think about encoding):

`https://public-api.wordpress.com/rest/v1.1/connect/site-info?url=https%3A//example.com/site/path`


Aligns with https://github.com/Automattic/wp-calypso/pull/24034
Related iOS update: https://github.com/wordpress-mobile/WordPress-iOS/pull/9245

The API logic and response are unchanged.

Fixes #796

cc: @seear