### PR TITLE
Remove offset property from ReaderSearchSitesResponse

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reader/ReaderSearchSitesDeserializer.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reader/ReaderSearchSitesDeserializer.java
@@ -23,7 +23,6 @@ class ReaderSearchSitesDeserializer implements JsonDeserializer<ReaderSearchSite
         JsonObject jsonObject = json.getAsJsonObject();
         ReaderSearchSitesResponse response = new ReaderSearchSitesResponse();
 
-        response.offset = getJsonInt(json, "offset");
         response.sites = new ArrayList<>();
 
         JsonArray jsonFeedsList = jsonObject.getAsJsonArray("feeds");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reader/ReaderSearchSitesResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reader/ReaderSearchSitesResponse.java
@@ -10,6 +10,5 @@ import java.util.List;
 
 @JsonAdapter(ReaderSearchSitesDeserializer.class)
 public class ReaderSearchSitesResponse {
-    public int offset;
     public @NonNull List<ReaderSiteModel> sites;
 }


### PR DESCRIPTION
It looks like there is no `offset` value in the returned json from the `/read/feed/` endpoint. I've tried the endpoint both with and without the `offset` parameter and it wasn't returned for either of them. Since we were not even using this property, I think it's best if we just remove it.

P.S: I realized this only now while I was working on #825 as I didn't check the response specifically during the review of #822 which is my bad.

@nbradbury Do you mind reviewing this? Thanks!