### PR TITLE
Introduced FETCH_PLANS action in SiteStore

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated;
+import org.wordpress.android.fluxc.store.SiteStore.OnPlanFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnProfileFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteDeleted;
@@ -111,6 +112,15 @@ public class SitesFragment extends Fragment {
             }
         });
 
+        view.findViewById(R.id.fetch_plans).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SiteModel site = mSiteStore.getSites().get(0);
+                // Export site
+                mDispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site));
+            }
+        });
+
         return view;
     }
 
@@ -193,6 +203,16 @@ public class SitesFragment extends Fragment {
             prependToLog("Export Site: error: " + event.error.type);
         } else {
             prependToLog("Export Site: success!");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onPlanFetched(OnPlanFetched event) {
+        if (event.isError()) {
+            prependToLog("Fetch Plans: error: " + event.error.type);
+        } else {
+            prependToLog("Fetch Plans: success, " + event.plans.size() + " Plans fetched");
         }
     }
 

--- a/example/src/main/res/layout/fragment_sites.xml
+++ b/example/src/main/res/layout/fragment_sites.xml
@@ -47,4 +47,9 @@
         android:layout_height="wrap_content"
         android:text="⚠️️ Delete First Site ⚠️️" />
 
+    <Button
+        android:id="@+id/fetch_plans"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch First Site Plans" />
 </LinearLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSit
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferStatusResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferPayload;
@@ -57,6 +58,8 @@ public enum SiteAction implements IAction {
     INITIATE_AUTOMATED_TRANSFER,
     @Action(payloadType = SiteModel.class)
     CHECK_AUTOMATED_TRANSFER_STATUS,
+    @Action(payloadType = SiteModel.class)
+    FETCH_PLANS,
 
     // Remote responses
     @Action(payloadType = SiteModel.class)
@@ -85,6 +88,8 @@ public enum SiteAction implements IAction {
     INITIATED_AUTOMATED_TRANSFER,
     @Action(payloadType = AutomatedTransferStatusResponsePayload.class)
     CHECKED_AUTOMATED_TRANSFER_STATUS,
+    @Action(payloadType = FetchedPlansPayload.class)
+    FETCHED_PLANS,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PlanModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PlanModel.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.fluxc.model
+
+class PlanModel {
+    var id: String? = null
+    var slug: String? = null
+    var name: String? = null
+    var isCurrentPlan: Boolean = false
+    var hasDomainCredit: Boolean = false
+    override fun toString(): String {
+        return "PlanModel(id=$id, slug=$slug, name=$name, isCurrentPlan=$isCurrentPlan, hasDomainCredit=$hasDomainCredit)"
+    }
+
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PlansModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PlansModel.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.model
+
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.network.BaseRequest
+import java.util.ArrayList
+
+class PlansModel : Payload<BaseRequest.BaseNetworkError> {
+    var sites: List<PlanModel>? = null
+
+    constructor() {
+        sites = ArrayList()
+    }
+
+    constructor(sites: List<PlanModel>) {
+        this.sites = sites
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/PlansResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/PlansResponse.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site
+
+import com.google.gson.Gson
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import com.google.gson.annotations.JsonAdapter
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
+import java.lang.reflect.Type
+
+@JsonAdapter(PlansDeserializer::class)
+class PlansResponse {
+    var plansMap: Map<Long, Plan>? = emptyMap()
+
+    inner class Plan {
+        var id: String? = null
+        var interval: Long = 0
+        @SerializedName("formatted_original_price")
+        var formattedOriginalPrice: String? = null
+        @SerializedName("raw_price")
+        var rawPrice: Long = 0
+        @SerializedName("formatted_price")
+        var formattedPrice: String? = null
+        @SerializedName("raw_discount")
+        var rawDiscount: Long = 0
+        @SerializedName("formatted_discount")
+        var formattedDiscount: String? = null
+        @SerializedName("product_slug")
+        var productSlug: String? = null
+        @SerializedName("product_name")
+        var productName: String? = null
+        @SerializedName("discount_reason")
+        var discountReason: String? = null
+        @SerializedName("is_domain_upgrade")
+        var isDomainUpgrade: String? = null
+        @SerializedName("currency_code")
+        var currencyCode: String? = null
+        @SerializedName("user_is_owner")
+        var userIsOwner: String? = null
+        @SerializedName("current_plan")
+        var currentPlan: Boolean = false
+        @SerializedName("has_domain_credit")
+        var hasDomainCredit: Boolean = false
+    }
+}
+internal class PlansDeserializer : JsonDeserializer<PlansResponse> {
+    @Throws(JsonParseException::class)
+    override fun deserialize(
+            json: JsonElement,
+            typeOfT: Type,
+            context: JsonDeserializationContext): PlansResponse {
+        val response = PlansResponse()
+        val tokenType = object : TypeToken<Map<Long, PlansResponse.Plan>>() {}.type
+        response.plansMap = Gson().fromJson<Map<Long, PlansResponse.Plan>>(json, tokenType)
+        return response
+    }
+}

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -53,6 +53,8 @@
 /sites/$site/media/$media_ID/delete/
 /sites/$site/media/new/
 
+/sites/$site/plans/
+
 /sites/$site/plugins
 /sites/$site/plugins/$name#String
 /sites/$site/plugins/$name#String/delete


### PR DESCRIPTION
This is first step for implementing a feature which allows user to [associate a custom domain](https://github.com/wordpress-mobile/WordPress-Android/issues/7923).

The user can associate a custom domain only if he/she has a 'domain credit' in his current plan.
This change introduces fetch plans action into SiteStore, from which the app can fetch all the plans of the user and then take a decision on whether he has a 'domain credit' in his active/current plan.
 
This response model is _not_ saved/cached into FluxC's DB (at least for now), this is to make sure that the user has a 'domain credit' **now**  as opposed to in the past (since the user might have spent it outside the app) 

This also includes a android test case to validate the action and also includes a 'Fetch plans for first site' in the example application to manually test out the action.