### PR TITLE
Introduced API to fetch domain contact information for a User.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountPushSocialResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountPushUsernameResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountRestPayload;
+import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.DomainContactPayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.IsAvailableResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.NewAccountResponsePayload;
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload;
@@ -70,6 +71,8 @@ public enum AccountAction implements IAction {
     UPDATE_SUBSCRIPTION_EMAIL_POST_FREQUENCY,
     @Action(payloadType = AddOrDeleteSubscriptionPayload.class)
     UPDATE_SUBSCRIPTION_NOTIFICATION_POST,
+    @Action
+    FETCH_DOMAIN_CONTACT,
 
     // Remote responses
     @Action(payloadType = AccountRestPayload.class)
@@ -94,6 +97,8 @@ public enum AccountAction implements IAction {
     FETCHED_SUBSCRIPTIONS,
     @Action(payloadType = SubscriptionResponsePayload.class)
     UPDATED_SUBSCRIPTION,
+    @Action(payloadType = DomainContactPayload.class)
+    FETCHED_DOMAIN_CONTACT,
 
     // Local actions
     @Action(payloadType = AccountModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/DomainContactModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/DomainContactModel.kt
@@ -1,16 +1,16 @@
 package org.wordpress.android.fluxc.model
 
-class DomainContactModel {
-    var firstName: String? = null
-    var lastName: String? = null
-    var organization: String? = null
-    var addressLine1: String? = null
-    var addressLine2: String? = null
-    var postalCode: String? = null
-    var city: String? = null
-    var state: String? = null
-    var countryCode: String? = null
-    var email: String? = null
-    var phone: String? = null
-    var fax: String? = null
-}
+class DomainContactModel(
+    val firstName: String?,
+    val lastName: String?,
+    val organization: String?,
+    val addressLine1: String?,
+    val addressLine2: String?,
+    val postalCode: String?,
+    val city: String?,
+    val state: String?,
+    val countryCode: String?,
+    val email: String?,
+    val phone: String?,
+    val fax: String?
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/DomainContactModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/DomainContactModel.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.model
+
+class DomainContactModel {
+    var firstName: String? = null
+    var lastName: String? = null
+    var organization: String? = null
+    var addressLine1: String? = null
+    var addressLine2: String? = null
+    var postalCode: String? = null
+    var city: String? = null
+    var state: String? = null
+    var countryCode: String? = null
+    var email: String? = null
+    var phone: String? = null
+    var fax: String? = null
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountDomainContactResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountDomainContactResponse.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.account
+
+class AccountDomainContactResponse {
+    var first_name: String? = null
+    var last_name: String? = null
+    var organization: String? = null
+    var address_1: String? = null
+    var address_2: String? = null
+    var postal_code: String? = null
+    var city: String? = null
+    var state: String? = null
+    var country_code: String? = null
+    var email: String? = null
+    var phone: String? = null
+    var fax: String? = null
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -1146,6 +1146,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         contactModel.setCountryCode(response.getCountry_code());
         contactModel.setPhone(response.getPhone());
         contactModel.setFax(response.getFax());
+        contactModel.setEmail(response.getEmail());
         return contactModel;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -879,18 +879,29 @@ public class AccountRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    /**
+     * Performs an HTTP GET call to v1.1 /me/domain-contact-information/ endpoint.  Upon receiving a response
+     * (success or error) a {@link AccountAction#FETCHED_DOMAIN_CONTACT} action is dispatched with a
+     * payload of type {@link DomainContactPayload}.
+     *
+     * {@link DomainContactPayload#isError()} can be used to check the request result.
+     */
     public void fetchDomainContact() {
         String url = WPCOMREST.me.domain_contact_information.getUrlV1_1();
         add(WPComGsonRequest.buildGetRequest(url, null, DomainContactResponse.class,
                 new Listener<DomainContactResponse>() {
                     @Override
                     public void onResponse(DomainContactResponse response) {
-                        DomainContactModel account = responseToDomainContactModel(response);
+                        DomainContactPayload payload = new DomainContactPayload(responseToDomainContactModel(response));
+                        mDispatcher.dispatch(AccountActionBuilder.newFetchedDomainContactAction(payload));
                     }
                 },
                 new WPComErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                        DomainContactError contactError = new DomainContactError(error.apiError, error.message);
+                        DomainContactPayload payload = new DomainContactPayload(contactError);
+                        mDispatcher.dispatch(AccountActionBuilder.newFetchedDomainContactAction(payload));
                     }
                 }));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -1134,19 +1134,19 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     private DomainContactModel responseToDomainContactModel(DomainContactResponse response) {
-        DomainContactModel contactModel = new DomainContactModel();
-        contactModel.setFirstName(StringEscapeUtils.unescapeHtml4(response.getFirst_name()));
-        contactModel.setLastName(StringEscapeUtils.unescapeHtml4(response.getLast_name()));
-        contactModel.setOrganization(response.getOrganization());
-        contactModel.setAddressLine1(response.getAddress_1());
-        contactModel.setAddressLine2(response.getAddress_2());
-        contactModel.setCity(response.getCity());
-        contactModel.setState(response.getState());
-        contactModel.setPostalCode(response.getPostal_code());
-        contactModel.setCountryCode(response.getCountry_code());
-        contactModel.setPhone(response.getPhone());
-        contactModel.setFax(response.getFax());
-        contactModel.setEmail(response.getEmail());
-        return contactModel;
+        String firstName = StringEscapeUtils.unescapeHtml4(response.getFirst_name());
+        String lastName = StringEscapeUtils.unescapeHtml4(response.getLast_name());
+        String organization = StringEscapeUtils.unescapeHtml4(response.getOrganization());
+        String addressLine1 = response.getAddress_1();
+        String addressLine2 = response.getAddress_2();
+        String city = response.getCity();
+        String state = response.getState();
+        String postalCode = response.getPostal_code();
+        String countryCode = response.getCountry_code();
+        String phone = response.getPhone();
+        String fax = response.getFax();
+        String email = response.getEmail();
+        return new DomainContactModel(firstName, lastName, organization, addressLine1, addressLine2, postalCode, city,
+                state, countryCode, email, phone, fax);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -41,6 +41,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AccountUsernameActionType;
 import org.wordpress.android.fluxc.store.AccountStore.AccountUsernameError;
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload.SubscriptionAction;
 import org.wordpress.android.fluxc.store.AccountStore.DomainContactError;
+import org.wordpress.android.fluxc.store.AccountStore.DomainContactErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.IsAvailableError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
@@ -899,7 +900,10 @@ public class AccountRestClient extends BaseWPComRestClient {
                 new WPComErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                        DomainContactError contactError = new DomainContactError(error.apiError, error.message);
+                        // Domain contact should always be available for a valid, authenticated user.
+                        // Therefore, only GENERIC_ERROR is identified here.
+                        DomainContactError contactError =
+                                new DomainContactError(DomainContactErrorType.GENERIC_ERROR, error.message);
                         DomainContactPayload payload = new DomainContactPayload(contactError);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedDomainContactAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -171,7 +171,7 @@ public class AccountRestClient extends BaseWPComRestClient {
     public static class DomainContactPayload extends Payload<DomainContactError> {
         @Nullable public DomainContactModel contactModel;
 
-        public DomainContactPayload(@Nullable DomainContactModel contactModel) {
+        public DomainContactPayload(@NonNull DomainContactModel contactModel) {
             this.contactModel = contactModel;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.account;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.android.volley.RequestQueue;
@@ -39,6 +40,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AccountSocialErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AccountUsernameActionType;
 import org.wordpress.android.fluxc.store.AccountStore.AccountUsernameError;
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload.SubscriptionAction;
+import org.wordpress.android.fluxc.store.AccountStore.DomainContactError;
 import org.wordpress.android.fluxc.store.AccountStore.IsAvailableError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserError;
 import org.wordpress.android.fluxc.store.AccountStore.NewUserErrorType;
@@ -162,6 +164,18 @@ public class AccountRestClient extends BaseWPComRestClient {
 
         public AccountFetchUsernameSuggestionsResponsePayload(List<String> suggestions) {
             this.suggestions = suggestions;
+        }
+    }
+
+    public static class DomainContactPayload extends Payload<DomainContactError> {
+        @Nullable public DomainContactModel contactModel;
+
+        public DomainContactPayload(@Nullable DomainContactModel contactModel) {
+            this.contactModel = contactModel;
+        }
+
+        public DomainContactPayload(@NonNull DomainContactError error) {
+            this.error = error;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2;
 import org.wordpress.android.fluxc.model.AccountModel;
+import org.wordpress.android.fluxc.model.DomainContactModel;
 import org.wordpress.android.fluxc.model.SubscriptionModel;
 import org.wordpress.android.fluxc.model.SubscriptionsModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener;
@@ -864,6 +865,22 @@ public class AccountRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void fetchDomainContact() {
+        String url = WPCOMREST.me.domain_contact_information.getUrlV1_1();
+        add(WPComGsonRequest.buildGetRequest(url, null, DomainContactResponse.class,
+                new Listener<DomainContactResponse>() {
+                    @Override
+                    public void onResponse(DomainContactResponse response) {
+                        DomainContactModel account = responseToDomainContactModel(response);
+                    }
+                },
+                new WPComErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                    }
+                }));
+    }
+
     private SubscriptionModel responseToSubscriptionModel(SubscriptionRestResponse response) {
         SubscriptionModel subscription = new SubscriptionModel();
         subscription.setSubscriptionId(response.ID);
@@ -1089,5 +1106,21 @@ public class AccountRestClient extends BaseWPComRestClient {
             accountModel.setPrimarySiteId(((Double) from.get("primary_site_ID")).longValue());
         }
         return !old.equals(accountModel);
+    }
+
+    private DomainContactModel responseToDomainContactModel(DomainContactResponse response) {
+        DomainContactModel contactModel = new DomainContactModel();
+        contactModel.setFirstName(StringEscapeUtils.unescapeHtml4(response.getFirst_name()));
+        contactModel.setLastName(StringEscapeUtils.unescapeHtml4(response.getLast_name()));
+        contactModel.setOrganization(response.getOrganization());
+        contactModel.setAddressLine1(response.getAddress_1());
+        contactModel.setAddressLine2(response.getAddress_2());
+        contactModel.setCity(response.getCity());
+        contactModel.setState(response.getState());
+        contactModel.setPostalCode(response.getPostal_code());
+        contactModel.setCountryCode(response.getCountry_code());
+        contactModel.setPhone(response.getPhone());
+        contactModel.setFax(response.getFax());
+        return contactModel;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/DomainContactResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/DomainContactResponse.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.account
 
-class AccountDomainContactResponse {
+class DomainContactResponse {
     var first_name: String? = null
     var last_name: String? = null
     var organization: String? = null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.store;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.android.volley.VolleyError;
@@ -15,6 +16,7 @@ import org.wordpress.android.fluxc.action.AuthenticationAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.AccountModel;
+import org.wordpress.android.fluxc.model.DomainContactModel;
 import org.wordpress.android.fluxc.model.SubscriptionModel;
 import org.wordpress.android.fluxc.model.SubscriptionsModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
@@ -361,6 +363,18 @@ public class AccountStore extends Store {
         public List<String> suggestions;
     }
 
+    public static class OnDomainContactFetched extends OnChanged<DomainContactError> {
+        @Nullable public DomainContactModel contactModel;
+
+        public OnDomainContactFetched(@Nullable DomainContactModel contactModel) {
+            this.contactModel = contactModel;
+        }
+
+        public OnDomainContactFetched(@NonNull DomainContactError error) {
+            this.error = error;
+        }
+    }
+
     public static class OnDiscoveryResponse extends OnChanged<DiscoveryError> {
         public String xmlRpcEndpoint;
         public String wpRestEndpoint;
@@ -611,6 +625,32 @@ public class AccountStore extends Store {
                 }
             }
 
+            return GENERIC_ERROR;
+        }
+    }
+
+    public static class DomainContactError implements OnChangedError {
+        public DomainContactErrorType type;
+        public String message;
+
+        public DomainContactError(@NonNull String type, @NonNull String message) {
+            this.type = DomainContactErrorType.fromString(type);
+            this.message = message;
+        }
+    }
+
+    public enum DomainContactErrorType {
+        INVALID_TOKEN,
+        GENERIC_ERROR;
+
+        public static DomainContactErrorType fromString(String string) {
+            if (string != null) {
+                for (DomainContactErrorType type : DomainContactErrorType.values()) {
+                    if (string.equalsIgnoreCase(type.name())) {
+                        return type;
+                    }
+                }
+            }
             return GENERIC_ERROR;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountPushSocialResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountPushUsernameResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.AccountRestPayload;
+import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.DomainContactPayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.IsAvailable;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.IsAvailableResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient.NewAccountResponsePayload;
@@ -366,11 +367,8 @@ public class AccountStore extends Store {
     public static class OnDomainContactFetched extends OnChanged<DomainContactError> {
         @Nullable public DomainContactModel contactModel;
 
-        public OnDomainContactFetched(@Nullable DomainContactModel contactModel) {
+        public OnDomainContactFetched(@Nullable DomainContactModel contactModel, @Nullable DomainContactError error) {
             this.contactModel = contactModel;
-        }
-
-        public OnDomainContactFetched(@NonNull DomainContactError error) {
             this.error = error;
         }
     }
@@ -870,6 +868,12 @@ public class AccountStore extends Store {
             case UPDATED_SUBSCRIPTION:
                 handleUpdatedSubscription((SubscriptionResponsePayload) payload);
                 break;
+            case FETCH_DOMAIN_CONTACT:
+                mAccountRestClient.fetchDomainContact();
+                break;
+            case FETCHED_DOMAIN_CONTACT:
+                handleFetchedDomainContact((DomainContactPayload) payload);
+                break;
         }
     }
 
@@ -1237,5 +1241,9 @@ public class AccountStore extends Store {
             event.type = payload.type;
         }
         emitChange(event);
+    }
+
+    private void handleFetchedDomainContact(DomainContactPayload payload) {
+        emitChange(new OnDomainContactFetched(payload.contactModel, payload.error));
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -628,10 +628,10 @@ public class AccountStore extends Store {
     }
 
     public static class DomainContactError implements OnChangedError {
-        public DomainContactErrorType type;
-        public String message;
+        @NonNull public DomainContactErrorType type;
+        @Nullable public String message;
 
-        public DomainContactError(@NonNull String type, @NonNull String message) {
+        public DomainContactError(@Nullable String type, @Nullable String message) {
             this.type = DomainContactErrorType.fromString(type);
             this.message = message;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -638,7 +638,6 @@ public class AccountStore extends Store {
     }
 
     public enum DomainContactErrorType {
-        INVALID_TOKEN,
         GENERIC_ERROR;
 
         public static DomainContactErrorType fromString(String string) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -631,25 +631,14 @@ public class AccountStore extends Store {
         @NonNull public DomainContactErrorType type;
         @Nullable public String message;
 
-        public DomainContactError(@Nullable String type, @Nullable String message) {
-            this.type = DomainContactErrorType.fromString(type);
+        public DomainContactError(@NonNull DomainContactErrorType type, @Nullable String message) {
+            this.type = type;
             this.message = message;
         }
     }
 
     public enum DomainContactErrorType {
         GENERIC_ERROR;
-
-        public static DomainContactErrorType fromString(String string) {
-            if (string != null) {
-                for (DomainContactErrorType type : DomainContactErrorType.values()) {
-                    if (string.equalsIgnoreCase(type.name())) {
-                        return type;
-                    }
-                }
-            }
-            return GENERIC_ERROR;
-        }
     }
 
     public static class AuthEmailError implements OnChangedError {

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -12,6 +12,7 @@
 /jetpack-blogs/$site/rest-api/
 
 /me/
+/me/domain-contact-information/
 /me/settings/
 /me/sites/
 /me/send-verification-email/


### PR DESCRIPTION
This in an API required for implementing [custom domain association feature](https://github.com/wordpress-mobile/WordPress-Android/issues/7923).

When User associates a custom domain, they have to input and confirm basic information about themselves. This information is utilized to register the domain for them (either publicly or with privacy protection). 

This API provides these basic information, which can be again utilized to prefill the contact information form, which the User will submit.