### PR TITLE
Store new naming for project directory in checkstyle config

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="active-configuration" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />


### PR DESCRIPTION
The [latest Checkstyle-IDEA](https://github.com/jshiell/checkstyle-idea/releases/tag/5.21.1) plugin version updated the naming of the project directory variable. This shouldn't cause any functional changes, as long as you've update to the latest Checkstyle IDEA plugin.