### PR TITLE
Support for numeric-only tags

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -354,6 +354,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         List<String> tags = new ArrayList<>(2);
         tags.add("fluxc");
         tags.add("generated-" + RandomStringUtils.randomAlphanumeric(8));
+        tags.add(RandomStringUtils.randomNumeric(8));
         mPost.setTagNameList(tags);
 
         String knownImageIds = BuildConfig.TEST_WPCOM_IMAGE_IDS_TEST1;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -32,7 +32,6 @@ import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.SearchPostsResponsePayload;
-import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
@@ -348,7 +347,7 @@ public class PostRestClient extends BaseWPComRestClient {
         for (Long categoryId : post.getCategoryIdList()) {
             categoryIds.add(categoryId);
         }
-        termsById.add(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY, categoryIds);
+        termsById.add("category", categoryIds);
         // categories are transmitted via the `term_by_id.categories` field
         params.put("terms_by_id", termsById);
 
@@ -358,7 +357,7 @@ public class PostRestClient extends BaseWPComRestClient {
             tags.add(tag);
         }
         JsonObject terms = new JsonObject();
-        terms.add(TaxonomyStore.DEFAULT_TAXONOMY_TAG, tags);
+        terms.add("post_tag", tags);
         // categories are transmitted via the `terms.post_tag` field
         params.put("terms", terms);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -342,7 +342,15 @@ public class PostRestClient extends BaseWPComRestClient {
 
         params.put("password", StringUtils.notNullStr(post.getPassword()));
 
-        params.put("categories", TextUtils.join(",", post.getCategoryIdList()));
+        // construct a json object with a `category` field holding a json array with the tags
+        JsonObject termsById = new JsonObject();
+        JsonArray categoryIds = new JsonArray();
+        for (Long categoryId : post.getCategoryIdList()) {
+            categoryIds.add(categoryId);
+        }
+        termsById.add(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY, categoryIds);
+        // categories are transmitted via the `term_by_id.categories` field
+        params.put("terms_by_id", termsById);
 
         // construct a json object with a `post_tag` field holding a json array with the tags
         JsonArray tags = new JsonArray();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -351,6 +351,7 @@ public class PostRestClient extends BaseWPComRestClient {
         }
         JsonObject terms = new JsonObject();
         terms.add(TaxonomyStore.DEFAULT_TAXONOMY_TAG, tags);
+        // categories are transmitted via the `terms.post_tag` field
         params.put("terms", terms);
 
         if (post.hasFeaturedImage()) {


### PR DESCRIPTION
Starting from [this issue](https://github.com/wordpress-mobile/WordPress-Android/issues/8008) over at the wpandroid repo, it seems that the backend doesn't like it when we send numeric-only tags as a simple list-in-a-string.

In this PR, I copied what Calypso does and sending the proper json structure(s) expected by the `v1.2` API endpoint.

Changes introduced:
1. `pushPost` now uses the `v1.2` rather than the `v1.1` version of the `/sites/$site/posts/new` and `/sites/$site/posts/$post/` endpoints
2. Instead of sending a simple comma-separated list of tags inside a string, now we send a JSON array and pointed by the `post_tag` field
3. Instead of sending a simple comma-separated list of category IDs inside a string, now we send a JSON array pointed by the `categories` field, itself pointed by the `terms_by_id` field. This change was actually needed from the move to `v1.2` of the endpoint.

To test:

* The `ReleaseStack_PostTestWPCom.testFullFeaturedPostUpload` should succeed. It's been expanded to test the numeric-only tag.

To test 2:

* Use the [wpandroid side PR](https://github.com/wordpress-mobile/WordPress-Android/pull/8059) to try [the original issue](https://github.com/wordpress-mobile/WordPress-Android/issues/8008)