### PR TITLE
Issue/fix supported audio subtypes

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaTestUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.media;
 
+import android.webkit.MimeTypeMap;
+
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.persistence.MediaSqlUtils;
 import org.wordpress.android.fluxc.utils.MediaUtils;
@@ -43,6 +45,20 @@ public class MediaTestUtils {
         media.setTitle(media.getFileName());
         return media;
     }
+
+    public static MediaModel generateMediaAudioFromPath(int localSiteId, long mediaId, String filePath) {
+        MediaModel media = new MediaModel();
+        media.setLocalSiteId(localSiteId);
+        media.setMediaId(mediaId);
+        media.setFilePath(filePath);
+        media.setFileName(MediaUtils.getFileName(filePath));
+        media.setFileExtension(MediaUtils.getExtension(filePath));
+        media.setMimeType(MimeTypeMap.getSingleton().getMimeTypeFromExtension(media.getFileExtension()));
+        media.setTitle(media.getFileName());
+
+        return media;
+    }
+
 
     public static MediaModel generateRandomizedMedia(int localSiteId) {
         MediaModel media = generateMedia(randomStr(5), randomStr(5), randomStr(5), randomStr(5));

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MediaUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MediaUtilsTest.java
@@ -1,5 +1,4 @@
 package org.wordpress.android.fluxc.utils;
-
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -97,7 +96,7 @@ public class MediaUtilsTest {
             String supportedVideoMimeType = MediaUtils.MIME_TYPE_VIDEO + supportedVideoType;
             Assert.assertTrue(MediaUtils.isSupportedVideoMimeType(supportedVideoMimeType));
         }
-        for (String unsupportedVideoType : MediaUtils.SUPPORTED_AUDIO_SUBTYPES) {
+        for (String unsupportedVideoType : MediaUtils.SUPPORTED_IMAGE_SUBTYPES) {
             String unsupportedVideoMimeType = MediaUtils.MIME_TYPE_VIDEO + unsupportedVideoType;
             Assert.assertFalse(MediaUtils.isSupportedVideoMimeType(unsupportedVideoMimeType));
         }
@@ -153,11 +152,7 @@ public class MediaUtilsTest {
             Assert.assertNotNull(mimeType);
             Assert.assertTrue(mimeType.equals(MediaUtils.MIME_TYPE_VIDEO + supportedVideoExtension));
         }
-        for (String supportedAudioExtension : MediaUtils.SUPPORTED_AUDIO_SUBTYPES) {
-            String mimeType = MediaUtils.getMimeTypeForExtension(supportedAudioExtension);
-            Assert.assertNotNull(mimeType);
-            Assert.assertTrue(mimeType.equals(MediaUtils.MIME_TYPE_AUDIO + supportedAudioExtension));
-        }
+
         for (String supportedApplicationExtension : MediaUtils.SUPPORTED_APPLICATION_SUBTYPES) {
             String mimeType = MediaUtils.getMimeTypeForExtension(supportedApplicationExtension);
             Assert.assertNotNull(mimeType);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -27,7 +27,15 @@ public class MediaUtils {
     public static final String[] SUPPORTED_VIDEO_SUBTYPES = {
             "mp4", "m4v", "mov", "wmv", "avi", "mpg", "ogv", "3gp", "3gpp", "3gpp2", "3g2", "mpeg", "quicktime", "webm"
     };
-    // supported audio file extensions {"mp3" : "mpeg", "m4a" : "mp4", "ogg" : "ogg", "wav" : "x-wav"}
+
+    // Following https://en.support.wordpress.com/accepted-filetypes
+    // accepted audio file types (extensions) are : mp3, m4a, ogg, wav
+    // In the Android API for each file type there is corresponding mime type
+    // which can be checked with usage of MimeTypeMap.getSingleton().getMimeTypeFromExtension()
+    // Here https://android.googlesource.com/platform/frameworks/base/+/56a2301/media/java/android/media/MediaFile.java
+    // we can get mapping of file type extension and mime type {extension : mime_type}
+    // which gives supported audio file extensions and mime types ->
+    // {"mp3" : "audio/mpeg", "m4a" : "audio/mp4", "ogg" : "audio/ogg", "wav" : "audio/x-wav"}
     public static final String[] SUPPORTED_AUDIO_SUBTYPES = {
             "mpeg", "mp4", "ogg", "x-wav"
     };

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -36,8 +36,9 @@ public class MediaUtils {
     // we can get mapping of file type extension and mime type {extension : mime_type}
     // which gives supported audio file extensions and mime types ->
     // {"mp3" : "audio/mpeg", "m4a" : "audio/mp4", "ogg" : "audio/ogg", "wav" : "audio/x-wav"}
+    // Special case -> On Samsung device for extension "wav" Android API returns "audio/vnd.wave"
     public static final String[] SUPPORTED_AUDIO_SUBTYPES = {
-            "mpeg", "mp4", "ogg", "x-wav"
+            "mpeg", "mp4", "ogg", "x-wav", "vnd.wave"
     };
     public static final String[] SUPPORTED_APPLICATION_SUBTYPES = {
             "pdf", "doc", "ppt", "odt", "pptx", "docx", "pps", "ppsx", "xls", "xlsx", "key", ".zip"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -27,8 +27,9 @@ public class MediaUtils {
     public static final String[] SUPPORTED_VIDEO_SUBTYPES = {
             "mp4", "m4v", "mov", "wmv", "avi", "mpg", "ogv", "3gp", "3gpp", "3gpp2", "3g2", "mpeg", "quicktime", "webm"
     };
+    //supported audio file extensions {"mp3" : "mpeg", "m4a" : "mp4", "ogg" : "ogg", "wav" : "x-wav"}
     public static final String[] SUPPORTED_AUDIO_SUBTYPES = {
-            "mp3", "m4a", "ogg", "wav"
+            "mpeg", "mp4", "ogg", "x-wav"
     };
     public static final String[] SUPPORTED_APPLICATION_SUBTYPES = {
             "pdf", "doc", "ppt", "odt", "pptx", "docx", "pps", "ppsx", "xls", "xlsx", "key", ".zip"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -36,7 +36,7 @@ public class MediaUtils {
     // we can get mapping of file type extension and mime type {extension : mime_type}
     // which gives supported audio file extensions and mime types ->
     // {"mp3" : "audio/mpeg", "m4a" : "audio/mp4", "ogg" : "audio/ogg", "wav" : "audio/x-wav"}
-    // Special case -> On Samsung device for extension "wav" Android API returns "audio/vnd.wave"
+    // Special case -> On Samsung device for "wav" audio file extension Android API returns "audio/vnd.wave"
     public static final String[] SUPPORTED_AUDIO_SUBTYPES = {
             "mpeg", "mp4", "ogg", "x-wav", "vnd.wave"
     };

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -27,7 +27,7 @@ public class MediaUtils {
     public static final String[] SUPPORTED_VIDEO_SUBTYPES = {
             "mp4", "m4v", "mov", "wmv", "avi", "mpg", "ogv", "3gp", "3gpp", "3gpp2", "3g2", "mpeg", "quicktime", "webm"
     };
-    //supported audio file extensions {"mp3" : "mpeg", "m4a" : "mp4", "ogg" : "ogg", "wav" : "x-wav"}
+    // supported audio file extensions {"mp3" : "mpeg", "m4a" : "mp4", "ogg" : "ogg", "wav" : "x-wav"}
     public static final String[] SUPPORTED_AUDIO_SUBTYPES = {
             "mpeg", "mp4", "ogg", "x-wav"
     };


### PR DESCRIPTION
Preparing for fix [#8052](https://github.com/wordpress-mobile/WordPress-Android/issues/8052) - Media Library: Allow uploading audio files

There was a bit confusion about file extensions and mime-types so I noticed that `MediaUtils.java` needed to be fixed in order to allow uploading audio files.

When we compare [Wordpress accepted file types](https://en.support.wordpress.com/accepted-filetypes/) with [Android Mime types](https://android.googlesource.com/platform/frameworks/base/+/56a2301/media/java/android/media/MediaFile.java), under the implementation of `MimeTypeMap.getSingleton().getMimeTypeFromExtension()`Android API will have something like this for Audio files types `{"extension" : "mime_type"}`  ->`{"mp3" : "audio/mpeg", "m4a" : "audio/mp4", "ogg" : "audio/ogg", "wav" : "audio/x-wav"}`.

With this fix uploading audio files will work in the example app.

In the future, [Danilo's PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/509) can be used to fix confusion for all other file types (image, video etc..)

Note: After this fix It wasn't easy to align audio file tests with other tests so I needed to tweak some audio file tests to stop failing

Edit : Special case -> On Samsung device for extension "wav" Android API will return "audio/vnd.wave"
