### PR TITLE
Implement rewind status model changes

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
@@ -24,13 +24,15 @@ val ACTIVITY_RESPONSE = ActivityLogRestClient.ActivitiesResponse.ActivityRespons
         "OK",
         "activity123")
 val ACTIVITY_RESPONSE_PAGE = ActivityLogRestClient.ActivitiesResponse.Page(listOf(ACTIVITY_RESPONSE))
-val RESTORE_RESPONSE = ActivityLogRestClient.RewindStatusResponse.RestoreStatusResponse(rewind_id = "123",
-        status = RewindStatusModel.RestoreStatus.Status.RUNNING.value,
+val REWIND_RESPONSE = ActivityLogRestClient.RewindStatusResponse.Rewind(rewindId = "123",
+        status = RewindStatusModel.Rewind.Status.RUNNING.value,
         progress = 10,
-        message = "running",
-        error_code = null,
-        reason = "nit")
-val REWIND_RESPONSE = ActivityLogRestClient.RewindStatusResponse("reason",
-        RewindStatusModel.State.ACTIVE.value,
-        Date(),
-        RESTORE_RESPONSE)
+        reason = "nit",
+        startedAt = Date())
+val REWIND_STATUS_RESPONSE = ActivityLogRestClient.RewindStatusResponse(
+        state = RewindStatusModel.State.ACTIVE.value,
+        reason = "reason",
+        last_updated = Date(),
+        can_autoconfigure = true,
+        credentials = listOf(),
+        rewind = REWIND_RESPONSE)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -148,7 +148,7 @@ class ActivityLogStoreTest {
 
         activityLogStore.onAction(action)
 
-        verify(activityLogSqlUtils).insertOrUpdateRewindStatus(siteModel, rewindStatusModel)
+        verify(activityLogSqlUtils).replaceRewindStatus(siteModel, rewindStatusModel)
         val expectedChangeEvent = ActivityLogStore.OnRewindStatusFetched(ActivityLogAction.FETCHED_REWIND_STATE)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
@@ -1,6 +1,15 @@
 package org.wordpress.android.fluxc.model.activity
 
-data class RewindStatusModel(val state: State, val reason: String?, val restore: RestoreStatus?) {
+import java.util.Date
+
+data class RewindStatusModel(
+    val state: State,
+    val reason: String?,
+    val lastUpdated: Date,
+    val canAutoconfigure: Boolean?,
+    val credentials: List<Credentials>?,
+    val rewind: Rewind?
+) {
     enum class State(val value: String) {
         ACTIVE("active"),
         INACTIVE("inactive"),
@@ -16,20 +25,23 @@ data class RewindStatusModel(val state: State, val reason: String?, val restore:
         }
     }
 
-    data class RestoreStatus(
-        val id: String,
+    data class Credentials(
+        val type: String,
+        val role: String,
+        val host: String?,
+        val port: Int?,
+        val stillValid: Boolean
+    )
+
+    data class Rewind(
+        val rewindId: String?,
         val status: Status,
+        val startedAt: Date,
         val progress: Int,
-        val message: String?,
-        val errorCode: String?,
-        val failureReason: String?
+        val reason: String?
     ) {
         enum class Status(val value: String) {
-            QUEUED("queued"),
-            FINISHED("finished"),
-            RUNNING("running"),
-            FAIL("fail"),
-            UNKNOWN("unknown");
+            RUNNING("running"), FINISHED("finished"), FAILED("failed");
 
             companion object {
                 fun fromValue(value: String): Status? {
@@ -40,23 +52,18 @@ data class RewindStatusModel(val state: State, val reason: String?, val restore:
 
         companion object {
             fun build(
-                restoreId: String?,
-                restoreState: String?,
-                restoreProgress: Int?,
-                restoreMessage: String?,
-                restoreErrorCode: String?,
-                restoreFailureReason: String?
-            ): RestoreStatus? {
-                return if (restoreId != null && restoreState != null && restoreProgress != null) {
-                    RestoreStatus(restoreId,
-                            Status.fromValue(restoreState) ?: Status.UNKNOWN,
-                            restoreProgress,
-                            restoreMessage,
-                            restoreErrorCode,
-                            restoreFailureReason)
-                } else {
-                    null
+                rewindId: String?,
+                stringStatus: String?,
+                longStartedAt: Long?,
+                progress: Int?,
+                reason: String?
+            ): Rewind? {
+                val status = stringStatus?.let { Status.fromValue(it) }
+                val startedAt = longStartedAt?.let { Date(it) }
+                if (status != null && startedAt != null && progress != null) {
+                    return Rewind(rewindId, status, startedAt, progress, reason)
                 }
+                return null
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Credentials
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
@@ -163,30 +164,33 @@ constructor(
 
     private fun buildRewindStatusPayload(response: RewindStatusResponse, site: SiteModel):
             FetchedRewindStatePayload {
-        val rewindStatusValue = response.state ?: return buildErrorPayload(site, RewindStatusErrorType.MISSING_STATE)
+        val rewindStatusValue = response.state
         val rewindStatus = RewindStatusModel.State.fromValue(rewindStatusValue)
                 ?: return buildErrorPayload(site, RewindStatusErrorType.INVALID_REWIND_STATE)
-        val restoreStatusModel = response.restoreResponse?.let {
-            val rewindId = it.rewind_id
+        val rewindModel = response.rewind?.let {
+            val rewindId = it.rewindId
                     ?: return buildErrorPayload(site, RewindStatusErrorType.MISSING_RESTORE_ID)
             val restoreStatusValue = it.status
-                    ?: return buildErrorPayload(site, RewindStatusErrorType.MISSING_RESTORE_STATUS)
-            val restoreStatus = RewindStatusModel.RestoreStatus.Status.fromValue(restoreStatusValue)
+            val restoreStatus = RewindStatusModel.Rewind.Status.fromValue(restoreStatusValue)
                     ?: return buildErrorPayload(site, RewindStatusErrorType.INVALID_RESTORE_STATUS)
-            RewindStatusModel.RestoreStatus(
-                    id = rewindId,
+            RewindStatusModel.Rewind(
+                    rewindId = rewindId,
                     status = restoreStatus,
                     progress = it.progress,
-                    message = it.message,
-                    errorCode = it.error_code,
-                    failureReason = it.reason
+                    startedAt = it.startedAt,
+                    reason = it.reason
             )
         }
 
         val rewindStatusModel = RewindStatusModel(
                 state = rewindStatus,
                 reason = response.reason,
-                restore = restoreStatusModel
+                lastUpdated = response.last_updated,
+                canAutoconfigure = response.can_autoconfigure,
+                credentials = response.credentials?.map {
+                    Credentials(it.type, it.role, it.host, it.port, it.still_valid)
+                },
+                rewind = rewindModel
         )
         return FetchedRewindStatePayload(rewindStatusModel, site)
     }
@@ -246,17 +250,26 @@ constructor(
     }
 
     data class RewindStatusResponse(
-        val reason: String,
-        val state: String?,
+        val state: String,
+        val reason: String?,
         val last_updated: Date,
-        val restoreResponse: RestoreStatusResponse?
+        val can_autoconfigure: Boolean?,
+        val credentials: List<Credentials>?,
+        val rewind: Rewind?
     ) {
-        data class RestoreStatusResponse(
-            val rewind_id: String?,
-            val status: String?,
-            val progress: Int = 0,
-            val message: String?,
-            val error_code: String?,
+        data class Credentials(
+            val type: String,
+            val role: String,
+            val host: String?,
+            val port: Int?,
+            val still_valid: Boolean
+        )
+
+        data class Rewind(
+            val rewindId: String?,
+            val status: String,
+            val startedAt: Date,
+            val progress: Int,
             val reason: String?
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -164,15 +164,15 @@ constructor(
 
     private fun buildRewindStatusPayload(response: RewindStatusResponse, site: SiteModel):
             FetchedRewindStatePayload {
-        val rewindStatusValue = response.state
-        val rewindStatus = RewindStatusModel.State.fromValue(rewindStatusValue)
-                ?: return buildErrorPayload(site, RewindStatusErrorType.INVALID_REWIND_STATE)
+        val stateValue = response.state
+        val state = RewindStatusModel.State.fromValue(stateValue)
+                ?: return buildErrorPayload(site, RewindStatusErrorType.INVALID_RESPONSE)
         val rewindModel = response.rewind?.let {
             val rewindId = it.rewindId
-                    ?: return buildErrorPayload(site, RewindStatusErrorType.MISSING_RESTORE_ID)
+                    ?: return buildErrorPayload(site, RewindStatusErrorType.MISSING_REWIND_ID)
             val restoreStatusValue = it.status
             val restoreStatus = RewindStatusModel.Rewind.Status.fromValue(restoreStatusValue)
-                    ?: return buildErrorPayload(site, RewindStatusErrorType.INVALID_RESTORE_STATUS)
+                    ?: return buildErrorPayload(site, RewindStatusErrorType.INVALID_REWIND_STATE)
             RewindStatusModel.Rewind(
                     rewindId = rewindId,
                     status = restoreStatus,
@@ -183,7 +183,7 @@ constructor(
         }
 
         val rewindStatusModel = RewindStatusModel(
-                state = rewindStatus,
+                state = state,
                 reason = response.reason,
                 lastUpdated = response.last_updated,
                 canAutoconfigure = response.can_autoconfigure,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.persistence
 
 import com.wellsql.generated.ActivityLogTable
+import com.wellsql.generated.RewindStatusCredentialsTable
 import com.wellsql.generated.RewindStatusTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
@@ -11,6 +12,7 @@ import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Credentials
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -71,16 +73,26 @@ class ActivityLogSqlUtils
     }
 
     fun getRewindStatusForSite(site: SiteModel): RewindStatusModel? {
-        return getRewindStatusBuilder(site)?.build()
+        val rewindStatusBuilder = getRewindStatusBuilder(site)
+        val credentials = rewindStatusBuilder?.id?.let { getCredentialsBuilder(it) }
+        return rewindStatusBuilder?.build(credentials?.map { it.build() })
     }
 
     private fun getRewindStatusBuilder(site: SiteModel): RewindStatusBuilder? {
         return WellSql.select(RewindStatusBuilder::class.java)
                 .where()
-                .equals(ActivityLogTable.LOCAL_SITE_ID, site.id)
+                .equals(RewindStatusTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
                 .asModel
                 .firstOrNull()
+    }
+
+    private fun getCredentialsBuilder(rewindId: Int): List<CredentialsBuilder> {
+        return WellSql.select(CredentialsBuilder::class.java)
+                .where()
+                .equals(RewindStatusCredentialsTable.REWIND_STATE_ID, rewindId)
+                .endWhere()
+                .asModel
     }
 
     private fun ActivityLogModel.toBuilder(site: SiteModel): ActivityLogBuilder {
@@ -109,14 +121,15 @@ class ActivityLogSqlUtils
         return RewindStatusBuilder(
                 localSiteId = site.id,
                 remoteSiteId = site.siteId,
-                rewindState = this.state.value,
+                state = this.state.value,
+                lastUpdated = this.lastUpdated.time,
                 reason = this.reason,
-                restoreId = this.restore?.id,
-                restoreFailureReason = this.restore?.failureReason,
-                restoreMessage = this.restore?.message,
-                restoreProgress = this.restore?.progress,
-                restoreErrorCode = this.restore?.errorCode,
-                restoreState = this.restore?.status?.value
+                canAutoconfigure = this.canAutoconfigure,
+                rewindId = this.rewind?.rewindId,
+                rewindStatus =  this.rewind?.status?.value,
+                rewindStartedAt = this.rewind?.startedAt?.time,
+                rewindProgress = this.rewind?.progress,
+                rewindReason = this.rewind?.reason
         )
     }
 
@@ -179,16 +192,17 @@ class ActivityLogSqlUtils
         @Column private var mId: Int = -1,
         @Column var localSiteId: Int,
         @Column var remoteSiteId: Long,
-        @Column var rewindState: String? = null,
+        @Column var state: String,
+        @Column var lastUpdated: Long,
         @Column var reason: String? = null,
-        @Column var restoreId: String? = null,
-        @Column var restoreState: String? = null,
-        @Column var restoreProgress: Int? = null,
-        @Column var restoreMessage: String? = null,
-        @Column var restoreErrorCode: String? = null,
-        @Column var restoreFailureReason: String? = null
+        @Column var canAutoconfigure: Boolean? = null,
+        @Column var rewindId: String? = null,
+        @Column var rewindStatus: String? = null,
+        @Column var rewindStartedAt: Long? = null,
+        @Column var rewindProgress: Int? = null,
+        @Column var rewindReason: String? = null
     ) : Identifiable {
-        constructor() : this(-1, 0, 0)
+        constructor() : this(-1, 0, 0, "", 0)
 
         override fun setId(id: Int) {
             this.mId = id
@@ -196,17 +210,44 @@ class ActivityLogSqlUtils
 
         override fun getId() = mId
 
-        fun build(): RewindStatusModel {
-            val restoreStatus = RewindStatusModel.RestoreStatus.build(
-                    restoreId,
-                    restoreState,
-                    restoreProgress,
-                    restoreMessage,
-                    restoreErrorCode,
-                    restoreFailureReason
+        fun build(credentials: List<Credentials>?): RewindStatusModel {
+            val restoreStatus = RewindStatusModel.Rewind.build(
+                    rewindId,
+                    rewindStatus,
+                    rewindStartedAt,
+                    rewindProgress,
+                    rewindReason
             )
-            return RewindStatusModel(rewindState?.let { RewindStatusModel.State.fromValue(it) }
-                    ?: RewindStatusModel.State.UNKNOWN, reason, restoreStatus)
+            return RewindStatusModel(
+                    RewindStatusModel.State.fromValue(state) ?: RewindStatusModel.State.UNKNOWN,
+                    reason,
+                    Date(lastUpdated),
+                    canAutoconfigure,
+                    credentials,
+                    restoreStatus)
+        }
+    }
+
+    @Table(name = "RewindStatusCredentials")
+    data class CredentialsBuilder(
+        @PrimaryKey @Column private var mId: Int = -1,
+        @Column var rewindStateId: Int,
+        @Column var type: String,
+        @Column var role: String,
+        @Column var stillValid: Boolean,
+        @Column var host: String? = null,
+        @Column var port: Int? = null
+    ) : Identifiable {
+        constructor(): this(-1, 0, "", "", false)
+
+        override fun setId(id: Int) {
+            this.mId = id
+        }
+
+        override fun getId() = mId
+
+        fun build(): Credentials {
+            return Credentials(type, role, host, port, stillValid)
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -67,8 +67,12 @@ class ActivityLogSqlUtils
                     .equals(RewindStatusTable.LOCAL_SITE_ID, existingRewindStatus.localSiteId)
                     .endWhere()
                     .put(rewindStatusBuilder, UpdateAllExceptId<RewindStatusBuilder>(RewindStatusBuilder::class.java))
+                    .execute()
         } else {
-            WellSql.insert(rewindStatusBuilder)
+            val insert = WellSql.insert(rewindStatusBuilder)
+            insert.execute()
+            WellSql.insert(rewindStatusModel.credentials?.map { it.toBuilder(rewindStatusBuilder.id) } ?: listOf())
+                    .execute()
         }
     }
 
@@ -130,6 +134,17 @@ class ActivityLogSqlUtils
                 rewindStartedAt = this.rewind?.startedAt?.time,
                 rewindProgress = this.rewind?.progress,
                 rewindReason = this.rewind?.reason
+        )
+    }
+
+    private fun Credentials.toBuilder(rewindStatusId: Int): CredentialsBuilder {
+        return CredentialsBuilder(
+                rewindStateId = rewindStatusId,
+                type = this.type,
+                role = this.role,
+                host = this.host,
+                port = this.port,
+                stillValid = this.stillValid
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -259,6 +259,18 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "PUBLISHED INTEGER,DISCARDED INTEGER,DISPLAY_NAME TEXT,ACTOR_TYPE TEXT,WPCOM_USER_ID "
                         + "INTEGER,AVATAR_URL TEXT,ROLE TEXT)");
                 oldVersion++;
+            case 31:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS RewindStatus");
+                db.execSQL(
+                        "CREATE TABLE RewindStatus (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "REMOTE_SITE_ID INTEGER,STATE TEXT NOT NULL,LAST_UPDATED INTEGER,REASON TEXT,"
+                        + "CAN_AUTOCONFIGURE INTEGER,REWIND_ID TEXT,REWIND_STATUS TEXT,REWIND_STARTED_AT INTEGER,"
+                        + "REWIND_PROGRESS INTEGER,REWIND_REASON TEXT)");
+                db.execSQL(
+                        "CREATE TABLE RewindStatusCredentials (_id INTEGER PRIMARY KEY AUTOINCREMENT,REWIND_STATE_ID "
+                        + "INTEGER,TYPE TEXT NOT NULL,ROLE TEXT NOT NULL,STILL_VALID INTEGER,HOST TEXT,PORT INTEGER)");
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -197,11 +197,8 @@ class ActivityLogStore
         GENERIC_ERROR,
         AUTHORIZATION_REQUIRED,
         INVALID_RESPONSE,
-        MISSING_STATE,
         INVALID_REWIND_STATE,
-        MISSING_RESTORE_ID,
-        MISSING_RESTORE_STATUS,
-        INVALID_RESTORE_STATUS
+        MISSING_REWIND_ID
     }
 
     class RewindStatusError(var type: RewindStatusErrorType, var message: String? = null) : Store.OnChangedError

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -90,7 +90,7 @@ class ActivityLogStore
             emitChange(OnRewindStatusFetched(payload.error, action))
         } else {
             if (payload.rewindStatusModelResponse != null) {
-                activityLogSqlUtils.insertOrUpdateRewindStatus(payload.site, payload.rewindStatusModelResponse)
+                activityLogSqlUtils.replaceRewindStatus(payload.site, payload.rewindStatusModelResponse)
             }
             emitChange(OnRewindStatusFetched(action))
         }


### PR DESCRIPTION
I found out that the `RewindStatus` coming from the API is completely different than what we expect. This PR implements the current state & tests everything from https://activitylogrewind.wordpress.com/2017/12/21/jetpack-rewind-state-machine/.  