### PR TITLE
WooCommerce: Add WCStatsStore and order stats

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -25,4 +25,5 @@ public interface MockedNetworkAppComponent {
     void inject(MockedStack_UploadStoreTest object);
     void inject(MockedStack_UploadTest object);
     void inject(MockedStack_WCOrdersTest object);
+    void inject(MockedStack_WCStatsTest object);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -1,0 +1,110 @@
+package org.wordpress.android.fluxc.mocked
+
+import com.google.gson.JsonObject
+import org.greenrobot.eventbus.Subscribe
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.action.WCStatsAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlin.properties.Delegates.notNull
+
+/**
+ * Tests using a Mocked Network app component. Test the network client itself and not the underlying
+ * network component(s).
+ */
+class MockedStack_WCStatsTest : MockedStack_Base() {
+    @Inject internal lateinit var orderStatsRestClient: OrderStatsRestClient
+    @Inject internal lateinit var dispatcher: Dispatcher
+
+    @Inject internal lateinit var interceptor: ResponseMockingInterceptor
+
+    private var lastAction: Action<*>? = null
+    private var countDownLatch: CountDownLatch by notNull()
+
+    private val siteModel = SiteModel().apply {
+        id = 5
+        siteId = 567
+    }
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mMockedNetworkAppComponent.inject(this)
+        dispatcher.register(this)
+        lastAction = null
+    }
+
+    @Test
+    fun testStatsDayFetchSuccess() {
+        interceptor.respondWith("wc-order-stats-response-success.json")
+        orderStatsRestClient.fetchStats(siteModel, OrderStatsApiUnit.DAY, "2018-04-20", 7)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCStatsAction.FETCHED_ORDER_STATS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchOrderStatsResponsePayload
+        assertNull(payload.error)
+        assertEquals(siteModel, payload.site)
+        assertEquals(OrderStatsApiUnit.DAY, payload.apiUnit)
+        assertNotNull(payload.stats)
+
+        with (payload.stats!!) {
+            assertEquals(siteModel.id, localSiteId)
+            assertEquals(OrderStatsApiUnit.DAY.toString(), unit)
+            assertEquals(18, fieldsList.size)
+            assertEquals(7, dataList.size)
+            assertEquals(18, dataList[0].size)
+
+            val revenueIndex = fieldsList.indexOf("total_sales")
+            assertEquals(182.5, dataList.map { it[revenueIndex] as Double }.sum(), 0.01)
+
+            val periodIndex = fieldsList.indexOf("period")
+            assertEquals("2018-04-14", dataList.first()[periodIndex])
+            assertEquals("2018-04-20", dataList.last()[periodIndex])
+        }
+    }
+
+    @Test
+    fun testStatsFetchInvalidParamError() {
+        val errorJson = JsonObject().apply {
+            addProperty("error", "rest_invalid_param")
+            addProperty("message", "Invalid parameter(s): date")
+        }
+
+        interceptor.respondWithError(errorJson)
+        orderStatsRestClient.fetchStats(siteModel, OrderStatsApiUnit.DAY, "invalid", 7)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCStatsAction.FETCHED_ORDER_STATS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchOrderStatsResponsePayload
+        assertNotNull(payload.error)
+        assertEquals(siteModel, payload.site)
+        assertEquals(OrderStatsApiUnit.DAY, payload.apiUnit)
+        assertNull(payload.stats)
+        assertEquals(OrderStatsErrorType.INVALID_PARAM, payload.error.type)
+    }
+
+    @Suppress("unused")
+    @Subscribe
+    fun onAction(action: Action<*>) {
+        lastAction = action
+        countDownLatch.countDown()
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import javax.inject.Singleton
 
 @Module
@@ -20,6 +21,15 @@ class MockedWCNetworkModule {
         requestQueue: RequestQueue,
         token: AccessToken,
         userAgent: UserAgent
-    ) =
-            OrderRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+    ) = OrderRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideOrderStatsRestClient(
+        appContext: Context,
+        dispatcher: Dispatcher,
+        requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = OrderStatsRestClient(appContext, dispatcher, requestQueue, token, userAgent)
 }

--- a/example/src/androidTest/resources/wc-order-stats-response-success.json
+++ b/example/src/androidTest/resources/wc-order-stats-response-success.json
@@ -1,0 +1,1215 @@
+{
+  "date": "2018-04-20",
+  "unit": "day",
+  "quantity": "7",
+  "fields": [
+    "period",
+    "orders",
+    "products",
+    "coupons",
+    "coupon_discount",
+    "total_sales",
+    "total_tax",
+    "total_shipping",
+    "total_shipping_tax",
+    "total_refund",
+    "total_tax_refund",
+    "total_shipping_refund",
+    "total_shipping_tax_refund",
+    "currency",
+    "gross_sales",
+    "net_sales",
+    "avg_order_value",
+    "avg_products_per_order"
+  ],
+  "data": [
+    [
+      "2018-04-14",
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      "2018-04-15",
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      "2018-04-16",
+      2,
+      3,
+      0,
+      0,
+      115,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      115,
+      115,
+      57.5,
+      1.5
+    ],
+    [
+      "2018-04-17",
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      "2018-04-18",
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      "2018-04-19",
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      "2018-04-20",
+      2,
+      2,
+      0,
+      0,
+      67.5,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      67.5,
+      67.5,
+      33.75,
+      1
+    ]
+  ],
+  "delta_fields": [
+    "period",
+    "delta",
+    "percentage_change",
+    "reference_period",
+    "favorable",
+    "direction",
+    "currency"
+  ],
+  "deltas": [
+    {
+      "period": "2018-04-14",
+      "orders": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "products": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupons": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-04-14",
+        0,
+        0,
+        "2018-04-13",
+        "",
+        "is-neutral",
+        "USD"
+      ]
+    },
+    {
+      "period": "2018-04-15",
+      "orders": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "products": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupons": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-04-15",
+        0,
+        0,
+        "2018-04-14",
+        "",
+        "is-neutral",
+        "USD"
+      ]
+    },
+    {
+      "period": "2018-04-16",
+      "orders": [
+        "2018-04-16",
+        2,
+        0,
+        "2018-04-15",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "products": [
+        "2018-04-16",
+        3,
+        0,
+        "2018-04-15",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "coupons": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-04-16",
+        115,
+        0,
+        "2018-04-15",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-04-16",
+        0,
+        0,
+        "2018-04-15",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-04-16",
+        115,
+        0,
+        "2018-04-15",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-04-16",
+        115,
+        0,
+        "2018-04-15",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-04-16",
+        57.5,
+        0,
+        "2018-04-15",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-04-16",
+        1.5,
+        0,
+        "2018-04-15",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ]
+    },
+    {
+      "period": "2018-04-17",
+      "orders": [
+        "2018-04-17",
+        -2,
+        -1,
+        "2018-04-16",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "products": [
+        "2018-04-17",
+        -3,
+        -1,
+        "2018-04-16",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "coupons": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-04-17",
+        -115,
+        -1,
+        "2018-04-16",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-04-17",
+        0,
+        0,
+        "2018-04-16",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-04-17",
+        -115,
+        -1,
+        "2018-04-16",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-04-17",
+        -115,
+        -1,
+        "2018-04-16",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-04-17",
+        -57.5,
+        -1,
+        "2018-04-16",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-04-17",
+        -1.5,
+        -1,
+        "2018-04-16",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ]
+    },
+    {
+      "period": "2018-04-18",
+      "orders": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "products": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupons": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-04-18",
+        0,
+        0,
+        "2018-04-17",
+        "",
+        "is-neutral",
+        "USD"
+      ]
+    },
+    {
+      "period": "2018-04-19",
+      "orders": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "products": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupons": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-04-19",
+        0,
+        0,
+        "2018-04-18",
+        "",
+        "is-neutral",
+        "USD"
+      ]
+    },
+    {
+      "period": "2018-04-20",
+      "orders": [
+        "2018-04-20",
+        2,
+        0,
+        "2018-04-19",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "products": [
+        "2018-04-20",
+        2,
+        0,
+        "2018-04-19",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "coupons": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-04-20",
+        67.5,
+        0,
+        "2018-04-19",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-04-20",
+        0,
+        0,
+        "2018-04-19",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-04-20",
+        67.5,
+        0,
+        "2018-04-19",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-04-20",
+        67.5,
+        0,
+        "2018-04-19",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-04-20",
+        33.75,
+        0,
+        "2018-04-19",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-04-20",
+        1,
+        0,
+        "2018-04-19",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ]
+    }
+  ],
+  "total_gross_sales": 182.5,
+  "total_net_sales": 182.5,
+  "total_orders": 4,
+  "total_products": 5,
+  "avg_gross_sales": 26.0714,
+  "avg_net_sales": 26.0714,
+  "avg_orders": 0.5714,
+  "avg_products": 0.7143
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -15,8 +15,10 @@ import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
 import org.wordpress.android.fluxc.action.WCOrderAction.POST_ORDER_NOTE
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
+import org.wordpress.android.fluxc.action.WCStatsAction
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
@@ -26,6 +28,10 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
+import org.wordpress.android.fluxc.store.WCStatsStore
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -36,6 +42,7 @@ class WooCommerceFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var wcOrderStore: WCOrderStore
+    @Inject internal lateinit var wcStatsStore: WCStatsStore
 
     private var pendingNotesOrderModel: WCOrderModel? = null
 
@@ -100,6 +107,13 @@ class WooCommerceFragment : Fragment() {
                 } ?: showNoOrdersToast(site)
             } ?: showNoWCSitesToast()
         }
