### PR TITLE
Revert removal of oldVersions++ in DB migration

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -181,6 +181,7 @@
           <property name="tokens" value="METHOD_DEF"/>
           <!-- TODO: We should set this value around 40 or 50 -->
           <property name="max" value="200"/>
+          <property name="severity" value="warning"/>
         </module>
 
         <!-- Checks for whitespace                               -->

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -56,7 +56,7 @@ public class WellSqlConfig extends DefaultWellConfig {
         }
     }
 
-    @SuppressWarnings({"FallThrough"})
+    @SuppressWarnings({"FallThrough", "MethodLength"})
     @Override
     public void onUpgrade(SQLiteDatabase db, WellTableManager helper, int oldVersion, int newVersion) {
         AppLog.d(T.DB, "Upgrading database from version " + oldVersion + " to " + newVersion);
@@ -66,48 +66,61 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 1:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add ICON_URL text;");
+                oldVersion++;
             case 2:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add FRAME_NONCE text;");
+                oldVersion++;
             case 3:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table AccountModel add EMAIL_VERIFIED boolean;");
+                oldVersion++;
             case 4:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add ORIGIN integer;");
+                oldVersion++;
             case 5:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add HAS_FREE_PLAN boolean;");
+                oldVersion++;
             case 6:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add UNMAPPED_URL text;");
+                oldVersion++;
             case 7:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table MediaModel add LOCAL_POST_ID integer;");
+                oldVersion++;
             case 8:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table MediaModel add FILE_URL_MEDIUM_SIZE text;");
                 db.execSQL("alter table MediaModel add FILE_URL_MEDIUM_LARGE_SIZE text;");
                 db.execSQL("alter table MediaModel add FILE_URL_LARGE_SIZE text;");
+                oldVersion++;
             case 9:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add MAX_UPLOAD_SIZE integer;");
+                oldVersion++;
             case 10:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add MEMORY_LIMIT integer;");
+                oldVersion++;
             case 11:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE RoleModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,SITE_ID INTEGER,"
                         + "NAME TEXT,DISPLAY_NAME TEXT)");
+                oldVersion++;
             case 12:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE PluginModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
                         + "NAME TEXT,DISPLAY_NAME TEXT,PLUGIN_URL TEXT,VERSION TEXT,SLUG TEXT,DESCRIPTION TEXT,"
                         + "AUTHOR_NAME TEXT,AUTHOR_URL TEXT,IS_ACTIVE INTEGER,IS_AUTO_UPDATE_ENABLED INTEGER)");
+                oldVersion++;
             case 13:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE PluginInfoModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                         + "NAME TEXT,SLUG TEXT,VERSION TEXT,RATING TEXT,ICON TEXT)");
+                oldVersion++;
             case 14:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE MediaUploadModel (_id INTEGER PRIMARY KEY,UPLOAD_STATE INTEGER,"
@@ -116,6 +129,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("CREATE TABLE PostUploadModel (_id INTEGER PRIMARY KEY,UPLOAD_STATE INTEGER,"
                         + "ASSOCIATED_MEDIA_IDS TEXT,ERROR_TYPE TEXT,ERROR_MESSAGE TEXT,FOREIGN KEY(_id) REFERENCES "
                         + "PostModel(_id) ON DELETE CASCADE)");
+                oldVersion++;
             case 15:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE ThemeModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
@@ -123,24 +137,30 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "AUTHOR_URL TEXT,THEME_URL TEXT,SCREENSHOT_URL TEXT,DEMO_URL TEXT,DOWNLOAD_URL TEXT,"
                         + "STYLESHEET TEXT,CURRENCY TEXT,PRICE REAL,ACTIVE INTEGER,AUTO_UPDATE INTEGER,"
                         + "AUTO_UPDATE_TRANSLATION INTEGER,IS_WP_COM_THEME INTEGER)");
+                oldVersion++;
             case 16:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table ThemeModel add FREE integer;");
                 db.execSQL("alter table ThemeModel add PRICE_TEXT integer;");
+                oldVersion++;
             case 17:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add EMAIL text;");
                 db.execSQL("alter table SiteModel add DISPLAY_NAME text;");
