### PR TITLE
WooCommerce: Stats: Update supported granularities

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -176,7 +176,7 @@ class WooCommerceFragment : Fragment() {
         }
 
         getFirstWCSite()?.let { site ->
-            wcStatsStore.getRevenueStatsForCurrentMonth(site).let { statsMap ->
+            wcStatsStore.getRevenueStats(site, StatsGranularity.DAYS).let { statsMap ->
                 if (statsMap.isEmpty()) {
                     prependToLog("No stats were stored for site " + site.name + " =(")
                     return

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -85,13 +85,13 @@ class WooCommerceFragment : Fragment() {
             getFirstWCSite()?.let { site ->
                 getFirstWCOrder()?.let { order ->
                     pendingNotesOrderModel = order
-                    showSingleLineDialog(activity, "Enter note", { editText ->
+                    showSingleLineDialog(activity, "Enter note") { editText ->
                         val newNote = WCOrderNoteModel().apply {
                             note = editText.text.toString()
                         }
                         val payload = PostOrderNotePayload(order, site, newNote)
                         dispatcher.dispatch(WCOrderActionBuilder.newPostOrderNoteAction(payload))
-                    })
+                    }
                 }
             }
         }
@@ -99,11 +99,11 @@ class WooCommerceFragment : Fragment() {
         update_latest_order_status.setOnClickListener {
             getFirstWCSite()?.let { site ->
                 wcOrderStore.getOrdersForSite(site).firstOrNull()?.let { order ->
-                    showSingleLineDialog(activity, "Enter new order status", { editText ->
+                    showSingleLineDialog(activity, "Enter new order status") { editText ->
                         val status = editText.text.toString()
                         val payload = UpdateOrderStatusPayload(order, site, status)
                         dispatcher.dispatch(WCOrderActionBuilder.newUpdateOrderStatusAction(payload))
-                    })
+                    }
                 } ?: showNoOrdersToast(site)
             } ?: showNoWCSitesToast()
         }

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -40,11 +40,11 @@
         android:id="@+id/fetch_order_stats"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Fetch Month-to-date Revenue Stats" />
+        android:text="Fetch 30-day Revenue Stats" />
 
     <Button
         android:id="@+id/fetch_order_stats_forced"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Fetch Month-to-date Revenue Stats (forced)" />
+        android:text="Fetch 30-day Revenue Stats (forced)" />
 </LinearLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -172,14 +172,14 @@ class WCStatsStoreTest {
     }
 
     @Test
-    fun testGetStatsForCurrentMonth() {
+    fun testGetStatsForDaysGranularity() {
         val orderStatsModel = WCStatsTestUtils.generateSampleStatsModel()
         val site = SiteModel().apply { id = orderStatsModel.localSiteId }
 
         WCStatsSqlUtils.insertOrUpdateStats(orderStatsModel)
 
-        val revenueStats = wcStatsStore.getRevenueStatsForCurrentMonth(site)
-        val orderStats = wcStatsStore.getOrderStatsForCurrentMonth(site)
+        val revenueStats = wcStatsStore.getRevenueStats(site, StatsGranularity.DAYS)
+        val orderStats = wcStatsStore.getOrderStats(site, StatsGranularity.DAYS)
 
         assertTrue(revenueStats.isNotEmpty())
         assertTrue(orderStats.isNotEmpty())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import javax.inject.Singleton
 
 @Singleton
@@ -28,6 +29,17 @@ class OrderStatsRestClient(
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     enum class OrderStatsApiUnit {
         DAY, WEEK, MONTH, YEAR;
+
+        companion object {
+            fun fromStatsGranularity(granularity: StatsGranularity): OrderStatsApiUnit {
+                return when (granularity) {
+                    StatsGranularity.DAYS -> DAY
+                    StatsGranularity.WEEKS -> WEEK
+                    StatsGranularity.MONTHS -> MONTH
+                    StatsGranularity.YEARS -> YEAR
+                }
+            }
+        }
 
         override fun toString() = name.toLowerCase()
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -29,21 +29,22 @@ class WCStatsStore @Inject constructor(
 ) : Store(dispatcher) {
     companion object {
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
+        private const val DATE_FORMAT_WEEK = "YYYY-'W'ww"
         private const val DATE_FORMAT_MONTH = "yyyy-MM"
         private const val DATE_FORMAT_YEAR = "yyyy"
         private const val DATE_FORMAT_DAY_OF_MONTH = "dd"
     }
 
     enum class StatsGranularity {
-        DAYS, MONTHS, YEARS;
+        DAYS, WEEKS, MONTHS, YEARS;
 
         companion object {
             fun fromOrderStatsApiUnit(apiUnit: OrderStatsApiUnit): StatsGranularity {
                 return when (apiUnit) {
                     OrderStatsApiUnit.DAY -> StatsGranularity.DAYS
+                    OrderStatsApiUnit.WEEK -> StatsGranularity.WEEKS
                     OrderStatsApiUnit.MONTH -> StatsGranularity.MONTHS
                     OrderStatsApiUnit.YEAR -> StatsGranularity.YEARS
-                    OrderStatsApiUnit.WEEK -> throw AssertionError("Not implemented!")
                 }
             }
         }
@@ -163,6 +164,7 @@ class WCStatsStore @Inject constructor(
                 wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
                         getFormattedDate(payload.site, StatsGranularity.DAYS), dayOfMonth, payload.forced)
             }
+            StatsGranularity.WEEKS -> TODO()
             StatsGranularity.MONTHS -> TODO()
             StatsGranularity.YEARS -> TODO()
         }
@@ -186,6 +188,7 @@ class WCStatsStore @Inject constructor(
     private fun getFormattedDate(site: SiteModel, granularity: StatsGranularity): String {
         return when (granularity) {
             StatsGranularity.DAYS -> SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_DAY)
+            StatsGranularity.WEEKS -> SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_WEEK)
             StatsGranularity.MONTHS -> SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_MONTH)
             StatsGranularity.YEARS -> SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_YEAR)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -193,8 +193,10 @@ class WCStatsStore @Inject constructor(
         when (payload.granularity) {
             StatsGranularity.DAYS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
                         getFormattedDate(payload.site, StatsGranularity.DAYS), STATS_QUANTITY_DAYS, payload.forced)
-            StatsGranularity.WEEKS -> TODO()
-            StatsGranularity.MONTHS -> TODO()
+            StatsGranularity.WEEKS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.WEEK,
+                        getFormattedDate(payload.site, StatsGranularity.WEEKS), STATS_QUANTITY_WEEKS, payload.forced)
+            StatsGranularity.MONTHS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.MONTH,
+                        getFormattedDate(payload.site, StatsGranularity.MONTHS), STATS_QUANTITY_MONTHS, payload.forced)
             StatsGranularity.YEARS -> TODO()
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -247,7 +247,8 @@ class WCStatsStore @Inject constructor(
                 return mapOf()
             }
 
-            return it.dataList.map { it[periodIndex].toString() to it[fieldIndex] as T }.toMap()
+            // Years are returned as numbers by the API, and Gson interprets them as floats - clean up the decimal
+            return it.dataList.map { it[periodIndex].toString().removeSuffix(".0") to it[fieldIndex] as T }.toMap()
         } ?: return mapOf()
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -190,17 +190,18 @@ class WCStatsStore @Inject constructor(
     }
 
     private fun fetchOrderStats(payload: FetchOrderStatsPayload) {
-        when (payload.granularity) {
-            StatsGranularity.DAYS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
-                    getFormattedDate(payload.site, StatsGranularity.DAYS), STATS_QUANTITY_DAYS, payload.forced)
-            StatsGranularity.WEEKS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.WEEK,
-                    getFormattedDate(payload.site, StatsGranularity.WEEKS), STATS_QUANTITY_WEEKS, payload.forced)
-            StatsGranularity.MONTHS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.MONTH,
-                    getFormattedDate(payload.site, StatsGranularity.MONTHS), STATS_QUANTITY_MONTHS, payload.forced)
-            StatsGranularity.YEARS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.YEAR,
-                    getFormattedDate(payload.site, StatsGranularity.YEARS),
-                    SiteUtils.getCurrentDateTimeForSite(payload.site, DATE_FORMAT_YEAR).toInt() - 2011 + 1)
+        val quantity = when (payload.granularity) {
+            StatsGranularity.DAYS -> STATS_QUANTITY_DAYS
+            StatsGranularity.WEEKS -> STATS_QUANTITY_WEEKS
+            StatsGranularity.MONTHS -> STATS_QUANTITY_MONTHS
+            StatsGranularity.YEARS -> {
+                // Years since 2011 (WooCommerce initial release), inclusive
+                SiteUtils.getCurrentDateTimeForSite(payload.site, DATE_FORMAT_YEAR).toInt() - 2011 + 1
+            }
         }
+
+        wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.fromStatsGranularity(payload.granularity),
+                getFormattedDate(payload.site, payload.granularity), quantity, payload.forced)
     }
 
     private fun handleFetchOrderStatsCompleted(payload: FetchOrderStatsResponsePayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -112,24 +112,18 @@ class WCStatsStore @Inject constructor(
     }
 
     /**
-     * Returns the revenue data for the given [site], in units of [granularity].
+     * Returns the revenue data by date for the given [site], in units of [granularity].
+     *
+     * The returned map has the format: "2018-05-01" -> 57.43
      *
      * The amount of data returned depends on the granularity:
      *
-     * [StatsGranularity.DAYS]: 30 days
-     * [StatsGranularity.WEEKS]: 17 weeks (about a quarter)
-     * [StatsGranularity.MONTHS]: 12 months
-     * [StatsGranularity.YEARS]: all years
+     * [StatsGranularity.DAYS]: the last 30 days, in increments of a day
+     * [StatsGranularity.WEEKS]: the last 17 weeks (about a quarter), in increments of a week
+     * [StatsGranularity.MONTHS]: the last 12 months, in increments of a month
+     * [StatsGranularity.YEARS]: all data since 2011, in increments on a year
      *
      * The start date is the current day/week/month/year, relative to the site's own timezone (not the current device's).
-     *
-     * The returned map has the format:
-     * {
-     * "2018-05-01" -> 57.43,
-     * "2018-05-02" -> 78.98,
-     * ...
-     * "2018-05-16" -> 68.24
-     * }
      *
      * The format of the date key in the returned map depends on the [granularity]:
      * [StatsGranularity.DAYS]: "2018-05-01"
@@ -142,30 +136,11 @@ class WCStatsStore @Inject constructor(
     }
 
     /**
-     * Returns the order volume data for the given [site], in units of [granularity].
+     * Returns the order volume data by date for the given [site], in units of [granularity].
      *
-     * The amount of data returned depends on the granularity:
+     * The returned map has the format: "2018-05-01" -> 15
      *
-     * [StatsGranularity.DAYS]: 30 days
-     * [StatsGranularity.WEEKS]: 17 weeks (about a quarter)
-     * [StatsGranularity.MONTHS]: 12 months
-     * [StatsGranularity.YEARS]: all years
-     *
-     * The start date is the current day/week/month/year, relative to the site's own timezone (not the current device's).
-     *
-     * The returned map has the format:
-     * {
-     * "2018-05-01" -> 15,
-     * "2018-05-02" -> 7,
-     * ...
-     * "2018-05-16" -> 24
-     * }
-     *
-     * The format of the date key in the returned map depends on the [granularity]:
-     * [StatsGranularity.DAYS]: "2018-05-01"
-     * [StatsGranularity.WEEKS]: "2018-W16"
-     * [StatsGranularity.MONTHS]: "2018-05"
-     * [StatsGranularity.YEARS]: "2018"
+     * See [getRevenueStats] for detail on the date formatting of the map keys.
      */
     fun getOrderStats(site: SiteModel, granularity: StatsGranularity): Map<String, Int> {
         return getStatsForField(site, OrderStatsField.ORDERS, granularity)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -28,6 +28,8 @@ class WCStatsStore @Inject constructor(
     private val wcOrderStatsClient: OrderStatsRestClient
 ) : Store(dispatcher) {
     companion object {
+        private const val STATS_QUANTITY_DAYS = 30
+
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
         private const val DATE_FORMAT_WEEK = "YYYY-'W'ww"
         private const val DATE_FORMAT_MONTH = "yyyy-MM"
@@ -105,9 +107,9 @@ class WCStatsStore @Inject constructor(
     }
 
     /**
-     * Returns the revenue data for the month so far for the given [site], in increments of days.
+     * Returns the revenue data for the last 30 days for the given [site], in increments of days.
      *
-     * The month so far is relative to the site's own timezone, not the current device's.
+     * The start date is the current day, relative to the site's own timezone (not the current device's).
      *
      * The returned map has the format:
      * {
@@ -122,9 +124,9 @@ class WCStatsStore @Inject constructor(
     }
 
     /**
-     * Returns the order volume data for the month so far for the given [site], in increments of days.
+     * Returns the order volume data for the last 30 days for the given [site], in increments of days.
      *
-     * The month so far is relative to the site's own timezone, not the current device's.
+     * The start date is the current day, relative to the site's own timezone (not the current device's).
      *
      * The returned map has the format:
      * {
@@ -158,12 +160,8 @@ class WCStatsStore @Inject constructor(
 
     private fun fetchOrderStats(payload: FetchOrderStatsPayload) {
         when (payload.granularity) {
-            StatsGranularity.DAYS -> {
-                // TODO: Calculate quantity from max(day-of-the-month, day-of-the-week) for week-to-date support
-                val dayOfMonth = SiteUtils.getCurrentDateTimeForSite(payload.site, DATE_FORMAT_DAY_OF_MONTH).toInt()
-                wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
-                        getFormattedDate(payload.site, StatsGranularity.DAYS), dayOfMonth, payload.forced)
-            }
+            StatsGranularity.DAYS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
+                        getFormattedDate(payload.site, StatsGranularity.DAYS), STATS_QUANTITY_DAYS, payload.forced)
             StatsGranularity.WEEKS -> TODO()
             StatsGranularity.MONTHS -> TODO()
             StatsGranularity.YEARS -> TODO()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -29,12 +29,13 @@ class WCStatsStore @Inject constructor(
 ) : Store(dispatcher) {
     companion object {
         private const val STATS_QUANTITY_DAYS = 30
+        private const val STATS_QUANTITY_WEEKS = 17
+        private const val STATS_QUANTITY_MONTHS = 12
 
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
         private const val DATE_FORMAT_WEEK = "YYYY-'W'ww"
         private const val DATE_FORMAT_MONTH = "yyyy-MM"
         private const val DATE_FORMAT_YEAR = "yyyy"
-        private const val DATE_FORMAT_DAY_OF_MONTH = "dd"
     }
 
     enum class StatsGranularity {
@@ -56,7 +57,11 @@ class WCStatsStore @Inject constructor(
      * Describes the parameters for fetching order stats for [site], up to the current day, month, or year
      * (depending on the given [granularity]).
      *
-     * Using [StatsGranularity.DAYS] will fetch data to cover both 'week so far' and 'month so far'.
+     * The amount of data fetched depends on the granularity:
+     * [StatsGranularity.DAYS]: the last 30 days, in increments of a day
+     * [StatsGranularity.WEEKS]: the last 17 weeks (about a quarter), in increments of a week
+     * [StatsGranularity.MONTHS]: the last 12 months, in increments of a month
+     * [StatsGranularity.YEARS]: all data since 2011, in increments on a year
      *
      * @param[granularity] the time units for the requested data
      * @param[forced] if true, ignores any cached result and forces a refresh from the server (defaults to false)
@@ -107,9 +112,16 @@ class WCStatsStore @Inject constructor(
     }
 
     /**
-     * Returns the revenue data for the last 30 days for the given [site], in increments of days.
+     * Returns the revenue data for the given [site], in units of [granularity].
      *
-     * The start date is the current day, relative to the site's own timezone (not the current device's).
+     * The amount of data returned depends on the granularity:
+     *
+     * [StatsGranularity.DAYS]: 30 days
+     * [StatsGranularity.WEEKS]: 17 weeks (about a quarter)
+     * [StatsGranularity.MONTHS]: 12 months
+     * [StatsGranularity.YEARS]: all years
+     *
+     * The start date is the current day/week/month/year, relative to the site's own timezone (not the current device's).
      *
      * The returned map has the format:
      * {
@@ -118,15 +130,28 @@ class WCStatsStore @Inject constructor(
      * ...
      * "2018-05-16" -> 68.24
      * }
+     *
+     * The format of the date key in the returned map depends on the [granularity]:
+     * [StatsGranularity.DAYS]: "2018-05-01"
+     * [StatsGranularity.WEEKS]: "2018-W16"
+     * [StatsGranularity.MONTHS]: "2018-05"
+     * [StatsGranularity.YEARS]: "2018"
      */
-    fun getRevenueStatsForCurrentMonth(site: SiteModel): Map<String, Double> {
-        return getCurrentMonthStatsForField(site, OrderStatsField.TOTAL_SALES)
+    fun getRevenueStats(site: SiteModel, granularity: StatsGranularity): Map<String, Double> {
+        return getStatsForField(site, OrderStatsField.TOTAL_SALES, granularity)
     }
 
     /**
-     * Returns the order volume data for the last 30 days for the given [site], in increments of days.
+     * Returns the order volume data for the given [site], in units of [granularity].
      *
-     * The start date is the current day, relative to the site's own timezone (not the current device's).
+     * The amount of data returned depends on the granularity:
+     *
+     * [StatsGranularity.DAYS]: 30 days
+     * [StatsGranularity.WEEKS]: 17 weeks (about a quarter)
+     * [StatsGranularity.MONTHS]: 12 months
+     * [StatsGranularity.YEARS]: all years
+     *
+     * The start date is the current day/week/month/year, relative to the site's own timezone (not the current device's).
      *
      * The returned map has the format:
      * {
@@ -135,9 +160,15 @@ class WCStatsStore @Inject constructor(
      * ...
      * "2018-05-16" -> 24
      * }
+     *
+     * The format of the date key in the returned map depends on the [granularity]:
+     * [StatsGranularity.DAYS]: "2018-05-01"
+     * [StatsGranularity.WEEKS]: "2018-W16"
+     * [StatsGranularity.MONTHS]: "2018-05"
+     * [StatsGranularity.YEARS]: "2018"
      */
-    fun getOrderStatsForCurrentMonth(site: SiteModel): Map<String, Int> {
-        return getCurrentMonthStatsForField(site, OrderStatsField.ORDERS)
+    fun getOrderStats(site: SiteModel, granularity: StatsGranularity): Map<String, Int> {
+        return getStatsForField(site, OrderStatsField.ORDERS, granularity)
     }
 
     /**
@@ -195,8 +226,13 @@ class WCStatsStore @Inject constructor(
     // The type of the stats field relies on knowledge of the real value of the stored JSON for that field
     // It's up to the function caller to be aware of the compatible types for any given field
     @Suppress("UNCHECKED_CAST")
-    private fun <T> getCurrentMonthStatsForField(site: SiteModel, field: OrderStatsField): Map<String, T> {
-        val rawStats = WCStatsSqlUtils.getRawStatsForSiteAndUnit(site, OrderStatsApiUnit.DAY)
+    private fun <T> getStatsForField(
+        site: SiteModel,
+        field: OrderStatsField,
+        granularity: StatsGranularity
+    ): Map<String, T> {
+        val apiUnit = OrderStatsApiUnit.fromStatsGranularity(granularity)
+        val rawStats = WCStatsSqlUtils.getRawStatsForSiteAndUnit(site, apiUnit)
         rawStats?.let {
             val periodIndex = it.getIndexForField(OrderStatsField.PERIOD)
             val fieldIndex = it.getIndexForField(field)
@@ -205,10 +241,8 @@ class WCStatsStore @Inject constructor(
                 reportMissingFieldError(it)
                 return mapOf()
             }
-            val dayOfMonth = SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_DAY_OF_MONTH).toInt()
-            return it.dataList
-                    .takeLast(dayOfMonth)
-                    .map { it[periodIndex].toString() to it[fieldIndex] as T }.toMap()
+
+            return it.dataList.map { it[periodIndex].toString() to it[fieldIndex] as T }.toMap()
         } ?: return mapOf()
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -192,12 +192,14 @@ class WCStatsStore @Inject constructor(
     private fun fetchOrderStats(payload: FetchOrderStatsPayload) {
         when (payload.granularity) {
             StatsGranularity.DAYS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.DAY,
-                        getFormattedDate(payload.site, StatsGranularity.DAYS), STATS_QUANTITY_DAYS, payload.forced)
+                    getFormattedDate(payload.site, StatsGranularity.DAYS), STATS_QUANTITY_DAYS, payload.forced)
             StatsGranularity.WEEKS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.WEEK,
-                        getFormattedDate(payload.site, StatsGranularity.WEEKS), STATS_QUANTITY_WEEKS, payload.forced)
+                    getFormattedDate(payload.site, StatsGranularity.WEEKS), STATS_QUANTITY_WEEKS, payload.forced)
             StatsGranularity.MONTHS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.MONTH,
-                        getFormattedDate(payload.site, StatsGranularity.MONTHS), STATS_QUANTITY_MONTHS, payload.forced)
-            StatsGranularity.YEARS -> TODO()
+                    getFormattedDate(payload.site, StatsGranularity.MONTHS), STATS_QUANTITY_MONTHS, payload.forced)
+            StatsGranularity.YEARS -> wcOrderStatsClient.fetchStats(payload.site, OrderStatsApiUnit.YEAR,
+                    getFormattedDate(payload.site, StatsGranularity.YEARS),
+                    SiteUtils.getCurrentDateTimeForSite(payload.site, DATE_FORMAT_YEAR).toInt() - 2011 + 1)
         }
     }
 


### PR DESCRIPTION
Updates the time periods for the store stats endpoint to reflect changes to the design of the WooCommerce app, and adds the remaining periods that were previously stubbed out:

* `DAYS` granularity now fetches the last 30 days (instead of the month-to-date + week-to-date)
* `WEEKS` granularity added, and fetches the last 17 weeks (about a quarter)
* `MONTHS` granularity added, and fetches the last 12 months
* `YEARS` granularity added, and fetches data since 2011 (WooCommerce first release)