### PR TITLE
Issue/crash subscription error

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -1191,7 +1191,7 @@ public class AccountStore extends Store {
     private void handleUpdatedSubscription(SubscriptionResponsePayload payload) {
         OnSubscriptionUpdated event = new OnSubscriptionUpdated();
         if (payload.isError()) {
-            event.error = new SubscriptionError(event.error.toString(), event.error.message);
+            event.error = payload.error;
         } else {
             event.subscribed = payload.isSubscribed;
             event.type = payload.type;


### PR DESCRIPTION
### Fix
Update the [`handleUpdatedSubscription` method ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/issue/crash-subscription-error?expand=1#diff-21a42e5cb9fc1d9531f135b868bc3e3aR1191) to assign the `OnSubscriptionUpdated` event error from the `SubscriptionResponsePayload` payload rather than creating a new `SubscriptionError`.   This solves a `NullPointerException` crash when `event.error` is `null` as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7796.