### PR TITLE
Default to empty string if order/note date created is null

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -163,7 +163,7 @@ class OrderRestClient(
             number = response.number ?: remoteOrderId.toString()
             status = response.status ?: ""
             currency = response.currency ?: ""
-            dateCreated = "${response.date_created_gmt}Z" // Store the date in UTC format
+            dateCreated = response.date_created_gmt?.let { "${it}Z" } ?: "" // Store the date in UTC format
             total = response.total ?: ""
             totalTax = response.total_tax ?: ""
             shippingTotal = response.shipping_total ?: ""
@@ -215,7 +215,7 @@ class OrderRestClient(
     private fun orderNoteResponseToOrderNoteModel(response: OrderNoteApiResponse): WCOrderNoteModel {
         return WCOrderNoteModel().apply {
             remoteNoteId = response.id ?: 0
-            dateCreated = "${response.date_created_gmt}Z"
+            dateCreated = response.date_created_gmt?.let { "${it}Z" } ?: ""
             note = response.note ?: ""
             isCustomerNote = response.customer_note
         }


### PR DESCRIPTION
If the `date_created_gmt` field is `null` (shouldn't happen in general, but at least one case of it has surfaced - probably an incomplete manual order), we should store an empty string in the db.

Previous behavior was to coerce `null` into the string `"null"`. It didn't really break anything but it doesn't make much sense.

cc @AmandaRiu 