### PR TITLE
Add change username and update plugin mocked tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -21,6 +21,7 @@ import dagger.Component;
 public interface MockedNetworkAppComponent {
     void inject(MockedStack_AccountTest object);
     void inject(MockedStack_JetpackTunnelTest object);
+    void inject(MockedStack_PluginTest object);
     void inject(MockedStack_SiteTest object);
     void inject(MockedStack_UploadStoreTest object);
     void inject(MockedStack_UploadTest object);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_PluginTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_PluginTest.kt
@@ -1,0 +1,66 @@
+package org.wordpress.android.fluxc.mocked
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.generated.PluginActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
+import org.wordpress.android.fluxc.store.PluginStore
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginUpdated
+import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+private const val UPDATE_PLUGIN_NAME = "UPDATE_PLUGIN_NAME"
+private const val UPDATE_PLUGIN_SLUG = "UPDATE_PLUGIN_SLUG"
+
+class MockedStack_PluginTest: MockedStack_Base() {
+    @Inject lateinit var dispatcher: Dispatcher
+    @Inject lateinit var pluginStore: PluginStore
+    @Inject lateinit var interceptor: ResponseMockingInterceptor
+
+    internal enum class TestEvents {
+        NONE,
+        SITE_PLUGIN_UPDATED
+    }
+
+    private lateinit var nextEvent: TestEvents
+    private lateinit var countDownLatch: CountDownLatch
+
+    override fun setUp() {
+        super.setUp()
+        mMockedNetworkAppComponent.inject(this)
+        dispatcher.register(this)
+    }
+
+    @Test
+    fun testUpdateSitePluginSuccess() {
+        val site = SiteModel()
+        site.setIsWPCom(true)
+        site.setIsJetpackConnected(true)
+        interceptor.respondWith("update-plugin-success-response.json")
+        nextEvent = TestEvents.SITE_PLUGIN_UPDATED
+        val payload = UpdateSitePluginPayload(site, UPDATE_PLUGIN_NAME, UPDATE_PLUGIN_SLUG)
+        dispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload))
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    fun onSitePluginUpdated(event: OnSitePluginUpdated) {
+        if (event.isError) {
+            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
+        }
+        assertEquals(nextEvent, TestEvents.SITE_PLUGIN_UPDATED)
+        assertEquals(event.pluginName, UPDATE_PLUGIN_NAME)
+        assertEquals(event.slug, UPDATE_PLUGIN_SLUG)
+        countDownLatch.countDown()
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_PluginTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_PluginTest.kt
@@ -22,8 +22,10 @@ private const val UPDATE_PLUGIN_SLUG = "UPDATE_PLUGIN_SLUG"
 
 class MockedStack_PluginTest : MockedStack_Base() {
     @Inject lateinit var dispatcher: Dispatcher
-    @Inject lateinit var pluginStore: PluginStore
     @Inject lateinit var interceptor: ResponseMockingInterceptor
+
+    @Suppress("unused") // Required for UPDATE_SITE_PLUGIN action
+    @Inject lateinit var pluginStore: PluginStore
 
     internal enum class TestEvents {
         NONE,

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_PluginTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_PluginTest.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 private const val UPDATE_PLUGIN_NAME = "UPDATE_PLUGIN_NAME"
 private const val UPDATE_PLUGIN_SLUG = "UPDATE_PLUGIN_SLUG"
 
-class MockedStack_PluginTest: MockedStack_Base() {
+class MockedStack_PluginTest : MockedStack_Base() {
     @Inject lateinit var dispatcher: Dispatcher
     @Inject lateinit var pluginStore: PluginStore
     @Inject lateinit var interceptor: ResponseMockingInterceptor

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -22,8 +22,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.ErrorLi
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Listener;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Token;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
+import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.post.PostXMLRPCClient;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
@@ -177,6 +179,22 @@ public class MockedNetworkModule {
                                                                     DiscoveryXMLRPCClient discoveryXMLRPCClient,
                                                                     DiscoveryWPAPIRestClient discoveryWPAPIRestClient) {
         return new SelfHostedEndpointFinder(dispatcher, discoveryXMLRPCClient, discoveryWPAPIRestClient);
+    }
+
+    @Singleton
+    @Provides
+    public PluginRestClient providePluginRestClient(Context appContext, Dispatcher dispatcher,
+                                                    RequestQueue requestQueue,
+                                                    AccessToken token, UserAgent userAgent) {
+        return new PluginRestClient(appContext, dispatcher, requestQueue, token, userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public PluginWPOrgClient providePluginWPOrgClient(Dispatcher dispatcher,
+                                                      RequestQueue requestQueue,
+                                                      UserAgent userAgent) {
+        return new PluginWPOrgClient(dispatcher, requestQueue, userAgent);
     }
 
     @Singleton

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -268,8 +268,9 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     public void testPluginActionNotAvailable() throws InterruptedException {
         // Setup some test objects to use in tests
         String pluginSlug = "doesn't matter";
+        String pluginName = "doesn't matter";
         SitePluginModel sitePluginModel = new SitePluginModel();
-        sitePluginModel.setName("name");
+        sitePluginModel.setName(pluginName);
         sitePluginModel.setSlug(pluginSlug);
         ImmutablePluginModel pluginModel = ImmutablePluginModel.newInstance(sitePluginModel, null);
         assertNotNull(pluginModel);
@@ -281,6 +282,14 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         wpComSite.setIsWPCom(true);
 
         TestEvents expectedEvent = TestEvents.PLUGIN_ACTION_NOT_AVAILABLE;
+
+        // Test configure plugin
+        ConfigureSitePluginPayload configureSelfHostedSitePlugin =
+                new ConfigureSitePluginPayload(selfHostedSite, pluginName, pluginSlug, true, true);
+        configureSitePlugin(configureSelfHostedSitePlugin, expectedEvent);
+        ConfigureSitePluginPayload configureWPComSitePlugin =
+                new ConfigureSitePluginPayload(wpComSite, pluginName, pluginSlug, true, true);
+        configureSitePlugin(configureWPComSitePlugin, expectedEvent);
 
         // Test delete plugin
         deleteSitePlugin(selfHostedSite, pluginModel, expectedEvent);
@@ -364,6 +373,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             if (event.error.type.equals(ConfigureSitePluginErrorType.UNKNOWN_PLUGIN)) {
                 assertEquals(mNextEvent, TestEvents.UNKNOWN_SITE_PLUGIN);
+            } else if (event.error.type.equals(ConfigureSitePluginErrorType.NOT_AVAILABLE)) {
+                assertEquals(mNextEvent, TestEvents.PLUGIN_ACTION_NOT_AVAILABLE);
             } else {
                 throw new AssertionError("Unexpected error occurred in onSitePluginConfigured with type: "
                         + event.error.type);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -110,14 +110,9 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         assertTrue(immutablePlugin.isInstalled());
         boolean isActive = !immutablePlugin.isActive();
 
-        mNextEvent = TestEvents.CONFIGURED_SITE_PLUGIN;
-        mCountDownLatch = new CountDownLatch(1);
-
         ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, immutablePlugin.getName(),
                 immutablePlugin.getSlug(), isActive, immutablePlugin.isAutoUpdateEnabled());
-        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        configureSitePlugin(payload, TestEvents.CONFIGURED_SITE_PLUGIN);
 
         ImmutablePluginModel configuredPlugin = mPluginStore.getImmutablePluginBySlug(site, immutablePlugin.getSlug());
         assertNotNull(configuredPlugin);
@@ -179,13 +174,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         String pluginName = "this-plugin-does-not-exist-name";
         String pluginSlug = "this-plugin-does-not-exist-slug";
 
-        mNextEvent = TestEvents.UNKNOWN_SITE_PLUGIN;
-        mCountDownLatch = new CountDownLatch(1);
-
         ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, pluginName, pluginSlug, false, false);
-        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        configureSitePlugin(payload, TestEvents.UNKNOWN_SITE_PLUGIN);
 
         signOutWPCom();
     }
@@ -465,6 +455,14 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         return mSiteStore.getSites().get(0);
     }
 
+    private void configureSitePlugin(ConfigureSitePluginPayload payload,
+                                     TestEvents testEvent) throws InterruptedException {
+        mNextEvent = testEvent;
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
     private void deleteSitePlugin(SiteModel site, @NonNull ImmutablePluginModel plugin) throws InterruptedException {
         deleteSitePlugin(site, plugin, TestEvents.DELETED_SITE_PLUGIN);
     }
@@ -496,13 +494,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     }
 
     private void deactivatePlugin(SiteModel site, ImmutablePluginModel plugin) throws InterruptedException {
-        mNextEvent = TestEvents.CONFIGURED_SITE_PLUGIN;
-        mCountDownLatch = new CountDownLatch(1);
-
         ConfigureSitePluginPayload payload = new ConfigureSitePluginPayload(site, plugin.getName(), plugin.getSlug(),
                 false, plugin.isAutoUpdateEnabled());
-        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(payload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        configureSitePlugin(payload, TestEvents.CONFIGURED_SITE_PLUGIN);
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -52,6 +52,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.wordpress.android.fluxc.model.SiteModel.ORIGIN_XMLRPC;
 
 public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
     @Inject SiteStore mSiteStore;
@@ -69,7 +70,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         SITE_REMOVED,
         UNKNOWN_SITE_PLUGIN,
         CONFIGURED_SITE_PLUGIN,
-        REMOVED_SITE_PLUGINS
+        REMOVED_SITE_PLUGINS,
+        PLUGIN_ACTION_NOT_AVAILABLE
     }
 
     private TestEvents mNextEvent;
@@ -271,6 +273,20 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         signOutWPCom();
     }
 
+    @Test
+    public void testPluginActionNotAvailable() throws InterruptedException {
+        String pluginSlug = "doesn't matter";
+
+        SiteModel selfHostedSite = new SiteModel();
+        selfHostedSite.setOrigin(ORIGIN_XMLRPC);
+
+        SiteModel nonJetpackWPComSite = new SiteModel();
+        nonJetpackWPComSite.setIsWPCom(true);
+
+        installSitePlugin(selfHostedSite, pluginSlug, TestEvents.PLUGIN_ACTION_NOT_AVAILABLE);
+        installSitePlugin(nonJetpackWPComSite, pluginSlug, TestEvents.PLUGIN_ACTION_NOT_AVAILABLE);
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
@@ -369,6 +385,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             if (event.error.type.equals(InstallSitePluginErrorType.NO_PACKAGE)) {
                 assertEquals(mNextEvent, TestEvents.INSTALL_SITE_PLUGIN_ERROR_NO_PACKAGE);
+            } else if (event.error.type.equals(InstallSitePluginErrorType.NOT_AVAILABLE)) {
+                assertEquals(mNextEvent, TestEvents.PLUGIN_ACTION_NOT_AVAILABLE);
             } else {
                 throw new AssertionError("Unexpected error occurred in onSitePluginInstalled with type: "
                         + event.error.type);

--- a/example/src/androidTest/resources/change-username-success.json
+++ b/example/src/androidTest/resources/change-username-success.json
@@ -1,0 +1,3 @@
+{
+  "success":true
+}

--- a/example/src/androidTest/resources/update-plugin-success-response.json
+++ b/example/src/androidTest/resources/update-plugin-success-response.json
@@ -1,0 +1,4 @@
+{
+  "slug": "UPDATE_PLUGIN_SLUG",
+  "name": "UPDATE_PLUGIN_NAME"
+}


### PR DESCRIPTION
Fixes #638 & #656. This PR adds 2 mocked tests for the issues mentioned. Both of the tests could be expanded by checking the DB changes. It's hard to do that for the username change test as it'll require setting up an account in the DB first. For the plugin test, there is nothing specific we expect from the endpoint except for it being successful as we don't know in the client what it'll get updated to. So, I opted to do the test over the expected event instead of DB changes which is pretty common for mocked tests.