### PR TITLE
Move OAuth token storage location

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.release;
 
 import android.content.Context;
-import android.preference.PreferenceManager;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.AfterClass;
@@ -58,7 +57,8 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
         // This ensures that the token is not re-used by other tests that don't extend this class,
         // and are supposed to use a different WordPress.com account
         Context context = getInstrumentation().getTargetContext().getApplicationContext();
-        PreferenceManager.getDefaultSharedPreferences(context).edit().putString("ACCOUNT_TOKEN_PREF_KEY", null).apply();
+        context.getSharedPreferences(context.getPackageName() + "_fluxc-preferences", Context.MODE_PRIVATE)
+                .edit().putString("ACCOUNT_TOKEN_PREF_KEY", null).apply();
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/AccessToken.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/AccessToken.java
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.auth;
 
 import android.content.Context;
-import android.preference.PreferenceManager;
+import android.content.SharedPreferences;
 import android.text.TextUtils;
 
 import javax.inject.Singleton;
@@ -14,7 +14,7 @@ public class AccessToken {
 
     public AccessToken(Context appContext) {
         mContext = appContext;
-        mToken = PreferenceManager.getDefaultSharedPreferences(mContext).getString(ACCOUNT_TOKEN_PREF_KEY, "");
+        mToken = getFluxCPreferences().getString(ACCOUNT_TOKEN_PREF_KEY, "");
     }
 
     public boolean exists() {
@@ -27,6 +27,10 @@ public class AccessToken {
 
     public void set(String token) {
         mToken = token;
-        PreferenceManager.getDefaultSharedPreferences(mContext).edit().putString(ACCOUNT_TOKEN_PREF_KEY, token).apply();
+        getFluxCPreferences().edit().putString(ACCOUNT_TOKEN_PREF_KEY, token).apply();
+    }
+
+    private SharedPreferences getFluxCPreferences() {
+        return mContext.getSharedPreferences(mContext.getPackageName() + "_fluxc-preferences", Context.MODE_PRIVATE);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/AccessToken.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/AccessToken.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.auth;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.text.TextUtils;
 
 import javax.inject.Singleton;
@@ -15,6 +16,11 @@ public class AccessToken {
     public AccessToken(Context appContext) {
         mContext = appContext;
         mToken = getFluxCPreferences().getString(ACCOUNT_TOKEN_PREF_KEY, "");
+        if (mToken.isEmpty()) {
+            // Check the old token storage location, since we might init the access token
+            // before the token migration completes (DB upgrade 38 -> 39)
+            mToken = PreferenceManager.getDefaultSharedPreferences(mContext).getString(ACCOUNT_TOKEN_PREF_KEY, "");
+        }
     }
 
     public boolean exists() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.persistence;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.support.annotation.StringDef;
 
 import com.yarolegovich.wellsql.DefaultWellConfig;
@@ -41,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 38;
+        return 39;
     }
 
     @Override
@@ -309,6 +311,18 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("CREATE TABLE QuickStartModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                            + "SITE_ID INTEGER,TASK_NAME TEXT,IS_DONE INTEGER,IS_SHOWN INTEGER)");
+                oldVersion++;
+            case 38:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                SharedPreferences defaultSharedPrefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+                String token = defaultSharedPrefs.getString("ACCOUNT_TOKEN_PREF_KEY", "");
+                if (!token.isEmpty()) {
+                    AppLog.d(T.DB, "Migrating token to fluxc-preferences");
+                    SharedPreferences fluxCPreferences = getContext().getSharedPreferences(
+                            getContext().getPackageName() + "_fluxc-preferences", Context.MODE_PRIVATE);
+                    fluxCPreferences.edit().putString("ACCOUNT_TOKEN_PREF_KEY", token).apply();
+                    defaultSharedPrefs.edit().remove("ACCOUNT_TOKEN_PREF_KEY").apply();
+                }
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
Moves the WordPress.com OAuth token storage location away from the default shared preferences location for the host app and into a custom location.

The backstory here is that we don't want the token to be stored as part of Android's auto backup feature, but we generally do want to include the default shared preferences file in the backup. With this change, the WP.com OAuth token won't be lumped in by default.

**This PR shouldn't be merged until the WPAndroid PR has also been tested and we're sure there are no migration issues.**

**To test:**
There will be a PR in WPAndroid making use of this, but this can also be tested with the FluxC example app:

1. Build `develop`, run the example app, log in to WordPress.com
2. Build this branch and run the example app
3. The token should be migrated to a new location, and you should stay logged in

Using Stetho, under Resources > Local Storage, you should see:
`org.wordpress.android.fluxc.example_preferences`, which is the default shared preferences location, and should not contain the token
and `org.wordpress.android.fluxc.example_fluxc-preferences`, which will contain the token