### PR TITLE
Fetch/pull orders filtered by a single order status

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -73,7 +73,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         val firstFetchOrders = orderStore.getOrdersForSite(sSite)
-        val isValid = firstFetchOrders.stream().allMatch { it -> it.status == statusFilter }
+        val isValid = firstFetchOrders.stream().allMatch { it.status == statusFilter }
         assertTrue(firstFetchOrders.isNotEmpty() &&
                 firstFetchOrders.size <= WCOrderStore.NUM_ORDERS_PER_FETCH && isValid)
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -53,7 +53,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.FETCHED_ORDERS
         mCountDownLatch = CountDownLatch(1)
 
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, false)))
+        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, loadMore = false)))
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
@@ -69,7 +69,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
         val statusFilter = "completed"
 
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, false, statusFilter)))
+        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, statusFilter, false)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         val firstFetchOrders = orderStore.getOrdersForSite(sSite)
@@ -84,7 +84,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         // Grab a list of orders
         nextEvent = TestEvent.FETCHED_ORDERS
         mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, false)))
+        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, loadMore = false)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         // Fetch notes for the first order returned

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -64,6 +64,22 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
 
     @Throws(InterruptedException::class)
     @Test
+    fun testFetchOrdersByStatus() {
+        nextEvent = TestEvent.FETCHED_ORDERS
+        mCountDownLatch = CountDownLatch(1)
+        val statusFilter = "completed"
+
+        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, false, statusFilter)))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        val firstFetchOrders = orderStore.getOrdersForSite(sSite)
+        val isValid = firstFetchOrders.stream().allMatch { it -> it.status == statusFilter }
+        assertTrue(firstFetchOrders.isNotEmpty() &&
+                firstFetchOrders.size <= WCOrderStore.NUM_ORDERS_PER_FETCH && isValid)
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
     fun testFetchOrderNotes() {
         // Grab a list of orders
         nextEvent = TestEvent.FETCHED_ORDERS

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
@@ -100,7 +101,7 @@ class WooCommerceFragment : Fragment() {
             getFirstWCSite()?.let { site ->
                 prependToLog("Submitting request to fetch only completed orders from the api")
                 pendingFetchCompletedOrders = true
-                val payload = FetchOrdersPayload(site, loadMore = false, statusFilter = "completed")
+                val payload = FetchOrdersPayload(site, loadMore = false, statusFilter = OrderStatus.COMPLETED)
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
             }
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -88,6 +88,8 @@ class WooCommerceFragment : Fragment() {
                         prependToLog("Submitting request to fetch " +
                                 "orders matching the following statuses $pendingFetchOrdersFilter")
                     }
+                    // First fetch orders from the API to seed the database with data before attempting to pull
+                    // orders by order status.
                     val payload = FetchOrdersPayload(site, loadMore = false)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
                 }
@@ -98,7 +100,7 @@ class WooCommerceFragment : Fragment() {
             getFirstWCSite()?.let { site ->
                 prependToLog("Submitting request to fetch only completed orders from the api")
                 pendingFetchCompletedOrders = true
-                val payload = FetchOrdersPayload(site, loadMore = false, status = "completed")
+                val payload = FetchOrdersPayload(site, loadMore = false, statusFilter = "completed")
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
             }
         }

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -25,6 +25,12 @@
         android:text="@string/wc_fetch_orders_by_status"/>
 
     <Button
+        android:id="@+id/fetch_orders_by_status_api"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch Completed Orders (API)"/>
+
+    <Button
         android:id="@+id/fetch_order_notes"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -22,7 +22,7 @@
         android:id="@+id/fetch_orders_by_status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/wc_fetch_orders_by_status"/>
+        android:text="Load Orders Filtered By Status (DB)"/>
 
     <Button
         android:id="@+id/fetch_orders_by_status_api"

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -19,6 +19,12 @@
         android:text="Fetch Orders" />
 
     <Button
+        android:id="@+id/fetch_orders_by_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/wc_fetch_orders_by_status"/>
+
+    <Button
         android:id="@+id/fetch_order_notes"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="wc_fetch_orders_by_status">Fetch Orders By Status</string>
 </resources>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -3,5 +3,4 @@
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
-    <string name="wc_fetch_orders_by_status">Load Orders Filtered By Status (DB)</string>
 </resources>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
-    <string name="wc_fetch_orders_by_status">Fetch Orders By Status</string>
+    <string name="wc_fetch_orders_by_status">Load Orders Filtered By Status (DB)</string>
 </resources>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -43,12 +43,13 @@ class OrderRestClient(
      *
      * Dispatches a [WCOrderAction.FETCHED_ORDERS] action with the resulting list of orders.
      */
-    fun fetchOrders(site: SiteModel, offset: Int) {
+    fun fetchOrders(site: SiteModel, offset: Int, status: String = "any") {
         val url = WOOCOMMERCE.orders.pathV2
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
         val params = mapOf(
                 "per_page" to WCOrderStore.NUM_ORDERS_PER_FETCH.toString(),
-                "offset" to offset.toString())
+                "offset" to offset.toString(),
+                "status" to status)
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderApiResponse>? ->
                     val orderModels = response?.map {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -42,6 +42,8 @@ class OrderRestClient(
      * orders is done by passing an [offset].
      *
      * Dispatches a [WCOrderAction.FETCHED_ORDERS] action with the resulting list of orders.
+     *
+     * @param [status] Filter by a single order status. Default to the API default of "any".
      */
     fun fetchOrders(site: SiteModel, offset: Int, status: String = "any") {
         val url = WOOCOMMERCE.orders.pathV2

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -33,7 +33,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     class FetchOrdersPayload(
         var site: SiteModel,
-        var loadMore: Boolean = false
+        var loadMore: Boolean = false,
+        var status: String = "any"
     ) : Payload<BaseNetworkError>()
 
     class FetchOrdersResponsePayload(
@@ -149,7 +150,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         } else {
             0
         }
-        wcOrderRestClient.fetchOrders(payload.site, offset)
+        wcOrderRestClient.fetchOrders(payload.site, offset, payload.status)
     }
 
     private fun updateOrderStatus(payload: UpdateOrderStatusPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -33,13 +33,14 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     class FetchOrdersPayload(
         var site: SiteModel,
-        var loadMore: Boolean = false,
-        var status: String = "any"
+        var statusFilter: String? = null,
+        var loadMore: Boolean = false
     ) : Payload<BaseNetworkError>()
 
     class FetchOrdersResponsePayload(
         var site: SiteModel,
         var orders: List<WCOrderModel> = emptyList(),
+        var statusFilter: String? = null,
         var loadedMore: Boolean = false,
         var canLoadMore: Boolean = false
     ) : Payload<OrderError>() {
@@ -101,7 +102,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     // OnChanged events
-    class OnOrderChanged(var rowsAffected: Int, var canLoadMore: Boolean = false) : OnChanged<OrderError>() {
+    class OnOrderChanged(var rowsAffected: Int, var statusFilter: String? = null, var canLoadMore: Boolean = false)
+        : OnChanged<OrderError>() {
         var causeOfChange: WCOrderAction? = null
     }
 
@@ -150,7 +152,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         } else {
             0
         }
-        wcOrderRestClient.fetchOrders(payload.site, offset, payload.status)
+        wcOrderRestClient.fetchOrders(payload.site, offset, payload.statusFilter)
     }
 
     private fun updateOrderStatus(payload: UpdateOrderStatusPayload) {
@@ -181,7 +183,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
             val rowsAffected = payload.orders.sumBy { OrderSqlUtils.insertOrUpdateOrder(it) }
 
-            onOrderChanged = OnOrderChanged(rowsAffected, payload.canLoadMore)
+            onOrderChanged = OnOrderChanged(rowsAffected, payload.statusFilter, payload.canLoadMore)
         }
 
         onOrderChanged.causeOfChange = WCOrderAction.FETCH_ORDERS


### PR DESCRIPTION
This PR adds an additional example to the Woo Fragment for testing fetching orders by one or more order status. A new button can now be found on the Woo screen labeled `FETCH ORDERS BY STATUS`. This will launch a simple text input dialog where a comma-separated list of order statuses may be entered. Upon submission logic will trim each entry and discard any empty items. If no valid filters are entered, all orders will be fetched without a filter. If one or more valid filters are entered, the results will be displayed to the log showing a count for each filter fetched.

![screenshot_1532452830](https://user-images.githubusercontent.com/5810477/43155379-7eb16cba-8f34-11e8-88d6-cd6973add5f3.png) ![screenshot_1532452837_small](https://user-images.githubusercontent.com/5810477/43155356-6b00087a-8f34-11e8-93e8-07e9ccc1ac93.png)
