### PR TITLE
WooCommerce: Add caching to order stats

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -20,6 +20,7 @@ import dagger.Component;
 })
 public interface MockedNetworkAppComponent {
     void inject(MockedStack_AccountTest object);
+    void inject(MockedStack_CacheTest object);
     void inject(MockedStack_JetpackTunnelTest object);
     void inject(MockedStack_PluginTest object);
     void inject(MockedStack_SiteTest object);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_CacheTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_CacheTest.kt
@@ -101,6 +101,8 @@ class MockedStack_CacheTest : MockedStack_Base() {
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
+        TestUtils.waitFor(2) // Make sure the cache expires
+
         val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
 
         assertNotNull(firstRequestCacheEntry)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_CacheTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_CacheTest.kt
@@ -1,0 +1,216 @@
+package org.wordpress.android.fluxc.mocked
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.JsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.properties.Delegates.notNull
+
+/**
+ * Tests using a Mocked Network app component. Test the network client itself and not the underlying
+ * network component(s).
+ */
+class MockedStack_CacheTest : MockedStack_Base() {
+    companion object {
+        private const val requestUrl = "https://public-api.wordpress.com/rest/v1/testrequest"
+
+        private val responseJson = JsonObject().apply { addProperty("success", "yes") }
+
+        private val networkErrorHandler = { networkError: WPComGsonNetworkError ->
+            throw AssertionError("Unexpected error with type: " + networkError.type)
+        }
+    }
+
+    @Inject internal lateinit var wpComRestClient: WPComRestClientForTests
+    @Inject internal lateinit var requestQueue: RequestQueue
+
+    @Inject internal lateinit var interceptor: ResponseMockingInterceptor
+
+    private var lastAction: Action<*>? = null
+    private var countDownLatch: CountDownLatch by notNull()
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mMockedNetworkAppComponent.inject(this)
+        lastAction = null
+    }
+
+    @Test
+    fun testSingleRepeatCaching() {
+        requestQueue.cache.clear()
+
+        // Make initial request
+        with (prepareAndCreateRequest()) {
+            enableCaching(BaseRequest.DEFAULT_CACHE_LIFETIME)
+            wpComRestClient.exposedAdd(this)
+        }
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(firstRequestCacheEntry)
+
+        // Repeat same request
+        with (prepareAndCreateRequest()) {
+            enableCaching(BaseRequest.DEFAULT_CACHE_LIFETIME)
+            wpComRestClient.exposedAdd(this)
+        }
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(secondRequestCacheEntry)
+        // Verify that the cache has not been renewed,
+        // which should mean that we read from it instead of making a network call
+        assertEquals(firstRequestCacheEntry.ttl, secondRequestCacheEntry.ttl)
+    }
+
+    @Test
+    fun testCacheExpiry() {
+        requestQueue.cache.clear()
+
+        // Make initial request with 1 millisecond cache expiry
+        with (prepareAndCreateRequest()) {
+            enableCaching(1)
+            wpComRestClient.exposedAdd(this)
+        }
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(firstRequestCacheEntry)
+        assertTrue(firstRequestCacheEntry.isExpired) // Should already be expired by the time we get here
+
+        // Repeat same request
+        with (prepareAndCreateRequest()) {
+            enableCaching(1)
+            wpComRestClient.exposedAdd(this)
+        }
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(secondRequestCacheEntry)
+        // Verify that the cache has been renewed, since the entry was expired
+        assertNotEquals(firstRequestCacheEntry.ttl, secondRequestCacheEntry.ttl)
+    }
+
+    @Test
+    fun testGetParamCaching() {
+        requestQueue.cache.clear()
+
+        // Make initial request
+        val paramMap = mutableMapOf("param" to "testvalue")
+        with (prepareAndCreateRequest(paramMap)) {
+            enableCaching(BaseRequest.DEFAULT_CACHE_LIFETIME)
+            wpComRestClient.exposedAdd(this)
+        }
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(firstRequestCacheEntry)
+
+        // Repeat same request but with a parameter change
+        paramMap["param"] = "differentvalue"
+        with (prepareAndCreateRequest(paramMap)) {
+            enableCaching(BaseRequest.DEFAULT_CACHE_LIFETIME)
+            wpComRestClient.exposedAdd(this)
+        }
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(secondRequestCacheEntry)
+        // Verify that the cache has been renewed, since the request params were different
+        assertNotEquals(firstRequestCacheEntry.ttl, secondRequestCacheEntry.ttl)
+    }
+
+    @Test
+    fun testForcedUpdate() {
+        requestQueue.cache.clear()
+
+        // Make initial request
+        with (prepareAndCreateRequest()) {
+            enableCaching(BaseRequest.DEFAULT_CACHE_LIFETIME)
+            wpComRestClient.exposedAdd(this)
+        }
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(firstRequestCacheEntry)
+
+        // Make the same request, but this time force update the network request
+        with (prepareAndCreateRequest()) {
+            enableCaching(BaseRequest.DEFAULT_CACHE_LIFETIME)
+            setShouldForceUpdate()
+            wpComRestClient.exposedAdd(this)
+        }
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(secondRequestCacheEntry)
+        // Verify that the cache has been renewed,
+        // since we ignored it and updated it with the results of a forced request
+        assertNotEquals(firstRequestCacheEntry.ttl, secondRequestCacheEntry.ttl)
+    }
+
+    private fun prepareAndCreateRequest(params: Map<String, String> = mapOf()): WPComGsonRequest<*> {
+        interceptor.respondWith(responseJson)
+
+        return WPComGsonRequest.buildGetRequest(requestUrl, params, Any::class.java,
+                { countDownLatch.countDown() },
+                networkErrorHandler)
+    }
+
+    @Singleton
+    class WPComRestClientForTests @Inject constructor(
+        appContext: Context,
+        dispatcher: Dispatcher,
+        requestQueue: RequestQueue,
+        accessToken: AccessToken,
+        userAgent: UserAgent
+    ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+        /**
+         * Wraps and exposes the protected [add] method so that tests can add requests directly.
+         */
+        fun <T> exposedAdd(request: WPComGsonRequest<T>?) { add(request) }
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
@@ -22,6 +22,9 @@ class ResponseMockingInterceptor : Interceptor {
     private var nextResponseJson: String? = null
     private var nextResponseCode: Int = 200
 
+    var lastRequestUrl: String = ""
+        private set
+
     fun respondWith(jsonResponseFileName: String) {
         nextResponseJson = getStringFromResourceFile(jsonResponseFileName)
         nextResponseCode = 200
@@ -51,7 +54,7 @@ class ResponseMockingInterceptor : Interceptor {
         // Give some time to create a realistic network event
         TestUtils.waitFor(1000)
 
-        val requestUrl = request.url().toString()
+        lastRequestUrl = request.url().toString()
 
         nextResponseJson?.let {
             // Will be a successful response if nextResponseCode is 200, otherwise an error response
@@ -63,7 +66,7 @@ class ResponseMockingInterceptor : Interceptor {
             return response
         }
 
-        throw IllegalStateException("Interceptor was not given a response for this request! URL: $requestUrl")
+        throw IllegalStateException("Interceptor was not given a response for this request! URL: $lastRequestUrl")
     }
 
     private fun buildResponse(request: Request, responseJson: String, responseCode: Int): Response {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -114,6 +114,13 @@ class WooCommerceFragment : Fragment() {
                 dispatcher.dispatch(WCStatsActionBuilder.newFetchOrderStatsAction(payload))
             } ?: showNoWCSitesToast()
         }
+
+        fetch_order_stats_forced.setOnClickListener {
+            getFirstWCSite()?.let {
+                val payload = FetchOrderStatsPayload(it, StatsGranularity.DAYS, true)
+                dispatcher.dispatch(WCStatsActionBuilder.newFetchOrderStatsAction(payload))
+            } ?: showNoWCSitesToast()
+        }
     }
 
     override fun onStart() {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -184,7 +184,8 @@ class WooCommerceFragment : Fragment() {
 
                 when (event.causeOfChange) {
                     WCStatsAction.FETCH_ORDER_STATS ->
-                        prependToLog("Fetched stats for " + statsMap.size + " days from " + site.name)
+                        prependToLog("Fetched stats for " + statsMap.size + " " +
+                                event.granularity.toString().toLowerCase() + " from " + site.name)
                     else -> prependToLog("WooCommerce stats were updated from a " + event.causeOfChange)
                 }
             }

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -42,4 +42,9 @@
         android:layout_height="wrap_content"
         android:text="Fetch Month-to-date Revenue Stats" />
 
+    <Button
+        android:id="@+id/fetch_order_stats_forced"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch Month-to-date Revenue Stats (forced)" />
 </LinearLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -106,7 +106,7 @@ class WCStatsStoreTest {
 
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
-            verify(mockOrderStatsRestClient).fetchStats(any(), any(), dateArgument.capture(), any())
+            verify(mockOrderStatsRestClient).fetchStats(any(), any(), dateArgument.capture(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -122,7 +122,7 @@ class WCStatsStoreTest {
 
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
-            verify(mockOrderStatsRestClient).fetchStats(any(), any(), dateArgument.capture(), any())
+            verify(mockOrderStatsRestClient).fetchStats(any(), any(), dateArgument.capture(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -245,25 +245,25 @@ public abstract class BaseRequest<T> extends Request<T> {
 
         if (cacheEntry == null) {
             cacheEntry = new Cache.Entry();
-        }
 
-        cacheEntry.data = response.data;
+            String headerValue = response.headers.get("Date");
+            if (headerValue != null) {
+                cacheEntry.serverDate = HttpHeaderParser.parseDateAsEpoch(headerValue);
+            }
+
+            headerValue = response.headers.get("Last-Modified");
+            if (headerValue != null) {
+                cacheEntry.lastModified = HttpHeaderParser.parseDateAsEpoch(headerValue);
+            }
+
+            cacheEntry.data = response.data;
+            cacheEntry.responseHeaders = response.headers;
+        }
 
         long now = System.currentTimeMillis();
         cacheEntry.ttl = now + mCacheTtl;
         cacheEntry.softTtl = now + mCacheSoftTtl;
 
-        String headerValue = response.headers.get("Date");
-        if (headerValue != null) {
-            cacheEntry.serverDate = HttpHeaderParser.parseDateAsEpoch(headerValue);
-        }
-
-        headerValue = response.headers.get("Last-Modified");
-        if (headerValue != null) {
-            cacheEntry.lastModified = HttpHeaderParser.parseDateAsEpoch(headerValue);
-        }
-
-        cacheEntry.responseHeaders = response.headers;
         return cacheEntry;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -53,6 +53,7 @@ public abstract class BaseRequest<T> extends Request<T> {
     protected final Map<String, String> mHeaders = new HashMap<>(2);
     private BaseErrorListener mErrorListener;
 
+    private boolean mResetCache;
     private int mCacheTtl;
     private int mCacheSoftTtl;
 
@@ -174,6 +175,20 @@ public abstract class BaseRequest<T> extends Request<T> {
         setShouldCache(true);
         mCacheTtl = timeToLive;
         mCacheSoftTtl = softTimeToLive;
+    }
+
+    /**
+     * Reset the cache for this request, to force an update over the network.
+     */
+    public void setShouldForceUpdate() {
+        mResetCache = true;
+    }
+
+    /**
+     * Returns true if this request should ignore the cache and force a fresh update over the network.
+     */
+    public boolean shouldForceUpdate() {
+        return mResetCache;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -79,7 +79,7 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
             } else {
                 res = mGson.fromJson(json, mClass);
             }
-            return Response.success(res, HttpHeaderParser.parseCacheHeaders(response));
+            return Response.success(res, createCacheEntry(response));
         } catch (UnsupportedEncodingException e) {
             return Response.error(new ParseError(e));
         } catch (JsonSyntaxException e) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -7,6 +7,7 @@ import com.android.volley.RequestQueue;
 
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.OnAuthFailedListener;
 import org.wordpress.android.fluxc.network.BaseRequest.OnParseErrorListener;
 import org.wordpress.android.fluxc.network.UserAgent;
@@ -72,7 +73,7 @@ public abstract class BaseWPComRestClient {
             request.setOnParseErrorListener(mOnParseErrorListener);
             request.setUserAgent(mUserAgent.getUserAgent());
         }
-        return mRequestQueue.add(request);
+        return addRequest(request);
     }
 
     protected Request addUnauthedRequest(WPComGsonRequest request) {
@@ -99,7 +100,7 @@ public abstract class BaseWPComRestClient {
         return request;
     }
 
-    private Request addRequest(WPComGsonRequest request) {
+    private Request addRequest(BaseRequest request) {
         if (request.shouldCache() && request.shouldForceUpdate()) {
             mRequestQueue.getCache().invalidate(request.mUri.toString(), true);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -58,7 +58,7 @@ public abstract class BaseWPComRestClient {
             request.addQueryParameter("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
         }
         // TODO: If !mAccountToken.exists() then trigger the mOnAuthFailedListener
-        return mRequestQueue.add(setRequestAuthParams(request, true));
+        return addRequest(setRequestAuthParams(request, true));
     }
 
     protected Request addUnauthedRequest(AccountSocialRequest request) {
@@ -84,7 +84,7 @@ public abstract class BaseWPComRestClient {
         if (addLocaleParameter) {
             request.addQueryParameter("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
         }
-        return mRequestQueue.add(setRequestAuthParams(request, false));
+        return addRequest(setRequestAuthParams(request, false));
     }
 
     protected AccessToken getAccessToken() {
@@ -97,5 +97,12 @@ public abstract class BaseWPComRestClient {
         request.setUserAgent(mUserAgent.getUserAgent());
         request.setAccessToken(shouldAuth ? mAccessToken.get() : null);
         return request;
+    }
+
+    private Request addRequest(WPComGsonRequest request) {
+        if (request.shouldCache() && request.shouldForceUpdate()) {
+            mRequestQueue.getCache().invalidate(request.mUri.toString(), true);
+        }
+        return mRequestQueue.add(request);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/BaseXMLRPCClient.java
@@ -45,6 +45,9 @@ public abstract class BaseXMLRPCClient {
     }
 
     protected Request add(XMLRPCRequest request) {
+        if (request.shouldCache() && request.shouldForceUpdate()) {
+            mRequestQueue.getCache().invalidate(request.mUri.toString(), true);
+        }
         return mRequestQueue.add(setRequestAuthParams(request));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -59,7 +59,7 @@ public class XMLRPCRequest extends BaseRequest<Object> {
             String data = new String(response.data, HttpHeaderParser.parseCharset(response.headers));
             InputStream is = new ByteArrayInputStream(data.getBytes(Charset.forName("UTF-8")));
             Object obj = XMLSerializerUtils.deserialize(XMLSerializerUtils.scrubXmlResponse(is));
-            return Response.success(obj, HttpHeaderParser.parseCacheHeaders(response));
+            return Response.success(obj, createCacheEntry(response));
         } catch (XMLRPCFault e) {
             return Response.error(new VolleyError(e));
         } catch (UnsupportedEncodingException e) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderStatsModel
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -67,6 +68,9 @@ class OrderStatsRestClient(
                     val payload = FetchOrderStatsResponsePayload(orderError, site, unit)
                     mDispatcher.dispatch(WCStatsActionBuilder.newFetchedOrderStatsAction(payload))
                 })
+
+        request.enableCaching(BaseRequest.DEFAULT_CACHE_LIFETIME)
+
         add(request)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -45,7 +45,7 @@ class OrderStatsRestClient(
      * Possible non-generic errors:
      * [OrderStatsErrorType.INVALID_PARAM] if [unit], [date], or [quantity] are invalid or incompatible
      */
-    fun fetchStats(site: SiteModel, unit: OrderStatsApiUnit, date: String, quantity: Int) {
+    fun fetchStats(site: SiteModel, unit: OrderStatsApiUnit, date: String, quantity: Int, force: Boolean = false) {
         val url = WPCOMV2.sites.site(site.siteId).stats.orders.url
         val params = mapOf(
                 "unit" to unit.toString(),
@@ -70,6 +70,7 @@ class OrderStatsRestClient(
                 })
 
         request.enableCaching(BaseRequest.DEFAULT_CACHE_LIFETIME)
+        if (force) request.setShouldForceUpdate()
 
         add(request)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -156,13 +156,12 @@ class WCStatsStore @Inject constructor(
     }
 
     private fun fetchOrderStats(payload: FetchOrderStatsPayload) {
-        // TODO: Caching, and skip cache if forced == true
         when (payload.granularity) {
             StatsGranularity.DAYS -> {
                 // TODO: Calculate quantity from max(day-of-the-month, day-of-the-week) for week-to-date support
                 val dayOfMonth = SiteUtils.getCurrentDateTimeForSite(payload.site, DATE_FORMAT_DAY_OF_MONTH).toInt()
                 wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
-                        getFormattedDate(payload.site, StatsGranularity.DAYS), dayOfMonth)
+                        getFormattedDate(payload.site, StatsGranularity.DAYS), dayOfMonth, payload.forced)
             }
             StatsGranularity.MONTHS -> TODO()
             StatsGranularity.YEARS -> TODO()


### PR DESCRIPTION
Adds a 10-minute cache for WooCommerce order stats fetch requests.

By default all FluxC network requests have caching turned off. This PR updates `BaseRequest`  to allow caching to be enabled for particular requests, and updates `GsonRequest` (and also `XMLRPCRequest`, though we'll probably never use caching there) to honor the cache settings. Following that, the cache is enabled for WooCommerce order stats requests.

I also added a 'forced' mechanism, where the cache is invalidated to force a real refresh from the server (this will mainly be used when the user pulls to refresh or some other manual refresh action), but still updates the cache so the next request can use it.

### To test

I added a second 'fetch stats' button to the example app that sends a forced request to help a bit with testing. Using Stetho or something like Charles is a good way to verify that the cache/forced mechanisms are working properly.

cc @AmandaRiu 