### PR TITLE
Update deprecated kotlin libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.31'
+    ext.kotlinVersion = '1.2.41'
 
     repositories {
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.automattic.android:fetchstyle:1.1'
     }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation project(':fluxc')
     implementation project(':plugins:woocommerce')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:support-v4:$supportLibraryVersion"

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -59,7 +59,7 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
 

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -50,7 +50,7 @@ android.buildTypes.all { buildType ->
 dependencies {
     implementation project(':fluxc');
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     // WordPress libs
     implementation ('org.wordpress:utils:1.20.0') {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -42,7 +42,7 @@ android {
 dependencies {
     implementation project(':fluxc')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     // WordPress libs
     implementation ('org.wordpress:utils:1.20.0') {


### PR DESCRIPTION
`kotlin-stdlib-jre7` has been deprecated and was generating compiler warnings - this updates everything to `kotlin-stdlib-jdk7`, and also bumps Kotlin and the gradle plugin to the latest.