### PR TITLE
Prune WPOrgPluginModelTable

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPOrgPluginTest.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.PluginStore.FetchPluginDirectoryPayload
 import org.wordpress.android.fluxc.store.PluginStore.OnPluginDirectoryFetched;
 import org.wordpress.android.fluxc.store.PluginStore.OnPluginDirectorySearched;
 import org.wordpress.android.fluxc.store.PluginStore.OnWPOrgPluginFetched;
+import org.wordpress.android.fluxc.store.PluginStore.OnWPOrgPluginsPruned;
 import org.wordpress.android.fluxc.store.PluginStore.SearchPluginDirectoryPayload;
 
 import java.util.List;
@@ -34,7 +35,8 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         PLUGIN_DIRECTORY_FETCHED,
         PLUGIN_DIRECTORY_SEARCHED,
         WPORG_PLUGIN_FETCHED,
-        WPORG_PLUGIN_DOES_NOT_EXIST
+        WPORG_PLUGIN_DOES_NOT_EXIST,
+        WPORG_PLUGINS_PRUNED
     }
 
     private SiteModel mSite;
@@ -156,6 +158,14 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         Assert.assertTrue(featuredPlugins.size() > 0);
     }
 
+    @Test
+    public void testPruneWPOrgPlugins() throws InterruptedException {
+        mNextEvent = TestEvents.WPORG_PLUGINS_PRUNED;
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(PluginActionBuilder.newPruneWporgPluginsAction());
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onPluginDirectoryFetched(OnPluginDirectoryFetched event) {
@@ -195,6 +205,16 @@ public class ReleaseStack_WPOrgPluginTest extends ReleaseStack_Base {
         }
 
         assertEquals(TestEvents.WPORG_PLUGIN_FETCHED, mNextEvent);
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onWPOrgPluginsPruned(OnWPOrgPluginsPruned event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred while pruning the WPOrgPlugins");
+        }
+        assertEquals(TestEvents.WPORG_PLUGINS_PRUNED, mNextEvent);
         mCountDownLatch.countDown();
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/plugin/PluginDirectorySqlUtilsTest.java
@@ -195,6 +195,12 @@ public class PluginDirectorySqlUtilsTest {
         }
     }
 
+    @Test
+    public void testPruneWPOrgPluginsWhileEmpty() {
+        // Ensure the pruning works even if there is nothing to prune
+        PluginSqlUtils.pruneWPOrgPlugins();
+    }
+
     @SuppressWarnings("unchecked")
     private List<PluginDirectoryModel> getPluginDirectoriesForType(PluginDirectoryType directoryType)
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -54,5 +54,7 @@ public enum PluginAction implements IAction {
 
     // Local actions
     @Action(payloadType = SiteModel.class)
-    REMOVE_SITE_PLUGINS
+    REMOVE_SITE_PLUGINS,
+    @Action
+    PRUNE_WPORG_PLUGINS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -158,6 +158,10 @@ public class PluginSqlUtils {
         return result;
     }
 
+    public static void pruneWPOrgPlugins() {
+        // TODO
+    }
+
     // Plugin Directory
 
     public static void deletePluginDirectoryForType(PluginDirectoryType directoryType) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.yarolegovich.wellsql.SelectQuery.ORDER_ASCENDING;
 
@@ -158,8 +160,28 @@ public class PluginSqlUtils {
         return result;
     }
 
+    /**
+     * This method will prune the `WPOrgPluginModel`s that are not stored as `PluginDirectoryModel`.
+     *
+     * `PluginDirectoryModelTable` holds the metadata of plugin lists and will be removed regularly by network requests.
+     * However, `WPOrgPluginModel`s are never removed even if they are not fetched by a network request for a long time
+     * because it might be used by other plugin directories. We need to periodically prune this table as it can get
+     * very large especially if the user keeps searching for plugins and never see them again.
+     *
+     * We'll first query the `PluginDirectoryModelTable` to find all the slugs that are in use and then remove all the
+     * rows from `WPOrgPluginModelTable` that are not in that slug set.
+     */
     public static void pruneWPOrgPlugins() {
-        // TODO
+        List<PluginDirectoryModel> allPluginDirectories = WellSql.select(PluginDirectoryModel.class).getAsModel();
+        Set<String> slugSet = new HashSet<>(allPluginDirectories.size());
+        for (PluginDirectoryModel pluginDirectoryModel : allPluginDirectories) {
+            slugSet.add(pluginDirectoryModel.getSlug());
+        }
+        WellSql.delete(WPOrgPluginModel.class)
+               .where()
+               .isNotIn(WPOrgPluginModelTable.SLUG, slugSet)
+               .endWhere()
+               .execute();
     }
 
     // Plugin Directory

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PluginSqlUtils.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import com.wellsql.generated.PluginDirectoryModelTable;
 import com.wellsql.generated.SitePluginModelTable;
 import com.wellsql.generated.WPOrgPluginModelTable;
+import com.yarolegovich.wellsql.DeleteQuery;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -177,11 +178,11 @@ public class PluginSqlUtils {
         for (PluginDirectoryModel pluginDirectoryModel : allPluginDirectories) {
             slugSet.add(pluginDirectoryModel.getSlug());
         }
-        WellSql.delete(WPOrgPluginModel.class)
-               .where()
-               .isNotIn(WPOrgPluginModelTable.SLUG, slugSet)
-               .endWhere()
-               .execute();
+        DeleteQuery<WPOrgPluginModel> deleteQuery = WellSql.delete(WPOrgPluginModel.class);
+        if (slugSet.size() > 0) {
+            deleteQuery.where().isNotIn(WPOrgPluginModelTable.SLUG, slugSet).endWhere();
+        }
+        deleteQuery.execute();
     }
 
     // Plugin Directory

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -341,6 +341,7 @@ public class PluginStore extends Store {
     }
 
     static class RemoveSitePluginsError implements OnChangedError {}
+    static class PruneWPOrgPluginsError implements OnChangedError {}
 
     // Error types
 
@@ -543,6 +544,8 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class OnWPOrgPluginsPruned extends OnChanged<PruneWPOrgPluginsError> { }
+
     private final PluginRestClient mPluginRestClient;
     private final PluginWPOrgClient mPluginWPOrgClient;
 
@@ -591,6 +594,9 @@ public class PluginStore extends Store {
             // Local actions
             case REMOVE_SITE_PLUGINS:
                 removeSitePlugins((SiteModel) action.getPayload());
+                break;
+            case PRUNE_WPORG_PLUGINS:
+                pruneWPOrgPlugins();
                 break;
             // Network callbacks
             case CONFIGURED_SITE_PLUGIN:
@@ -741,6 +747,11 @@ public class PluginStore extends Store {
         }
         int rowsAffected = PluginSqlUtils.deleteSitePlugins(site);
         emitChange(new OnSitePluginsRemoved(site, rowsAffected));
+    }
+
+    private void pruneWPOrgPlugins() {
+        PluginSqlUtils.pruneWPOrgPlugins();
+        emitChange(new OnWPOrgPluginsPruned());
     }
 
     // Network callbacks


### PR DESCRIPTION
Fixes #720. When we fetch wporg plugins from remote, we save the details into 2 tables in our DB. First, we have the `WPOrgPluginModelTable` which holds the actual object with all the details. Second, we have `PluginDirectoryModelTable` which only holds the metadata of these plugins which is used for determining what each list should show. So, for example, if the user is visiting the `NEW` plugins, we'll query the `PluginDirectoryModelTable` with the `NEW` `DIRECTORY_TYPE` and then using the slugs on that model, query the actual models from the `WPOrgPluginModelTable`.

When a first page of a certain plugin directory is fetched, we remove all the records for that directory from the `PluginDirectoryModelTable` which means the information of the metadata always remain fresh. However, since multiple directory types might have a record for the same plugin, we never delete plugins from  `WPOrgPluginModelTable`.

This means that the more the user uses the plugins feature, the more likely that we'll have unused `WPOrgPluginModel` records in our table. The biggest culprit for this is the search feature. Let's say the user searches for an odd string and we get 50 plugins for it in our DB, user installs one of them and never makes the same search. Now we have 49 plugins in our DB that may not ever get queried. That's wasted space on the user's device.

This PR gives the client a way to address that problem through `PRUNE_WPORG_PLUGINS` action. This action will remove all the `WPOrgPluginModel` records in the DB that doesn't have metadata for it in the `PluginDirectoryModelTable`. It'll trigger `OnWPOrgPluginsPruned` once it's done.

This could have been achieved through a simple method call in the `PluginStore` as well, but this ensures that the query is run in the BG thread and is consistent with the rest of the FluxC actions. It's up to the client for where and when to call this action.

To Test:
* Review and run the unit tests. I suggest debugging the test and checking `shouldBeKept` to make sure it has both `true` and `false` values.
* Run the connected test

@nbradbury I requested a review from you since we have to assign it to someone and we talked about this issue when we worked on plugins. Let me know if you don't have the time for it and I'll ask someone else. Thanks!