+
+        fetch_order_stats.setOnClickListener {
+            getFirstWCSite()?.let {
+                val payload = FetchOrderStatsPayload(it, StatsGranularity.DAYS)
+                dispatcher.dispatch(WCStatsActionBuilder.newFetchOrderStatsAction(payload))
+            } ?: showNoWCSitesToast()
+        }
     }
 
     override fun onStart() {
@@ -141,6 +155,30 @@ class WooCommerceFragment : Fragment() {
                     UPDATE_ORDER_STATUS ->
                         with (orderList[0]) { prependToLog("Updated order status for $number to $status") }
                     else -> prependToLog("Order store was updated from a " + event.causeOfChange)
+                }
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCStatsChanged(event: OnWCStatsChanged) {
+        if (event.isError) {
+            prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
+            return
+        }
+
+        getFirstWCSite()?.let { site ->
+            wcStatsStore.getRevenueStatsForCurrentMonth(site).let { statsMap ->
+                if (statsMap.isEmpty()) {
+                    prependToLog("No stats were stored for site " + site.name + " =(")
+                    return
+                }
+
+                when (event.causeOfChange) {
+                    WCStatsAction.FETCH_ORDER_STATS ->
+                        prependToLog("Fetched stats for " + statsMap.size + " days from " + site.name)
+                    else -> prependToLog("WooCommerce stats were updated from a " + event.causeOfChange)
                 }
             }
         }

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -36,4 +36,10 @@
         android:layout_height="wrap_content"
         android:text="Update Latest Order Status" />
 
+    <Button
+        android:id="@+id/fetch_order_stats"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch Month-to-date Revenue Stats" />
+
 </LinearLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtilsTest.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.fluxc.utils
+
+import org.junit.Test
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.DateTimeUtils
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SiteUtilsTest {
+    companion object {
+        const val UTC8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX"
+    }
+
+    @Test
+    fun testGetCurrentDateTimeUtcSite() {
+        val siteModel = SiteModel()
+        with (siteModel) {
+            val formattedDate = SiteUtils.getCurrentDateTimeForSite(this, UTC8601_FORMAT)
+            val currentTimeUtc = DateTimeUtils.iso8601UTCFromDate(Date())
+            assertEquals(currentTimeUtc, formattedDate.replace("Z", "+00:00"))
+        }
+
+        siteModel.timezone = ""
+        with (siteModel) {
+            val formattedDate = SiteUtils.getCurrentDateTimeForSite(this, UTC8601_FORMAT)
+            val currentTimeUtc = DateTimeUtils.iso8601UTCFromDate(Date())
+            assertEquals(currentTimeUtc, formattedDate.replace("Z", "+00:00"))
+        }
+
+        siteModel.timezone = "0"
+        with (siteModel) {
+            val formattedDate = SiteUtils.getCurrentDateTimeForSite(this, UTC8601_FORMAT)
+            val currentTimeUtc = DateTimeUtils.iso8601UTCFromDate(Date())
+            assertEquals(currentTimeUtc, formattedDate.replace("Z", "+00:00"))
+        }
+    }
+
+    @Test
+    fun testGetCurrentDateTimeForNonUtcSite() {
+        val hourFormat = SimpleDateFormat("HH", Locale.ROOT)
+
+        val estSite = SiteModel().apply { timezone = "-4" }
+        with (estSite) {
+            val formattedDate = SiteUtils.getCurrentDateTimeForSite(this, UTC8601_FORMAT)
+            assertEquals("-04:00", formattedDate.takeLast(6))
+
+            val currentHour = hourFormat.format(DateTimeUtils.nowUTC())
+            assertNotEquals(currentHour, SiteUtils.getCurrentDateTimeForSite(this, hourFormat))
+        }
+
+        val acstSite = SiteModel().apply { timezone = "9.5" }
+        with (acstSite) {
+            val formattedDate = SiteUtils.getCurrentDateTimeForSite(this, UTC8601_FORMAT)
+            assertEquals("+09:30", formattedDate.takeLast(6))
+
+            val currentHour = hourFormat.format(DateTimeUtils.nowUTC())
+            assertNotEquals(currentHour, SiteUtils.getCurrentDateTimeForSite(this, hourFormat))
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/SiteUtilsTest.kt
@@ -59,5 +59,23 @@ class SiteUtilsTest {
             val currentHour = hourFormat.format(DateTimeUtils.nowUTC())
             assertNotEquals(currentHour, SiteUtils.getCurrentDateTimeForSite(this, hourFormat))
         }
+
+        val nptSite = SiteModel().apply { timezone = "5.75" }
+        with (nptSite) {
+            val formattedDate = SiteUtils.getCurrentDateTimeForSite(this, UTC8601_FORMAT)
+            assertEquals("+05:45", formattedDate.takeLast(6))
+
+            val currentHour = hourFormat.format(DateTimeUtils.nowUTC())
+            assertNotEquals(currentHour, SiteUtils.getCurrentDateTimeForSite(this, hourFormat))
+        }
+
+        val imaginaryQuarterTimeZoneSite = SiteModel().apply { timezone = "-2.25" }
+        with (imaginaryQuarterTimeZoneSite) {
+            val formattedDate = SiteUtils.getCurrentDateTimeForSite(this, UTC8601_FORMAT)
+            assertEquals("-02:15", formattedDate.takeLast(6))
+
+            val currentHour = hourFormat.format(DateTimeUtils.nowUTC())
+            assertNotEquals(currentHour, SiteUtils.getCurrentDateTimeForSite(this, hourFormat))
+        }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -186,4 +186,16 @@ class WCStatsStoreTest {
         assertEquals(revenueStats.size, orderStats.size)
         assertEquals(revenueStats.keys, orderStats.keys)
     }
+
+    @Test
+    fun testGetStatsCurrencyForSite() {
+        val orderStatsModel = WCStatsTestUtils.generateSampleStatsModel()
+        val site = SiteModel().apply { id = orderStatsModel.localSiteId }
+
+        assertNull(wcStatsStore.getStatsCurrencyForSite(site))
+
+        WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel)
+
+        assertEquals("USD", wcStatsStore.getStatsCurrencyForSite(site))
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.wc.stats
 
+import com.nhaarman.mockito_kotlin.mock
 import com.yarolegovich.wellsql.WellSql
 import org.junit.Before
 import org.junit.Test
@@ -7,15 +8,24 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderStatsModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
 import org.wordpress.android.fluxc.persistence.WCStatsSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.store.WCStatsStore
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
 class WCStatsStoreTest {
+    private val wcStatsStore = WCStatsStore(Dispatcher(), mock())
+
     @Before
     fun setUp() {
         val appContext = RuntimeEnvironment.application.applicationContext
@@ -57,6 +67,7 @@ class WCStatsStoreTest {
             assertEquals("day", first().unit)
             assertEquals("month", get(1).unit)
         }
+
         // Add another "day" entry, but for another site
         val orderStatsModel4 = WCStatsTestUtils.generateSampleStatsModel(localSiteId = 8)
         WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel4)
@@ -67,5 +78,53 @@ class WCStatsStoreTest {
             assertEquals("month", get(1).unit)
             assertEquals("day", get(2).unit)
         }
+    }
+
+    @Test
+    fun testGetRawStatsForSiteAndUnit() {
+        val dayOrderStatsModel = WCStatsTestUtils.generateSampleStatsModel()
+        val site = SiteModel().apply { id = dayOrderStatsModel.localSiteId }
+        val monthOrderStatsModel =
+                WCStatsTestUtils.generateSampleStatsModel(unit = "month", fields = "fake-data", data = "fake-data")
+        WCStatsSqlUtils.insertOrUpdateStats(dayOrderStatsModel)
+        WCStatsSqlUtils.insertOrUpdateStats(monthOrderStatsModel)
+
+        val site2 = SiteModel().apply { id = 8 }
+        val altSiteOrderStatsModel = WCStatsTestUtils.generateSampleStatsModel(localSiteId = site2.id)
+        WCStatsSqlUtils.insertOrUpdateStats(altSiteOrderStatsModel)
+
+        val dayOrderStats = WCStatsSqlUtils.getRawStatsForSiteAndUnit(site, OrderStatsApiUnit.DAY)
+        assertNotNull(dayOrderStats)
+        with (dayOrderStats!!) {
+            assertEquals("day", unit)
+        }
+
+        val altSiteDayOrderStats = WCStatsSqlUtils.getRawStatsForSiteAndUnit(site2, OrderStatsApiUnit.DAY)
+        assertNotNull(altSiteDayOrderStats)
+
+        val monthOrderStatus = WCStatsSqlUtils.getRawStatsForSiteAndUnit(site, OrderStatsApiUnit.MONTH)
+        assertNotNull(monthOrderStatus)
+        with (monthOrderStatus!!) {
+            assertEquals("month", unit)
+        }
+
+        val nonExistentSite = WCStatsSqlUtils.getRawStatsForSiteAndUnit(
+                SiteModel().apply { id = 88 }, OrderStatsApiUnit.DAY)
+        assertNull(nonExistentSite)
+
+        val missingData = WCStatsSqlUtils.getRawStatsForSiteAndUnit(site, OrderStatsApiUnit.YEAR)
+        assertNull(missingData)
+    }
+
+    @Test
+    fun testGetRevenueStatsForCurrentMonth() {
+        val orderStatsModel = WCStatsTestUtils.generateSampleStatsModel()
+        val site = SiteModel().apply { id = orderStatsModel.localSiteId }
+
+        WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel)
+
+        val monthStats = wcStatsStore.getRevenueStatsForCurrentMonth(site)
+
+        assertTrue(monthStats.isNotEmpty())
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.fluxc.wc.stats
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.WCOrderStatsModel
+import org.wordpress.android.fluxc.persistence.WCStatsSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import kotlin.test.assertEquals
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCStatsStoreTest {
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+
+        val config = SingleStoreWellSqlConfigForTests(appContext, WCOrderStatsModel::class.java,
+                WellSqlConfig.ADDON_WOOCOMMERCE)
+        WellSql.init(config)
+        config.reset()
+    }
+
+    @Test
+    fun testSimpleInsertionAndRetrieval() {
+        val orderStatsModel = WCStatsTestUtils.generateSampleStatsModel()
+
+        WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel)
+
+        with (WellSql.select(WCOrderStatsModel::class.java).asModel) {
+            assertEquals(1, size)
+            assertEquals("day", first().unit)
+        }
+
+        // Create a second stats entry for this site
+        val orderStatsModel2 =
+                WCStatsTestUtils.generateSampleStatsModel(unit = "month", fields = "fake-data", data = "fake-data")
+        WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel2)
+
+        with (WellSql.select(WCOrderStatsModel::class.java).asModel) {
+            assertEquals(2, size)
+            assertEquals("day", first().unit)
+            assertEquals("month", get(1).unit)
+        }
+
+        // Overwrite an existing entry
+        val orderStatsModel3 = WCStatsTestUtils.generateSampleStatsModel()
+        WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel3)
+
+        with (WellSql.select(WCOrderStatsModel::class.java).asModel) {
+            assertEquals(2, size)
+            assertEquals("day", first().unit)
+            assertEquals("month", get(1).unit)
+        }
+        // Add another "day" entry, but for another site
+        val orderStatsModel4 = WCStatsTestUtils.generateSampleStatsModel(localSiteId = 8)
+        WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel4)
+
+        with (WellSql.select(WCOrderStatsModel::class.java).asModel) {
+            assertEquals(3, size)
+            assertEquals("day", first().unit)
+            assertEquals("month", get(1).unit)
+            assertEquals("day", get(2).unit)
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -172,14 +172,18 @@ class WCStatsStoreTest {
     }
 
     @Test
-    fun testGetRevenueStatsForCurrentMonth() {
+    fun testGetStatsForCurrentMonth() {
         val orderStatsModel = WCStatsTestUtils.generateSampleStatsModel()
         val site = SiteModel().apply { id = orderStatsModel.localSiteId }
 
         WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel)
 
-        val monthStats = wcStatsStore.getRevenueStatsForCurrentMonth(site)
+        val revenueStats = wcStatsStore.getRevenueStatsForCurrentMonth(site)
+        val orderStats = wcStatsStore.getOrderStatsForCurrentMonth(site)
 
-        assertTrue(monthStats.isNotEmpty())
+        assertTrue(revenueStats.isNotEmpty())
+        assertTrue(orderStats.isNotEmpty())
+        assertEquals(revenueStats.size, orderStats.size)
+        assertEquals(revenueStats.keys, orderStats.keys)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsTestUtils.kt
@@ -2,11 +2,12 @@ package org.wordpress.android.fluxc.wc.stats
 
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.WCOrderStatsModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
 
 object WCStatsTestUtils {
     fun generateSampleStatsModel(
         localSiteId: Int = 6,
-        unit: String = "day",
+        unit: String = OrderStatsApiUnit.DAY.toString(),
         fields: String = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/order-stats-fields.json"),
         data: String = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/order-stats-data.json")
     ): WCOrderStatsModel {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.utils;
 
+import android.support.annotation.NonNull;
+
 import org.wordpress.android.fluxc.model.SiteModel;
 
 import java.text.SimpleDateFormat;
@@ -16,7 +18,7 @@ public class SiteUtils {
      *
      * Imported from WordPress-Android with some modifications.
      */
-    public static String getCurrentDateTimeForSite(SiteModel site, String pattern) {
+    public static @NonNull String getCurrentDateTimeForSite(@NonNull SiteModel site, @NonNull String pattern) {
         SimpleDateFormat dateFormat = new SimpleDateFormat(pattern, Locale.ROOT);
         return getCurrentDateTimeForSite(site, dateFormat);
     }
@@ -27,7 +29,8 @@ public class SiteUtils {
      *
      * Imported from WordPress-Android with some modifications.
      */
-    public static String getCurrentDateTimeForSite(SiteModel site, SimpleDateFormat dateFormat) {
+    public static @NonNull String getCurrentDateTimeForSite(@NonNull SiteModel site,
+                                                            @NonNull SimpleDateFormat dateFormat) {
         String wpTimeZone = site.getTimezone();
 
         /*

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -44,8 +44,19 @@ public class SiteUtils {
         } else {
             String[] timezoneSplit = split(wpTimeZone, ".");
             timezoneNormalized = timezoneSplit[0];
-            if (timezoneSplit.length > 1 && timezoneSplit[1].equals("5")) {
-                timezoneNormalized += ":30";
+            if (timezoneSplit.length > 1) {
+                switch (timezoneSplit[1]) {
+                    case "5":
+                        timezoneNormalized += ":30";
+                        break;
+                    case "75":
+                        timezoneNormalized += ":45";
+                        break;
+                    case "25":
+                        // Not used by any timezones as of current writing, but you never know
+                        timezoneNormalized += ":15";
+                        break;
+                }
             }
             if (timezoneNormalized.startsWith("-")) {
                 timezoneNormalized = "GMT" + timezoneNormalized;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -1,0 +1,64 @@
+package org.wordpress.android.fluxc.utils;
+
+import org.wordpress.android.fluxc.model.SiteModel;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.apache.commons.lang3.StringUtils.split;
+
+public class SiteUtils {
+    /**
+     * Given a {@link SiteModel} and a {@link String} compatible with {@link SimpleDateFormat},
+     * returns a formatted date that accounts for the site's timezone setting.
+     *
+     * Imported from WordPress-Android with some modifications.
+     */
+    public static String getCurrentDateTimeForSite(SiteModel site, String pattern) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(pattern, Locale.ROOT);
+        return getCurrentDateTimeForSite(site, dateFormat);
+    }
+
+    /**
+     * Given a {@link SiteModel} and a {@link SimpleDateFormat},
+     * returns a formatted date that accounts for the site's timezone setting.
+     *
+     * Imported from WordPress-Android with some modifications.
+     */
+    public static String getCurrentDateTimeForSite(SiteModel site, SimpleDateFormat dateFormat) {
+        String wpTimeZone = site.getTimezone();
+
+        /*
+        Convert the timezone to a form that is compatible with Java TimeZone class
+        WordPress returns something like the following:
+           UTC+0:30 ----> 0.5
+           UTC+1 ----> 1.0
+           UTC-0:30 ----> -1.0
+        */
+
+        String timezoneNormalized;
+        if (wpTimeZone == null || wpTimeZone.isEmpty() || wpTimeZone.equals("0") || wpTimeZone.equals("0.0")) {
+            timezoneNormalized = "GMT";
+        } else {
+            String[] timezoneSplit = split(wpTimeZone, ".");
+            timezoneNormalized = timezoneSplit[0];
+            if (timezoneSplit.length > 1 && timezoneSplit[1].equals("5")) {
+                timezoneNormalized += ":30";
+            }
+            if (timezoneNormalized.startsWith("-")) {
+                timezoneNormalized = "GMT" + timezoneNormalized;
+            } else {
+                if (timezoneNormalized.startsWith("+")) {
+                    timezoneNormalized = "GMT" + timezoneNormalized;
+                } else {
+                    timezoneNormalized = "GMT+" + timezoneNormalized;
+                }
+            }
+        }
+
+        dateFormat.setTimeZone(TimeZone.getTimeZone(timezoneNormalized));
+        return dateFormat.format(new Date());
+    }
+}

--- a/fluxc/src/main/tools/wp-com-v2-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-v2-endpoints.txt
@@ -5,4 +5,6 @@
 /sites/$site/activity
 /sites/$site/rewind
 
+/sites/$site/stats/orders/
+
 /users/username/suggestions/

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
@@ -1,0 +1,18 @@
+package org.wordpress.android.fluxc.action;
+
+import org.wordpress.android.fluxc.annotations.Action;
+import org.wordpress.android.fluxc.annotations.ActionEnum;
+import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsPayload;
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload;
+
+@ActionEnum
+public enum WCStatsAction implements IAction {
+    // Remote actions
+    @Action(payloadType = FetchOrderStatsPayload.class)
+    FETCH_ORDER_STATS,
+
+    // Remote responses
+    @Action(payloadType = FetchOrderStatsResponsePayload.class)
+    FETCHED_ORDER_STATS
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatsModel.kt
@@ -27,6 +27,29 @@ data class WCOrderStatsModel(@PrimaryKey @Column private var id: Int = 0) : Iden
         gson.fromJson(data, responseType) as? List<List<Any>> ?: emptyList()
     }
 
+    enum class OrderStatsField {
+        PERIOD,
+        ORDERS,
+        PRODUCTS,
+        COUPONS,
+        COUPON_DISCOUNT,
+        TOTAL_SALES,
+        TOTAL_TAX,
+        TOTAL_SHIPPING,
+        TOTAL_SHIPPING_TAX,
+        TOTAL_REFUND,
+        TOTAL_TAX_REFUND,
+        TOTAL_SHIPPING_REFUND,
+        TOTAL_SHIPPING_TAX_REFUND,
+        CURRENCY,
+        GROSS_SALES,
+        NET_SALES,
+        AVG_ORDER_VALUE,
+        AVG_PRODUCTS_PER_ORDER;
+
+        override fun toString() = name.toLowerCase()
+    }
+
     companion object {
         private val gson by lazy { Gson() }
     }
@@ -36,4 +59,6 @@ data class WCOrderStatsModel(@PrimaryKey @Column private var id: Int = 0) : Iden
     override fun setId(id: Int) {
         this.id = id
     }
+
+    fun getIndexForField(field: OrderStatsField) = fieldsList.indexOf(field.toString())
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -21,6 +22,15 @@ class ReleaseWCNetworkModule {
         @Named("regular") requestQueue: RequestQueue,
         token: AccessToken,
         userAgent: UserAgent
-    ) =
-            OrderRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+    ) = OrderRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideOrderStatsRestClient(
+        appContext: Context,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = OrderStatsRestClient(appContext, dispatcher, requestQueue, token, userAgent)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsApiResponse.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats
+
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.network.Response
+
+class OrderStatsApiResponse : Response {
+    val fields: JsonElement? = null
+    val data: JsonElement? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -5,6 +5,7 @@ import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderStatsModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -44,7 +45,13 @@ class OrderStatsRestClient(
 
         val request = WPComGsonRequest.buildGetRequest(url, params, OrderStatsApiResponse::class.java,
                 { apiResponse ->
-                    // TODO: Process response and dispatch event
+                    val model = WCOrderStatsModel().apply {
+                        this.localSiteId = site.id
+                        this.unit = unit.toString()
+                        this.fields = apiResponse.fields.toString()
+                        this.data = apiResponse.data.toString()
+                    }
+                    // TODO: Dispatch event
                 },
                 { networkError ->
                     // TODO: Dispatch error event

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import javax.inject.Singleton
+
+@Singleton
+class OrderStatsRestClient(
+    appContext: Context,
+    dispatcher: Dispatcher,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    enum class OrderStatsApiUnit {
+        DAY, WEEK, MONTH, YEAR;
+
+        override fun toString() = name.toLowerCase()
+    }
+
+    /**
+     * Makes a GET call to `/wpcom/v2/sites/$site/data/orders/`, retrieving data for the given
+     * WooCommerce [SiteModel].
+     *
+     * @param[site] the site to fetch order data for
+     * @param[unit] one of 'day', 'week', 'month', or 'year'
+     * @param[date] the latest date to include in the results. Should match the [unit], e.g.:
+     * 'day':'1955-11-05', 'week':'1955-W44', 'month':'1955-11', 'year':'1955'
+     * @param[quantity] how many [unit]s to fetch
+     */
+    fun fetchStats(site: SiteModel, unit: OrderStatsApiUnit, date: String, quantity: Int) {
+        val url = WPCOMV2.sites.site(site.siteId).stats.orders.url
+        val params = mapOf(
+                "unit" to unit.toString(),
+                "date" to date,
+                "quantity" to quantity.toString())
+
+        val request = WPComGsonRequest.buildGetRequest(url, params, OrderStatsApiResponse::class.java,
+                { apiResponse ->
+                    // TODO: Process response and dispatch event
+                },
+                { networkError ->
+                    // TODO: Dispatch error event
+                })
+        add(request)
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -36,4 +36,12 @@ object WCStatsSqlUtils {
                 .endGroup().endWhere()
                 .asModel.firstOrNull()
     }
+
+    fun getFirstRawStatsForSite(site: SiteModel): WCOrderStatsModel? {
+        return WellSql.select(WCOrderStatsModel::class.java)
+                .where()
+                .equals(WCOrderStatsModelTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .asModel.firstOrNull()
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.WCOrderStatsModelTable
+import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.WCOrderStatsModel
+
+object WCStatsSqlUtils {
+    fun insertOrUpdateStats(stats: WCOrderStatsModel): Int {
+        val statsResult = WellSql.select(WCOrderStatsModel::class.java)
+                .where().beginGroup()
+                .equals(WCOrderStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
+                .equals(WCOrderStatsModelTable.UNIT, stats.unit)
+                .endGroup().endWhere()
+                .asModel
+
+        if (statsResult.isEmpty()) {
+            // Insert
+            WellSql.insert(stats).asSingleTransaction(true).execute()
+            return 1
+        } else {
+            // Update
+            val oldId = statsResult[0].id
+            return WellSql.update(WCOrderStatsModel::class.java).whereId(oldId)
+                    .put(stats, UpdateAllExceptId(WCOrderStatsModel::class.java)).execute()
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -2,7 +2,9 @@ package org.wordpress.android.fluxc.persistence
 
 import com.wellsql.generated.WCOrderStatsModelTable
 import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderStatsModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
 
 object WCStatsSqlUtils {
     fun insertOrUpdateStats(stats: WCOrderStatsModel): Int {
@@ -23,5 +25,15 @@ object WCStatsSqlUtils {
             return WellSql.update(WCOrderStatsModel::class.java).whereId(oldId)
                     .put(stats, UpdateAllExceptId(WCOrderStatsModel::class.java)).execute()
         }
+    }
+
+    fun getRawStatsForSiteAndUnit(site: SiteModel, unit: OrderStatsApiUnit): WCOrderStatsModel? {
+        return WellSql.select(WCOrderStatsModel::class.java)
+                .where()
+                .beginGroup()
+                .equals(WCOrderStatsModelTable.LOCAL_SITE_ID, site.id)
+                .equals(WCOrderStatsModelTable.UNIT, unit)
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -104,9 +104,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         var causeOfChange: WCOrderAction? = null
     }
 
-    override fun onRegister() {
-        AppLog.d(T.API, "WCOrderStore onRegister")
-    }
+    override fun onRegister() = AppLog.d(T.API, "WCOrderStore onRegister")
 
     /**
      * Given a [SiteModel] and optional statuses, returns all orders for that site matching any of those statuses.

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -142,9 +142,10 @@ class WCStatsStore @Inject constructor(
         // TODO: Caching, and skip cache if forced == true
         when (payload.granularity) {
             StatsGranularity.DAYS -> {
-                // TODO: Calculate quantity from max(day-of-the-month, day-of-the-week) - for now, 31 covers all cases
+                // TODO: Calculate quantity from max(day-of-the-month, day-of-the-week) for week-to-date support
+                val dayOfMonth = SiteUtils.getCurrentDateTimeForSite(payload.site, DATE_FORMAT_DAY_OF_MONTH).toInt()
                 wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
-                        getFormattedDate(payload.site, StatsGranularity.DAYS), 31)
+                        getFormattedDate(payload.site, StatsGranularity.DAYS), dayOfMonth)
             }
             StatsGranularity.MONTHS -> TODO()
             StatsGranularity.YEARS -> TODO()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -90,9 +90,7 @@ class WCStatsStore @Inject constructor(
         var causeOfChange: WCStatsAction? = null
     }
 
-    override fun onRegister() {
-        AppLog.d(T.API, "WCStatsStore onRegister")
-    }
+    override fun onRegister() = AppLog.d(T.API, "WCStatsStore onRegister")
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -121,6 +121,23 @@ class WCStatsStore @Inject constructor(
         return getCurrentMonthStatsForField(site, OrderStatsField.TOTAL_SALES)
     }
 
+    /**
+     * Returns the order volume data for the month so far for the given [site], in increments of days.
+     *
+     * The month so far is relative to the site's own timezone, not the current device's.
+     *
+     * The returned map has the format:
+     * {
+     * "2018-05-01" -> 15,
+     * "2018-05-02" -> 7,
+     * ...
+     * "2018-05-16" -> 24
+     * }
+     */
+    fun getOrderStatsForCurrentMonth(site: SiteModel): Map<String, Int> {
+        return getCurrentMonthStatsForField(site, OrderStatsField.ORDERS)
+    }
+
     private fun fetchOrderStats(payload: FetchOrderStatsPayload) {
         // TODO: Caching, and skip cache if forced == true
         when (payload.granularity) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -138,6 +138,20 @@ class WCStatsStore @Inject constructor(
         return getCurrentMonthStatsForField(site, OrderStatsField.ORDERS)
     }
 
+    /**
+     * Returns the currency code associated with stored stats for the [site], as an ISO 4217 currency code (eg. USD).
+     */
+    fun getStatsCurrencyForSite(site: SiteModel): String? {
+        val rawStats = WCStatsSqlUtils.getFirstRawStatsForSite(site)
+        rawStats?.let { statsModel ->
+            statsModel.dataList.firstOrNull()?.let {
+                val currencyIndex = statsModel.getIndexForField(OrderStatsField.CURRENCY)
+                return it[currencyIndex] as String
+            }
+        }
+        return null
+    }
+
     private fun fetchOrderStats(payload: FetchOrderStatsPayload) {
         // TODO: Caching, and skip cache if forced == true
         when (payload.granularity) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -14,10 +14,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRe
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
 import org.wordpress.android.fluxc.persistence.WCStatsSqlUtils
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import java.text.SimpleDateFormat
-import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,10 +27,10 @@ class WCStatsStore @Inject constructor(
     private val wcOrderStatsClient: OrderStatsRestClient
 ) : Store(dispatcher) {
     companion object {
-        private val DATE_FORMAT_DAY = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-        private val DATE_FORMAT_MONTH = SimpleDateFormat("yyyy-MM", Locale.US)
-        private val DATE_FORMAT_YEAR = SimpleDateFormat("yyyy", Locale.US)
-        private val DATE_FORMAT_DAY_OF_MONTH = SimpleDateFormat("dd", Locale.US)
+        private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
+        private const val DATE_FORMAT_MONTH = "yyyy-MM"
+        private const val DATE_FORMAT_YEAR = "yyyy"
+        private const val DATE_FORMAT_DAY_OF_MONTH = "dd"
     }
 
     enum class StatsGranularity {
@@ -110,8 +109,7 @@ class WCStatsStore @Inject constructor(
         rawStats?.let {
             val periodIndex = it.getIndexForField(OrderStatsField.PERIOD)
             val revenueIndex = it.getIndexForField(OrderStatsField.TOTAL_SALES)
-            // TODO: Temp - use the site's timezone
-            val dayOfMonth = DATE_FORMAT_DAY_OF_MONTH.format(Date()).toInt()
+            val dayOfMonth = SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_DAY_OF_MONTH).toInt()
             return it.dataList
                     .takeLast(dayOfMonth)
                     .map { it[periodIndex].toString() to it[revenueIndex] as Double }.toMap()
@@ -147,11 +145,10 @@ class WCStatsStore @Inject constructor(
     }
 
     private fun getFormattedDate(site: SiteModel, granularity: StatsGranularity): String {
-        // TODO Use site.timezone to get the correct current day for the site
         return when (granularity) {
-            StatsGranularity.DAYS -> DATE_FORMAT_DAY.format(Date())
-            StatsGranularity.MONTHS -> DATE_FORMAT_MONTH.format(Date())
-            StatsGranularity.YEARS -> DATE_FORMAT_YEAR.format(Date())
+            StatsGranularity.DAYS -> SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_DAY)
+            StatsGranularity.MONTHS -> SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_MONTH)
+            StatsGranularity.YEARS -> SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_YEAR)
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -1,0 +1,117 @@
+package org.wordpress.android.fluxc.store
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.action.WCStatsAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderStatsModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.GENERIC_ERROR
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WCStatsStore @Inject constructor(
+    dispatcher: Dispatcher,
+    private val wcOrderStatsClient: OrderStatsRestClient
+) : Store(dispatcher) {
+    companion object {
+        private val DATE_FORMAT_DAY = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        private val DATE_FORMAT_MONTH = SimpleDateFormat("yyyy-MM", Locale.US)
+        private val DATE_FORMAT_YEAR = SimpleDateFormat("yyyy", Locale.US)
+    }
+
+    enum class StatsGranularity { DAYS, MONTHS, YEARS }
+
+    /**
+     * Describes the parameters for fetching order stats for [site], up to the current day, month, or year
+     * (depending on the given [granularity]).
+     *
+     * Using [StatsGranularity.DAYS] will fetch data to cover both 'week so far' and 'month so far'.
+     *
+     * @param[granularity] the time units for the requested data
+     * @param[forced] if true, ignores any cached result and forces a refresh from the server (defaults to false)
+     */
+    class FetchOrderStatsPayload(
+        val site: SiteModel,
+        val granularity: StatsGranularity,
+        val forced: Boolean = false
+    ) : Payload<BaseNetworkError>()
+
+    class FetchOrderStatsResponsePayload(
+        val site: SiteModel,
+        val apiUnit: OrderStatsApiUnit,
+        val stats: WCOrderStatsModel? = null
+    ) : Payload<OrderStatsError>() {
+        constructor(error: OrderStatsError, site: SiteModel, apiUnit: OrderStatsApiUnit) : this(site, apiUnit) {
+            this.error = error
+        }
+    }
+
+    class OrderStatsError(val type: OrderStatsErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
+
+    enum class OrderStatsErrorType {
+        INVALID_PARAM,
+        GENERIC_ERROR;
+
+        companion object {
+            private val reverseMap = OrderStatsErrorType.values().associateBy(OrderStatsErrorType::name)
+            fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: GENERIC_ERROR
+        }
+    }
+
+    // OnChanged events
+    class OnWCStatsChanged(val rowsAffected: Int, val granularity: StatsGranularity) : OnChanged<OrderStatsError>() {
+        var causeOfChange: WCStatsAction? = null
+    }
+
+    override fun onRegister() {
+        AppLog.d(T.API, "WCStatsStore onRegister")
+    }
+
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? WCStatsAction ?: return
+        when (actionType) {
+            WCStatsAction.FETCH_ORDER_STATS -> fetchOrderStats(action.payload as FetchOrderStatsPayload)
+            WCStatsAction.FETCHED_ORDER_STATS ->
+                handleFetchOrderStatsCompleted(action.payload as FetchOrderStatsResponsePayload)
+        }
+    }
+
+    private fun fetchOrderStats(payload: FetchOrderStatsPayload) {
+        // TODO: Caching, and skip cache if forced == true
+        when (payload.granularity) {
+            StatsGranularity.DAYS -> {
+                // TODO: Calculate quantity from max(day-of-the-month, day-of-the-week) - for now, 31 covers all cases
+                wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
+                        getFormattedDate(payload.site, StatsGranularity.DAYS), 31)
+            }
+            StatsGranularity.MONTHS -> TODO()
+            StatsGranularity.YEARS -> TODO()
+        }
+    }
+
+    private fun handleFetchOrderStatsCompleted(payload: FetchOrderStatsResponsePayload) {
+        // TODO
+    }
+
+    private fun getFormattedDate(site: SiteModel, granularity: StatsGranularity): String {
+        // TODO Use site.timezone to get the correct current day for the site
+        return when (granularity) {
+            StatsGranularity.DAYS -> DATE_FORMAT_DAY.format(Date())
+            StatsGranularity.MONTHS -> DATE_FORMAT_MONTH.format(Date())
+            StatsGranularity.YEARS -> DATE_FORMAT_YEAR.format(Date())
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -14,9 +14,7 @@ import javax.inject.Singleton
 
 @Singleton
 class WooCommerceStore @Inject constructor(dispatcher: Dispatcher) : Store(dispatcher) {
-    override fun onRegister() {
-        AppLog.d(T.API, "WooCommerceStore onRegister")
-    }
+    override fun onRegister() = AppLog.d(T.API, "WooCommerceStore onRegister")
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {}


### PR DESCRIPTION
Adds support for retrieving order stats for WooCommerce via the `/wpcom/v2/sites/$site/data/orders/` endpoint.

Currently only supports a month-to-date view for stats, which means only data with a granularity of 'days' is fetched, and only as far back as the start of the current month. This will be expanded later to include week-to-date, year-to-date, and all time (by year) data.

This relies on #809, which adds the `WCOrderStatsModel` table along with the migration step directly to `develop` (while this PR targets a `wc-stats` feature branch), to avoid later migration headaches. ~#809 should be reviewed and merged first.~

<hr>

### TODO:
* [x] Support revenue and order volume data (from the API and through `WCStatsStore`) for:
  * [x] Month-to-date (broken down by days)
* [x] Use the site's timezone instead of the device's
* [x] Request only the necessary quantity of data for month-to-date
* [x] Supply the currency for the stats per site
* [x] ~Database migration~ --> #809
* [x] Extract `WCOrderStatsModel` and its migration to a separate PR against `develop`, so feature branch code can be release in a beta without migration issues down the road: #809

### Future PRs:
* Revenue and order volume data through `WCStatsStore` for:
  * Week-to-date (broken down by days)
  * Year-to-date (broken down by months)
  * Years-to-date (broken down by years)
* Calculate the right minimal number of days to cover week-to-date and month-to-date when requesting `"day"` units from the API
* ~Use the site's start of week setting for week-to-date data~ -> not supported by the API, use device locale's start of week setting instead
* Caching