### PR TITLE
Improvements to DB layer of ListModel and PostListModel 

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/ListSqlUtilsTest.kt
@@ -42,8 +42,8 @@ class ListSqlUtilsTest {
          * 3. Verify the `localSiteId` value
          * 4. Verify that `dateCreated` and `lastModified` are equal since this is the first time it's created
          */
-        listSqlUtils.insertOrUpdateList(testSite, listType)
-        val insertedList = listSqlUtils.getList(testSite, listType)
+        listSqlUtils.insertOrUpdateList(testSite.id, listType)
+        val insertedList = listSqlUtils.getList(testSite.id, listType)
         assertNotNull(insertedList)
         assertEquals(testSite.id, insertedList?.localSiteId)
         assertEquals(insertedList?.dateCreated, insertedList?.lastModified)
@@ -56,8 +56,8 @@ class ListSqlUtilsTest {
          * 5. Verify the `dateCreated` and `lastModified` values are different since this is an update. (See point 1)
          */
         Thread.sleep(1000)
-        listSqlUtils.insertOrUpdateList(testSite, listType)
-        val updatedList = listSqlUtils.getList(testSite, listType)
+        listSqlUtils.insertOrUpdateList(testSite.id, listType)
+        val updatedList = listSqlUtils.getList(testSite.id, listType)
         assertNotNull(updatedList)
         assertEquals(testSite.id, updatedList?.localSiteId)
         assertNotEquals(updatedList?.dateCreated, updatedList?.lastModified)
@@ -78,14 +78,14 @@ class ListSqlUtilsTest {
          * 1. Insert a test list
          * 2. Verify that the list is inserted correctly
          */
-        listSqlUtils.insertOrUpdateList(testSite, listType)
-        assertNotNull(listSqlUtils.getList(testSite, listType))
+        listSqlUtils.insertOrUpdateList(testSite.id, listType)
+        assertNotNull(listSqlUtils.getList(testSite.id, listType))
 
         /**
          * 1. Delete the inserted test list
          * 2. Verify that the list is deleted correctly
          */
-        listSqlUtils.deleteList(testSite, listType)
-        assertNull(listSqlUtils.getList(testSite, listType))
+        listSqlUtils.deleteList(testSite.id, listType)
+        assertNull(listSqlUtils.getList(testSite.id, listType))
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
@@ -47,7 +47,7 @@ class PostListSqlUtilsTest {
          * 2. A list of test [PostListModel]s will be generated and inserted in the DB
          * 3. Verify that the [PostListModel] instances are inserted correctly
          */
-        val testList = insertTestList(testSite, listType)
+        val testList = insertTestList(testSite.id, listType)
         val postList = generatePostList(testList, testSite.id, postCount)
         postListSqlUtils.insertPostList(postList)
         assertEquals(postCount, postListSqlUtils.getPostList(testList.id)?.size)
@@ -65,7 +65,7 @@ class PostListSqlUtilsTest {
          * 2. A list of test [PostListModel]s will be generated and inserted in the DB
          * 3. Verify that the [PostListModel] instances are inserted correctly
          */
-        val testList = insertTestList(testSite, listType)
+        val testList = insertTestList(testSite.id, listType)
         val postList = generatePostList(testList, testSite.id, postCount)
         postListSqlUtils.insertPostList(postList)
         assertEquals(postCount, postListSqlUtils.getPostList(testList.id)?.size)
@@ -74,7 +74,7 @@ class PostListSqlUtilsTest {
          * 1. Delete the inserted list
          * 2. Verify that deleting the list also deletes the inserted [PostListModel]s due to foreign key restriction
          */
-        listSqlUtils.deleteList(testSite, listType)
+        listSqlUtils.deleteList(testSite.id, listType)
         assertEquals(0, postListSqlUtils.getPostList(testList.id)?.size)
     }
 
@@ -88,7 +88,7 @@ class PostListSqlUtilsTest {
          * 2. Generate a [PostListModel] for every list type with the same id and insert it
          * 3. Verify that the [PostListModel] was inserted correctly
          */
-        val testLists = ListType.values().map { insertTestList(testSite, it) }
+        val testLists = ListType.values().map { insertTestList(testSite.id, it) }
         val postList = testLists.map { generatePostListModel(it.id, testSite.id, testPostId) }
         postListSqlUtils.insertPostList(postList)
         testLists.forEach { list ->
@@ -121,7 +121,7 @@ class PostListSqlUtilsTest {
         val testPostId = 1245 // value doesn't matter
         val listType = ListType.POSTS_ALL
 
-        val testLists = listOf(testSite1, testSite2).map { insertTestList(it, listType) }
+        val testLists = listOf(testSite1, testSite2).map { insertTestList(it.id, listType) }
         val postList = testLists.map {
             generatePostListModel(it.id, it.localSiteId, testPostId)
         }
@@ -161,7 +161,7 @@ class PostListSqlUtilsTest {
          * 2. Generate a [PostListModel] for `date1` and insert it in the DB
          * 3. Verify that it's inserted correctly and [PostListModel.date] equals to `date1`
          */
-        val testList = insertTestList(testSite, listType)
+        val testList = insertTestList(testSite.id, listType)
         val postListModel = generatePostListModel(testList.id, testSite.id, testPostId, date1)
         postListSqlUtils.insertPostList(listOf(postListModel))
         val insertedPostList = postListSqlUtils.getPostList(testList.id)
@@ -181,11 +181,11 @@ class PostListSqlUtilsTest {
     }
 
     /**
-     * Creates and inserts a [ListModel] for a random test site. It also verifies that the list is inserted correctly.
+     * Creates and inserts a [ListModel] for the given site. It also verifies that the list is inserted correctly.
      */
-    private fun insertTestList(siteModel: SiteModel, listType: ListType): ListModel {
-        listSqlUtils.insertOrUpdateList(siteModel, listType)
-        val list = listSqlUtils.getList(siteModel, listType)
+    private fun insertTestList(localSiteId: Int, listType: ListType): ListModel {
+        listSqlUtils.insertOrUpdateList(localSiteId, listType)
+        val list = listSqlUtils.getList(localSiteId, listType)
         assertNotNull(list)
         return list!!
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/PostListSqlUtilsTest.kt
@@ -50,7 +50,7 @@ class PostListSqlUtilsTest {
         val testList = insertTestList(testSite.id, listType)
         val postList = generatePostList(testList, testSite.id, postCount)
         postListSqlUtils.insertPostList(postList)
-        assertEquals(postCount, postListSqlUtils.getPostList(testList.id)?.size)
+        assertEquals(postCount, postListSqlUtils.getPostList(testList.id).size)
     }
 
     @Test
@@ -68,14 +68,14 @@ class PostListSqlUtilsTest {
         val testList = insertTestList(testSite.id, listType)
         val postList = generatePostList(testList, testSite.id, postCount)
         postListSqlUtils.insertPostList(postList)
-        assertEquals(postCount, postListSqlUtils.getPostList(testList.id)?.size)
+        assertEquals(postCount, postListSqlUtils.getPostList(testList.id).size)
 
         /**
          * 1. Delete the inserted list
          * 2. Verify that deleting the list also deletes the inserted [PostListModel]s due to foreign key restriction
          */
         listSqlUtils.deleteList(testSite.id, listType)
-        assertEquals(0, postListSqlUtils.getPostList(testList.id)?.size)
+        assertEquals(0, postListSqlUtils.getPostList(testList.id).size)
     }
 
     @Test
@@ -92,7 +92,7 @@ class PostListSqlUtilsTest {
         val postList = testLists.map { generatePostListModel(it.id, testSite.id, testPostId) }
         postListSqlUtils.insertPostList(postList)
         testLists.forEach { list ->
-            assertEquals(1, postListSqlUtils.getPostList(list.id)?.size)
+            assertEquals(1, postListSqlUtils.getPostList(list.id).size)
         }
 
         /**
@@ -101,7 +101,7 @@ class PostListSqlUtilsTest {
          */
         postListSqlUtils.deletePost(testSite.id, testPostId)
         testLists.forEach {
-            assertEquals(0, postListSqlUtils.getPostList(it.id)?.size)
+            assertEquals(0, postListSqlUtils.getPostList(it.id).size)
         }
     }
 
@@ -133,8 +133,8 @@ class PostListSqlUtilsTest {
          */
         testLists.forEach {
             val insertedPostList = postListSqlUtils.getPostList(it.id)
-            assertEquals(1, insertedPostList?.size)
-            assertEquals(testPostId, insertedPostList?.get(0)?.postId)
+            assertEquals(1, insertedPostList.size)
+            assertEquals(testPostId, insertedPostList[0].postId)
         }
 
         /**
@@ -143,8 +143,8 @@ class PostListSqlUtilsTest {
          * 3. Verify that it's NOT deleted from the second list
          */
         postListSqlUtils.deletePost(testSite1.id, testPostId)
-        assertEquals(0, postListSqlUtils.getPostList(testLists[0].id)?.size)
-        assertEquals(1, postListSqlUtils.getPostList(testLists[1].id)?.size)
+        assertEquals(0, postListSqlUtils.getPostList(testLists[0].id).size)
+        assertEquals(1, postListSqlUtils.getPostList(testLists[1].id).size)
     }
 
     @Test
@@ -165,7 +165,7 @@ class PostListSqlUtilsTest {
         val postListModel = generatePostListModel(testList.id, testSite.id, testPostId, date1)
         postListSqlUtils.insertPostList(listOf(postListModel))
         val insertedPostList = postListSqlUtils.getPostList(testList.id)
-        assertEquals(date1, insertedPostList?.firstOrNull()?.date)
+        assertEquals(date1, insertedPostList.firstOrNull()?.date)
 
         /**
          * 1. Update the `date` of `postListModel` to a different date: `date2`
@@ -176,8 +176,8 @@ class PostListSqlUtilsTest {
         postListModel.date = date2
         postListSqlUtils.insertPostList(listOf(postListModel))
         val updatedPostList = postListSqlUtils.getPostList(testList.id)
-        assertEquals(insertedPostList?.size, updatedPostList?.size)
-        assertEquals(date2, updatedPostList?.firstOrNull()?.date)
+        assertEquals(insertedPostList.size, updatedPostList.size)
+        assertEquals(date2, updatedPostList.firstOrNull()?.date)
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ListModel.kt
@@ -7,7 +7,10 @@ import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 
 @Table
-@RawConstraints("UNIQUE(LOCAL_SITE_ID, TYPE)")
+@RawConstraints(
+        "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+        "UNIQUE(LOCAL_SITE_ID, TYPE)"
+)
 class ListModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     enum class ListType(val value: String) {
         POSTS_ALL("posts_all"),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostListModel.kt
@@ -9,10 +9,12 @@ import com.yarolegovich.wellsql.core.annotation.Table
 @Table
 @RawConstraints(
         "FOREIGN KEY(LIST_ID) REFERENCES ListModel(_id) ON DELETE CASCADE",
-        "UNIQUE(LIST_ID, POST_ID)"
+        "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+        "UNIQUE(LIST_ID, LOCAL_SITE_ID, POST_ID)"
 )
 class PostListModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var listId: Int = 0
+    @Column var localSiteId: Int = 0
     @Column var postId: Int = 0
     @Column var date: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
@@ -5,7 +5,6 @@ import com.wellsql.generated.ListModelTable
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.ListModel
 import org.wordpress.android.fluxc.model.ListModel.ListType
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
 import javax.inject.Inject
@@ -14,18 +13,19 @@ import javax.inject.Singleton
 @Singleton
 class ListSqlUtils @Inject constructor() {
     /**
-     * This function either creates a new [ListModel] for the [siteModel] and [listType] or updates the existing record.
+     * This function either creates a new [ListModel] for the [localSiteId] and [listType] or updates
+     * the existing record.
      *
      * If there is an existing record, only the [ListModel.lastModified] will be updated with the current [Date].
-     * If there is no existing record, a new [ListModel] will be created for [siteModel] and [listType]. The current
+     * If there is no existing record, a new [ListModel] will be created for [localSiteId] and [listType]. The current
      * [Date] will be assigned to both [ListModel.dateCreated] and [ListModel.lastModified].
      */
-    fun insertOrUpdateList(siteModel: SiteModel, listType: ListType) {
+    fun insertOrUpdateList(localSiteId: Int, listType: ListType) {
         val now = DateTimeUtils.iso8601FromDate(Date())
         val listModel = ListModel()
         listModel.lastModified = now
 
-        val existing = getList(siteModel, listType)
+        val existing = getList(localSiteId, listType)
         if (existing != null) {
             WellSql.update<ListModel>(ListModel::class.java)
                     .whereId(existing.id)
@@ -36,21 +36,21 @@ class ListSqlUtils @Inject constructor() {
                     }.execute()
         } else {
             listModel.type = listType.value
-            listModel.localSiteId = siteModel.id
+            listModel.localSiteId = localSiteId
             listModel.dateCreated = now
             WellSql.insert(listModel).execute()
         }
     }
 
     /**
-     * This function returns the [ListModel] record for the given [siteModel] and [type] if there is one.
+     * This function returns the [ListModel] record for the given [localSiteId] and [type] if there is one.
      *
-     * Since there shouldn't be more than one record for a [siteModel] and [type] combination, [firstOrNull] is used.
+     * Since there shouldn't be more than one record for a [localSiteId] and [type] combination, [firstOrNull] is used.
      */
-    fun getList(siteModel: SiteModel, type: ListType): ListModel? {
+    fun getList(localSiteId: Int, type: ListType): ListModel? {
         return WellSql.select(ListModel::class.java)
                 .where()
-                .equals(ListModelTable.LOCAL_SITE_ID, siteModel.id)
+                .equals(ListModelTable.LOCAL_SITE_ID, localSiteId)
                 .equals(ListModelTable.TYPE, type.value)
                 .endWhere()
                 .asModel
@@ -58,12 +58,12 @@ class ListSqlUtils @Inject constructor() {
     }
 
     /**
-     * This function deletes the [ListModel] record for the given [siteModel] and [type] if there is one.
+     * This function deletes the [ListModel] record for the given [localSiteId] and [type] if there is one.
      *
      * To ensure that we have the same `where` queries for both `select` and `delete` queries, [getList] is utilized.
      */
-    fun deleteList(siteModel: SiteModel, type: ListType) {
-        val existing = getList(siteModel, type)
+    fun deleteList(localSiteId: Int, type: ListType) {
+        val existing = getList(localSiteId, type)
         existing?.let {
             WellSql.delete(ListModel::class.java).whereId(it.id)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
@@ -43,27 +43,28 @@ class ListSqlUtils @Inject constructor() {
     }
 
     /**
-     * This function returns the [ListModel] record for the given [localSiteId] and [type] if there is one.
+     * This function returns the [ListModel] record for the given [localSiteId] and [listType] if there is one.
      *
-     * Since there shouldn't be more than one record for a [localSiteId] and [type] combination, [firstOrNull] is used.
+     * Since there shouldn't be more than one record for a [localSiteId] and [listType] combination,
+     * [firstOrNull] is used.
      */
-    fun getList(localSiteId: Int, type: ListType): ListModel? {
+    fun getList(localSiteId: Int, listType: ListType): ListModel? {
         return WellSql.select(ListModel::class.java)
                 .where()
                 .equals(ListModelTable.LOCAL_SITE_ID, localSiteId)
-                .equals(ListModelTable.TYPE, type.value)
+                .equals(ListModelTable.TYPE, listType.value)
                 .endWhere()
                 .asModel
                 .firstOrNull()
     }
 
     /**
-     * This function deletes the [ListModel] record for the given [localSiteId] and [type] if there is one.
+     * This function deletes the [ListModel] record for the given [localSiteId] and [listType] if there is one.
      *
      * To ensure that we have the same `where` queries for both `select` and `delete` queries, [getList] is utilized.
      */
-    fun deleteList(localSiteId: Int, type: ListType) {
-        val existing = getList(localSiteId, type)
+    fun deleteList(localSiteId: Int, listType: ListType) {
+        val existing = getList(localSiteId, listType)
         existing?.let {
             WellSql.delete(ListModel::class.java).whereId(it.id)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
@@ -32,7 +32,7 @@ class PostListSqlUtils @Inject constructor() {
     /**
      * This function returns a list of [PostListModel] records for the given [listId].
      */
-    fun getPostList(listId: Int): List<PostListModel>? =
+    fun getPostList(listId: Int): List<PostListModel> =
             WellSql.select(PostListModel::class.java)
                     .where()
                     .equals(PostListModelTable.LIST_ID, listId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostListSqlUtils.kt
@@ -40,11 +40,12 @@ class PostListSqlUtils @Inject constructor() {
                     .asModel
 
     /**
-     * This function deletes every [PostListModel] record for the given [postId].
+     * This function deletes every [PostListModel] record of a site with [localSiteId] for the given [postId].
      */
-    fun deletePost(postId: Int) {
+    fun deletePost(localSiteId: Int, postId: Int) {
         WellSql.delete(PostListModel::class.java)
                 .where()
+                .equals(PostListModelTable.LOCAL_SITE_ID, localSiteId)
                 .equals(PostListModelTable.POST_ID, postId)
                 .endWhere()
                 .execute()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 39;
+        return 40;
     }
 
     @Override
@@ -323,6 +323,16 @@ public class WellSqlConfig extends DefaultWellConfig {
                     fluxCPreferences.edit().putString("ACCOUNT_TOKEN_PREF_KEY", token).apply();
                     defaultSharedPrefs.edit().remove("ACCOUNT_TOKEN_PREF_KEY").apply();
                 }
+                oldVersion++;
+            case 39:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("CREATE TABLE PostListModel (LIST_ID INTEGER,LOCAL_SITE_ID INTEGER,POST_ID INTEGER,"
+                           + "DATE TEXT,_id INTEGER PRIMARY KEY AUTOINCREMENT,FOREIGN KEY(LIST_ID) "
+                           + "REFERENCES ListModel(_id) ON DELETE CASCADE,FOREIGN KEY(LOCAL_SITE_ID) "
+                           + "REFERENCES SiteModel(_id) ON DELETE CASCADE,UNIQUE(LIST_ID, LOCAL_SITE_ID, POST_ID))");
+                db.execSQL("CREATE TABLE ListModel (DATE_CREATED TEXT,LAST_MODIFIED TEXT,LOCAL_SITE_ID INTEGER,"
+                           + "TYPE TEXT,_id INTEGER PRIMARY KEY AUTOINCREMENT,FOREIGN KEY(LOCAL_SITE_ID) "
+                           + "REFERENCES SiteModel(_id) ON DELETE CASCADE,UNIQUE(LOCAL_SITE_ID, TYPE))");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
This is a follow up to #848. I missed a few things in my original PR, so I am trying to fix them here:

1. The migrations for `ListModelTable` and `PostListModelTable` are added.
2. `ListSqlUtils` no longer needs a `SiteModel` and instead works with `localSiteId`. This was an oversight by me. Although there are arguments to be made for both approaches, I am a strong believer in not having dependencies unless it's absolutely necessary.
3. Adds `localSiteId` property to `PostListModel`. As mentioned [in this comment](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/848#issuecomment-407091197), I failed to take self-hosted sites into account when I thought the `siteId` would not be necessary. For context: When a post is deleted, we need to remove every instance of it from `PostListModel`, however we can't do that for self-hosted sites because the `postId` is not unique.
4. Adds FK restrictions for the `localSiteId` for both `ListModel` and `PostListModel`. I know we have not been doing this a lot for other features, but since these models are only going to be used for post pagination, I think it's a good feature to try them out and see how we like them. With these restrictions, deleting a site will delete all the `ListModel` and `PostListModel` records for it. Deleting a `ListModel` will delete `PostListModel`s associated with it.
5. Adds tests for FK restrictions. It also tries to improve the existing tests a bit and updates the tests to reflect the other changes.

I think that covers the major changes. Let me know if anything is not clear!