### PR TITLE
Use system file separator for generating WOOCOMMERCE file

### DIFF
--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -78,7 +78,7 @@ public class EndpointProcessor extends AbstractProcessor {
                 generateXMLRPCEndpointFile();
                 generateWPAPIEndpointFile();
                 generateWPORGAPIEndpointFile();
-            } else if (outputPath.contains("/plugins/woocommerce/build/")) {
+            } else if (outputPath.contains(fs + "plugins" + fs + "woocommerce" + fs + "build" + fs)) {
                 generateWCWPAPIPluginEndpointFile();
             }
         } catch (IOException e) {


### PR DESCRIPTION
Clean and rebuild the project on Mac to make sure it still works. /cc @AmandaRiu 