### PR TITLE
NotificationStore with device registration/unregistration

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -22,6 +22,7 @@ public interface MockedNetworkAppComponent {
     void inject(MockedStack_AccountTest object);
     void inject(MockedStack_CacheTest object);
     void inject(MockedStack_JetpackTunnelTest object);
+    void inject(MockedStack_NotificationTest object);
     void inject(MockedStack_PluginTest object);
     void inject(MockedStack_SiteTest object);
     void inject(MockedStack_UploadStoreTest object);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -1,0 +1,104 @@
+package org.wordpress.android.fluxc.mocked
+
+import com.google.gson.JsonObject
+import org.greenrobot.eventbus.Subscribe
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.action.NotificationAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
+import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
+import org.wordpress.android.fluxc.store.NotificationStore.NotificationAppKey
+import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlin.properties.Delegates
+
+/**
+ * Tests using a Mocked Network app component. Test the network client itself and not the underlying
+ * network component(s).
+ */
+class MockedStack_NotificationTest : MockedStack_Base() {
+    @Inject internal lateinit var notificationRestClient: NotificationRestClient
+    @Inject internal lateinit var dispatcher: Dispatcher
+
+    @Inject internal lateinit var interceptor: ResponseMockingInterceptor
+
+    private var lastAction: Action<*>? = null
+    private var countDownLatch: CountDownLatch by Delegates.notNull()
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mMockedNetworkAppComponent.inject(this)
+        dispatcher.register(this)
+        lastAction = null
+    }
+
+    @Test
+    fun testRegistrationWordPress() {
+        val responseJson = JsonObject().apply { addProperty("ID", 12345678) }
+
+        interceptor.respondWith(responseJson)
+
+        val gcmToken = "sample-token"
+        val uuid = "sample-uuid"
+        notificationRestClient.registerDeviceForPushNotifications(gcmToken, NotificationAppKey.WORDPRESS, uuid)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(NotificationAction.REGISTERED_DEVICE, lastAction!!.type)
+
+        val requestBodyMap = interceptor.lastRequestBody
+
+        assertEquals(gcmToken, requestBodyMap["device_token"])
+        assertEquals("org.wordpress.android", requestBodyMap["app_secret_key"])
+        // No site was specified, so the site selection param should be omitted
+        assertNull(requestBodyMap["selected_blog_id"])
+
+        val payload = lastAction!!.payload as RegisterDeviceResponsePayload
+
+        assertEquals(responseJson.get("ID").asString, payload.deviceId)
+    }
+
+    @Test
+    fun testRegistrationWooCommerce() {
+        val responseJson = JsonObject().apply { addProperty("ID", 12345678) }
+
+        interceptor.respondWith(responseJson)
+
+        val gcmToken = "sample-token"
+        val uuid = "sample-uuid"
+        val site = SiteModel().apply { siteId = 123456 }
+        notificationRestClient.registerDeviceForPushNotifications(gcmToken, NotificationAppKey.WOOCOMMERCE, uuid, site)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(NotificationAction.REGISTERED_DEVICE, lastAction!!.type)
+
+        val requestBodyMap = interceptor.lastRequestBody
+
+        assertEquals(gcmToken, requestBodyMap["device_token"])
+        assertEquals("com.woocommerce.android", requestBodyMap["app_secret_key"])
+        assertEquals(site.siteId.toString(), requestBodyMap["selected_blog_id"])
+
+        val payload = lastAction!!.payload as RegisterDeviceResponsePayload
+
+        assertEquals(responseJson.get("ID").asString, payload.deviceId)
+    }
+
+    @Suppress("unused")
+    @Subscribe
+    fun onAction(action: Action<*>) {
+        lastAction = action
+        countDownLatch.countDown()
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -95,6 +95,24 @@ class MockedStack_NotificationTest : MockedStack_Base() {
         assertEquals(responseJson.get("ID").asString, payload.deviceId)
     }
 
+    @Test
+    fun testUnregistration() {
+        val responseJson = JsonObject().apply { addProperty("success", "true") }
+
+        interceptor.respondWith(responseJson)
+
+        notificationRestClient.unregisterDeviceForPushNotifications("12345678")
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(NotificationAction.UNREGISTERED_DEVICE, lastAction!!.type)
+
+        val requestBodyMap = interceptor.lastRequestBody
+
+        assertTrue(requestBodyMap.isEmpty())
+    }
+
     @Suppress("unused")
     @Subscribe
     fun onAction(action: Action<*>) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.mocked
 import com.google.gson.JsonObject
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
@@ -61,7 +61,7 @@ class MockedStack_NotificationTest : MockedStack_Base() {
         assertEquals(gcmToken, requestBodyMap["device_token"])
         assertEquals("org.wordpress.android", requestBodyMap["app_secret_key"])
         // No site was specified, so the site selection param should be omitted
-        assertNull(requestBodyMap["selected_blog_id"])
+        assertFalse(requestBodyMap.keys.contains("selected_blog_id"))
 
         val payload = lastAction!!.payload as RegisterDeviceResponsePayload
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.ErrorLi
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Listener;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Token;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
@@ -157,6 +158,14 @@ public class MockedNetworkModule {
     public AccountRestClient provideAccountRestClient(Context appContext, Dispatcher dispatcher, RequestQueue
             requestQueue, AppSecrets appSecrets, AccessToken token, UserAgent userAgent) {
         return new AccountRestClient(appContext, dispatcher, requestQueue, appSecrets, token, userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public NotificationRestClient provideNotificationRestClient(Context appContext, Dispatcher dispatcher,
+                                                                RequestQueue requestQueue,
+                                                                AccessToken token, UserAgent userAgent) {
+        return new NotificationRestClient(appContext, dispatcher, requestQueue, token, userAgent);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.action;
+
+import org.wordpress.android.fluxc.annotations.Action;
+import org.wordpress.android.fluxc.annotations.ActionEnum;
+import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.NotificationStore.RegisterDevicePayload;
+import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload;
+
+@ActionEnum
+public enum NotificationAction implements IAction {
+    // Remote actions
+    @Action(payloadType = RegisterDevicePayload.class)
+    REGISTER_DEVICE, // Register device for push notifications with WordPress.com
+
+    // Remote responses
+    @Action(payloadType = RegisterDeviceResponsePayload.class)
+    REGISTERED_DEVICE, // Response to device registration received
+
+    // Local actions
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -5,16 +5,21 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDevicePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload;
+import org.wordpress.android.fluxc.store.NotificationStore.UnregisterDeviceResponsePayload;
 
 @ActionEnum
 public enum NotificationAction implements IAction {
     // Remote actions
     @Action(payloadType = RegisterDevicePayload.class)
     REGISTER_DEVICE, // Register device for push notifications with WordPress.com
+    @Action
+    UNREGISTER_DEVICE, // Unregister device for push notifications with WordPress.com
 
     // Remote responses
     @Action(payloadType = RegisterDeviceResponsePayload.class)
     REGISTERED_DEVICE, // Response to device registration received
+    @Action(payloadType = UnregisterDeviceResponsePayload.class)
+    UNREGISTERED_DEVICE // Response to device unregistration
 
     // Local actions
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.reader.ReaderRestClient;
@@ -141,6 +142,14 @@ public class ReleaseNetworkModule {
                                                       AppSecrets appSecrets,
                                                       AccessToken token, UserAgent userAgent) {
         return new AccountRestClient(appContext, dispatcher, requestQueue, appSecrets, token, userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public NotificationRestClient provideNotificationRestClient(Context appContext, Dispatcher dispatcher,
+                                                        @Named("regular") RequestQueue requestQueue,
+                                                        AccessToken token, UserAgent userAgent) {
+        return new NotificationRestClient(appContext, dispatcher, requestQueue, token, userAgent);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/AccessToken.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/AccessToken.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
 
+import org.wordpress.android.fluxc.utils.PreferenceUtils;
+
 import javax.inject.Singleton;
 
 @Singleton
@@ -37,6 +39,6 @@ public class AccessToken {
     }
 
     private SharedPreferences getFluxCPreferences() {
-        return mContext.getSharedPreferences(mContext.getPackageName() + "_fluxc-preferences", Context.MODE_PRIVATE);
+        return PreferenceUtils.getFluxCPreferences(mContext);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -1,0 +1,52 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.notifications
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.NotificationActionBuilder
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.NotificationStore.DeviceRegistrationError
+import org.wordpress.android.fluxc.store.NotificationStore.DeviceRegistrationErrorType
+import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
+import javax.inject.Singleton
+
+@Singleton
+class NotificationRestClient constructor(
+    appContext: Context?,
+    private val dispatcher: Dispatcher,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    fun registerDeviceForPushNotifications(params: Map<String, String>) {
+        val url = WPCOMREST.devices.new_.urlV1
+        val request = WPComGsonRequest.buildPostRequest(
+                url, params, RegisterDeviceRestResponse::class.java,
+                { response ->
+                    response.id?.takeIf { it.isNotEmpty() }?.let {
+                        val payload = RegisterDeviceResponsePayload(it)
+                        dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
+                    } ?: run {
+                        val registrationError = DeviceRegistrationError(DeviceRegistrationErrorType.MISSING_DEVICE_ID)
+                        val payload = RegisterDeviceResponsePayload(registrationError)
+                        dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
+                    }
+                },
+                { wpComError ->
+                    val registrationError = networkErrorToRegistrationError(wpComError)
+                    val payload = RegisterDeviceResponsePayload(registrationError)
+                    dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
+                })
+        add(request)
+    }
+
+    private fun networkErrorToRegistrationError(wpComError: WPComGsonNetworkError): DeviceRegistrationError {
+        val orderErrorType = DeviceRegistrationErrorType.fromString(wpComError.apiError)
+        return DeviceRegistrationError(orderErrorType, wpComError.message)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -12,7 +12,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.NotificationStore.DeviceRegistrationError
 import org.wordpress.android.fluxc.store.NotificationStore.DeviceRegistrationErrorType
+import org.wordpress.android.fluxc.store.NotificationStore.DeviceUnregistrationError
+import org.wordpress.android.fluxc.store.NotificationStore.DeviceUnregistrationErrorType
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
+import org.wordpress.android.fluxc.store.NotificationStore.UnregisterDeviceResponsePayload
 import javax.inject.Singleton
 
 @Singleton
@@ -41,6 +44,22 @@ class NotificationRestClient constructor(
                     val registrationError = networkErrorToRegistrationError(wpComError)
                     val payload = RegisterDeviceResponsePayload(registrationError)
                     dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
+                })
+        add(request)
+    }
+
+    fun unregisterDeviceForPushNotifications(deviceId: String) {
+        val url = WPCOMREST.devices.deviceId(deviceId).delete.urlV1
+        val request = WPComGsonRequest.buildPostRequest(
+                url, null, Any::class.java,
+                {
+                    val payload = UnregisterDeviceResponsePayload()
+                    dispatcher.dispatch(NotificationActionBuilder.newUnregisteredDeviceAction(payload))
+                },
+                { wpComError ->
+                    val payload = UnregisterDeviceResponsePayload(DeviceUnregistrationError(
+                            DeviceUnregistrationErrorType.GENERIC_ERROR, wpComError.message))
+                    dispatcher.dispatch(NotificationActionBuilder.newUnregisteredDeviceAction(payload))
                 })
         add(request)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.NotificationStore.DeviceRegistrationErr
 import org.wordpress.android.fluxc.store.NotificationStore.DeviceRegistrationErrorType
 import org.wordpress.android.fluxc.store.NotificationStore.DeviceUnregistrationError
 import org.wordpress.android.fluxc.store.NotificationStore.DeviceUnregistrationErrorType
+import org.wordpress.android.fluxc.store.NotificationStore.NotificationAppKey
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.UnregisterDeviceResponsePayload
 import org.wordpress.android.util.DeviceUtils
@@ -30,12 +31,17 @@ class NotificationRestClient constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    fun registerDeviceForPushNotifications(gcmToken: String, appKey: String, uuid: String, site: SiteModel? = null) {
+    fun registerDeviceForPushNotifications(
+        gcmToken: String,
+        appKey: NotificationAppKey,
+        uuid: String,
+        site: SiteModel? = null
+    ) {
         val deviceName = DeviceUtils.getInstance().getDeviceName(appContext)
         val params = mapOf(
                 "device_token" to gcmToken,
                 "device_family" to "android",
-                "app_secret_key" to appKey,
+                "app_secret_key" to appKey.value,
                 "device_name" to deviceName,
                 "device_model" to "${Build.MANUFACTURER} ${Build.MODEL}",
                 "app_version" to PackageUtils.getVersionName(appContext),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.notifications
 
 import android.content.Context
+import android.os.Build
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -16,17 +18,33 @@ import org.wordpress.android.fluxc.store.NotificationStore.DeviceUnregistrationE
 import org.wordpress.android.fluxc.store.NotificationStore.DeviceUnregistrationErrorType
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.UnregisterDeviceResponsePayload
+import org.wordpress.android.util.DeviceUtils
+import org.wordpress.android.util.PackageUtils
 import javax.inject.Singleton
 
 @Singleton
 class NotificationRestClient constructor(
-    appContext: Context?,
+    private val appContext: Context?,
     private val dispatcher: Dispatcher,
     requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    fun registerDeviceForPushNotifications(params: Map<String, String>) {
+    fun registerDeviceForPushNotifications(gcmToken: String, appKey: String, uuid: String, site: SiteModel? = null) {
+        val deviceName = DeviceUtils.getInstance().getDeviceName(appContext)
+        val params = mapOf(
+                "device_token" to gcmToken,
+                "device_family" to "android",
+                "app_secret_key" to appKey,
+                "device_name" to deviceName,
+                "device_model" to "${Build.MANUFACTURER} ${Build.MODEL}",
+                "app_version" to PackageUtils.getVersionName(appContext),
+                "version_code" to PackageUtils.getVersionCode(appContext).toString(),
+                "os_version" to Build.VERSION.RELEASE,
+                "device_uuid" to uuid,
+                "selected_blog_id" to site?.siteId.toString().takeIf { site != null }
+        )
+
         val url = WPCOMREST.devices.new_.urlV1
         val request = WPComGsonRequest.buildPostRequest(
                 url, params, RegisterDeviceRestResponse::class.java,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -38,7 +38,7 @@ class NotificationRestClient constructor(
         site: SiteModel? = null
     ) {
         val deviceName = DeviceUtils.getInstance().getDeviceName(appContext)
-        val params = mapOf(
+        val params = listOfNotNull(
                 "device_token" to gcmToken,
                 "device_family" to "android",
                 "app_secret_key" to appKey.value,
@@ -48,8 +48,8 @@ class NotificationRestClient constructor(
                 "version_code" to PackageUtils.getVersionCode(appContext).toString(),
                 "os_version" to Build.VERSION.RELEASE,
                 "device_uuid" to uuid,
-                "selected_blog_id" to site?.siteId.toString().takeIf { site != null }
-        )
+                ("selected_blog_id" to site?.siteId.toString()).takeIf { site != null }
+        ).toMap()
 
         val url = WPCOMREST.devices.new_.urlV1
         val request = WPComGsonRequest.buildPostRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/RegisterDeviceRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/RegisterDeviceRestResponse.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.notifications
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+
+class RegisterDeviceRestResponse : Response {
+    @SerializedName("ID")
+    val id: String? = null
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -34,9 +34,14 @@ constructor(
 
     class RegisterDevicePayload(
         val gcmToken: String,
-        val appKey: String,
+        val appKey: NotificationAppKey,
         val site: SiteModel?
     ) : Payload<BaseNetworkError>()
+
+    enum class NotificationAppKey(val value: String) {
+        WORDPRESS("org.wordpress.android"),
+        WOOCOMMERCE("com.woocommerce.android")
+    }
 
     class RegisterDeviceResponsePayload(
         val deviceId: String? = null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import android.content.Context
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -8,6 +9,7 @@ import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
+import org.wordpress.android.fluxc.utils.PreferenceUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Locale
@@ -16,7 +18,15 @@ import javax.inject.Singleton
 
 @Singleton
 class NotificationStore @Inject
-constructor(dispatcher: Dispatcher, private val notificationRestClient: NotificationRestClient) : Store(dispatcher) {
+constructor(
+    dispatcher: Dispatcher,
+    private val context: Context,
+    private val notificationRestClient: NotificationRestClient
+) : Store(dispatcher) {
+    companion object {
+        const val WPCOM_PUSH_DEVICE_SERVER_ID = "NOTIFICATIONS_SERVER_ID_PREF_KEY"
+    }
+
     class RegisterDevicePayload(
         val params: Map<String, String>
     ) : Payload<BaseNetworkError>()
@@ -66,8 +76,20 @@ constructor(dispatcher: Dispatcher, private val notificationRestClient: Notifica
     private fun handleRegisteredDevice(payload: RegisterDeviceResponsePayload) {
         val onDeviceRegistered = OnDeviceRegistered(payload.deviceId)
 
-        if (payload.isError) {
-            onDeviceRegistered.error = payload.error
+        with(payload) {
+            if (isError || deviceId.isNullOrEmpty()) {
+                when (error.type) {
+                    DeviceRegistrationErrorType.MISSING_DEVICE_ID ->
+                        AppLog.e(T.NOTIFS, "Server response missing device_id - registration skipped!")
+                    DeviceRegistrationErrorType.GENERIC_ERROR ->
+                        AppLog.e(T.NOTIFS, "Error trying to register device: ${error.type} - ${error.message}")
+                }
+                onDeviceRegistered.error = payload.error
+            } else {
+                PreferenceUtils.getFluxCPreferences(context)
+                        .edit().putString(WPCOM_PUSH_DEVICE_SERVER_ID, deviceId).apply()
+                AppLog.i(T.NOTIFS, "Server response OK. Device ID: $deviceId")
+            }
         }
 
         emitChange(onDeviceRegistered)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -1,0 +1,75 @@
+package org.wordpress.android.fluxc.store
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.action.NotificationAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NotificationStore @Inject
+constructor(dispatcher: Dispatcher, private val notificationRestClient: NotificationRestClient) : Store(dispatcher) {
+    class RegisterDevicePayload(
+        val params: Map<String, String>
+    ) : Payload<BaseNetworkError>()
+
+    class RegisterDeviceResponsePayload(
+        val deviceId: String? = null
+    ) : Payload<DeviceRegistrationError>() {
+        constructor(error: DeviceRegistrationError, deviceId: String? = null) : this(deviceId) { this.error = error }
+    }
+
+    class DeviceRegistrationError(
+        val type: DeviceRegistrationErrorType = DeviceRegistrationErrorType.GENERIC_ERROR,
+        val message: String = ""
+    ) : OnChangedError
+
+    enum class DeviceRegistrationErrorType {
+        MISSING_DEVICE_ID,
+        GENERIC_ERROR;
+
+        companion object {
+            private val reverseMap = DeviceRegistrationErrorType.values().associateBy(DeviceRegistrationErrorType::name)
+            fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: GENERIC_ERROR
+        }
+    }
+
+    // OnChanged events
+    class OnDeviceRegistered(val deviceId: String?) : OnChanged<DeviceRegistrationError>()
+
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? NotificationAction ?: return
+        when (actionType) {
+            NotificationAction.REGISTER_DEVICE -> registerDevice(action.payload as RegisterDevicePayload)
+            NotificationAction.REGISTERED_DEVICE ->
+                handleRegisteredDevice(action.payload as RegisterDeviceResponsePayload)
+        }
+    }
+
+    override fun onRegister() {
+        AppLog.d(T.API, NotificationStore::class.java.simpleName + " onRegister")
+    }
+
+    private fun registerDevice(payload: RegisterDevicePayload) {
+        notificationRestClient.registerDeviceForPushNotifications(payload.params)
+    }
+
+    private fun handleRegisteredDevice(payload: RegisterDeviceResponsePayload) {
+        val onDeviceRegistered = OnDeviceRegistered(payload.deviceId)
+
+        if (payload.isError) {
+            onDeviceRegistered.error = payload.error
+        }
+
+        emitChange(onDeviceRegistered)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -37,6 +37,10 @@ constructor(
         constructor(error: DeviceRegistrationError, deviceId: String? = null) : this(deviceId) { this.error = error }
     }
 
+    class UnregisterDeviceResponsePayload() : Payload<DeviceUnregistrationError>() {
+        constructor(error: DeviceUnregistrationError) : this() { this.error = error }
+    }
+
     class DeviceRegistrationError(
         val type: DeviceRegistrationErrorType = DeviceRegistrationErrorType.GENERIC_ERROR,
         val message: String = ""
@@ -52,16 +56,28 @@ constructor(
         }
     }
 
+    class DeviceUnregistrationError(
+        val type: DeviceUnregistrationErrorType = DeviceUnregistrationErrorType.GENERIC_ERROR,
+        val message: String = ""
+    ) : OnChangedError
+
+    enum class DeviceUnregistrationErrorType { GENERIC_ERROR; }
+
     // OnChanged events
     class OnDeviceRegistered(val deviceId: String?) : OnChanged<DeviceRegistrationError>()
+
+    class OnDeviceUnregistered : OnChanged<DeviceUnregistrationError>()
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? NotificationAction ?: return
         when (actionType) {
             NotificationAction.REGISTER_DEVICE -> registerDevice(action.payload as RegisterDevicePayload)
+            NotificationAction.UNREGISTER_DEVICE -> unregisterDevice()
             NotificationAction.REGISTERED_DEVICE ->
                 handleRegisteredDevice(action.payload as RegisterDeviceResponsePayload)
+            NotificationAction.UNREGISTERED_DEVICE ->
+                handleUnregisteredDevice(action.payload as UnregisterDeviceResponsePayload)
         }
     }
 
@@ -71,6 +87,11 @@ constructor(
 
     private fun registerDevice(payload: RegisterDevicePayload) {
         notificationRestClient.registerDeviceForPushNotifications(payload.params)
+    }
+
+    private fun unregisterDevice() {
+        val deviceId = PreferenceUtils.getFluxCPreferences(context).getString(WPCOM_PUSH_DEVICE_SERVER_ID, "")
+        notificationRestClient.unregisterDeviceForPushNotifications(deviceId)
     }
 
     private fun handleRegisteredDevice(payload: RegisterDeviceResponsePayload) {
@@ -93,5 +114,21 @@ constructor(
         }
 
         emitChange(onDeviceRegistered)
+    }
+
+    private fun handleUnregisteredDevice(payload: UnregisterDeviceResponsePayload) {
+        val onDeviceUnregistered = OnDeviceUnregistered()
+
+        PreferenceUtils.getFluxCPreferences(context).edit().remove(WPCOM_PUSH_DEVICE_SERVER_ID).apply()
+        if (payload.isError) {
+            with(payload.error) {
+                AppLog.e(T.NOTIFS, "Unregister device action failed: $type - $message")
+            }
+            onDeviceUnregistered.error = payload.error
+        } else {
+            AppLog.i(T.NOTIFS, "Unregister device action succeeded")
+        }
+
+        emitChange(onDeviceUnregistered)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
 import org.wordpress.android.fluxc.utils.PreferenceUtils
@@ -28,7 +29,10 @@ constructor(
     }
 
     class RegisterDevicePayload(
-        val params: Map<String, String>
+        val gcmToken: String,
+        val appKey: String,
+        val uuid: String,
+        val site: SiteModel?
     ) : Payload<BaseNetworkError>()
 
     class RegisterDeviceResponsePayload(
@@ -86,7 +90,9 @@ constructor(
     }
 
     private fun registerDevice(payload: RegisterDevicePayload) {
-        notificationRestClient.registerDeviceForPushNotifications(payload.params)
+        with(payload) {
+            notificationRestClient.registerDeviceForPushNotifications(gcmToken, appKey, uuid, site)
+        }
     }
 
     private fun unregisterDevice() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/PreferenceUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/PreferenceUtils.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+
+object PreferenceUtils {
+    @JvmStatic
+    fun getFluxCPreferences(context: Context): SharedPreferences {
+        return context.getSharedPreferences("${context.packageName}_fluxc-preferences", Context.MODE_PRIVATE)
+    }
+}

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -4,6 +4,7 @@
 /connect/site-info/
 
 /devices/new/
+/devices/$deviceId#String/delete/
 
 /is-available/blog/
 /is-available/domain/

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -3,6 +3,8 @@
 
 /connect/site-info/
 
+/devices/new/
+
 /is-available/blog/
 /is-available/domain/
 /is-available/email/


### PR DESCRIPTION
Adds a basic `NotificationStore`, with support for registering and unregistering the device for push notifications with WordPress.com (using a GCM/FCM token).

Also adds new support for a site ID parameter during registration, which configures the server to only send notifications for that site (and not for any site on the account). This is intended for use with the WooCommerce app.

This replicates much of the registration/deregistration work done in the WordPress app - we could migrate that over to use the `NotificationStore` at some point too.

**Not ready for review**

### TODO:
* [x] Move device registration parameter config to FluxC
* [x] Move UUID creation and storage logic to FluxC
* [x] Define preset values for app key
* [x] Add tests