### PR TITLE
Delete scheduled posts in connected tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -287,6 +287,14 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         // The post should now have a future created date and should have 'future' status
         assertEquals(futureDate, finalPost.getDateCreated());
         assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
+
+        // Delete the post
+        mNextEvent = TestEvents.POST_DELETED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(finalPost, sSite)));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -288,13 +288,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(futureDate, finalPost.getDateCreated());
         assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
 
-        // Delete the post
-        mNextEvent = TestEvents.POST_DELETED;
-        mCountDownLatch = new CountDownLatch(1);
-
-        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(finalPost, sSite)));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        deletePost(finalPost);
     }
 
     @Test
@@ -623,12 +617,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        mNextEvent = TestEvents.POST_DELETED;
-        mCountDownLatch = new CountDownLatch(1);
-
-        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(uploadedPost, sSite)));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        deletePost(uploadedPost);
 
         // The post should be removed from the db (regardless of whether it was deleted or just trashed on the server)
         assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost.getId()));
@@ -853,6 +842,15 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
 
         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void deletePost(PostModel post) throws InterruptedException {
+        mNextEvent = TestEvents.POST_DELETED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(post, sSite)));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -278,6 +278,14 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // The post should now have a future created date and should have 'future' status
         assertEquals(futureDate, finalPost.getDateCreated());
         assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
+
+        // Delete the post
+        mNextEvent = TestEvents.POST_DELETED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(finalPost, sSite)));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -279,13 +279,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(futureDate, finalPost.getDateCreated());
         assertEquals(PostStatus.SCHEDULED, PostStatus.fromPost(finalPost));
 
-        // Delete the post
-        mNextEvent = TestEvents.POST_DELETED;
-        mCountDownLatch = new CountDownLatch(1);
-
-        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(finalPost, sSite)));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        deletePost(finalPost);
     }
 
     @Test
@@ -609,12 +603,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(mPost.getId());
 
-        mNextEvent = TestEvents.POST_DELETED;
-        mCountDownLatch = new CountDownLatch(1);
-
-        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(uploadedPost, sSite)));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        deletePost(uploadedPost);
 
         // The post should be removed from the db (regardless of whether it was deleted or just trashed on the server)
         assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost.getId()));
@@ -1078,6 +1067,15 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
 
         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    private void deletePost(PostModel post) throws InterruptedException {
+        mNextEvent = TestEvents.POST_DELETED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(post, sSite)));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }


### PR DESCRIPTION
One of our connected tests creates a post and then makes it scheduled. This isn't a problem for the post tests, but it causes an issue for the comment tests (WP.com specifically, at the moment). This is because the comment tests rely on a published to comment on. If there are 20 scheduled posts, all the posts we fetch are scheduled, and there's no published post for the comment tests to use.

(This was causing the tests to fail consistently on Firebase, since the test site reached 20 scheduled posts.)

So, this PR just deletes the scheduled post at the end of the test.

There are other failing tests that are flaky, we need to lock those down too but this one is highest priority since it's guaranteed test failure.

cc @oguzkocer 