### PR TITLE
WooCommerce Store: Add Order Note Capability

### DIFF
--- a/example/src/androidTest/resources/wc-order-note-post-response-success.json
+++ b/example/src/androidTest/resources/wc-order-note-post-response-success.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "id": 86,
+    "date_created": "2018-05-04T02:07:50",
+    "date_created_gmt": "2018-05-04T02:07:50",
+    "note": "Test rest note",
+    "customer_note": true,
+    "_links": {
+      "self": [
+        {
+          "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders\/104\/notes\/86"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders\/104\/notes"
+        }
+      ],
+      "up": [
+        {
+          "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders\/104"
+        }
+      ]
+    }
+  }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -13,15 +13,18 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
+import org.wordpress.android.fluxc.action.WCOrderAction.POST_ORDER_NOTE
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.AppLog
@@ -67,6 +70,21 @@ class WooCommerceFragment : Fragment() {
                     pendingNotesOrderModel = order
                     val payload = FetchOrderNotesPayload(order, site)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderNotesAction(payload))
+                }
+            }
+        }
+
+        post_order_note.setOnClickListener {
+            getFirstWCSite()?.let { site ->
+                getFirstWCOrder()?.let { order ->
+                    pendingNotesOrderModel = order
+                    showSingleLineDialog(activity, "Enter note", { editText ->
+                        val newNote = WCOrderNoteModel().apply {
+                            note = editText.text.toString()
+                        }
+                        val payload = PostOrderNotePayload(order, site, newNote)
+                        dispatcher.dispatch(WCOrderActionBuilder.newPostOrderNoteAction(payload))
+                    })
                 }
             }
         }
@@ -118,6 +136,8 @@ class WooCommerceFragment : Fragment() {
                                     "${pendingNotesOrderModel!!.remoteOrderId}. ${event.rowsAffected} " +
                                     "notes inserted into database.")
                     }
+                    POST_ORDER_NOTE -> prependToLog("Posted ${event.rowsAffected} " +
+                            "note to the api for order ${pendingNotesOrderModel!!.remoteOrderId}")
                     UPDATE_ORDER_STATUS ->
                         with (orderList[0]) { prependToLog("Updated order status for $number to $status") }
                     else -> prependToLog("Order store was updated from a " + event.causeOfChange)

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -25,6 +25,12 @@
         android:text="Fetch Order Notes"/>
 
     <Button
+        android:id="@+id/post_order_note"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Post Order Note"/>
+
+    <Button
         android:id="@+id/update_latest_order_status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -4,7 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderNotesApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderNoteApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatus
 
 object OrderTestUtils {
@@ -22,8 +22,8 @@ object OrderTestUtils {
     }
 
     fun getOrderNotesFromJsonString(json: String, siteId: Int, orderId: Int): List<WCOrderNoteModel> {
-        val responseType = object : TypeToken<List<OrderNotesApiResponse>>() {}.type
-        val converted = Gson().fromJson(json, responseType) as? List<OrderNotesApiResponse> ?: emptyList()
+        val responseType = object : TypeToken<List<OrderNoteApiResponse>>() {}.type
+        val converted = Gson().fromJson(json, responseType) as? List<OrderNoteApiResponse> ?: emptyList()
         return converted.map {
             WCOrderNoteModel().apply {
                 remoteNoteId = it.id ?: 0

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -7,6 +7,8 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload;
 
@@ -19,6 +21,8 @@ public enum WCOrderAction implements IAction {
     UPDATE_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesPayload.class)
     FETCH_ORDER_NOTES,
+    @Action(payloadType = PostOrderNotePayload.class)
+    POST_ORDER_NOTE,
 
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
@@ -26,5 +30,7 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = RemoteOrderPayload.class)
     UPDATED_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesResponsePayload.class)
-    FETCHED_ORDER_NOTES
+    FETCHED_ORDER_NOTES,
+    @Action(payloadType = RemoteOrderNotePayload.class)
+    POSTED_ORDER_NOTE
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import org.wordpress.android.fluxc.network.Response
 
-class OrderNotesApiResponse : Response {
+class OrderNoteApiResponse : Response {
     val id: Long? = null
     val date_created_gmt: String? = null
     val note: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -137,7 +137,6 @@ class OrderRestClient(
     fun postOrderNote(order: WCOrderModel, site: SiteModel, note: WCOrderNoteModel) {
         val url = WOOCOMMERCE.orders.id(order.remoteOrderId).notes.pathV2
 
-        println("AMANDA-TEST >  PATH = $url")
         val params = mutableMapOf("note" to note.note, "customer_note" to note.isCustomerNote)
         val request = JetpackTunnelGsonRequest.buildPostRequest(
                 url, site.siteId, params, OrderNoteApiResponse::class.java,


### PR DESCRIPTION
Added the ability to post a new order note to the API and dispatch the results. 

- Updated Example App and added a `Post Order Note` button to the Woo page
- Added Unit Tests
- Added Mocked UI Test
- Added Release UI Test
- Renamed 'OrderNotesApiResponse' to 'OrderNoteApiResponse' for a more consistent and accurate representation

cc: @aforcier 