### PR TITLE
Remove started_at field in wrong format until it's fixed

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
@@ -28,7 +28,6 @@ val REWIND_RESPONSE = ActivityLogRestClient.RewindStatusResponse.Rewind(rewind_i
         status = RewindStatusModel.Rewind.Status.RUNNING.value,
         progress = 10,
         reason = "nit",
-        started_at = Date(),
         site_id = null,
         restore_id = null)
 val REWIND_STATUS_RESPONSE = ActivityLogRestClient.RewindStatusResponse(

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -230,7 +230,6 @@ class ActivityLogRestClientTest {
                     assertEquals(this.progress, REWIND_RESPONSE.progress)
                     assertEquals(this.rewindId, REWIND_RESPONSE.rewind_id)
                     assertEquals(this.reason, REWIND_RESPONSE.reason)
-                    assertEquals(this.startedAt, REWIND_RESPONSE.started_at)
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
@@ -36,7 +36,6 @@ data class RewindStatusModel(
     data class Rewind(
         val rewindId: String?,
         val status: Status,
-        val startedAt: Date,
         val progress: Int,
         val reason: String?
     ) {
@@ -61,7 +60,7 @@ data class RewindStatusModel(
                 val status = stringStatus?.let { Status.fromValue(it) }
                 val startedAt = longStartedAt?.let { Date(it) }
                 if (status != null && startedAt != null && progress != null) {
-                    return Rewind(rewindId, status, startedAt, progress, reason)
+                    return Rewind(rewindId, status, progress, reason)
                 }
                 return null
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
@@ -53,13 +53,11 @@ data class RewindStatusModel(
             fun build(
                 rewindId: String?,
                 stringStatus: String?,
-                longStartedAt: Long?,
                 progress: Int?,
                 reason: String?
             ): Rewind? {
                 val status = stringStatus?.let { Status.fromValue(it) }
-                val startedAt = longStartedAt?.let { Date(it) }
-                if (status != null && startedAt != null && progress != null) {
+                if (status != null && progress != null) {
                     return Rewind(rewindId, status, progress, reason)
                 }
                 return null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -177,7 +177,6 @@ constructor(
                     rewindId = rewindId,
                     status = restoreStatus,
                     progress = it.progress,
-                    startedAt = it.started_at,
                     reason = it.reason
             )
         }
@@ -270,7 +269,6 @@ constructor(
             val restore_id: String?,
             val site_id: String?,
             val status: String,
-            val started_at: Date,
             val progress: Int,
             val reason: String?
         )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -129,7 +129,6 @@ class ActivityLogSqlUtils
                 canAutoconfigure = this.canAutoconfigure,
                 rewindId = this.rewind?.rewindId,
                 rewindStatus = this.rewind?.status?.value,
-                rewindStartedAt = this.rewind?.startedAt?.time,
                 rewindProgress = this.rewind?.progress,
                 rewindReason = this.rewind?.reason
         )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -212,7 +212,6 @@ class ActivityLogSqlUtils
         @Column var canAutoconfigure: Boolean? = null,
         @Column var rewindId: String? = null,
         @Column var rewindStatus: String? = null,
-        @Column var rewindStartedAt: Long? = null,
         @Column var rewindProgress: Int? = null,
         @Column var rewindReason: String? = null
     ) : Identifiable {
@@ -228,7 +227,6 @@ class ActivityLogSqlUtils
             val restoreStatus = RewindStatusModel.Rewind.build(
                     rewindId,
                     rewindStatus,
-                    rewindStartedAt,
                     rewindProgress,
                     rewindReason
             )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -41,7 +41,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 34;
+        return 35;
     }
 
     @Override
@@ -282,6 +282,15 @@ public class WellSqlConfig extends DefaultWellConfig {
                         "CREATE TABLE RewindStatusCredentials (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID "
                         + "INTEGER,REMOTE_SITE_ID INTEGER,REWIND_STATE_ID INTEGER,TYPE TEXT NOT NULL,ROLE TEXT NOT "
                         + "NULL,STILL_VALID INTEGER,HOST TEXT,PORT INTEGER)");
+                oldVersion++;
+            case 34:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS RewindStatus");
+                db.execSQL(
+                        "CREATE TABLE RewindStatus (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "REMOTE_SITE_ID INTEGER,STATE TEXT NOT NULL,LAST_UPDATED INTEGER,REASON TEXT,"
+                        + "CAN_AUTOCONFIGURE INTEGER,REWIND_ID TEXT,REWIND_STATUS TEXT,REWIND_PROGRESS INTEGER,"
+                        + "REWIND_REASON TEXT)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
- `started_at` field is returned from the API in a non-standard format (missing timezone). We are currently not using the field so I'm removing it from the model to prevent crashes. 
- the only way to remove a column from database table is to recreate the table but that's ok because we use DB only as a cache anyway