+                oldVersion++;
             case 18:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add JETPACK_VERSION text;");
+                oldVersion++;
             case 19:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table TermModel add POST_COUNT integer;");
+                oldVersion++;
             case 20:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table PluginModel rename to SitePluginModel;");
                 db.execSQL("alter table PluginInfoModel rename to WPOrgPluginModel;");
+                oldVersion++;
             case 21:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SitePluginModel add SETTINGS_URL text;");
@@ -160,13 +180,16 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_THREE INTEGER;");
                 db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_FOUR INTEGER;");
                 db.execSQL("alter table WPOrgPluginModel add NUMBER_OF_RATINGS_OF_FIVE INTEGER;");
+                oldVersion++;
             case 22:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table ThemeModel add MOBILE_FRIENDLY_CATEGORY_SLUG text;");
+                oldVersion++;
             case 23:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE PluginDirectoryModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                         + "SLUG TEXT,DIRECTORY_TYPE TEXT,PAGE INTEGER)");
+                oldVersion++;
             case 24:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 // Start with a clean slate for Plugins. This migration adds unique constraints for SitePluginModel
@@ -188,19 +211,23 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "DOWNLOAD_COUNT INTEGER,NUMBER_OF_RATINGS INTEGER,NUMBER_OF_RATINGS_OF_ONE INTEGER,"
                         + "NUMBER_OF_RATINGS_OF_TWO INTEGER,NUMBER_OF_RATINGS_OF_THREE INTEGER,"
                         + "NUMBER_OF_RATINGS_OF_FOUR INTEGER,NUMBER_OF_RATINGS_OF_FIVE INTEGER,UNIQUE (SLUG))");
+                oldVersion++;
             case 25:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add SPACE_AVAILABLE INTEGER");
                 db.execSQL("alter table SiteModel add SPACE_ALLOWED INTEGER");
                 db.execSQL("alter table SiteModel add SPACE_USED INTEGER");
                 db.execSQL("alter table SiteModel add SPACE_PERCENT_USED REAL");
+                oldVersion++;
             case 26:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("ALTER TABLE SiteModel ADD IS_WP_COM_STORE INTEGER");
                 db.execSQL("ALTER TABLE SiteModel ADD HAS_WOO_COMMERCE INTEGER");
+                oldVersion++;
             case 27:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table AccountModel add TRACKS_OPT_OUT boolean;");
+                oldVersion++;
             case 28:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL(
@@ -214,12 +241,14 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "REMOTE_SITE_ID INTEGER,REWIND_STATE TEXT,REASON TEXT,RESTORE_ID TEXT,RESTORE_STATE TEXT,"
                         + "RESTORE_PROGRESS INTEGER,RESTORE_MESSAGE TEXT,RESTORE_ERROR_CODE TEXT,"
                         + "RESTORE_FAILURE_REASON TEXT)");
+                oldVersion++;
             case 29:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE SubscriptionModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                            + "SUBSCRIPTION_ID TEXT,BLOG_ID TEXT,BLOG_NAME TEXT,FEED_ID TEXT,URL TEXT,"
                            + "SHOULD_NOTIFY_POSTS INTEGER,SHOULD_EMAIL_POSTS INTEGER,EMAIL_POSTS_FREQUENCY TEXT,"
                            + "SHOULD_EMAIL_COMMENTS INTEGER)");
+                oldVersion++;
             case 30:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("DROP TABLE IF EXISTS ActivityLogModel");
@@ -229,6 +258,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "NOT NULL,NAME TEXT,TYPE TEXT,GRIDICON TEXT,STATUS TEXT,REWINDABLE INTEGER,REWIND_ID TEXT,"
                         + "PUBLISHED INTEGER,DISCARDED INTEGER,DISPLAY_NAME TEXT,ACTOR_TYPE TEXT,WPCOM_USER_ID "
                         + "INTEGER,AVATAR_URL TEXT,ROLE TEXT)");
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();


### PR DESCRIPTION
- add back `oldVersions++` to migration steps
- change severity of MethodLength to Warning and suppress it in the migration step