### PR TITLE
Fix broken build by re-arranging repository order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.automattic.android:fetchstyle:1.1'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext.kotlinVersion = '1.2.41'
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {
@@ -18,8 +18,8 @@ allprojects {
     apply plugin: 'checkstyle'
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     task checkstyle(type: Checkstyle) {


### PR DESCRIPTION
Fixes failing Travis builds. Also updates to the latest gradle plugin.

<hr>

Travis started failing builds with error:

```
* What went wrong:
Could not resolve all files for configuration ':fluxc:debugCompileClasspath'.
> Could not find support-core-ui.aar (com.android.support:support-core-ui:27.1.1).
  Searched in the following locations:
      https://jcenter.bintray.com/com/android/support/support-core-ui/27.1.1/support-core-ui-27.1.1.aar
```

I was able to reproduce this locally when appending `--refresh-dependencies`. The file isn't found in `jcenter()`, yet the `google()` repo isn't being checked, which does have the file. Some Internet searching turned up that this can be avoided by putting `google()` first in dependency declaration lists in gradle.

It's not clear if this is an intermittent issue or, if it's not, what changed. My guess is that we were relying on the `jcenter` link all along, but something changed on that end and now there's no `aar` file (a pom file [exists though](https://jcenter.bintray.com/com/android/support/support-core-ui/27.1.1/:support-core-ui-27.1.1.pom)).

Anyway, with this change the Google repo is checked first and the first is found successfully in my local builds (at https://dl.google.com/dl/android/maven2/com/android/support/support-core-ui/27.1.1/support-core-ui-27.1.1.aar).