### PR TITLE
Fix wrong mapping of actor type in ActivityLogModel

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -157,7 +157,7 @@ class ActivityLogSqlUtils
                     wpcomUserID != null ||
                     avatarURL != null ||
                     role != null) {
-                ActivityLogModel.ActivityActor(displayName, type, wpcomUserID, avatarURL, role)
+                ActivityLogModel.ActivityActor(displayName, actorType, wpcomUserID, avatarURL, role)
             } else null
             return ActivityLogModel(activityID,
                     summary,


### PR DESCRIPTION
Passing ActivityLog type instead of Actor type while reading data from database