### PR TITLE
Adds ListModel and PostListModel and DB queries for them

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.persistence.ListSqlUtils
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @RunWith(RobolectricTestRunner::class)
 class ListSqlUtilsTest {
@@ -65,5 +66,18 @@ class ListSqlUtilsTest {
          * Verify that initially created list and updated list has the same `dateCreated`
          */
         assertEquals(insertedList?.dateCreated, updatedList?.dateCreated)
+    }
+
+    @Test
+    fun testDeleteList() {
+        val testSite = SiteModel()
+        testSite.id = 123 // value doesn't matter
+        val listType = ListType.POSTS_ALL
+
+        listSqlUtils.insertOrUpdateList(testSite, listType)
+        assertNotNull(listSqlUtils.getList(testSite, listType))
+
+        listSqlUtils.deleteList(testSite, listType)
+        assertNull(listSqlUtils.getList(testSite, listType))
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
@@ -74,9 +74,17 @@ class ListSqlUtilsTest {
         testSite.id = 123 // value doesn't matter
         val listType = ListType.POSTS_ALL
 
+        /**
+         * 1. Insert a test list
+         * 2. Verify that the list is inserted correctly
+         */
         listSqlUtils.insertOrUpdateList(testSite, listType)
         assertNotNull(listSqlUtils.getList(testSite, listType))
 
+        /**
+         * 1. Delete the inserted test list
+         * 2. Verify that the list is deleted correctly
+         */
         listSqlUtils.deleteList(testSite, listType)
         assertNull(listSqlUtils.getList(testSite, listType))
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.fluxc.utils
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.ListModel
+import org.wordpress.android.fluxc.model.ListModel.ListType
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.ListSqlUtils
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+
+@RunWith(RobolectricTestRunner::class)
+class ListSqlUtilsTest {
+    private lateinit var listSqlUtils: ListSqlUtils
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(appContext, ListModel::class.java)
+        WellSql.init(config)
+        config.reset()
+
+        listSqlUtils = ListSqlUtils()
+    }
+
+    @Test
+    fun testInsertOrUpdateList() {
+        val testSite = SiteModel()
+        testSite.id = 123 // value doesn't matter
+        val listType = ListType.POSTS_ALL
+
+        /**
+         * 1. Insert a new list for `testSite` and `listType`
+         * 2. Verify that it's inserted
+         * 3. Verify the `localSiteId` value
+         * 4. Verify that `dateCreated` and `lastModified` are equal since this is the first time it's created
+         */
+        listSqlUtils.insertOrUpdateList(testSite, listType)
+        val insertedList = listSqlUtils.getList(testSite, listType)
+        assertNotNull(insertedList)
+        assertEquals(insertedList?.localSiteId, testSite.id)
+        assertEquals(insertedList?.dateCreated, insertedList?.lastModified)
+
+        /**
+         * 1. Wait 1 second before the update test to ensure `lastModified` value will be different
+         * 2. Insert the same list which should update instead
+         * 3. Verify that it's inserted
+         * 4. Verify the `localSiteId` value
+         * 5. Verify the `dateCreated` and `lastModified` values are different since this is an update. (See point 1)
+         */
+        Thread.sleep(1000)
+        listSqlUtils.insertOrUpdateList(testSite, listType)
+        val updatedList = listSqlUtils.getList(testSite, listType)
+        assertNotNull(updatedList)
+        assertEquals(updatedList?.localSiteId, testSite.id)
+        assertNotEquals(updatedList?.dateCreated, updatedList?.lastModified)
+
+        /**
+         * Verify that initially created list and updated list has the same `dateCreated`
+         */
+        assertEquals(insertedList?.dateCreated, updatedList?.dateCreated)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
@@ -45,7 +45,7 @@ class ListSqlUtilsTest {
         listSqlUtils.insertOrUpdateList(testSite, listType)
         val insertedList = listSqlUtils.getList(testSite, listType)
         assertNotNull(insertedList)
-        assertEquals(insertedList?.localSiteId, testSite.id)
+        assertEquals(testSite.id, insertedList?.localSiteId)
         assertEquals(insertedList?.dateCreated, insertedList?.lastModified)
 
         /**
@@ -59,7 +59,7 @@ class ListSqlUtilsTest {
         listSqlUtils.insertOrUpdateList(testSite, listType)
         val updatedList = listSqlUtils.getList(testSite, listType)
         assertNotNull(updatedList)
-        assertEquals(updatedList?.localSiteId, testSite.id)
+        assertEquals(testSite.id, updatedList?.localSiteId)
         assertNotEquals(updatedList?.dateCreated, updatedList?.lastModified)
 
         /**

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
@@ -35,8 +35,8 @@ class PostListSqlUtilsTest {
     @Test
     fun testInsertOrUpdatePostList() {
         val testSite = SiteModel()
-        testSite.id = 123
-        val postCount = 20
+        testSite.id = 123 // value doesn't matter
+        val postCount = 20 // value doesn't matter
         val listType = ListType.POSTS_ALL
 
         /**
@@ -54,9 +54,9 @@ class PostListSqlUtilsTest {
     @Test
     fun testDeletePostList() {
         val testSite = SiteModel()
-        testSite.id = 123
+        testSite.id = 123 // value doesn't matter
+        val postCount = 20 // value doesn't matter
         val listType = ListType.POSTS_ALL
-        val postCount = 20
 
         /**
          * 1. Since a [PostListModel] requires a [ListModel] in the DB due to the foreign key restriction, a test list
@@ -77,6 +77,34 @@ class PostListSqlUtilsTest {
         assertEquals(postListSqlUtils.getPostList(testList.id)?.size, 0)
     }
 
+    @Test
+    fun testDeletePost() {
+        val testSite = SiteModel()
+        testSite.id = 123 // value doesn't matter
+        val testPostId = 1245 // value doesn't matter
+
+        /**
+         * 1. Insert a test list for every list type. There should at least be 2 list types for a good test.
+         * 2. Generate a [PostListModel] for every list type with the same id and insert it
+         * 3. Verify that the [PostListModel] was inserted correctly
+         */
+        val testLists = ListType.values().map { insertTestList(testSite, it) }
+        val postList = testLists.map { generatePostListModel(it.id, testPostId) }
+        postListSqlUtils.insertPostList(postList)
+        testLists.forEach {
+            assertEquals(postListSqlUtils.getPostList(it.id)?.size, 1)
+        }
+
+        /**
+         * 1. Delete [PostListModel]s for which [PostListModel.postId] == `testPostId`
+         * 2. Verify that [PostListModel]s from every list is deleted
+         */
+        postListSqlUtils.deletePost(testPostId)
+        testLists.forEach {
+            assertEquals(postListSqlUtils.getPostList(it.id)?.size, 0)
+        }
+    }
+
     /**
      * Creates and inserts a [ListModel] for a random test site. It also verifies that the list is inserted correctly.
      */
@@ -91,16 +119,21 @@ class PostListSqlUtilsTest {
      * Helper function that creates a list of [PostListModel] to be used in tests.
      * The [PostListModel.date] will be the same date for all [PostListModel]s.
      */
-    private fun generatePostList(listModel: ListModel, count: Int): List<PostListModel> {
-        val postList = ArrayList<PostListModel>()
-        val testDate = "1955-11-05T14:15:00Z"
-        (1..count).forEach { index ->
-            val postListModel = PostListModel()
-            postListModel.listId = listModel.id
-            postListModel.postId = index
-            postListModel.date = testDate
-            postList.add(postListModel)
-        }
-        return postList
+    private fun generatePostList(listModel: ListModel, count: Int): List<PostListModel> =
+            (1..count).map { generatePostListModel(listModel.id, it) }
+
+    /**
+     * Helper function that generates a [PostListModel] instance.
+     */
+    private fun generatePostListModel(
+        listId: Int,
+        postId: Int,
+        date: String = "1955-11-05T14:15:00Z" // just a random valid date since most test don't care about it
+    ): PostListModel {
+        val postListModel = PostListModel()
+        postListModel.listId = listId
+        postListModel.postId = postId
+        postListModel.date = date
+        return postListModel
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
@@ -1,0 +1,82 @@
+package org.wordpress.android.fluxc.utils
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.wordpress.android.fluxc.model.ListModel
+import org.wordpress.android.fluxc.model.ListModel.ListType
+import org.wordpress.android.fluxc.model.PostListModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.ListSqlUtils
+import org.wordpress.android.fluxc.persistence.PostListSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(RobolectricTestRunner::class)
+class PostListSqlUtilsTest {
+    private lateinit var listSqlUtils: ListSqlUtils
+    private lateinit var postListSqlUtils: PostListSqlUtils
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = WellSqlConfig(appContext)
+        WellSql.init(config)
+        config.reset()
+
+        listSqlUtils = ListSqlUtils()
+        postListSqlUtils = PostListSqlUtils()
+    }
+
+    @Test
+    fun testInsertOrUpdatePostList() {
+        /**
+         * 1. Since a [PostListModel] requires a [ListModel] in the DB due to the foreign key restriction, a test list
+         * will be inserted in the DB.
+         * 2. A list of test [PostListModel]s will be generated and inserted in the DB
+         */
+        val postCount = 20
+        val testList = insertTestList()
+        val postList = generatePostList(testList, postCount)
+        postListSqlUtils.insertPostList(postList)
+
+        /**
+         * Verify that the [PostListModel] instances are inserted correctly
+         */
+        assertEquals(postListSqlUtils.getPostList(testList.id)?.size, postCount)
+    }
+
+    /**
+     * Creates and inserts a [ListModel] for a random test site. It also verifies that the list is inserted correctly.
+     */
+    private fun insertTestList(): ListModel {
+        val testSite = SiteModel()
+        testSite.id = 123
+        val listType = ListType.POSTS_ALL
+        listSqlUtils.insertOrUpdateList(testSite, listType)
+        val list = listSqlUtils.getList(testSite, listType)
+        assertNotNull(list)
+        return list!!
+    }
+
+    /**
+     * Helper function that creates a list of [PostListModel] to be used in tests.
+     * The [PostListModel.date] will be the same date for all [PostListModel]s.
+     */
+    private fun generatePostList(listModel: ListModel, count: Int): List<PostListModel> {
+        val postList = ArrayList<PostListModel>()
+        val testDate = "1955-11-05T14:15:00Z"
+        (1..count).forEach { index ->
+            val postListModel = PostListModel()
+            postListModel.listId = listModel.id
+            postListModel.postId = index
+            postListModel.date = testDate
+            postList.add(postListModel)
+        }
+        return postList
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
@@ -47,7 +47,7 @@ class PostListSqlUtilsTest {
          */
         val testList = insertTestList(testSite, listType)
         val postList = generatePostList(testList, postCount)
-        postListSqlUtils.insertPostList(testList.id, postList)
+        postListSqlUtils.insertPostList(postList)
         assertEquals(postCount, postListSqlUtils.getPostList(testList.id)?.size)
     }
 
@@ -66,7 +66,7 @@ class PostListSqlUtilsTest {
          */
         val testList = insertTestList(testSite, listType)
         val postList = generatePostList(testList, postCount)
-        postListSqlUtils.insertPostList(testList.id, postList)
+        postListSqlUtils.insertPostList(postList)
         assertEquals(postCount, postListSqlUtils.getPostList(testList.id)?.size)
 
         /**
@@ -89,8 +89,9 @@ class PostListSqlUtilsTest {
          * 3. Verify that the [PostListModel] was inserted correctly
          */
         val testLists = ListType.values().map { insertTestList(testSite, it) }
+        val postList = testLists.map { generatePostListModel(it.id, testPostId) }
+        postListSqlUtils.insertPostList(postList)
         testLists.forEach { list ->
-            postListSqlUtils.insertPostList(list.id, arrayListOf(generatePostListModel(list.id, testPostId)))
             assertEquals(1, postListSqlUtils.getPostList(list.id)?.size)
         }
 
@@ -121,7 +122,7 @@ class PostListSqlUtilsTest {
          */
         val testList = insertTestList(testSite, listType)
         val postListModel = generatePostListModel(testList.id, testPostId, date1)
-        postListSqlUtils.insertPostList(testList.id, arrayListOf(postListModel))
+        postListSqlUtils.insertPostList(arrayListOf(postListModel))
         val insertedPostList = postListSqlUtils.getPostList(testList.id)
         assertEquals(date1, insertedPostList?.firstOrNull()?.date)
 
@@ -132,7 +133,7 @@ class PostListSqlUtilsTest {
          * 4. Verify that the `date` is correctly updated after the second insertion.
          */
         postListModel.date = date2
-        postListSqlUtils.insertPostList(testList.id, arrayListOf(postListModel))
+        postListSqlUtils.insertPostList(arrayListOf(postListModel))
         val updatedPostList = postListSqlUtils.getPostList(testList.id)
         assertEquals(insertedPostList?.size, updatedPostList?.size)
         assertEquals(date2, updatedPostList?.firstOrNull()?.date)

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
@@ -34,31 +34,55 @@ class PostListSqlUtilsTest {
 
     @Test
     fun testInsertOrUpdatePostList() {
+        val testSite = SiteModel()
+        testSite.id = 123
+        val postCount = 20
+        val listType = ListType.POSTS_ALL
+
         /**
          * 1. Since a [PostListModel] requires a [ListModel] in the DB due to the foreign key restriction, a test list
          * will be inserted in the DB.
          * 2. A list of test [PostListModel]s will be generated and inserted in the DB
+         * 3. Verify that the [PostListModel] instances are inserted correctly
          */
-        val postCount = 20
-        val testList = insertTestList()
+        val testList = insertTestList(testSite, listType)
         val postList = generatePostList(testList, postCount)
         postListSqlUtils.insertPostList(postList)
+        assertEquals(postListSqlUtils.getPostList(testList.id)?.size, postCount)
+    }
+
+    @Test
+    fun testDeletePostList() {
+        val testSite = SiteModel()
+        testSite.id = 123
+        val listType = ListType.POSTS_ALL
+        val postCount = 20
 
         /**
-         * Verify that the [PostListModel] instances are inserted correctly
+         * 1. Since a [PostListModel] requires a [ListModel] in the DB due to the foreign key restriction, a test list
+         * will be inserted in the DB.
+         * 2. A list of test [PostListModel]s will be generated and inserted in the DB
+         * 3. Verify that the [PostListModel] instances are inserted correctly
          */
+        val testList = insertTestList(testSite, listType)
+        val postList = generatePostList(testList, postCount)
+        postListSqlUtils.insertPostList(postList)
         assertEquals(postListSqlUtils.getPostList(testList.id)?.size, postCount)
+
+        /**
+         * 1. Delete the inserted list
+         * 2. Verify that deleting the list also deletes the inserted [PostListModel]s due to foreign key restriction
+         */
+        listSqlUtils.deleteList(testSite, listType)
+        assertEquals(postListSqlUtils.getPostList(testList.id)?.size, 0)
     }
 
     /**
      * Creates and inserts a [ListModel] for a random test site. It also verifies that the list is inserted correctly.
      */
-    private fun insertTestList(): ListModel {
-        val testSite = SiteModel()
-        testSite.id = 123
-        val listType = ListType.POSTS_ALL
-        listSqlUtils.insertOrUpdateList(testSite, listType)
-        val list = listSqlUtils.getList(testSite, listType)
+    private fun insertTestList(siteModel: SiteModel, listType: ListType): ListModel {
+        listSqlUtils.insertOrUpdateList(siteModel, listType)
+        val list = listSqlUtils.getList(siteModel, listType)
         assertNotNull(list)
         return list!!
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
@@ -47,7 +47,7 @@ class PostListSqlUtilsTest {
          */
         val testList = insertTestList(testSite, listType)
         val postList = generatePostList(testList, postCount)
-        postListSqlUtils.insertPostList(postList)
+        postListSqlUtils.insertPostList(testList.id, postList)
         assertEquals(postListSqlUtils.getPostList(testList.id)?.size, postCount)
     }
 
@@ -66,7 +66,7 @@ class PostListSqlUtilsTest {
          */
         val testList = insertTestList(testSite, listType)
         val postList = generatePostList(testList, postCount)
-        postListSqlUtils.insertPostList(postList)
+        postListSqlUtils.insertPostList(testList.id, postList)
         assertEquals(postListSqlUtils.getPostList(testList.id)?.size, postCount)
 
         /**
@@ -89,10 +89,9 @@ class PostListSqlUtilsTest {
          * 3. Verify that the [PostListModel] was inserted correctly
          */
         val testLists = ListType.values().map { insertTestList(testSite, it) }
-        val postList = testLists.map { generatePostListModel(it.id, testPostId) }
-        postListSqlUtils.insertPostList(postList)
-        testLists.forEach {
-            assertEquals(postListSqlUtils.getPostList(it.id)?.size, 1)
+        testLists.forEach { list ->
+            postListSqlUtils.insertPostList(list.id, arrayListOf(generatePostListModel(list.id, testPostId)))
+            assertEquals(postListSqlUtils.getPostList(list.id)?.size, 1)
         }
 
         /**

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
@@ -48,7 +48,7 @@ class PostListSqlUtilsTest {
         val testList = insertTestList(testSite, listType)
         val postList = generatePostList(testList, postCount)
         postListSqlUtils.insertPostList(testList.id, postList)
-        assertEquals(postListSqlUtils.getPostList(testList.id)?.size, postCount)
+        assertEquals(postCount, postListSqlUtils.getPostList(testList.id)?.size)
     }
 
     @Test
@@ -67,14 +67,14 @@ class PostListSqlUtilsTest {
         val testList = insertTestList(testSite, listType)
         val postList = generatePostList(testList, postCount)
         postListSqlUtils.insertPostList(testList.id, postList)
-        assertEquals(postListSqlUtils.getPostList(testList.id)?.size, postCount)
+        assertEquals(postCount, postListSqlUtils.getPostList(testList.id)?.size)
 
         /**
          * 1. Delete the inserted list
          * 2. Verify that deleting the list also deletes the inserted [PostListModel]s due to foreign key restriction
          */
         listSqlUtils.deleteList(testSite, listType)
-        assertEquals(postListSqlUtils.getPostList(testList.id)?.size, 0)
+        assertEquals(0, postListSqlUtils.getPostList(testList.id)?.size)
     }
 
     @Test
@@ -91,7 +91,7 @@ class PostListSqlUtilsTest {
         val testLists = ListType.values().map { insertTestList(testSite, it) }
         testLists.forEach { list ->
             postListSqlUtils.insertPostList(list.id, arrayListOf(generatePostListModel(list.id, testPostId)))
-            assertEquals(postListSqlUtils.getPostList(list.id)?.size, 1)
+            assertEquals(1, postListSqlUtils.getPostList(list.id)?.size)
         }
 
         /**
@@ -100,7 +100,7 @@ class PostListSqlUtilsTest {
          */
         postListSqlUtils.deletePost(testPostId)
         testLists.forEach {
-            assertEquals(postListSqlUtils.getPostList(it.id)?.size, 0)
+            assertEquals(0, postListSqlUtils.getPostList(it.id)?.size)
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ListModel.kt
@@ -10,7 +10,8 @@ import com.yarolegovich.wellsql.core.annotation.Table
 @RawConstraints("UNIQUE (type)")
 class ListModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     enum class ListType(val value: String) {
-        POSTS_ALL("posts_all");
+        POSTS_ALL("posts_all"),
+        POSTS_SCHEDULED("post_scheduled"); // only added for test purposes (for now)
     }
 
     @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ListModel.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
+import com.yarolegovich.wellsql.core.annotation.Table
+
+@Table
+@RawConstraints("UNIQUE (type)")
+class ListModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    enum class ListType(val value: String) {
+        POSTS_ALL("posts_all");
+    }
+
+    @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    @Column var lastModified: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    @Column var localSiteId: Int = 0
+    @Column var type: String? = null
+
+    override fun getId(): Int = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ListModel.kt
@@ -7,7 +7,7 @@ import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 
 @Table
-@RawConstraints("UNIQUE (type)")
+@RawConstraints("UNIQUE(LOCAL_SITE_ID, TYPE)")
 class ListModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     enum class ListType(val value: String) {
         POSTS_ALL("posts_all"),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostListModel.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
+import com.yarolegovich.wellsql.core.annotation.Table
+
+@Table
+@RawConstraints("FOREIGN KEY(LIST_ID) REFERENCES ListModel(_id) ON DELETE CASCADE")
+class PostListModel(@PrimaryKey @Column private var id: Int = 0): Identifiable {
+    @Column var listId: Int = 0
+    @Column var postId: Int = 0
+    @Column var date: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+
+    override fun getId(): Int = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostListModel.kt
@@ -7,7 +7,10 @@ import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 
 @Table
-@RawConstraints("FOREIGN KEY(LIST_ID) REFERENCES ListModel(_id) ON DELETE CASCADE")
+@RawConstraints(
+        "FOREIGN KEY(LIST_ID) REFERENCES ListModel(_id) ON DELETE CASCADE",
+        "UNIQUE(LIST_ID, POST_ID)"
+)
 class PostListModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var listId: Int = 0
     @Column var postId: Int = 0

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostListModel.kt
@@ -8,7 +8,7 @@ import com.yarolegovich.wellsql.core.annotation.Table
 
 @Table
 @RawConstraints("FOREIGN KEY(LIST_ID) REFERENCES ListModel(_id) ON DELETE CASCADE")
-class PostListModel(@PrimaryKey @Column private var id: Int = 0): Identifiable {
+class PostListModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var listId: Int = 0
     @Column var postId: Int = 0
     @Column var date: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
@@ -35,8 +35,7 @@ class ListSqlUtils @Inject constructor() {
         }
     }
 
-    fun getList(siteModel: SiteModel, type: ListType?): ListModel? {
-        if (type == null) return null
+    fun getList(siteModel: SiteModel, type: ListType): ListModel? {
         return WellSql.select(ListModel::class.java)
                 .where()
                 .equals(ListModelTable.LOCAL_SITE_ID, siteModel.id)
@@ -44,5 +43,12 @@ class ListSqlUtils @Inject constructor() {
                 .endWhere()
                 .asModel
                 .firstOrNull()
+    }
+
+    fun deleteList(siteModel: SiteModel, type: ListType) {
+        val existing = getList(siteModel, type)
+        existing?.let {
+            WellSql.delete(ListModel::class.java).whereId(it.id)
+        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.ListModelTable
+import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.ListModel
+import org.wordpress.android.fluxc.model.ListModel.ListType
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ListSqlUtils @Inject constructor() {
+    fun insertOrUpdateList(siteModel: SiteModel, listType: ListType) {
+        val now = DateTimeUtils.iso8601FromDate(Date())
+        val listModel = ListModel()
+        listModel.type = listType.value
+        listModel.localSiteId = siteModel.id
+        listModel.lastModified = now
+        val existing = getList(siteModel, listType)
+        if (existing != null) {
+            listModel.dateCreated = existing.dateCreated
+            WellSql.update(ListModel::class.java)
+                    .whereId(existing.id)
+                    .put(listModel, UpdateAllExceptId<ListModel>(ListModel::class.java))
+                    .execute()
+        } else {
+            listModel.dateCreated = now
+            WellSql.insert(listModel).execute()
+        }
+    }
+
+    fun getList(siteModel: SiteModel, type: ListType?): ListModel? {
+        if (type == null) return null
+        return WellSql.select(ListModel::class.java)
+                .where()
+                .equals(ListModelTable.LOCAL_SITE_ID, siteModel.id)
+                .equals(ListModelTable.TYPE, type.value)
+                .endWhere()
+                .asModel
+                .firstOrNull()
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
@@ -13,6 +13,13 @@ import javax.inject.Singleton
 
 @Singleton
 class ListSqlUtils @Inject constructor() {
+    /**
+     * This function either creates a new [ListModel] for the [siteModel] and [listType] or updates the existing record.
+     *
+     * If there is an existing record, only the [ListModel.lastModified] will be updated with the current [Date].
+     * If there is no existing record, a new [ListModel] will be created for [siteModel] and [listType]. The current
+     * [Date] will be assigned to both [ListModel.dateCreated] and [ListModel.lastModified].
+     */
     fun insertOrUpdateList(siteModel: SiteModel, listType: ListType) {
         val now = DateTimeUtils.iso8601FromDate(Date())
         val listModel = ListModel()
@@ -35,6 +42,11 @@ class ListSqlUtils @Inject constructor() {
         }
     }
 
+    /**
+     * This function returns the [ListModel] record for the given [siteModel] and [type] if there is one.
+     *
+     * Since there shouldn't be more than one record for a [siteModel] and [type] combination, [firstOrNull] is used.
+     */
     fun getList(siteModel: SiteModel, type: ListType): ListModel? {
         return WellSql.select(ListModel::class.java)
                 .where()
@@ -45,6 +57,11 @@ class ListSqlUtils @Inject constructor() {
                 .firstOrNull()
     }
 
+    /**
+     * This function deletes the [ListModel] record for the given [siteModel] and [type] if there is one.
+     *
+     * To ensure that we have the same `where` queries for both `select` and `delete` queries, [getList] is utilized.
+     */
     fun deleteList(siteModel: SiteModel, type: ListType) {
         val existing = getList(siteModel, type)
         existing?.let {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.PostListModelTable
+import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.PostListModel
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PostListSqlUtils @Inject constructor() {
+    fun insertPostList(postList: List<PostListModel>) {
+        for (postListModel in postList) {
+            WellSql.delete(PostListModel::class.java)
+                    .where()
+                    .equals(PostListModelTable.LIST_ID, postListModel.listId)
+                    .equals(PostListModelTable.POST_ID, postListModel.postId)
+                    .endWhere()
+                    .execute()
+        }
+        WellSql.insert(postList).asSingleTransaction(true).execute()
+    }
+
+    fun getPostList(listId: Int): List<PostListModel>? =
+            WellSql.select(PostListModel::class.java)
+                    .where()
+                    .equals(PostListModelTable.LIST_ID, listId)
+                    .endWhere()
+                    .asModel
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
@@ -8,6 +8,11 @@ import javax.inject.Singleton
 
 @Singleton
 class PostListSqlUtils @Inject constructor() {
+    /**
+     * This function inserts the [postList] in the [PostListModelTable].
+     *
+     * To avoid duplicate rows, it'll first delete the existing records for [postList].
+     */
     fun insertPostList(postList: List<PostListModel>) {
         for (postListModel in postList) {
             WellSql.delete(PostListModel::class.java)
@@ -20,6 +25,9 @@ class PostListSqlUtils @Inject constructor() {
         WellSql.insert(postList).asSingleTransaction(true).execute()
     }
 
+    /**
+     * This function returns a list of [PostListModel] records for the given [listId].
+     */
     fun getPostList(listId: Int): List<PostListModel>? =
             WellSql.select(PostListModel::class.java)
                     .where()
@@ -27,6 +35,9 @@ class PostListSqlUtils @Inject constructor() {
                     .endWhere()
                     .asModel
 
+    /**
+     * This function deletes every [PostListModel] record for the given [postId].
+     */
     fun deletePost(postId: Int) {
         WellSql.delete(PostListModel::class.java)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
@@ -26,4 +26,12 @@ class PostListSqlUtils @Inject constructor() {
                     .equals(PostListModelTable.LIST_ID, listId)
                     .endWhere()
                     .asModel
+
+    fun deletePost(postId: Int) {
+        WellSql.delete(PostListModel::class.java)
+                .where()
+                .equals(PostListModelTable.POST_ID, postId)
+                .endWhere()
+                .execute()
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
@@ -24,7 +24,7 @@ class PostListSqlUtils @Inject constructor() {
         WellSql.delete(PostListModel::class.java)
                 .where()
                 .equals(PostListModelTable.LIST_ID, listId)
-                .isIn(PostListModelTable.POST_ID,postIds)
+                .isIn(PostListModelTable.POST_ID, postIds)
                 .endWhere()
                 .execute()
         WellSql.insert(postList).asSingleTransaction(true).execute()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
@@ -9,19 +9,24 @@ import javax.inject.Singleton
 @Singleton
 class PostListSqlUtils @Inject constructor() {
     /**
-     * This function inserts the [postList] in the [PostListModelTable].
+     * This function inserts the [postList] for a [listId] in the [PostListModelTable]. Every post in the [postList]
+     * needs to have the same [PostListModel.listId] as the passed in [listId].
      *
      * To avoid duplicate rows, it'll first delete the existing records for [postList].
+     *
+     * The [listId] parameter is passed in to optimize the delete query. If it's not passed in, we'd need to run
+     * several `delete` queries for different [PostListModel.listId] & [PostListModel.postId] combinations. Since this
+     * function is intended to be used for inserting a set of [PostListModel]s for a single list, this is a nice
+     * optimization especially when the post list gets larger.
      */
-    fun insertPostList(postList: List<PostListModel>) {
-        for (postListModel in postList) {
-            WellSql.delete(PostListModel::class.java)
-                    .where()
-                    .equals(PostListModelTable.LIST_ID, postListModel.listId)
-                    .equals(PostListModelTable.POST_ID, postListModel.postId)
-                    .endWhere()
-                    .execute()
-        }
+    fun insertPostList(listId: Int, postList: List<PostListModel>) {
+        val postIds = postList.map { it.postId }
+        WellSql.delete(PostListModel::class.java)
+                .where()
+                .equals(PostListModelTable.LIST_ID, listId)
+                .isIn(PostListModelTable.POST_ID,postIds)
+                .endWhere()
+                .execute()
         WellSql.insert(postList).asSingleTransaction(true).execute()
     }
 


### PR DESCRIPTION
Fixes #839 & #840. This PR is a part of the post pagination project in which we are separating the post list information from the actual post objects. It adds a slightly modified version of the following DB schema:

<img width="460" alt="post pagination db" src="https://user-images.githubusercontent.com/662023/42597187-f35df7f4-8525-11e8-9970-9059eecc867f.png">

It also adds `ListSqlUtils` & `PostListSqlUtils` with some of the queries that are planned to be used as part of the post pagination project. All the queries are tested in `ListSqlUtilsTest` & `PostListSqlUtilsTest`. It's possible that small modifications might be made to the changes in this PR at a later time when they are put into use as in this PR I tried to focus on what's necessary for the foundation of the feature.

P.S: The PR targets a WIP branch. I'd prefer to keep the changes in the WIP branch until we reflect them in WPAndroid. Even though this PR has no breaking changes since it's all addition, the subsequent PRs will be breaking the current posts feature.