### PR TITLE
Travis: Speed tweaks, parallel jobs, and mocked connected tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - ANDROID_TARGET=android-15
 
 before_install:
-  # TODO: Remove the following line when Travis' platform-tools are updated to v24+
+  # Not always needed if Travis' platform-tools are up to date, but keeping for safety
   - echo yes | android update sdk -a --filter platform-tools --no-ui --force
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,15 @@ before_install:
   # Not always needed if Travis' platform-tools are up to date, but keeping for safety
   - echo yes | android update sdk -a --filter platform-tools --no-ui --force
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache
+
 script:
   - ./gradlew assembleDebug assembleRelease
   - ./gradlew testRelease

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
 env:
   global:
     - MALLOC_ARENA_MAX=2
-    - GRADLE_OPTS="-Xmx768m -Xms256m -Xss1m"
+    - GRADLE_OPTS="-Xmx4g"
     - ANDROID_SDKS=android-15
     - ANDROID_TARGET=android-15
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
     - GRADLE_OPTS="-Xmx4g"
     - ANDROID_SDKS=android-15
     - ANDROID_TARGET=android-15
+  matrix:
+    - TASK=build-and-lint
+    - TASK=unit-tests
 
 before_install:
   # Not always needed if Travis' platform-tools are up to date, but keeping for safety
@@ -31,9 +34,12 @@ cache:
     - $HOME/.android/build-cache
 
 script:
-  - ./gradlew assembleDebug assembleRelease
-  - ./gradlew testRelease
-  - ./gradlew lint || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1)
-  - ./gradlew checkstyle
-  - ./gradlew ktlint
-  - find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || return 0
+  - set -e # Exit and fail right away if any individual step fails
+  - if [ "$TASK" == "build-and-lint" ]; then
+      ./gradlew assembleDebug assembleRelease;
+      ./gradlew checkstyle ktlint;
+      ./gradlew lint || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
+      find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || return 0;
+    elif [ "$TASK" == "unit-tests" ]; then
+      ./gradlew example:assembleRelease example:testRelease;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ android:
     - platform-tools
     - tools
     - build-tools-27.0.3
-    - android-16
     - android-27
 
 env:
@@ -38,6 +37,7 @@ cache:
 before_script:
   - if [ "$TASK" == "mocked-connected-tests" ]; then
       echo "Starting AVD for mocked connected tests";
+      android-update-sdk --components=android-16;
       android-update-sdk --components=sys-img-armeabi-v7a-android-16 --accept-licenses='android-sdk-license-[0-9a-f]{8}';
       echo no | android create avd --force -n test -t android-16 --abi armeabi-v7a --skin QVGA;
       emulator -avd test -no-audio -no-window &

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ android:
     - platform-tools
     - tools
     - build-tools-27.0.3
+    - android-16
     - android-27
 
 env:
@@ -19,6 +20,7 @@ env:
   matrix:
     - TASK=build-and-lint
     - TASK=unit-tests
+    - TASK=mocked-connected-tests
 
 before_install:
   # Not always needed if Travis' platform-tools are up to date, but keeping for safety
@@ -33,6 +35,14 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
 
+before_script:
+  - if [ "$TASK" == "mocked-connected-tests" ]; then
+      echo "Starting AVD for mocked connected tests";
+      android-update-sdk --components=sys-img-armeabi-v7a-android-16 --accept-licenses='android-sdk-license-[0-9a-f]{8}';
+      echo no | android create avd --force -n test -t android-16 --abi armeabi-v7a --skin QVGA;
+      emulator -avd test -no-audio -no-window &
+    fi
+
 script:
   - set -e # Exit and fail right away if any individual step fails
   - if [ "$TASK" == "build-and-lint" ]; then
@@ -42,4 +52,8 @@ script:
       find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || return 0;
     elif [ "$TASK" == "unit-tests" ]; then
       ./gradlew example:assembleRelease example:testRelease;
+    elif [ "$TASK" == "mocked-connected-tests" ]; then
+      ./gradlew example:assembleDebug example:assembleDebugAndroidTest;
+      android-wait-for-emulator;
+      ./gradlew cAT -Pandroid.testInstrumentationRunnerArguments.package=org.wordpress.android.fluxc.mocked;
     fi


### PR DESCRIPTION
This PR makes a few changes to Travis:

* Increases the memory available to the gradle daemon (should speed things up slightly - the last time we tried this it broke unit tests, but all the gradle updates since then seem to have fixed this)
* Adds a build cache to Travis - not sure this makes a huge difference and it seems to be per-branch, but apparently it can speed up build time after the branch is built on Travis once
* Splits the existing tasks into two parallel jobs (build + lint/style, and build + unit tests)
* Adds a third parallel job, which runs the mocked connected tests on an emulator
* Also ends the build as soon as any step fails, and runs the faster checkstyle/ktlint tasks before lint

The three parallel tasks are `build-and-lint`, `unit-tests`, and `mocked-connected-tests`:

**`build-and-lint`**: Fully build the project (release & debug) and run lint and checkstyle/ktlint.

**`unit-tests`**: Build only the example app (and only the release config), and run the unit tests.

**`mocked-connected-tests`**: Create and boot an emulator (letting it run in the background). Meanwhile, build only the example app and the example app connected tests, and then run the mocked connected tests on the emulator.

Each task has to first download and install the Android SDK and related components. I looked into making this a shared first step for all the tasks, but it's not doable on Travis (the installed files don't survive across multiple build stages).

#### Note about the connected test emulator

The connected test job takes about the same time as the build job (usually the longest), sometimes a bit longer. I think there are some possible optimizations here - for example I'm using an API 16 emulator because I read reports that it's the fastest on Travis, but this might not be true anymore, or not true for us. I'd like to tweak this, but for now it doesn't seem like a great use of time.

<hr>

Travis has seemed to be a bit flakier than usual this week, with some timeout issues when downloading things from Google's servers. It seems fine so far today but I'm a bit worried that we're tripling the chances of a build timing out. I'm going to keep the PR open for a while and periodically re-build to get a sense of things before I mark it as ready to review/merge.