### PR TITLE
Delete Activity Log data only when new data is succesfully fetched

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -43,7 +43,6 @@ class ActivityLogStoreTest {
         val action = ActivityLogActionBuilder.newFetchActivitiesAction(payload)
         activityLogStore.onAction(action)
 
-        verify(activityLogSqlUtils).deleteActivityLog()
         verify(activityLogRestClient).fetchActivity(siteModel, number, offset)
     }
 
@@ -96,6 +95,7 @@ class ActivityLogStoreTest {
                 false,
                 ActivityLogAction.FETCHED_ACTIVITIES)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
+        verify(activityLogSqlUtils).deleteActivityLog()
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -70,8 +70,6 @@ class ActivityLogStore
                     fetchActivityLogPayload.site,
                     SelectQuery.ORDER_ASCENDING
             ).size
-        } else {
-            activityLogSqlUtils.deleteActivityLog()
         }
         activityLogRestClient.fetchActivity(fetchActivityLogPayload.site, ACTIVITY_LOG_PAGE_SIZE, offset)
     }
@@ -84,6 +82,9 @@ class ActivityLogStore
         if (payload.error != null) {
             emitChange(OnActivityLogFetched(payload.error, action))
         } else {
+            if (payload.offset == 0) {
+                activityLogSqlUtils.deleteActivityLog()
+            }
             val rowsAffected = if (payload.activityLogModels.isNotEmpty())
                 activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
             else 0


### PR DESCRIPTION
- it makes sense to delete the activity log only when we have successfully fetched the new data. Checking the offset makes sure we only delete the previous data when the new data starts at 0 (it is a new fetch of the first page)