### PR TITLE
Support turning order models into id sets and back

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -9,6 +9,7 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.OrderAddress.AddressType
+import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
@@ -83,6 +84,11 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     override fun setId(id: Int) {
         this.id = id
     }
+
+    /**
+     * Returns an [OrderIdentifier], representing a unique identifier for this [WCOrderModel].
+     */
+    fun getIdentifier() = OrderIdentifier(this)
 
     /**
      * Returns true if there are shipping details defined for this order,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderIdentifier.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderIdentifier.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.model.order
+
+import org.wordpress.android.fluxc.model.WCOrderModel
+
+typealias OrderIdentifier = String
+
+data class OrderIdSet(val id: Int, val remoteOrderId: Long, val localSiteId: Int)
+
+@Suppress("FunctionName")
+fun OrderIdentifier(orderModel: WCOrderModel): OrderIdentifier {
+    return with(orderModel) { "$id-$remoteOrderId-$localSiteId" }
+}
+
+fun OrderIdentifier.toIdSet(): OrderIdSet {
+    val (id, remoteOrderId, localSiteId) = split("-")
+    return OrderIdSet(id.toInt(), remoteOrderId.toLong(), localSiteId.toInt())
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -7,6 +7,7 @@ import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.order.OrderIdSet
 
 object OrderSqlUtils {
     fun insertOrUpdateOrder(order: WCOrderModel): Int {
@@ -31,6 +32,20 @@ object OrderSqlUtils {
             return WellSql.update(WCOrderModel::class.java).whereId(oldId)
                     .put(order, UpdateAllExceptId(WCOrderModel::class.java)).execute()
         }
+    }
+
+    fun getOrderForIdSet(orderIdSet: OrderIdSet): WCOrderModel? {
+        val (id, remoteOrderId, localSiteId) = orderIdSet
+        return WellSql.select(WCOrderModel::class.java)
+                .where().beginGroup()
+                .equals(WCOrderModelTable.ID, id)
+                .or()
+                .beginGroup()
+                .equals(WCOrderModelTable.REMOTE_ORDER_ID, remoteOrderId)
+                .equals(WCOrderModelTable.LOCAL_SITE_ID, localSiteId)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
     }
 
     fun getOrdersForSite(site: SiteModel, status: List<String> = emptyList()): List<WCOrderModel> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.store
 
-import com.wellsql.generated.WCOrderModelTable
-import com.yarolegovich.wellsql.WellSql
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -12,6 +10,8 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatus
@@ -101,12 +101,11 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
             OrderSqlUtils.getOrdersForSite(site, status = status.asList())
 
     /**
-     * Given a local ID for an order, returns that order as a [WCOrderModel].
+     * Given an [OrderIdentifier], returns the corresponding order from the database as a [WCOrderModel].
      */
-    fun getOrderByLocalOrderId(localId: Int): WCOrderModel? =
-            WellSql.select(WCOrderModel::class.java)
-                .where().equals(WCOrderModelTable.ID, localId).endWhere()
-                .asModel.firstOrNull()
+    fun getOrderByIdentifier(orderIdentifier: OrderIdentifier): WCOrderModel? {
+        return OrderSqlUtils.getOrderForIdSet((orderIdentifier.toIdSet()))
+    }
 
     /**
      * Returns the notes belonging to supplied [WCOrderModel] as a list of [WCOrderNoteModel].


### PR DESCRIPTION
Adds `OrderIdentifier`, which is a composite id for orders made up their local id, remote id, and local site id (really a `typealias`'d `String`). This is meant to be a safe way to serialize and deserialize a partial `WCOrderModel` (e.g. for passing it in a `Bundle`), without the risk of accidentally storing and restoring the wrong id (e.g. storing the local site id instead of the local order id, and then attempting to load the order by its local order id).

I removed `getOrderByLocalOrderId()` entirely - it's possible it might have some other use in the future, but for now it's not needed for the implementation and it seems best to remove temptation 😛 

cc @AmandaRiu 