### PR TITLE
Add ability to fetch order counts with optional filter

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload
@@ -106,6 +107,23 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals("60.00", discountTotal)
             assertEquals("20\$off, 40\$off", discountCodes)
         }
+    }
+
+    @Test
+    fun testOrdersCountFetchSuccess() {
+        val statusFilter = CoreOrderStatus.COMPLETED.value
+
+        interceptor.respondWith("wc-completed-orders-response-success.json")
+        orderRestClient.fetchOrders(siteModel, 0, statusFilter, countOnly = true)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_ORDERS_COUNT, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchOrdersCountResponsePayload
+        assertNull(payload.error)
+        assertEquals(4, payload.count)
+        assertEquals(statusFilter, payload.statusFilter)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -4,25 +4,30 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 
 class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
     internal enum class TestEvent {
         NONE,
         FETCHED_ORDERS,
+        FETCHED_ORDERS_COUNT,
         FETCHED_ORDER_NOTES,
         POST_ORDER_NOTE,
         POSTED_ORDER_NOTE
@@ -36,6 +41,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         number = "1125"
         dateCreated = "2018-04-20T15:45:14Z"
     }
+    private var lastEvent: OnOrderChanged? = null
 
     @Throws(Exception::class)
     override fun setUp() {
@@ -76,6 +82,40 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         val isValid = firstFetchOrders.stream().allMatch { it.status == statusFilter }
         assertTrue(firstFetchOrders.isNotEmpty() &&
                 firstFetchOrders.size <= WCOrderStore.NUM_ORDERS_PER_FETCH && isValid)
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchOrdersCount_completedFilter() {
+        nextEvent = TestEvent.FETCHED_ORDERS_COUNT
+        mCountDownLatch = CountDownLatch(1)
+        val statusFilter = CoreOrderStatus.COMPLETED.value
+
+        mDispatcher.dispatch(
+                WCOrderActionBuilder.newFetchOrdersCountAction(FetchOrdersCountPayload(sSite, statusFilter)))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        this.lastEvent?.let {
+            assertTrue(it.rowsAffected > 0)
+            assertEquals(it.statusFilter, statusFilter)
+        } ?: fail()
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchOrdersCount_emptyFilter() {
+        nextEvent = TestEvent.FETCHED_ORDERS_COUNT
+        mCountDownLatch = CountDownLatch(1)
+        val statusFilter = ""
+
+        mDispatcher.dispatch(
+                WCOrderActionBuilder.newFetchOrdersCountAction(FetchOrdersCountPayload(sSite, statusFilter)))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        this.lastEvent?.let {
+            assertTrue(it.rowsAffected > 0)
+            assertEquals(it.statusFilter, statusFilter)
+        } ?: fail()
     }
 
     @Throws(InterruptedException::class)
@@ -126,9 +166,15 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
             throw AssertionError("OnOrderChanged has error: " + it.type)
         }
 
+        lastEvent = event
+
         when (event.causeOfChange) {
             WCOrderAction.FETCH_ORDERS -> {
                 assertEquals(TestEvent.FETCHED_ORDERS, nextEvent)
+                mCountDownLatch.countDown()
+            }
+            WCOrderAction.FETCH_ORDERS_COUNT -> {
+                assertEquals(TestEvent.FETCHED_ORDERS_COUNT, nextEvent)
                 mCountDownLatch.countDown()
             }
             WCOrderAction.FETCH_ORDER_NOTES -> {

--- a/example/src/androidTest/resources/wc-completed-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-completed-orders-response-success.json
@@ -1,0 +1,803 @@
+{
+  "data": [
+    {
+      "id": 95,
+      "parent_id": 0,
+      "number": "95",
+      "order_key": "wc_order_5a8f1ec6110fa",
+      "created_via": "checkout",
+      "version": "3.2.6",
+      "status": "completed",
+      "currency": "USD",
+      "date_created": "2018-02-22T19:49:26",
+      "date_created_gmt": "2018-02-22T19:49:26",
+      "date_modified": "2018-07-24T15:52:43",
+      "date_modified_gmt": "2018-07-24T15:52:43",
+      "discount_total": "0.00",
+      "discount_tax": "0.00",
+      "shipping_total": "0.00",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "85.00",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 1,
+      "customer_ip_address": "24.52.34.206",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10.13; rv:58.0) gecko\/20100101 firefox\/58.0",
+      "customer_note": "",
+      "billing": {
+        "first_name": "Ricki",
+        "last_name": "Ricardo",
+        "company": "I Love Lucille Ball Inc",
+        "address_1": "351 S Studio Dr",
+        "address_2": "",
+        "city": "Lake Buena Vista",
+        "state": "FL",
+        "postcode": "32830",
+        "country": "US",
+        "email": "amanda.riu@automattic.com",
+        "phone": "5552223355"
+      },
+      "shipping": {
+        "first_name": "Ricki",
+        "last_name": "Ricardo",
+        "company": "I Love Lucille Ball Inc",
+        "address_1": "351 S Studio Dr",
+        "address_2": "",
+        "city": "Lake Buena Vista",
+        "state": "FL",
+        "postcode": "32830",
+        "country": "US"
+      },
+      "payment_method": "cheque",
+      "payment_method_title": "Check payments",
+      "transaction_id": "",
+      "date_paid": "2018-02-22T19:57:12",
+      "date_paid_gmt": "2018-02-22T19:57:12",
+      "date_completed": "2018-07-24T15:52:43",
+      "date_completed_gmt": "2018-07-24T15:52:43",
+      "cart_hash": "09240eb15bdfedb81640152681ef5f5d",
+      "meta_data": [
+        {
+          "id": 1091,
+          "key": "_shipping_phone",
+          "value": "5552223355"
+        },
+        {
+          "id": 1092,
+          "key": "mailchimp_woocommerce_is_subscribed",
+          "value": "0"
+        },
+        {
+          "id": 1095,
+          "key": "_order_stock_reduced",
+          "value": "yes"
+        },
+        {
+          "id": 1096,
+          "key": "_download_permissions_granted",
+          "value": "yes"
+        }
+      ],
+      "line_items": [
+        {
+          "id": 32,
+          "name": "Red Ninja Hoodie",
+          "product_id": 72,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "35.00",
+          "subtotal_tax": "0.00",
+          "total": "35.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "red-ninja-hoodie",
+          "price": 35
+        },
+        {
+          "id": 33,
+          "name": "Ship Your Idea Hoodie",
+          "product_id": 57,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "50.00",
+          "subtotal_tax": "0.00",
+          "total": "50.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "ship-your-idea-hoodie",
+          "price": 50
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 34,
+          "method_title": "Free shipping",
+          "method_id": "free_shipping:1",
+          "total": "0.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 255,
+              "key": "Items",
+              "value": "Red Ninja Hoodie &times; 1, Ship Your Idea Hoodie &times; 1"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [],
+      "refunds": [],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders\/95"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders"
+          }
+        ],
+        "customer": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/customers\/1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 90,
+      "parent_id": 0,
+      "number": "90",
+      "order_key": "wc_order_5a877de89e043",
+      "created_via": "checkout",
+      "version": "3.2.6",
+      "status": "completed",
+      "currency": "USD",
+      "date_created": "2018-02-17T00:57:12",
+      "date_created_gmt": "2018-02-17T00:57:12",
+      "date_modified": "2018-07-29T23:09:52",
+      "date_modified_gmt": "2018-07-29T23:09:52",
+      "discount_total": "6.00",
+      "discount_tax": "0.00",
+      "shipping_total": "0.00",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "54.00",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 0,
+      "customer_ip_address": "52.33.247.158",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10_13_3) applewebkit\/604.5.6 (khtml, like gecko) version\/11.0.3 safari\/604.5.6",
+      "customer_note": "test order",
+      "billing": {
+        "first_name": "Bob",
+        "last_name": "George",
+        "company": "",
+        "address_1": "123 Address Ave",
+        "address_2": "",
+        "city": "Denver",
+        "state": "CO",
+        "postcode": "80204",
+        "country": "US",
+        "email": "bgtest@bob.com",
+        "phone": "3035551212"
+      },
+      "shipping": {
+        "first_name": "Bob",
+        "last_name": "George",
+        "company": "",
+        "address_1": "123 Address Ave",
+        "address_2": "",
+        "city": "Denver",
+        "state": "CO",
+        "postcode": "80204",
+        "country": "US"
+      },
+      "payment_method": "cod",
+      "payment_method_title": "Cash on delivery",
+      "transaction_id": "",
+      "date_paid": "2018-06-16T03:52:10",
+      "date_paid_gmt": "2018-06-16T03:52:10",
+      "date_completed": "2018-07-29T23:09:52",
+      "date_completed_gmt": "2018-07-29T23:09:52",
+      "cart_hash": "8b3215219a13da53d11a687ee8e5d7bf",
+      "meta_data": [
+        {
+          "id": 916,
+          "key": "_shipping_phone",
+          "value": "3035551212"
+        },
+        {
+          "id": 917,
+          "key": "mailchimp_woocommerce_is_subscribed",
+          "value": "0"
+        },
+        {
+          "id": 918,
+          "key": "_download_permissions_granted",
+          "value": "yes"
+        },
+        {
+          "id": 922,
+          "key": "_order_stock_reduced",
+          "value": "yes"
+        }
+      ],
+      "line_items": [
+        {
+          "id": 21,
+          "name": "White Woo Themes T-Shirt",
+          "product_id": 54,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "25.00",
+          "subtotal_tax": "0.00",
+          "total": "22.50",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "white-woo-themes-t-shirt",
+          "price": 22.5
+        },
+        {
+          "id": 22,
+          "name": "Red Ninja Hoodie",
+          "product_id": 72,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "35.00",
+          "subtotal_tax": "0.00",
+          "total": "31.50",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "red-ninja-hoodie",
+          "price": 31.5
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 23,
+          "method_title": "Free shipping",
+          "method_id": "free_shipping:1",
+          "total": "0.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 177,
+              "key": "Items",
+              "value": "White Woo Themes T-Shirt &times; 1, Red Ninja Hoodie &times; 1"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [
+        {
+          "id": 24,
+          "code": "10-percent-off",
+          "discount": "6",
+          "discount_tax": "0",
+          "meta_data": [
+            {
+              "id": 180,
+              "key": "coupon_data",
+              "value": {
+                "id": 73,
+                "code": "10-percent-off",
+                "amount": "10",
+                "date_created": {
+                  "date": "2018-01-12 00:03:05.000000",
+                  "timezone_type": 1,
+                  "timezone": "+00:00"
+                },
+                "date_modified": {
+                  "date": "2018-01-12 00:03:05.000000",
+                  "timezone_type": 1,
+                  "timezone": "+00:00"
+                },
+                "date_expires": null,
+                "discount_type": "percent",
+                "description": "",
+                "usage_count": 1,
+                "individual_use": false,
+                "product_ids": [],
+                "excluded_product_ids": [],
+                "usage_limit": 0,
+                "usage_limit_per_user": 0,
+                "limit_usage_to_x_items": null,
+                "free_shipping": false,
+                "product_categories": [],
+                "excluded_product_categories": [],
+                "exclude_sale_items": false,
+                "minimum_amount": "30.00",
+                "maximum_amount": "",
+                "email_restrictions": [],
+                "used_by": [
+                  "d.kotlen@test.com"
+                ],
+                "virtual": false,
+                "meta_data": [
+                  {
+                    "id": 531,
+                    "key": "_publicize_pending",
+                    "value": "1"
+                  },
+                  {
+                    "id": 550,
+                    "key": "promotion_type",
+                    "value": "percent"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "refunds": [],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders\/90"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders"
+          }
+        ]
+      }
+    },
+    {
+      "id": 87,
+      "parent_id": 0,
+      "number": "87",
+      "order_key": "wc_order_5a877711717ec",
+      "created_via": "checkout",
+      "version": "3.2.6",
+      "status": "completed",
+      "currency": "USD",
+      "date_created": "2018-02-17T00:28:01",
+      "date_created_gmt": "2018-02-17T00:28:01",
+      "date_modified": "2018-07-25T23:49:48",
+      "date_modified_gmt": "2018-07-25T23:49:48",
+      "discount_total": "36.70",
+      "discount_tax": "0.00",
+      "shipping_total": "0.00",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "330.30",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 0,
+      "customer_ip_address": "24.52.34.206",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10_13_3) applewebkit\/537.36 (khtml, like gecko) chrome\/64.0.3282.167 safari\/537.36",
+      "customer_note": "",
+      "billing": {
+        "first_name": "Dave",
+        "last_name": "Kotlen",
+        "company": "",
+        "address_1": "239 70th St",
+        "address_2": "",
+        "city": "Niagara Falls",
+        "state": "NY",
+        "postcode": "14304",
+        "country": "US",
+        "email": "d.kotlen@test.com",
+        "phone": "7162831535"
+      },
+      "shipping": {
+        "first_name": "Gloria",
+        "last_name": "Kotlen",
+        "company": "",
+        "address_1": "1143 Westwood Cir",
+        "address_2": "203",
+        "city": "Niagara Falls",
+        "state": "NY",
+        "postcode": "14304",
+        "country": "US"
+      },
+      "payment_method": "cheque",
+      "payment_method_title": "Check payments",
+      "transaction_id": "",
+      "date_paid": "2018-02-17T00:29:57",
+      "date_paid_gmt": "2018-02-17T00:29:57",
+      "date_completed": "2018-07-25T23:49:48",
+      "date_completed_gmt": "2018-07-25T23:49:48",
+      "cart_hash": "97081c8e0c54b6a5c5a83b35823b5301",
+      "meta_data": [
+        {
+          "id": 832,
+          "key": "_shipping_phone",
+          "value": ""
+        },
+        {
+          "id": 833,
+          "key": "mailchimp_woocommerce_is_subscribed",
+          "value": "0"
+        },
+        {
+          "id": 837,
+          "key": "_order_stock_reduced",
+          "value": "yes"
+        },
+        {
+          "id": 839,
+          "key": "_download_permissions_granted",
+          "value": "yes"
+        }
+      ],
+      "line_items": [
+        {
+          "id": 14,
+          "name": "Cap",
+          "product_id": 61,
+          "variation_id": 0,
+          "quantity": 12,
+          "tax_class": "",
+          "subtotal": "222.00",
+          "subtotal_tax": "0.00",
+          "total": "199.80",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "cap",
+          "price": 16.65
+        },
+        {
+          "id": 15,
+          "name": "Ship Your Idea Hoodie",
+          "product_id": 57,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "50.00",
+          "subtotal_tax": "0.00",
+          "total": "45.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "ship-your-idea-hoodie",
+          "price": 45
+        },
+        {
+          "id": 16,
+          "name": "Sunglasses",
+          "product_id": 69,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "10.00",
+          "subtotal_tax": "0.00",
+          "total": "9.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "sunglasses",
+          "price": 9
+        },
+        {
+          "id": 17,
+          "name": "Ship Your Idea T-Shirt (green)",
+          "product_id": 67,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "15.00",
+          "subtotal_tax": "0.00",
+          "total": "13.50",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "ship-your-idea-t-shirt-(green)",
+          "price": 13.5
+        },
+        {
+          "id": 18,
+          "name": "Red Ninja Hoodie",
+          "product_id": 72,
+          "variation_id": 0,
+          "quantity": 2,
+          "tax_class": "",
+          "subtotal": "70.00",
+          "subtotal_tax": "0.00",
+          "total": "63.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "red-ninja-hoodie",
+          "price": 31.5
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 19,
+          "method_title": "Free shipping",
+          "method_id": "free_shipping:1",
+          "total": "0.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 151,
+              "key": "Items",
+              "value": "Cap &times; 12, Ship Your Idea Hoodie &times; 1, Sunglasses &times; 1, Ship Your Idea T-Shirt (green) &times; 1, Red Ninja Hoodie &times; 2"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [
+        {
+          "id": 20,
+          "code": "10-percent-off",
+          "discount": "36.70",
+          "discount_tax": "0",
+          "meta_data": [
+            {
+              "id": 154,
+              "key": "coupon_data",
+              "value": {
+                "id": 73,
+                "code": "10-percent-off",
+                "amount": "10",
+                "date_created": {
+                  "date": "2018-01-12 00:03:05.000000",
+                  "timezone_type": 1,
+                  "timezone": "+00:00"
+                },
+                "date_modified": {
+                  "date": "2018-01-12 00:03:05.000000",
+                  "timezone_type": 1,
+                  "timezone": "+00:00"
+                },
+                "date_expires": null,
+                "discount_type": "percent",
+                "description": "",
+                "usage_count": 0,
+                "individual_use": false,
+                "product_ids": [],
+                "excluded_product_ids": [],
+                "usage_limit": 0,
+                "usage_limit_per_user": 0,
+                "limit_usage_to_x_items": null,
+                "free_shipping": false,
+                "product_categories": [],
+                "excluded_product_categories": [],
+                "exclude_sale_items": false,
+                "minimum_amount": "30.00",
+                "maximum_amount": "",
+                "email_restrictions": [],
+                "used_by": [],
+                "virtual": false,
+                "meta_data": [
+                  {
+                    "id": 531,
+                    "key": "_publicize_pending",
+                    "value": "1"
+                  },
+                  {
+                    "id": 550,
+                    "key": "promotion_type",
+                    "value": "percent"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "refunds": [
+        {
+          "id": 88,
+          "refund": "Too many hats!",
+          "total": "-133.20"
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders\/87"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders"
+          }
+        ]
+      }
+    },
+    {
+      "id": 85,
+      "parent_id": 0,
+      "number": "85",
+      "order_key": "wc_order_5a8775dc4c6de",
+      "created_via": "checkout",
+      "version": "3.2.6",
+      "status": "completed",
+      "currency": "USD",
+      "date_created": "2018-02-17T00:22:52",
+      "date_created_gmt": "2018-02-17T00:22:52",
+      "date_modified": "2018-07-30T15:57:37",
+      "date_modified_gmt": "2018-07-30T15:57:37",
+      "discount_total": "0.00",
+      "discount_tax": "0.00",
+      "shipping_total": "0.00",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "65.00",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 0,
+      "customer_ip_address": "24.52.34.206",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10_13_3) applewebkit\/537.36 (khtml, like gecko) chrome\/64.0.3282.167 safari\/537.36",
+      "customer_note": "",
+      "billing": {
+        "first_name": "Jenny",
+        "last_name": "Forrest",
+        "company": "",
+        "address_1": "11330 16th Ave",
+        "address_2": "",
+        "city": "Buffalo",
+        "state": "NY",
+        "postcode": "14333",
+        "country": "US",
+        "email": "jenny@forrest.com",
+        "phone": "7165551234"
+      },
+      "shipping": {
+        "first_name": "Jenny",
+        "last_name": "Forrest",
+        "company": "",
+        "address_1": "11330 16th Ave",
+        "address_2": "",
+        "city": "Buffalo",
+        "state": "NY",
+        "postcode": "14333",
+        "country": "US"
+      },
+      "payment_method": "cheque",
+      "payment_method_title": "Check payments",
+      "transaction_id": "",
+      "date_paid": "2018-02-17T00:23:27",
+      "date_paid_gmt": "2018-02-17T00:23:27",
+      "date_completed": "2018-07-30T15:57:37",
+      "date_completed_gmt": "2018-07-30T15:57:37",
+      "cart_hash": "825f5f47cd5d666953576420e8097138",
+      "meta_data": [
+        {
+          "id": 733,
+          "key": "_shipping_phone",
+          "value": "7165551234"
+        },
+        {
+          "id": 734,
+          "key": "mailchimp_woocommerce_is_subscribed",
+          "value": "0"
+        },
+        {
+          "id": 737,
+          "key": "_order_stock_reduced",
+          "value": "yes"
+        },
+        {
+          "id": 738,
+          "key": "_download_permissions_granted",
+          "value": "yes"
+        }
+      ],
+      "line_items": [
+        {
+          "id": 6,
+          "name": "Ship Your Idea T-Shirt (green)",
+          "product_id": 67,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "15.00",
+          "subtotal_tax": "0.00",
+          "total": "15.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "ship-your-idea-t-shirt-(green)",
+          "price": 15
+        },
+        {
+          "id": 7,
+          "name": "Ship Your Ideas T-Shirt",
+          "product_id": 64,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "15.00",
+          "subtotal_tax": "0.00",
+          "total": "15.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "ship-your-ideas-t-shirt",
+          "price": 15
+        },
+        {
+          "id": 8,
+          "name": "Sunglasses",
+          "product_id": 69,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "10.00",
+          "subtotal_tax": "0.00",
+          "total": "10.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "sunglasses",
+          "price": 10
+        },
+        {
+          "id": 9,
+          "name": "White Woo Themes T-Shirt",
+          "product_id": 54,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "25.00",
+          "subtotal_tax": "0.00",
+          "total": "25.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "white-woo-themes-t-shirt",
+          "price": 25
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 10,
+          "method_title": "Free shipping",
+          "method_id": "free_shipping:1",
+          "total": "0.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 78,
+              "key": "Items",
+              "value": "Ship Your Idea T-Shirt (green) &times; 1, Ship Your Ideas T-Shirt &times; 1, Sunglasses &times; 1, White Woo Themes T-Shirt &times; 1"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [],
+      "refunds": [],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders\/85"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/amandatestsatomic1.blog\/wp-json\/wc\/v2\/orders"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -198,6 +198,9 @@ class WooCommerceFragment : Fragment() {
 
         getFirstWCSite()?.let { site ->
             wcOrderStore.getOrdersForSite(site).let { orderList ->
+                // We check if the rowsAffected value is zero because not all events will causes data to be
+                // saved to the orders table (such as the FETCH-ORDERS-COUNT...so the orderList would always
+                // be empty even if there were orders available.
                 if (orderList.isEmpty() && event.rowsAffected == 0) {
                     prependToLog("No orders were stored for site " + site.name + " =(")
                     return

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -12,6 +12,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
 import org.wordpress.android.fluxc.action.WCOrderAction.POST_ORDER_NOTE
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
@@ -25,6 +26,7 @@ import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
@@ -72,6 +74,24 @@ class WooCommerceFragment : Fragment() {
                 val payload = FetchOrdersPayload(it, loadMore = false)
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
             } ?: showNoWCSitesToast()
+        }
+
+        fetch_orders_count.setOnClickListener {
+            getFirstWCSite()?.let { site ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter a single order status to filter by or leave blank for no filter:") { editText ->
+
+                    // only use the status for filtering if it's not empty
+                    val statusFilter = editText.text.toString().trim().takeIf { it.isNotEmpty() }
+                    statusFilter?.let {
+                        prependToLog("Submitting request to fetch a count of $it orders")
+                    } ?: prependToLog("No valid filters defined, fetching count of all orders")
+
+                    val payload = FetchOrdersCountPayload(site, statusFilter)
+                    dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersCountAction(payload))
+                }
+            }
         }
 
         fetch_orders_by_status.setOnClickListener {
@@ -178,7 +198,7 @@ class WooCommerceFragment : Fragment() {
 
         getFirstWCSite()?.let { site ->
             wcOrderStore.getOrdersForSite(site).let { orderList ->
-                if (orderList.isEmpty()) {
+                if (orderList.isEmpty() && event.rowsAffected == 0) {
                     prependToLog("No orders were stored for site " + site.name + " =(")
                     return
                 }
@@ -203,6 +223,12 @@ class WooCommerceFragment : Fragment() {
                         } else {
                             prependToLog("Fetched ${event.rowsAffected} orders from: ${site.name}")
                         }
+                    }
+                    FETCH_ORDERS_COUNT -> {
+                        val append = if (event.canLoadMore) "+" else ""
+                        event.statusFilter?.let {
+                            prependToLog("Count of $it orders: ${event.rowsAffected}$append")
+                        } ?: prependToLog("Count of all orders: ${event.rowsAffected}$append")
                     }
                     FETCH_ORDER_NOTES -> {
                         val notes = wcOrderStore.getOrderNotesForOrder(pendingNotesOrderModel!!)

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -12,11 +12,23 @@
         android:layout_height="wrap_content"
         android:text="Log Sites" />
 
-    <Button
-        android:id="@+id/fetch_orders"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Fetch Orders" />
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/fetch_orders"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fetch Orders" />
+
+        <Button
+            android:id="@+id/fetch_orders_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fetch Orders Count"/>
+    </LinearLayout>
 
     <Button
         android:id="@+id/fetch_orders_by_status"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -5,6 +5,8 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload;
@@ -17,6 +19,8 @@ public enum WCOrderAction implements IAction {
     // Remote actions
     @Action(payloadType = FetchOrdersPayload.class)
     FETCH_ORDERS,
+    @Action(payloadType = FetchOrdersCountPayload.class)
+    FETCH_ORDERS_COUNT,
     @Action(payloadType = UpdateOrderStatusPayload.class)
     UPDATE_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesPayload.class)
@@ -27,6 +31,8 @@ public enum WCOrderAction implements IAction {
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
     FETCHED_ORDERS,
+    @Action(payloadType = FetchOrdersCountResponsePayload.class)
+    FETCHED_ORDERS_COUNT,
     @Action(payloadType = RemoteOrderPayload.class)
     UPDATED_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesResponsePayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -49,7 +49,7 @@ class OrderRestClient(
      */
     fun fetchOrders(site: SiteModel, offset: Int, filterByStatus: String? = null, countOnly: Boolean = false) {
         // If null, set the filter to the api default value of "any", which will not apply any order status filters.
-        val statusFilter = filterByStatus ?: "any"
+        val statusFilter = if (filterByStatus.isNullOrBlank()) { "any" } else { filterByStatus!! }
 
         val url = WOOCOMMERCE.orders.pathV2
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
@@ -44,8 +45,9 @@ class OrderRestClient(
      * Dispatches a [WCOrderAction.FETCHED_ORDERS] action with the resulting list of orders.
      *
      * @param [filterByStatus] Nullable. If not null, fetch only orders with a matching order status.
+     * @param [countOnly] Default false. If true, only a total count of orders will be returned in the payload.
      */
-    fun fetchOrders(site: SiteModel, offset: Int, filterByStatus: String? = null) {
+    fun fetchOrders(site: SiteModel, offset: Int, filterByStatus: String? = null, countOnly: Boolean = false) {
         // If null, set the filter to the api default value of "any", which will not apply any order status filters.
         val statusFilter = filterByStatus ?: "any"
 
@@ -62,13 +64,26 @@ class OrderRestClient(
                     }.orEmpty()
 
                     val canLoadMore = orderModels.size == WCOrderStore.NUM_ORDERS_PER_FETCH
-                    val payload = FetchOrdersResponsePayload(site, orderModels, filterByStatus, offset > 0, canLoadMore)
-                    mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
+
+                    if (countOnly) {
+                        val payload = FetchOrdersCountResponsePayload(
+                                site, orderModels.size, filterByStatus, canLoadMore)
+                        mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersCountAction(payload))
+                    } else {
+                        val payload = FetchOrdersResponsePayload(
+                                site, orderModels, filterByStatus, offset > 0, canLoadMore)
+                        mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
+                    }
                 },
                 WPComErrorListener { networkError ->
                     val orderError = networkErrorToOrderError(networkError)
-                    val payload = FetchOrdersResponsePayload(orderError, site)
-                    mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
+                    if (countOnly) {
+                        val payload = FetchOrdersCountResponsePayload(orderError, site)
+                        mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersCountAction(payload))
+                    } else {
+                        val payload = FetchOrdersResponsePayload(orderError, site)
+                        mDispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
+                    }
                 },
                 { request: WPComGsonRequest<*> -> add(request) })
         add(request)


### PR DESCRIPTION
Add logic to process request for a count of orders optionally filtered by order status. This is part of the project to add a "Orders to fulfill" card to the dashboard of the WooCommerce-Android app.

## Design Notes
### API
No API endpoint for requesting just the total count of orders so while I've added a new `FETCH[ED]_ORDERS_COUNT` action, I'm reusing the fetchOrders() api endpoint to fetch the list of orders and just counting the results. Since it's done this way, I've continued to use the default value for the `per_page` parameter. So the maximum count returned will be this value. I plan on using the `canLoadMore` value to determine how the count should be displayed. 

**Using this view as an example:**

![orders](https://user-images.githubusercontent.com/5810477/43563941-fb16cc76-95e9-11e8-8a1f-fa72780be8b6.png)

_If `canLoadMore=true` and `count=50`_, then the title would be:

> **You have 50+ orders to fulfill**

### DB
The results of using this new feature are **not saved to the database**, even though we are fetching full orders to build the result from. This is to keep the orders list view in proper sync since currently we drop all orders from the table and repopulate it after after successful orders fetch. This method will definitely be used by the dashboard to get and display a count, but we have no idea what the current order list view is filtered by or actively displaying. If the user clicks the **VIEW ORDERS** button, then the app will navigate to the orders view and a request to officially fetch all `processing` orders would be executed.

### Dispatching and handling the response
Since the database is not at all involved in this feature, the OnOrderChanged event contains all the information needed to fulfill the request. I've reused the `rowsAffected` property and populate it with the total order count and the `canLoadMore` property controls whether or not a `+` symbol is appended to the total count in the UI.  

**Note:** _I actually struggled with this because the `rowsAffected` field is always used to represent total records in the database, so my use is actually misleading. Would love to get some other peoples opinions on this and will happily add this field if anyone else also thinks it's a good idea._ 🤓

## Testing

1. Added new tests to the release and mocked WC orders tests.
2. Added a new button to the Example app:

![screenshot_1533188655](https://user-images.githubusercontent.com/5810477/43564782-c7198ebe-95ed-11e8-9900-af8a6a29c052.png)

Clicking the `FETCH ORDERS COUNT` button will open a dialog window: 

![screenshot_1533188691](https://user-images.githubusercontent.com/5810477/43564842-0274e468-95ee-11e8-9b18-89d8f9821dfc.png)

**Options:**
- Leave blank: fetch all orders (no filter)
<img width="342" alt="screen shot no filter" src="https://user-images.githubusercontent.com/5810477/43564858-0f5f855c-95ee-11e8-8b80-90f7db33720f.png">

- Enter a single order status: will fetch a count of orders by that order status.

<img width="334" alt="screen shot 2018-08-02 at 12 47 03 am" src="https://user-images.githubusercontent.com/5810477/43564874-239c0f72-95ee-11e8-8938-002978bdacef.png">

 cc: @nbradbury @aforcier 
