### PR TITLE
Allow the UserAgent app ID to be configured

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.mocked;
 
-import org.wordpress.android.fluxc.example.di.AppSecretsModule;
+import org.wordpress.android.fluxc.example.di.AppConfigModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.MockedNetworkModule;
 import org.wordpress.android.fluxc.module.MockedWCNetworkModule;
@@ -13,7 +13,7 @@ import dagger.Component;
 @Singleton
 @Component(modules = {
         AppContextModule.class,
-        AppSecretsModule.class,
+        AppConfigModule.class,
         ReleaseBaseModule.class,
         MockedNetworkModule.class, // Mocked module
         MockedWCNetworkModule.class // Mocked module

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -106,12 +106,6 @@ public class MockedNetworkModule {
 
     @Singleton
     @Provides
-    public UserAgent provideUserAgent(Context appContext) {
-        return new UserAgent(appContext);
-    }
-
-    @Singleton
-    @Provides
     public SiteRestClient provideSiteRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
                                                 AppSecrets appSecrets,
                                                 AccessToken token, UserAgent userAgent) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
-import org.wordpress.android.fluxc.example.di.AppSecretsModule;
+import org.wordpress.android.fluxc.example.di.AppConfigModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.MockedToolsModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
@@ -17,7 +17,7 @@ import dagger.Component;
 @Singleton
 @Component(modules = {
         AppContextModule.class,
-        AppSecretsModule.class,
+        AppConfigModule.class,
         ReleaseOkHttpClientModule.class,
         ReleaseBaseModule.class,
         ReleaseNetworkModule.class,

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/di/AppComponentDebug.kt
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/di/AppComponentDebug.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 @Component(modules = arrayOf(
         AndroidInjectionModule::class,
         ApplicationModule::class,
-        AppSecretsModule::class,
+        AppConfigModule::class,
         DebugOkHttpClientModule::class,
         InterceptorModule::class,
         ReleaseBaseModule::class,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppComponent.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppComponent.kt
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 @Component(modules = arrayOf(
         AndroidInjectionModule::class,
         ApplicationModule::class,
-        AppSecretsModule::class,
+        AppConfigModule::class,
         ReleaseOkHttpClientModule::class,
         ReleaseBaseModule::class,
         ReleaseNetworkModule::class,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.example.di;
 
+import android.content.Context;
 import android.text.TextUtils;
 
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -32,5 +34,10 @@ public class AppConfigModule {
             AppLog.e(T.API, "OAUTH_APP_ID or OAUTH_APP_SECRET is empty, check your gradle.properties");
         }
         return new AppSecrets(appId, appSecret);
+    }
+
+    @Provides
+    public UserAgent provideUserAgent(Context appContext) {
+        return new UserAgent(appContext);
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -1,7 +1,8 @@
-package org.wordpress.android.fluxc.instaflux;
+package org.wordpress.android.fluxc.example.di;
 
 import android.text.TextUtils;
 
+import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -12,11 +13,10 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-public class AppSecretsModule {
+public class AppConfigModule {
     public String getStringBuildConfigValue(String fieldName) {
         try {
-            String packageName = getClass().getPackage().getName();
-            Class<?> clazz = Class.forName(packageName + ".BuildConfig");
+            Class<?> clazz = Class.forName(BuildConfig.APPLICATION_ID + ".BuildConfig");
             Field field = clazz.getField(fieldName);
             return (String) field.get(null);
         } catch (Exception e) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -38,6 +38,6 @@ public class AppConfigModule {
 
     @Provides
     public UserAgent provideUserAgent(Context appContext) {
-        return new UserAgent(appContext);
+        return new UserAgent(appContext, "fluxc-example-android");
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -83,12 +83,6 @@ public class ReleaseNetworkModule {
 
     @Singleton
     @Provides
-    public UserAgent provideUserAgent(Context appContext) {
-        return new UserAgent(appContext);
-    }
-
-    @Singleton
-    @Provides
     public SiteRestClient provideSiteRestClient(Context appContext, Dispatcher dispatcher,
                                                 @Named("regular") RequestQueue requestQueue,
                                                 AppSecrets appSecrets,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.fluxc.network;
 
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.webkit.WebView;
+
+import org.wordpress.android.util.PackageUtils;
 
 public class UserAgent {
     private String mUserAgent;
@@ -40,23 +40,5 @@ public class UserAgent {
     @Override
     public String toString() {
         return getUserAgent();
-    }
-
-    // TODO: reuse util methods
-    private PackageInfo getPackageInfo(Context context) {
-        try {
-            PackageManager manager = context.getPackageManager();
-            return manager.getPackageInfo(context.getPackageName(), 0);
-        } catch (PackageManager.NameNotFoundException e) {
-            return null;
-        }
-    }
-
-    private String getVersionName(Context context) {
-        PackageInfo packageInfo = getPackageInfo(context);
-        if (packageInfo != null) {
-            return packageInfo.versionName;
-        }
-        return "0";
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
@@ -6,11 +6,10 @@ import android.content.pm.PackageManager;
 import android.webkit.WebView;
 
 public class UserAgent {
-    private static final String USER_AGENT_APPNAME = "wp-android";
     private String mUserAgent;
     private String mDefaultUserAgent;
 
-    public UserAgent(Context appContext) {
+    public UserAgent(Context appContext, String appName) {
         // Device's default User-Agent string.
         // E.g.:
         //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
@@ -27,8 +26,7 @@ public class UserAgent {
         //    "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
         //    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
         //    wp-android/4.7"
-        // Note that app versions prior to 4.7 simply used "wp-android" as the user agent
-        mUserAgent = mDefaultUserAgent + " " + USER_AGENT_APPNAME + "/" + getVersionName(appContext);
+        mUserAgent = mDefaultUserAgent + " " + appName + "/" + PackageUtils.getVersionName(appContext);
     }
 
     public String getUserAgent() {

--- a/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/AppComponentDebug.java
+++ b/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/AppComponentDebug.java
@@ -12,7 +12,7 @@ import dagger.Component;
 @Singleton
 @Component(modules = {
         AppContextModule.class,
-        AppSecretsModule.class,
+        AppConfigModule.class,
         DebugOkHttpClientModule.class,
         InterceptorModule.class,
         ReleaseBaseModule.class,

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppComponent.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppComponent.java
@@ -12,7 +12,7 @@ import dagger.Component;
 @Singleton
 @Component(modules = {
         AppContextModule.class,
-        AppSecretsModule.class,
+        AppConfigModule.class,
         ReleaseOkHttpClientModule.class,
         ReleaseBaseModule.class,
         ReleaseNetworkModule.class

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
@@ -38,6 +38,6 @@ public class AppConfigModule {
 
     @Provides
     public UserAgent provideUserAgent(Context appContext) {
-        return new UserAgent(appContext);
+        return new UserAgent(appContext, "instaflux-android");
     }
 }

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
@@ -1,7 +1,9 @@
 package org.wordpress.android.fluxc.instaflux;
 
+import android.content.Context;
 import android.text.TextUtils;
 
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -32,5 +34,10 @@ public class AppConfigModule {
             AppLog.e(T.API, "OAUTH_APP_ID or OAUTH_APP_SECRET is empty, check your gradle.properties");
         }
         return new AppSecrets(appId, appSecret);
+    }
+
+    @Provides
+    public UserAgent provideUserAgent(Context appContext) {
+        return new UserAgent(appContext);
     }
 }

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
@@ -1,8 +1,7 @@
-package org.wordpress.android.fluxc.example.di;
+package org.wordpress.android.fluxc.instaflux;
 
 import android.text.TextUtils;
 
-import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -13,10 +12,11 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-public class AppSecretsModule {
+public class AppConfigModule {
     public String getStringBuildConfigValue(String fieldName) {
         try {
-            Class<?> clazz = Class.forName(BuildConfig.APPLICATION_ID + ".BuildConfig");
+            String packageName = getClass().getPackage().getName();
+            Class<?> clazz = Class.forName(packageName + ".BuildConfig");
             Field field = clazz.getField(fieldName);
             return (String) field.get(null);
         } catch (Exception e) {


### PR DESCRIPTION
Removes the baked-in `"wp-android"` app ID the `UserAgent` was appending to the user agent header for network requests. FluxC now requires the host app to supply a `UserAgent`, configured with the app ID string.

Our example apps also no longer masquerade as WPAndroid in their requests (though the main reason for this change was to allow the WooCommerce app to use its own app id).

Note that merging this will break WPAndroid, and https://github.com/wordpress-mobile/WordPress-Android/pull/7817 should also be reviewed and ready to be merged after this one.