### PR TITLE
Add migration for WooCommerce order and order note tables

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -41,7 +41,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 31;
+        return 32;
     }
 
     @Override
@@ -259,6 +259,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "PUBLISHED INTEGER,DISCARDED INTEGER,DISPLAY_NAME TEXT,ACTOR_TYPE TEXT,WPCOM_USER_ID "
                         + "INTEGER,AVATAR_URL TEXT,ROLE TEXT)");
                 oldVersion++;
+            case 31:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -293,7 +297,30 @@ public class WellSqlConfig extends DefaultWellConfig {
     private void migrateAddOn(@AddOn String addOnName, SQLiteDatabase db, int oldDbVersion) {
         if (mActiveAddOns.contains(addOnName)) {
             switch (oldDbVersion) {
-                // TODO
+                case 30:
+                    db.execSQL("DROP TABLE IF EXISTS WCOrderModel");
+                    db.execSQL("DROP TABLE IF EXISTS WCOrderNoteModel");
+                    db.execSQL("CREATE TABLE WCOrderModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                               + "REMOTE_ORDER_ID INTEGER,NUMBER TEXT NOT NULL,STATUS TEXT NOT NULL,"
+                               + "CURRENCY TEXT NOT NULL,DATE_CREATED TEXT NOT NULL,TOTAL TEXT NOT NULL,"
+                               + "TOTAL_TAX TEXT NOT NULL,SHIPPING_TOTAL TEXT NOT NULL,PAYMENT_METHOD TEXT NOT NULL,"
+                               + "PAYMENT_METHOD_TITLE TEXT NOT NULL,PRICES_INCLUDE_TAX INTEGER,"
+                               + "CUSTOMER_NOTE TEXT NOT NULL,DISCOUNT_TOTAL TEXT NOT NULL,"
+                               + "DISCOUNT_CODES TEXT NOT NULL,REFUND_TOTAL REAL,BILLING_FIRST_NAME TEXT NOT NULL,"
+                               + "BILLING_LAST_NAME TEXT NOT NULL,BILLING_COMPANY TEXT NOT NULL,"
+                               + "BILLING_ADDRESS1 TEXT NOT NULL,BILLING_ADDRESS2 TEXT NOT NULL,"
+                               + "BILLING_CITY TEXT NOT NULL,BILLING_STATE TEXT NOT NULL,"
+                               + "BILLING_POSTCODE TEXT NOT NULL,BILLING_COUNTRY TEXT NOT NULL,"
+                               + "BILLING_EMAIL TEXT NOT NULL,BILLING_PHONE TEXT NOT NULL,"
+                               + "SHIPPING_FIRST_NAME TEXT NOT NULL,SHIPPING_LAST_NAME TEXT NOT NULL,"
+                               + "SHIPPING_COMPANY TEXT NOT NULL,SHIPPING_ADDRESS1 TEXT NOT NULL,"
+                               + "SHIPPING_ADDRESS2 TEXT NOT NULL,SHIPPING_CITY TEXT NOT NULL,"
+                               + "SHIPPING_STATE TEXT NOT NULL,SHIPPING_POSTCODE TEXT NOT NULL,"
+                               + "SHIPPING_COUNTRY TEXT NOT NULL,LINE_ITEMS TEXT NOT NULL)");
+                    db.execSQL("CREATE TABLE WCOrderNoteModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                               + "LOCAL_SITE_ID INTEGER,LOCAL_ORDER_ID INTEGER,REMOTE_NOTE_ID INTEGER,"
+                               + "DATE_CREATED TEXT NOT NULL,NOTE TEXT NOT NULL,IS_CUSTOMER_NOTE INTEGER)");
+                    break;
             }
         }
     }


### PR DESCRIPTION
Adds the migration steps for the order and order notes tables to `WellSqlConfig`.

This is a prerequisite for merging `wc-orders` into `develop`. With the bulk of the orders-related API work done for now,

Note that one thing never covered in the migration possibilities is an app having an existing database and _then_ enabling `ADDON_WOOCOMMERCE`. This is not supported - we can add a workaround for this in the future, but it doesn't affect anything for the foreseeable future since the Woo app has the addon enabled from day 1.

Some background on the addon configuration for WooCommerce in FluxC: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/642

#### To test:
There are two migration paths:
1. An app with `ADDON_WOOCOMMERCE` enabled (e.g. FluxC's own example app, the Woo app) upgrades to version ~`31`~`32`
2. An app without `ADDON_WOOCOMMERCE` (e.g. FluxC's Instaflux app, the WordPress app) upgrades to version ~`31`~`32`

Case 1 behaves like a normal migration - any previous versions of the orders and order notes tables are wiped and re-added with the correct, current schema.

Case 2 _looks_ like a migration - there will be a "Upgrading database from version x to 32" log, and a "Migrating to version 32", but no actual database queries will be run and there won't be any WC* tables added (this can be verified via Stetho). 

Migrating from FluxC `develop` to this branch should cause no crashes for either the example app or Instaflux. The same goes for the WordPress and Woo apps.

cc @AmandaRiu 