### PR TITLE
Fix error in rewind status mapping

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
@@ -26,8 +26,8 @@ val ACTIVITY_RESPONSE = ActivityLogRestClient.ActivitiesResponse.ActivityRespons
 val ACTIVITY_RESPONSE_PAGE = ActivityLogRestClient.ActivitiesResponse.Page(listOf(ACTIVITY_RESPONSE))
 val REWIND_RESPONSE = ActivityLogRestClient.RewindStatusResponse.Rewind(rewind_id = "123",
         status = RewindStatusModel.Rewind.Status.RUNNING.value,
-        progress = 10,
-        reason = "nit",
+        progress = null,
+        reason = null,
         site_id = null,
         restore_id = 5)
 val REWIND_STATUS_RESPONSE = ActivityLogRestClient.RewindStatusResponse(

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -227,9 +227,6 @@ class ActivityLogRestClientTest {
                 assertNotNull(this.rewind)
                 this.rewind?.apply {
                     assertEquals(this.status.value, REWIND_RESPONSE.status)
-                    assertEquals(this.progress, REWIND_RESPONSE.progress)
-                    assertEquals(this.rewindId, REWIND_RESPONSE.rewind_id)
-                    assertEquals(this.reason, REWIND_RESPONSE.reason)
                 }
             }
         }
