### PR TITLE
Use correct year format for week stats requests

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -33,7 +33,7 @@ class WCStatsStore @Inject constructor(
         private const val STATS_QUANTITY_MONTHS = 12
 
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
-        private const val DATE_FORMAT_WEEK = "YYYY-'W'ww"
+        private const val DATE_FORMAT_WEEK = "yyyy-'W'ww"
         private const val DATE_FORMAT_MONTH = "yyyy-MM"
         private const val DATE_FORMAT_YEAR = "yyyy"
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -28,9 +28,9 @@ class WCStatsStore @Inject constructor(
     private val wcOrderStatsClient: OrderStatsRestClient
 ) : Store(dispatcher) {
     companion object {
-        private const val STATS_QUANTITY_DAYS = 30
-        private const val STATS_QUANTITY_WEEKS = 17
-        private const val STATS_QUANTITY_MONTHS = 12
+        const val STATS_QUANTITY_DAYS = 30
+        const val STATS_QUANTITY_WEEKS = 17
+        const val STATS_QUANTITY_MONTHS = 12
 
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
         private const val DATE_FORMAT_WEEK = "yyyy-'W'ww"


### PR DESCRIPTION
Fixes a bug where I was accidentally using the [week-year](https://docs.oracle.com/javase/7/docs/api/java/util/GregorianCalendar.html) instead of the year for weeks requests to the order stats endpoint.

(This doesn't generally cause any obvious problems for now, but week years are different from normal years and may have caused problems later. Also it's only supported on API 24+, so it would have broken things for older Android versions.)

I also made the stats quantity constants public so they can be referenced from the host app if need be.