### PR TITLE
Introduced Fetch Supported Countries API

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -30,7 +30,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains;
-import org.wordpress.android.fluxc.store.SiteStore.OnSupportedCountriesFetched;
+import org.wordpress.android.fluxc.store.SiteStore.OnDomainSupportedCountriesFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnWPComSiteFetched;
 import org.wordpress.android.fluxc.store.SiteStore.PlansErrorType;
@@ -75,7 +75,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         INITIATE_INELIGIBLE_AUTOMATED_TRANSFER,
         AUTOMATED_TRANSFER_NOT_FOUND,
         CHECK_BLACKLISTED_DOMAIN_AVAILABILITY,
-        FETCHED_SUPPORTED_COUNTRIES
+        FETCHED_DOMAIN_SUPPORTED_COUNTRIES
     }
 
     private TestEvents mNextEvent;
@@ -318,8 +318,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     public void testFetchSupportedCountries() throws InterruptedException {
         authenticateUser(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         // Fetch supported countries
-        mDispatcher.dispatch(SiteActionBuilder.newFetchSupportedCountriesAction());
-        mNextEvent = TestEvents.FETCHED_SUPPORTED_COUNTRIES;
+        mDispatcher.dispatch(SiteActionBuilder.newFetchDomainSupportedCountriesAction());
+        mNextEvent = TestEvents.FETCHED_DOMAIN_SUPPORTED_COUNTRIES;
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -505,11 +505,11 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onSupportedCountriesFetched(OnSupportedCountriesFetched event) {
+    public void onDomainSupportedCountriesFetched(OnDomainSupportedCountriesFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.FETCHED_SUPPORTED_COUNTRIES, mNextEvent);
+        assertEquals(TestEvents.FETCHED_DOMAIN_SUPPORTED_COUNTRIES, mNextEvent);
         assertNotNull(event.supportedCountries);
         assertFalse(event.supportedCountries.isEmpty());
         mCountDownLatch.countDown();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -75,7 +75,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         INITIATE_INELIGIBLE_AUTOMATED_TRANSFER,
         AUTOMATED_TRANSFER_NOT_FOUND,
         CHECK_BLACKLISTED_DOMAIN_AVAILABILITY,
-        FETCH_SUPPORT_COUNTRIES
+        FETCHED_SUPPORTED_COUNTRIES
     }
 
     private TestEvents mNextEvent;
@@ -319,7 +319,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         authenticateUser(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         // Fetch supported countries
         mDispatcher.dispatch(SiteActionBuilder.newFetchSupportedCountriesAction());
-        mNextEvent = TestEvents.FETCH_SUPPORT_COUNTRIES;
+        mNextEvent = TestEvents.FETCHED_SUPPORTED_COUNTRIES;
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -509,7 +509,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.FETCH_SUPPORT_COUNTRIES, mNextEvent);
+        assertEquals(TestEvents.FETCHED_SUPPORTED_COUNTRIES, mNextEvent);
         assertNotNull(event.supportedCountries);
         assertFalse(event.supportedCountries.isEmpty());
         mCountDownLatch.countDown();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains;
+import org.wordpress.android.fluxc.store.SiteStore.OnSupportedCountriesFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnWPComSiteFetched;
 import org.wordpress.android.fluxc.store.SiteStore.PlansErrorType;
@@ -73,7 +74,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         INELIGIBLE_FOR_AUTOMATED_TRANSFER,
         INITIATE_INELIGIBLE_AUTOMATED_TRANSFER,
         AUTOMATED_TRANSFER_NOT_FOUND,
-        CHECK_BLACKLISTED_DOMAIN_AVAILABILITY
+        CHECK_BLACKLISTED_DOMAIN_AVAILABILITY,
+        FETCH_SUPPORT_COUNTRIES
     }
 
     private TestEvents mNextEvent;
@@ -312,6 +314,16 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
+    public void testFetchSupportedCountries() throws InterruptedException {
+        authenticateUser(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        // Fetch supported countries
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSupportedCountriesAction());
+        mNextEvent = TestEvents.FETCH_SUPPORT_COUNTRIES;
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
@@ -488,6 +500,18 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertEquals(TestEvents.CHECK_BLACKLISTED_DOMAIN_AVAILABILITY, mNextEvent);
         assertEquals(event.status, DomainAvailabilityStatus.BLACKLISTED_DOMAIN);
         assertEquals(event.mappable, DomainMappabilityStatus.BLACKLISTED_DOMAIN);
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onSupportedCountriesFetched(OnSupportedCountriesFetched event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(TestEvents.FETCH_SUPPORT_COUNTRIES, mNextEvent);
+        assertNotNull(event.supportedCountries);
+        assertFalse(event.supportedCountries.isEmpty());
         mCountDownLatch.countDown();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.SupportedCountriesResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesResponsePayload;
 
 @ActionEnum
 public enum SiteAction implements IAction {
@@ -65,7 +65,7 @@ public enum SiteAction implements IAction {
     @Action(payloadType = String.class)
     CHECK_DOMAIN_AVAILABILITY,
     @Action
-    FETCH_SUPPORTED_COUNTRIES,
+    FETCH_DOMAIN_SUPPORTED_COUNTRIES,
 
     // Remote responses
     @Action(payloadType = SiteModel.class)
@@ -98,8 +98,8 @@ public enum SiteAction implements IAction {
     FETCHED_PLANS,
     @Action(payloadType = DomainAvailabilityResponsePayload.class)
     CHECKED_DOMAIN_AVAILABILITY,
-    @Action(payloadType = SupportedCountriesResponsePayload.class)
-    FETCHED_SUPPORTED_COUNTRIES,
+    @Action(payloadType = DomainSupportedCountriesResponsePayload.class)
+    FETCHED_DOMAIN_SUPPORTED_COUNTRIES,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.SupportedCountriesResponsePayload;
 
 @ActionEnum
 public enum SiteAction implements IAction {
@@ -63,6 +64,8 @@ public enum SiteAction implements IAction {
     FETCH_PLANS,
     @Action(payloadType = String.class)
     CHECK_DOMAIN_AVAILABILITY,
+    @Action
+    FETCH_SUPPORTED_COUNTRIES,
 
     // Remote responses
     @Action(payloadType = SiteModel.class)
@@ -95,6 +98,8 @@ public enum SiteAction implements IAction {
     FETCHED_PLANS,
     @Action(payloadType = DomainAvailabilityResponsePayload.class)
     CHECKED_DOMAIN_AVAILABILITY,
+    @Action(payloadType = SupportedCountriesResponsePayload.class)
+    FETCHED_SUPPORTED_COUNTRIES,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -571,12 +571,12 @@ public class SiteRestClient extends BaseWPComRestClient {
      */
     public void fetchSupportedCountries() {
         String url = WPCOMREST.domains.supported_countries.getUrlV1_1();
-        final WPComGsonRequest<ArrayList<SupportedCountriesResponse>> request =
+        final WPComGsonRequest<ArrayList<SupportedCountryResponse>> request =
                 WPComGsonRequest.buildGetRequest(url, null,
-                        new TypeToken<ArrayList<SupportedCountriesResponse>>() {}.getType(),
-                        new Listener<ArrayList<SupportedCountriesResponse>>() {
+                        new TypeToken<ArrayList<SupportedCountryResponse>>() {}.getType(),
+                        new Listener<ArrayList<SupportedCountryResponse>>() {
                             @Override
-                            public void onResponse(ArrayList<SupportedCountriesResponse> response) {
+                            public void onResponse(ArrayList<SupportedCountryResponse> response) {
                                 SupportedCountriesResponsePayload payload =
                                         new SupportedCountriesResponsePayload(response);
                                 mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedCountriesAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -58,6 +58,9 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.SupportedCountriesError;
+import org.wordpress.android.fluxc.store.SiteStore.SupportedCountriesResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.SupportedCountryErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesError;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesErrorType;
 import org.wordpress.android.util.AppLog;
@@ -554,6 +557,40 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 DomainAvailabilityResponsePayload payload =
                                         new DomainAvailabilityResponsePayload(domainAvailabilityError);
                                 mDispatcher.dispatch(SiteActionBuilder.newCheckedDomainAvailabilityAction(payload));
+                            }
+                        });
+        add(request);
+    }
+
+    /**
+     * Performs an HTTP GET call to v1.1 /domains/supported-countries/ endpoint. Upon receiving a response
+     * (success or error) a {@link SiteAction#FETCHED_SUPPORTED_COUNTRIES} action is dispatched with a
+     * payload of type {@link SupportedCountriesResponsePayload}.
+     *
+     * {@link SupportedCountriesResponsePayload#isError()} can be used to check the request result.
+     */
+    public void fetchSupportedCountries() {
+        String url = WPCOMREST.domains.supported_countries.getUrlV1_1();
+        final WPComGsonRequest<ArrayList<SupportedCountriesResponse>> request =
+                WPComGsonRequest.buildGetRequest(url, null,
+                        new TypeToken<ArrayList<SupportedCountriesResponse>>() {}.getType(),
+                        new Listener<ArrayList<SupportedCountriesResponse>>() {
+                            @Override
+                            public void onResponse(ArrayList<SupportedCountriesResponse> response) {
+                                SupportedCountriesResponsePayload payload =
+                                        new SupportedCountriesResponsePayload(response);
+                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedCountriesAction(payload));
+                            }
+                        },
+                        new WPComErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                                SupportedCountriesError supportedCountriesError = new SupportedCountriesError(
+                                        SupportedCountryErrorType.GENERIC_ERROR,
+                                        error.message);
+                                SupportedCountriesResponsePayload payload =
+                                        new SupportedCountriesResponsePayload(supportedCountriesError);
+                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedCountriesAction(payload));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -42,14 +42,17 @@ import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityError;
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityStatus;
+import org.wordpress.android.fluxc.store.SiteStore.DomainMappabilityStatus;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesError;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesErrorType;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
-import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityStatus;
-import org.wordpress.android.fluxc.store.SiteStore.DomainMappabilityStatus;
 import org.wordpress.android.fluxc.store.SiteStore.PlansError;
 import org.wordpress.android.fluxc.store.SiteStore.PostFormatsError;
 import org.wordpress.android.fluxc.store.SiteStore.PostFormatsErrorType;
@@ -58,9 +61,6 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.SupportedCountriesError;
-import org.wordpress.android.fluxc.store.SiteStore.SupportedCountriesResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.SupportedCountryErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesError;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesErrorType;
 import org.wordpress.android.util.AppLog;
@@ -564,10 +564,10 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     /**
      * Performs an HTTP GET call to v1.1 /domains/supported-countries/ endpoint. Upon receiving a response
-     * (success or error) a {@link SiteAction#FETCHED_SUPPORTED_COUNTRIES} action is dispatched with a
-     * payload of type {@link SupportedCountriesResponsePayload}.
+     * (success or error) a {@link SiteAction#FETCHED_DOMAIN_SUPPORTED_COUNTRIES} action is dispatched with a
+     * payload of type {@link DomainSupportedCountriesResponsePayload}.
      *
-     * {@link SupportedCountriesResponsePayload#isError()} can be used to check the request result.
+     * {@link DomainSupportedCountriesResponsePayload#isError()} can be used to check the request result.
      */
     public void fetchSupportedCountries() {
         String url = WPCOMREST.domains.supported_countries.getUrlV1_1();
@@ -577,9 +577,10 @@ public class SiteRestClient extends BaseWPComRestClient {
                         new Listener<ArrayList<SupportedCountryResponse>>() {
                             @Override
                             public void onResponse(ArrayList<SupportedCountryResponse> response) {
-                                SupportedCountriesResponsePayload payload =
-                                        new SupportedCountriesResponsePayload(response);
-                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedCountriesAction(payload));
+                                DomainSupportedCountriesResponsePayload payload =
+                                        new DomainSupportedCountriesResponsePayload(response);
+                                mDispatcher.dispatch(
+                                        SiteActionBuilder.newFetchedDomainSupportedCountriesAction(payload));
                             }
                         },
                         new WPComErrorListener() {
@@ -587,11 +588,14 @@ public class SiteRestClient extends BaseWPComRestClient {
                             public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                                 // Supported Countries API should always return a response for a valid,
                                 // authenticated user. Therefore, only GENERIC_ERROR is identified here.
-                                SupportedCountriesError supportedCountriesError = new SupportedCountriesError(
-                                        SupportedCountryErrorType.GENERIC_ERROR, error.message);
-                                SupportedCountriesResponsePayload payload =
-                                        new SupportedCountriesResponsePayload(supportedCountriesError);
-                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedCountriesAction(payload));
+                                DomainSupportedCountriesError domainSupportedCountriesError =
+                                        new DomainSupportedCountriesError(
+                                                DomainSupportedCountriesErrorType.GENERIC_ERROR,
+                                                error.message);
+                                DomainSupportedCountriesResponsePayload payload =
+                                        new DomainSupportedCountriesResponsePayload(domainSupportedCountriesError);
+                                mDispatcher.dispatch(
+                                        SiteActionBuilder.newFetchedDomainSupportedCountriesAction(payload));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -585,9 +585,10 @@ public class SiteRestClient extends BaseWPComRestClient {
                         new WPComErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                                // Supported Countries API should always return a response for a valid,
+                                // authenticated user. Therefore, only GENERIC_ERROR is identified here.
                                 SupportedCountriesError supportedCountriesError = new SupportedCountriesError(
-                                        SupportedCountryErrorType.GENERIC_ERROR,
-                                        error.message);
+                                        SupportedCountryErrorType.GENERIC_ERROR, error.message);
                                 SupportedCountriesResponsePayload payload =
                                         new SupportedCountriesResponsePayload(supportedCountriesError);
                                 mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedCountriesAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SupportedCountriesResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SupportedCountriesResponse.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site
+
+class SupportedCountriesResponse(
+    val code: String?,
+    val name: String?
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SupportedCountryResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SupportedCountryResponse.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site
 
-class SupportedCountriesResponse(
+class SupportedCountryResponse(
     val code: String?,
     val name: String?
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1164,6 +1164,7 @@ public class SiteStore extends Store {
                 handleCheckedDomainAvailability((DomainAvailabilityResponsePayload) action.getPayload());
                 break;
             case FETCH_SUPPORTED_COUNTRIES:
+                mSiteRestClient.fetchSupportedCountries();
                 break;
             case FETCHED_SUPPORTED_COUNTRIES:
                 handleFetchedSupportedCountries((SupportedCountriesResponsePayload) action.getPayload());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -354,10 +354,6 @@ public class SiteStore extends Store {
             this.type = type;
             this.message = message;
         }
-
-        public SupportedCountriesError(@NonNull SupportedCountryErrorType type) {
-            this.type = type;
-        }
     }
 
     // OnChanged Events

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -29,7 +29,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.Export
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.FetchWPComSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPComResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
-import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedCountriesResponse;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedCountryResponse;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
@@ -239,11 +239,11 @@ public class SiteStore extends Store {
     }
 
     public static class SupportedCountriesResponsePayload extends Payload<SupportedCountriesError> {
-        public List<SupportedCountriesResponse> supportedCountriesResponses;
+        public List<SupportedCountryResponse> supportedCountries;
 
         public SupportedCountriesResponsePayload(
-                @Nullable List<SupportedCountriesResponse> supportedCountriesResponses) {
-            this.supportedCountriesResponses = supportedCountriesResponses;
+                @Nullable List<SupportedCountryResponse> supportedCountryRespons) {
+            this.supportedCountries = supportedCountryRespons;
         }
 
         public SupportedCountriesResponsePayload(@NonNull SupportedCountriesError error) {
@@ -529,9 +529,9 @@ public class SiteStore extends Store {
     }
 
     public static class OnSupportedCountriesFetched extends OnChanged<SupportedCountriesError> {
-        public @Nullable List<SupportedCountriesResponse> supportedCountries;
+        public @Nullable List<SupportedCountryResponse> supportedCountries;
 
-        public OnSupportedCountriesFetched(@Nullable List<SupportedCountriesResponse> supportedCountries,
+        public OnSupportedCountriesFetched(@Nullable List<SupportedCountryResponse> supportedCountries,
                                            @Nullable SupportedCountriesError error) {
             this.supportedCountries = supportedCountries;
             this.error = error;
@@ -1483,7 +1483,7 @@ public class SiteStore extends Store {
     }
 
     private void handleFetchedSupportedCountries(SupportedCountriesResponsePayload payload) {
-        emitChange(new OnSupportedCountriesFetched(payload.supportedCountriesResponses, payload.error));
+        emitChange(new OnSupportedCountriesFetched(payload.supportedCountries, payload.error));
     }
 
     // Automated Transfers

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -488,16 +488,6 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class OnSupportedCountriesFetched extends OnChanged<SupportedCountriesError> {
-        public @Nullable List<SupportedCountriesResponse> supportedCountries;
-
-        public OnSupportedCountriesFetched(@Nullable List<SupportedCountriesResponse> supportedCountries,
-                                           @Nullable SupportedCountriesError error) {
-            this.supportedCountries = supportedCountries;
-            this.error = error;
-        }
-    }
-
     public enum DomainAvailabilityStatus {
         BLACKLISTED_DOMAIN,
         INVALID_TLD,
@@ -535,6 +525,16 @@ public class SiteStore extends Store {
                 }
             }
             return UNKNOWN_STATUS;
+        }
+    }
+
+    public static class OnSupportedCountriesFetched extends OnChanged<SupportedCountriesError> {
+        public @Nullable List<SupportedCountriesResponse> supportedCountries;
+
+        public OnSupportedCountriesFetched(@Nullable List<SupportedCountriesResponse> supportedCountries,
+                                           @Nullable SupportedCountriesError error) {
+            this.supportedCountries = supportedCountries;
+            this.error = error;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -238,15 +238,14 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class SupportedCountriesResponsePayload extends Payload<SupportedCountriesError> {
+    public static class DomainSupportedCountriesResponsePayload extends Payload<DomainSupportedCountriesError> {
         public List<SupportedCountryResponse> supportedCountries;
 
-        public SupportedCountriesResponsePayload(
-                @Nullable List<SupportedCountryResponse> supportedCountryRespons) {
-            this.supportedCountries = supportedCountryRespons;
+        public DomainSupportedCountriesResponsePayload(@Nullable List<SupportedCountryResponse> supportedCountries) {
+            this.supportedCountries = supportedCountries;
         }
 
-        public SupportedCountriesResponsePayload(@NonNull SupportedCountriesError error) {
+        public DomainSupportedCountriesResponsePayload(@NonNull DomainSupportedCountriesError error) {
             this.error = error;
         }
     }
@@ -346,11 +345,11 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class SupportedCountriesError implements OnChangedError {
-        @NonNull public SupportedCountryErrorType type;
+    public static class DomainSupportedCountriesError implements OnChangedError {
+        @NonNull public DomainSupportedCountriesErrorType type;
         @Nullable public String message;
 
-        public SupportedCountriesError(@NonNull SupportedCountryErrorType type, @Nullable String message) {
+        public DomainSupportedCountriesError(@NonNull DomainSupportedCountriesErrorType type, @Nullable String message) {
             this.type = type;
             this.message = message;
         }
@@ -524,11 +523,11 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class OnSupportedCountriesFetched extends OnChanged<SupportedCountriesError> {
+    public static class OnDomainSupportedCountriesFetched extends OnChanged<DomainSupportedCountriesError> {
         public @Nullable List<SupportedCountryResponse> supportedCountries;
 
-        public OnSupportedCountriesFetched(@Nullable List<SupportedCountryResponse> supportedCountries,
-                                           @Nullable SupportedCountriesError error) {
+        public OnDomainSupportedCountriesFetched(@Nullable List<SupportedCountryResponse> supportedCountries,
+                                                 @Nullable DomainSupportedCountriesError error) {
             this.supportedCountries = supportedCountries;
             this.error = error;
         }
@@ -735,7 +734,7 @@ public class SiteStore extends Store {
         GENERIC_ERROR
     }
 
-    public enum SupportedCountryErrorType {
+    public enum DomainSupportedCountriesErrorType {
         GENERIC_ERROR
     }
 
@@ -1160,11 +1159,11 @@ public class SiteStore extends Store {
             case CHECKED_DOMAIN_AVAILABILITY:
                 handleCheckedDomainAvailability((DomainAvailabilityResponsePayload) action.getPayload());
                 break;
-            case FETCH_SUPPORTED_COUNTRIES:
+            case FETCH_DOMAIN_SUPPORTED_COUNTRIES:
                 mSiteRestClient.fetchSupportedCountries();
                 break;
-            case FETCHED_SUPPORTED_COUNTRIES:
-                handleFetchedSupportedCountries((SupportedCountriesResponsePayload) action.getPayload());
+            case FETCHED_DOMAIN_SUPPORTED_COUNTRIES:
+                handleFetchedSupportedCountries((DomainSupportedCountriesResponsePayload) action.getPayload());
                 break;
             // Automated Transfer
             case CHECK_AUTOMATED_TRANSFER_ELIGIBILITY:
@@ -1478,8 +1477,8 @@ public class SiteStore extends Store {
                         payload.error));
     }
 
-    private void handleFetchedSupportedCountries(SupportedCountriesResponsePayload payload) {
-        emitChange(new OnSupportedCountriesFetched(payload.supportedCountries, payload.error));
+    private void handleFetchedSupportedCountries(DomainSupportedCountriesResponsePayload payload) {
+        emitChange(new OnDomainSupportedCountriesFetched(payload.supportedCountries, payload.error));
     }
 
     // Automated Transfers

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -493,6 +493,7 @@ public class SiteStore extends Store {
 
         public OnSupportedCountriesFetched(@Nullable List<SupportedCountriesResponse> supportedCountries,
                                            @Nullable SupportedCountriesError error) {
+            this.supportedCountries = supportedCountries;
             this.error = error;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -349,7 +349,9 @@ public class SiteStore extends Store {
         @NonNull public DomainSupportedCountriesErrorType type;
         @Nullable public String message;
 
-        public DomainSupportedCountriesError(@NonNull DomainSupportedCountriesErrorType type, @Nullable String message) {
+        public DomainSupportedCountriesError(
+                @NonNull DomainSupportedCountriesErrorType type,
+                @Nullable String message) {
             this.type = type;
             this.message = message;
         }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -27,6 +27,7 @@
 /read/site/$site#String/post_email_subscriptions/update
 
 /domains/suggestions
+/domains/supported-countries/
 /domains/$domainName#String/is-available
 
 /meta/external-media/pexels


### PR DESCRIPTION
This is an API required for implementing [custom domain association feature](https://github.com/wordpress-mobile/WordPress-Android/issues/7923).

When User associates a custom domain, they have to input and confirm basic information about themselves.
In this screen, they will be required to select one of the supported countries.

This API provides a list of supported countries from which User can select.