### PR TITLE
Support retrying Jetpack tunnel GET requests on timeout

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
@@ -52,7 +52,8 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
                     assertEquals("rest_no_route", error.apiError)
                     assertEquals("No route was found matching the URL and request method", error.message)
                     countDownLatch.countDown()
-                })
+                },
+                {})
 
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
         jetpackTunnelClient.exposedAdd(request)
@@ -75,7 +76,8 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
                 WPComErrorListener { error ->
                     throw AssertionError("Unexpected BaseNetworkError: " +
                             error.apiError + " - " + error.message)
-                })
+                },
+                {})
 
         interceptor.respondWith("jetpack-tunnel-root-response-success.json")
         jetpackTunnelClient.exposedAdd(request)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JetpackTunnelTest.kt
@@ -28,6 +28,10 @@ import javax.inject.Singleton
  * network component(s).
  */
 class MockedStack_JetpackTunnelTest : MockedStack_Base() {
+    companion object {
+        private const val DUMMY_SITE_ID = 567L
+    }
+
     @Inject internal lateinit var jetpackTunnelClient: JetpackTunnelClientForTests
 
     @Inject internal lateinit var interceptor: ResponseMockingInterceptor
@@ -43,7 +47,7 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
         val countDownLatch = CountDownLatch(1)
         val url = "/"
 
-        val request = JetpackTunnelGsonRequest.buildGetRequest(url, 567, mapOf(),
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, DUMMY_SITE_ID, mapOf(),
                 RootWPAPIRestResponse::class.java,
                 { _: RootWPAPIRestResponse? ->
                     throw AssertionError("Unexpected success!")
@@ -67,7 +71,7 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
         val url = "/"
         val params = mapOf("context" to "view")
 
-        val request = JetpackTunnelGsonRequest.buildGetRequest(url, 567, params,
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, DUMMY_SITE_ID, params,
                 RootWPAPIRestResponse::class.java,
                 { response: RootWPAPIRestResponse? ->
                     // Verify that the successful response is correctly parsed
@@ -92,7 +96,7 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
 
         val requestBody = mapOf<String, Any>("title" to "New Title", "description" to "New Description")
 
-        val request = JetpackTunnelGsonRequest.buildPostRequest(url, 567, requestBody,
+        val request = JetpackTunnelGsonRequest.buildPostRequest(url, DUMMY_SITE_ID, requestBody,
                 SettingsAPIResponse::class.java,
                 { response: SettingsAPIResponse? ->
                     // Verify that the successful response is correctly parsed
@@ -119,7 +123,7 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
         val url = "/"
         var retriesAttempted = 0
 
-        val request = JetpackTunnelGsonRequest.buildGetRequest(url, 567, mapOf(),
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, DUMMY_SITE_ID, mapOf(),
                 RootWPAPIRestResponse::class.java,
                 { _: RootWPAPIRestResponse? ->
                     throw AssertionError("Unexpected success!")
@@ -156,7 +160,7 @@ class MockedStack_JetpackTunnelTest : MockedStack_Base() {
         val url = "/"
         var retriesAttempted = 0
 
-        val request = JetpackTunnelGsonRequest.buildGetRequest(url, 567, mapOf(),
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, DUMMY_SITE_ID, mapOf(),
                 RootWPAPIRestResponse::class.java,
                 { response: RootWPAPIRestResponse? ->
                     // Verify that the successful response is correctly parsed

--- a/example/src/androidTest/resources/jetpack-tunnel-timeout-error.json
+++ b/example/src/androidTest/resources/jetpack-tunnel-timeout-error.json
@@ -1,0 +1,4 @@
+{
+  "error": "http_request_failed",
+  "message": "cURL error 28: Operation timed out after 5001 milliseconds with 11111 bytes received"
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -24,7 +24,8 @@ class JetpackTunnelGsonRequestTest {
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, 567, params,
                 Any::class.java,
                 { _: Any? -> },
-                WPComErrorListener { _ -> }
+                WPComErrorListener { _ -> },
+                {}
         )
 
         // Verify that the request was built and wrapped as expected

--- a/example/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -14,6 +14,10 @@ import kotlin.test.assertNull
 
 @RunWith(RobolectricTestRunner::class)
 class JetpackTunnelGsonRequestTest {
+    companion object {
+        private const val DUMMY_SITE_ID = 567L
+    }
+
     private val gson by lazy { Gson() }
 
     @Test
@@ -21,7 +25,7 @@ class JetpackTunnelGsonRequestTest {
         val url = "/"
         val params = mapOf("context" to "view")
 
-        val request = JetpackTunnelGsonRequest.buildGetRequest(url, 567, params,
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, DUMMY_SITE_ID, params,
                 Any::class.java,
                 { _: Any? -> },
                 WPComErrorListener { _ -> },
@@ -29,7 +33,7 @@ class JetpackTunnelGsonRequestTest {
         )
 
         // Verify that the request was built and wrapped as expected
-        assertEquals(WPCOMREST.jetpack_blogs.site(567).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
+        assertEquals(WPCOMREST.jetpack_blogs.site(DUMMY_SITE_ID).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
         val parsedUri = Uri.parse(request?.url)
         assertEquals(2, parsedUri.queryParameterNames.size)
         assertEquals("/&_method=get&context=view", parsedUri.getQueryParameter("path"))
@@ -47,14 +51,14 @@ class JetpackTunnelGsonRequestTest {
 
         val requestBody = mapOf<String, Any>("title" to "New Title", "description" to "New Description")
 
-        val request = JetpackTunnelGsonRequest.buildPostRequest(url, 567, requestBody,
+        val request = JetpackTunnelGsonRequest.buildPostRequest(url, DUMMY_SITE_ID, requestBody,
                 Any::class.java,
                 { _: Any? -> },
                 WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected
-        assertEquals(WPCOMREST.jetpack_blogs.site(567).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
+        assertEquals(WPCOMREST.jetpack_blogs.site(DUMMY_SITE_ID).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
         val parsedUri = Uri.parse(request?.url)
         assertEquals(0, parsedUri.queryParameterNames.size)
         val body = String(request?.body!!)
@@ -71,14 +75,14 @@ class JetpackTunnelGsonRequestTest {
 
         val requestBody = mapOf<String, Any>("title" to "New Title", "description" to "New Description")
 
-        val request = JetpackTunnelGsonRequest.buildPutRequest(url, 567, requestBody,
+        val request = JetpackTunnelGsonRequest.buildPutRequest(url, DUMMY_SITE_ID, requestBody,
                 Any::class.java,
                 { _: Any? -> },
                 WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected
-        assertEquals(WPCOMREST.jetpack_blogs.site(567).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
+        assertEquals(WPCOMREST.jetpack_blogs.site(DUMMY_SITE_ID).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
         val parsedUri = Uri.parse(request?.url)
         assertEquals(0, parsedUri.queryParameterNames.size)
         val body = String(request?.body!!)
@@ -95,14 +99,14 @@ class JetpackTunnelGsonRequestTest {
 
         val requestBody = mapOf<String, Any>("title" to "New Title", "description" to "New Description")
 
-        val request = JetpackTunnelGsonRequest.buildPatchRequest(url, 567, requestBody,
+        val request = JetpackTunnelGsonRequest.buildPatchRequest(url, DUMMY_SITE_ID, requestBody,
                 Any::class.java,
                 { _: Any? -> },
                 WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected
-        assertEquals(WPCOMREST.jetpack_blogs.site(567).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
+        assertEquals(WPCOMREST.jetpack_blogs.site(DUMMY_SITE_ID).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
         val parsedUri = Uri.parse(request?.url)
         assertEquals(0, parsedUri.queryParameterNames.size)
         val body = String(request?.body!!)
@@ -118,14 +122,14 @@ class JetpackTunnelGsonRequestTest {
         val url = "/wp/v2/posts/6"
         val params = mapOf("force" to "true")
 
-        val request = JetpackTunnelGsonRequest.buildDeleteRequest(url, 567, params,
+        val request = JetpackTunnelGsonRequest.buildDeleteRequest(url, DUMMY_SITE_ID, params,
                 Any::class.java,
                 { _: Any? -> },
                 WPComErrorListener { _ -> }
         )
 
         // Verify that the request was built and wrapped as expected
-        assertEquals(WPCOMREST.jetpack_blogs.site(567).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
+        assertEquals(WPCOMREST.jetpack_blogs.site(DUMMY_SITE_ID).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
         val parsedUri = Uri.parse(request?.url)
         assertEquals(0, parsedUri.queryParameterNames.size)
         val body = String(request?.body!!)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
@@ -18,12 +18,12 @@ class JetpackTimeoutRequestHandler<T>(
     url: String,
     params: Map<String, String>,
     type: Type,
-    listener: Listener<JetpackTunnelResponse<T>>,
+    listener: Listener<T>,
     errorListener: WPComErrorListener,
     retryListener: (WPComGsonRequest<*>) -> Unit,
     private val maxRetries: Int = DEFAULT_MAX_RETRIES
 ) {
-    private val gsonRequest: WPComGsonRequest<JetpackTunnelResponse<T>>
+    private val gsonRequest: WPComGsonRequest<T>
     private var numRetries = 0
 
     init {
@@ -36,7 +36,7 @@ class JetpackTimeoutRequestHandler<T>(
         const val ADDITIONAL_RETRY_DELAY_MS = 5000L
     }
 
-    fun getRequest(): WPComGsonRequest<JetpackTunnelResponse<T>> {
+    fun getRequest(): WPComGsonRequest<T> {
         return gsonRequest
     }
 
@@ -47,7 +47,7 @@ class JetpackTimeoutRequestHandler<T>(
     private fun buildJPTimeoutRetryListener(
         wpApiEndpoint: String,
         wpComErrorListener: WPComErrorListener,
-        jpTimeoutListener: (WPComGsonRequest<JetpackTunnelResponse<T>>) -> Unit
+        jpTimeoutListener: (WPComGsonRequest<T>) -> Unit
     ): WPComErrorListener {
         return WPComErrorListener { error ->
             if (error.isJetpackTimeoutError()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
+
+import com.android.volley.Response.Listener
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
+import org.wordpress.android.util.AppLog
+import java.lang.reflect.Type
+
+/**
+ * Wraps a [WPComGsonRequest] with a custom error handler for Jetpack timeout errors (which occur when the overall
+ * request to the Jetpack site takes longer than 5 seconds).
+ *
+ * Will retry up to [maxRetries] times, and finally trigger the normal error handler for the request.
+ */
+class JetpackTimeoutRequestHandler<T>(
+    url: String,
+    params: Map<String, String>,
+    type: Type,
+    listener: Listener<JetpackTunnelResponse<T>>,
+    errorListener: WPComErrorListener,
+    retryListener: (WPComGsonRequest<*>) -> Unit,
+    private val maxRetries: Int = DEFAULT_MAX_RETRIES
+) {
+    private val gsonRequest: WPComGsonRequest<JetpackTunnelResponse<T>>
+    private var numRetries = 0
+
+    init {
+        val wrappedErrorListener = buildJPTimeoutRetryListener(url, errorListener, retryListener)
+        gsonRequest = WPComGsonRequest.buildGetRequest(url, params, type, listener, wrappedErrorListener)
+    }
+
+    companion object {
+        const val DEFAULT_MAX_RETRIES = 2
+    }
+
+    fun getRequest(): WPComGsonRequest<JetpackTunnelResponse<T>> {
+        return gsonRequest
+    }
+
+    /**
+     * Wraps the given [WPComErrorListener] in a new one that recognizes Jetpack timeout errors and triggers the
+     * [jpTimeoutListener] (if provided) to do custom handling.
+     */
+    private fun buildJPTimeoutRetryListener(
+        wpApiEndpoint: String,
+        wpComErrorListener: WPComErrorListener,
+        jpTimeoutListener: (WPComGsonRequest<JetpackTunnelResponse<T>>) -> Unit
+    ): WPComErrorListener {
+        return WPComErrorListener { error ->
+            if (error.apiError == "http_request_failed" && error.message.startsWith("cURL error 28")) {
+                if (numRetries < maxRetries) {
+                    AppLog.e(AppLog.T.API, "5-second timeout reached for endpoint $wpApiEndpoint, retrying...")
+                    numRetries++
+                    jpTimeoutListener(gsonRequest)
+                } else {
+                    AppLog.e(AppLog.T.API,
+                            "5-second timeout reached for endpoint $wpApiEndpoint - maximum retries reached")
+                    wpComErrorListener.onErrorResponse(error)
+                }
+            } else {
+                wpComErrorListener.onErrorResponse(error)
+            }
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import com.android.volley.Response.Listener
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.util.AppLog
 import java.lang.reflect.Type
 
@@ -49,7 +50,7 @@ class JetpackTimeoutRequestHandler<T>(
         jpTimeoutListener: (WPComGsonRequest<JetpackTunnelResponse<T>>) -> Unit
     ): WPComErrorListener {
         return WPComErrorListener { error ->
-            if (error.apiError == "http_request_failed" && error.message.startsWith("cURL error 28")) {
+            if (error.isJetpackTimeoutError()) {
                 if (numRetries < maxRetries) {
                     AppLog.e(AppLog.T.API, "5-second timeout reached for endpoint $wpApiEndpoint, retrying...")
                     if (numRetries > 0) {
@@ -70,5 +71,9 @@ class JetpackTimeoutRequestHandler<T>(
                 wpComErrorListener.onErrorResponse(error)
             }
         }
+    }
+
+    private fun WPComGsonNetworkError.isJetpackTimeoutError(): Boolean {
+        return apiError == "http_request_failed" && message.startsWith("cURL error 28")
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -109,7 +109,7 @@ object JetpackTunnelGsonRequest {
         type: Type,
         listener: (T?) -> Unit,
         errorListener: WPComErrorListener,
-        jpTimeoutListener: ((WPComGsonRequest<*>) -> Unit)? = null
+        jpTimeoutListener: ((WPComGsonRequest<*>) -> Unit)?
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedParams = createTunnelParams(params, wpApiEndpoint)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -6,6 +6,7 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
+import org.wordpress.android.util.AppLog
 import java.lang.reflect.Type
 import java.net.URLEncoder
 
@@ -98,6 +99,7 @@ object JetpackTunnelGsonRequest {
      * @param type the Type defining the expected response
      * @param listener the success listener
      * @param errorListener the error listener
+     * @param jpTimeoutListener the listener for Jetpack timeout errors (can be used to silently retry the request)
      *
      * @param T the expected response object from the WP-API endpoint
      */
@@ -107,7 +109,8 @@ object JetpackTunnelGsonRequest {
         params: Map<String, String>,
         type: Type,
         listener: (T?) -> Unit,
-        errorListener: WPComErrorListener
+        errorListener: WPComErrorListener,
+        jpTimeoutListener: ((WPComGsonRequest<*>) -> Unit)? = null
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedParams = createTunnelParams(params, wpApiEndpoint)
 
@@ -115,8 +118,12 @@ object JetpackTunnelGsonRequest {
         val wrappedType = TypeToken.getParameterized(JetpackTunnelResponse::class.java, type).type
         val wrappedListener = Response.Listener<JetpackTunnelResponse<T>> { listener(it.data) }
 
-        return WPComGsonRequest.buildGetRequest(tunnelRequestUrl, wrappedParams, wrappedType,
+        val retryRequest = WPComGsonRequest.buildGetRequest(tunnelRequestUrl, wrappedParams, wrappedType,
                 wrappedListener, errorListener)
+        val wrappedErrorListener = buildJPTimeoutRetryListener(errorListener, retryRequest, jpTimeoutListener)
+
+        return WPComGsonRequest.buildGetRequest(tunnelRequestUrl, wrappedParams, wrappedType,
+                wrappedListener, wrappedErrorListener)
     }
 
     /**
@@ -266,5 +273,26 @@ object JetpackTunnelGsonRequest {
             }
         }
         return result
+    }
+
+    /**
+     * Wraps the given [WPComErrorListener] in a new one that recognizes Jetpack timeout errors and triggers the
+     * [jpTimeoutListener] (if provided) to do custom handling.
+     */
+    private fun <T> buildJPTimeoutRetryListener(
+        wpComErrorListener: WPComErrorListener,
+        retryRequest: WPComGsonRequest<JetpackTunnelResponse<T>>,
+        jpTimeoutListener: ((WPComGsonRequest<JetpackTunnelResponse<T>>) -> Unit)?
+    ): WPComErrorListener {
+        return jpTimeoutListener?.let {
+            WPComErrorListener { error ->
+                if (error.apiError == "http_request_failed" && error.message.startsWith("cURL error 28")) {
+                    AppLog.e(AppLog.T.API, "5-second Jetpack timeout reached, retrying...")
+                    it(retryRequest)
+                } else {
+                    wpComErrorListener.onErrorResponse(error)
+                }
+            }
+        } ?: wpComErrorListener
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
@@ -62,7 +63,8 @@ class OrderRestClient(
                     val orderError = networkErrorToOrderError(networkError)
                     val payload = FetchOrdersResponsePayload(orderError, site)
                     mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
-                })
+                },
+                { request: WPComGsonRequest<*> -> add(request) })
         add(request)
     }
 
@@ -123,7 +125,8 @@ class OrderRestClient(
                     val orderError = networkErrorToOrderError(networkError)
                     val payload = FetchOrderNotesResponsePayload(orderError, site, order)
                     mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderNotesAction(payload))
-                })
+                },
+                { request: WPComGsonRequest<*> -> add(request) })
         add(request)
     }
 


### PR DESCRIPTION
Adds a mechanism for silently retrying GET requests through the Jetpack tunnel when we get a timeout error.

The Jetpack timeout error basically happens when a request through to the remote site ends up taking longer than 5 seconds. The response we get through the Jetpack tunnel looks like this:

```js
{
  "error": "http_request_failed",
  "message": "cURL error 28: Operation timed out after 5001 milliseconds with x bytes received"
}
```

(With HTTP status `400`.)

Retrying the request manually immediately or after a few seconds has tended to work in my experience, so the hope is that we can avoid too much user friction and just have a slight delay in completing the network action most of the time.

In the longer term I'd like us to expand this solution in a few ways:
1. Support POST/PUT/PATCH retries

This is trickier since in general these methods are not safe, and we can't call them multiple times. We would probably want to do something more complex than just retry in those cases, and maybe somehow verify if the resource was created on the server, and only retry in that case.

2. Track retry events

It might be nice to have some data on all this, patching through to analytics when a timeout occurs, for what endpoint, and whether a retry was successful.

### To test

This one's fun 😀 It's not easy to reliably trigger a legitimate Jetpack timeout error. It's pretty rare for fetching orders and order notes, and seems to appear a bit more often for `product` WooCommerce endpoints, which we don't use in FluxC yet. It's probably possible to set it up by modifying a site and adding some delays to PHP calls, but we can simulate the whole thing using Charles.

One way is to set a breakpoint on a request, like the one made when fetching orders through the example app, and modify the raw response to return the error message above and a HTTP 400.

A better way is to use Charles' [Rewrite function](https://www.charlesproxy.com/documentation/tools/rewrite/). This can be setup to always modify requests of a certain type according to your specifications. Mine looks like this:

<img width="1603" alt="charles-rewrite" src="https://user-images.githubusercontent.com/9613966/42714418-19b0cd2c-86c1-11e8-97b0-a04f0581bfef.png">

(Replace the `11111111` in the URL with the ID of the site you're testing with.)

This will allow you to test the retry behavior. You should see 3 total failed requests come through to Charles with this active - the first failed attempt, and then the two retries. You should only get an error message at the UI level after the last failed attempt.

To test success after a retry, you can turn off Rewrite after the first retry is done - there's a 5 second delay between the first and second retry. You can also add more time by manually increasing [this value](https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/feature/wc-5-second-timeout-retry?expand=1#diff-42f3c5eee34b95ebe1f502c77163420eR36).

cc @nbradbury 