@@ -298,7 +295,7 @@ class ActivityLogRestClientTest {
 
         verify(requestQueue).add(any<WPComGsonRequest<RewindResponse>>())
 
-        val restoreId = "restoreId"
+        val restoreId = 10L
         rewindSuccessMethodCaptor.firstValue.invoke(RewindResponse(restoreId))
 
         verify(dispatcher).dispatch(mRewindActionCaptor.capture())

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -296,7 +296,7 @@ class ActivityLogRestClientTest {
         verify(requestQueue).add(any<WPComGsonRequest<RewindResponse>>())
 
         val restoreId = 10L
-        rewindSuccessMethodCaptor.firstValue.invoke(RewindResponse(restoreId))
+        rewindSuccessMethodCaptor.firstValue.invoke(RewindResponse(restoreId, true, null))
 
         verify(dispatcher).dispatch(mRewindActionCaptor.capture())
         assertEquals(restoreId, mRewindActionCaptor.firstValue.payload.restoreId)
@@ -311,6 +311,21 @@ class ActivityLogRestClientTest {
         verify(requestQueue).add(any<WPComGsonRequest<RewindResponse>>())
 
         errorMethodCaptor.firstValue.invoke(WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR)))
+
+        verify(dispatcher).dispatch(mRewindActionCaptor.capture())
+        assertTrue(mRewindActionCaptor.firstValue.payload.isError)
+    }
+
+    @Test
+    fun postRewindApiError() {
+        initPostRewind()
+
+        activityRestClient.rewind(site, "rewindId")
+
+        verify(requestQueue).add(any<WPComGsonRequest<RewindResponse>>())
+
+        val restoreId = 10L
+        rewindSuccessMethodCaptor.firstValue.invoke(RewindResponse(restoreId, false, "error"))
 
         verify(dispatcher).dispatch(mRewindActionCaptor.capture())
         assertTrue(mRewindActionCaptor.firstValue.payload.isError)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -168,7 +168,7 @@ class ActivityLogStoreTest {
     @Test
     fun emitsRewindResult() {
         val rewindId = "rewindId"
-        val restoreId = "restoreId"
+        val restoreId = 10L
         val payload = ActivityLogStore.RewindResultPayload(rewindId, restoreId, siteModel)
         val action = ActivityLogActionBuilder.newRewindResultAction(payload)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
@@ -37,15 +37,15 @@ data class RewindStatusModel(
         val rewindId: String?,
         val restoreId: Long,
         val status: Status,
-        val progress: Int,
+        val progress: Int?,
         val reason: String?
     ) {
         enum class Status(val value: String) {
             RUNNING("running"), FINISHED("finished"), FAILED("failed");
 
             companion object {
-                fun fromValue(value: String): Status? {
-                    return Status.values().firstOrNull { it.value == value }
+                fun fromValue(value: String?): Status? {
+                    return value?.let { Status.values().firstOrNull { it.value == value } }
                 }
             }
         }
@@ -59,7 +59,7 @@ data class RewindStatusModel(
                 reason: String?
             ): Rewind? {
                 val status = stringStatus?.let { Status.fromValue(it) }
-                if (status != null && progress != null && restoreId != null) {
+                if (status != null && restoreId != null) {
                     return Rewind(rewindId, restoreId, status, progress, reason)
                 }
                 return null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -268,14 +268,14 @@ constructor(
         )
 
         data class Rewind(
-            val rewind_id: String?,
-            val restore_id: Long?,
             val site_id: String?,
-            val status: String,
-            val progress: Int,
+            val status: String?,
+            val restore_id: Long?,
+            val rewind_id: String?,
+            val progress: Int?,
             val reason: String?
         )
     }
 
-    class RewindResponse(val restore_id: String)
+    class RewindResponse(val restore_id: Long)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -21,7 +21,10 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.ActivityError
 import org.wordpress.android.fluxc.store.ActivityLogStore.ActivityLogErrorType
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedRewindStatePayload
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindError
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindErrorType
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindErrorType.API_ERROR
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindResultPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusError
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusErrorType
 import java.util.Date
@@ -90,8 +93,13 @@ constructor(
         val url = WPCOMREST.activity_log.site(site.siteId).rewind.to.rewind(rewindId).urlV1
         val request = wpComGsonRequestBuilder.buildPostRequest(url, mapOf(), RewindResponse::class.java,
                 { response ->
-                    val payload = ActivityLogStore.RewindResultPayload(rewindId, response.restore_id, site)
-                    dispatcher.dispatch(ActivityLogActionBuilder.newRewindResultAction(payload))
+                    if (response.ok != true && (response.error != null && response.error.isNotEmpty())) {
+                        val payload = RewindResultPayload(RewindError(API_ERROR, response.error), rewindId, site)
+                        dispatcher.dispatch(ActivityLogActionBuilder.newRewindResultAction(payload))
+                    } else {
+                        val payload = ActivityLogStore.RewindResultPayload(rewindId, response.restore_id, site)
+                        dispatcher.dispatch(ActivityLogActionBuilder.newRewindResultAction(payload))
+                    }
                 },
                 { networkError ->
                     val error = ActivityLogStore.RewindError(genericToError(networkError,
@@ -277,5 +285,5 @@ constructor(
         )
     }
 
-    class RewindResponse(val restore_id: Long)
+    class RewindResponse(val restore_id: Long, val ok: Boolean?, val error: String?)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -148,6 +148,7 @@ class ActivityLogSqlUtils
                 reason = this.reason,
                 canAutoconfigure = this.canAutoconfigure,
                 rewindId = this.rewind?.rewindId,
+                restoreId = this.rewind?.restoreId,
                 rewindStatus = this.rewind?.status?.value,
                 rewindProgress = this.rewind?.progress,
                 rewindReason = this.rewind?.reason

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -219,6 +219,7 @@ class ActivityLogStore
 
     enum class RewindErrorType {
         GENERIC_ERROR,
+        API_ERROR,
         AUTHORIZATION_REQUIRED,
         INVALID_RESPONSE,
         MISSING_STATE

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -137,7 +137,7 @@ class ActivityLogStore
 
     data class OnRewind(
         val rewindId: String,
-        val restoreId: String? = null,
+        val restoreId: Long? = null,
         var causeOfChange: ActivityLogAction
     ) : Store.OnChanged<RewindError>() {
         constructor(rewindId: String, error: RewindError, causeOfChange: ActivityLogAction) :
@@ -185,7 +185,7 @@ class ActivityLogStore
 
     class RewindResultPayload(
         val rewindId: String,
-        val restoreId: String? = null,
+        val restoreId: Long? = null,
         val site: SiteModel
     ) : Payload<RewindError>() {
         constructor(error: RewindError, rewindId: String, site: SiteModel) : this(rewindId = rewindId, site = site) {


### PR DESCRIPTION
- there was a missing restore ID when mapping `Rewind` from DB and this made it null in the result
- progress is now nullable in `Rewind`
- I've noticed that the `RewindResponse` contains extra fields with an `error` so I've included them and created a new `API_ERROR` type