### PR TITLE
Convert OrderStatus to an enum for improved flexibility

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -72,7 +72,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals(siteModel.id, localSiteId)
             assertEquals(949, remoteOrderId)
             assertEquals("949", number)
-            assertEquals(OrderStatus.PROCESSING, status)
+            assertEquals(OrderStatus.PROCESSING.toString(), status)
             assertEquals("USD", currency)
             assertEquals("2018-04-02T14:57:39Z", dateCreated)
             assertEquals("44.00", total)
@@ -126,13 +126,13 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         val originalOrder = WCOrderModel().apply {
             id = 8
             localSiteId = siteModel.id
-            status = OrderStatus.PROCESSING
+            status = OrderStatus.PROCESSING.toString()
             remoteOrderId = 88
             total = "15.00"
         }
 
         interceptor.respondWith("wc-order-update-response-success.json")
-        orderRestClient.updateOrderStatus(originalOrder, siteModel, OrderStatus.REFUNDED)
+        orderRestClient.updateOrderStatus(originalOrder, siteModel, OrderStatus.REFUNDED.toString())
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -144,7 +144,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals(originalOrder.id, order.id)
             assertEquals(siteModel.id, order.localSiteId)
             assertEquals(originalOrder.remoteOrderId, order.remoteOrderId)
-            assertEquals(OrderStatus.REFUNDED, order.status)
+            assertEquals(OrderStatus.REFUNDED.toString(), order.status)
         }
     }
 
@@ -153,7 +153,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         val originalOrder = WCOrderModel().apply {
             id = 8
             localSiteId = siteModel.id
-            status = OrderStatus.PROCESSING
+            status = OrderStatus.PROCESSING.toString()
             remoteOrderId = 88
             total = "15.00"
         }
@@ -164,7 +164,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWithError(errorJson, 400)
-        orderRestClient.updateOrderStatus(originalOrder, siteModel, OrderStatus.REFUNDED)
+        orderRestClient.updateOrderStatus(originalOrder, siteModel, OrderStatus.REFUNDED.toString())
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -101,7 +101,8 @@ class WooCommerceFragment : Fragment() {
             getFirstWCSite()?.let { site ->
                 prependToLog("Submitting request to fetch only completed orders from the api")
                 pendingFetchCompletedOrders = true
-                val payload = FetchOrdersPayload(site, loadMore = false, statusFilter = OrderStatus.COMPLETED)
+                val payload = FetchOrdersPayload(
+                        site, loadMore = false, statusFilter = OrderStatus.COMPLETED.toString())
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
             }
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -59,8 +59,8 @@ class OrderSqlUtilsTest {
     @Test
     fun testGetOrdersForSite() {
         val processingOrder = OrderTestUtils.generateSampleOrder(3)
-        val onHoldOrder = OrderTestUtils.generateSampleOrder(4, OrderStatus.ON_HOLD)
-        val cancelledOrder = OrderTestUtils.generateSampleOrder(5, OrderStatus.CANCELLED)
+        val onHoldOrder = OrderTestUtils.generateSampleOrder(4, OrderStatus.ON_HOLD.toString())
+        val cancelledOrder = OrderTestUtils.generateSampleOrder(5, OrderStatus.CANCELLED.toString())
         OrderSqlUtils.insertOrUpdateOrder(processingOrder)
         OrderSqlUtils.insertOrUpdateOrder(onHoldOrder)
         OrderSqlUtils.insertOrUpdateOrder(cancelledOrder)
@@ -71,11 +71,12 @@ class OrderSqlUtilsTest {
         assertEquals(3, storedOrders.size)
 
         // Test pulling orders with a single status specified
-        val processingOrders = OrderSqlUtils.getOrdersForSite(site, listOf(OrderStatus.PROCESSING))
+        val processingOrders = OrderSqlUtils.getOrdersForSite(site, listOf(OrderStatus.PROCESSING.toString()))
         assertEquals(1, processingOrders.size)
 
         // Test pulling orders with multiple statuses specified
-        val mixStatusOrders = OrderSqlUtils.getOrdersForSite(site, listOf(OrderStatus.ON_HOLD, OrderStatus.CANCELLED))
+        val mixStatusOrders = OrderSqlUtils.getOrdersForSite(
+                site, listOf(OrderStatus.ON_HOLD.toString(), OrderStatus.CANCELLED.toString()))
         assertEquals(2, mixStatusOrders.size)
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderNoteApiRespo
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatus
 
 object OrderTestUtils {
-    fun generateSampleOrder(remoteId: Long, orderStatus: String = OrderStatus.PROCESSING): WCOrderModel {
+    fun generateSampleOrder(remoteId: Long, orderStatus: String = OrderStatus.PROCESSING.toString()): WCOrderModel {
         return WCOrderModel().apply {
             remoteOrderId = remoteId
             localSiteId = 6

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -58,15 +58,16 @@ class WCOrderStoreTest {
     @Test
     fun testGetOrders() {
         val processingOrder = OrderTestUtils.generateSampleOrder(3)
-        val onHoldOrder = OrderTestUtils.generateSampleOrder(4, OrderStatus.ON_HOLD)
-        val cancelledOrder = OrderTestUtils.generateSampleOrder(5, OrderStatus.CANCELLED)
+        val onHoldOrder = OrderTestUtils.generateSampleOrder(4, OrderStatus.ON_HOLD.toString())
+        val cancelledOrder = OrderTestUtils.generateSampleOrder(5, OrderStatus.CANCELLED.toString())
         OrderSqlUtils.insertOrUpdateOrder(processingOrder)
         OrderSqlUtils.insertOrUpdateOrder(onHoldOrder)
         OrderSqlUtils.insertOrUpdateOrder(cancelledOrder)
 
         val site = SiteModel().apply { id = processingOrder.localSiteId }
 
-        val orderList = orderStore.getOrdersForSite(site, OrderStatus.PROCESSING, OrderStatus.CANCELLED)
+        val orderList = orderStore.getOrdersForSite(
+                site, OrderStatus.PROCESSING.toString(), OrderStatus.CANCELLED.toString())
 
         assertEquals(2, orderList.size)
         assertTrue(orderList.contains(processingOrder))
@@ -100,7 +101,7 @@ class WCOrderStoreTest {
         assertEquals(1, orderList.size)
         assertTrue(orderList.contains(customStatusOrder))
 
-        val orderList2 = orderStore.getOrdersForSite(site, customStatus, OrderStatus.CANCELLED)
+        val orderList2 = orderStore.getOrdersForSite(site, customStatus, OrderStatus.CANCELLED.toString())
         assertEquals(1, orderList2.size)
         assertTrue(orderList2.contains(customStatusOrder))
 
@@ -115,12 +116,12 @@ class WCOrderStoreTest {
         OrderSqlUtils.insertOrUpdateOrder(orderModel)
 
         // Simulate incoming action with updated order model
-        val payload = RemoteOrderPayload(orderModel.apply { status = OrderStatus.REFUNDED }, site)
+        val payload = RemoteOrderPayload(orderModel.apply { status = OrderStatus.REFUNDED.toString() }, site)
         orderStore.onAction(WCOrderActionBuilder.newUpdatedOrderStatusAction(payload))
 
         with (orderStore.getOrderByIdentifier(orderModel.getIdentifier())!!) {
             // The version of the order model in the database should have the updated status
-            assertEquals(OrderStatus.REFUNDED, status)
+            assertEquals(OrderStatus.REFUNDED.toString(), status)
             // Other fields should not be altered by the update
             assertEquals(orderModel.currency, currency)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderStatus.kt
@@ -1,12 +1,40 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
-object OrderStatus {
+enum class OrderStatus {
     // Standard core WooCommerce order statuses
-    const val PENDING = "pending"
-    const val ON_HOLD = "on-hold"
-    const val PROCESSING = "processing"
-    const val COMPLETED = "completed"
-    const val CANCELLED = "cancelled"
-    const val REFUNDED = "refunded"
-    const val FAILED = "failed"
+    PENDING {
+        override fun toString(): String {
+            return "pending"
+        }
+    },
+    ON_HOLD {
+        override fun toString(): String {
+            return "on-hold"
+        }
+    },
+    PROCESSING {
+        override fun toString(): String {
+            return "processing"
+        }
+    },
+    COMPLETED {
+        override fun toString(): String {
+            return "completed"
+        }
+    },
+    CANCELLED {
+        override fun toString(): String {
+            return "cancelled"
+        }
+    },
+    REFUNDED {
+        override fun toString(): String {
+            return "refunded"
+        }
+    },
+    FAILED {
+        override fun toString(): String {
+            return "failed"
+        }
+    }
 }


### PR DESCRIPTION
Converted the `OrderStatus` class from a static object to an enum for more flexibility in situations where the values must be iterated over.

**To Test**
- Run Unit and Instrumented WC tests
- In the Woo page of the Example app, test using the two order status options