### PR TITLE
Remote jetpack install

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.41'
+    ext.kotlinVersion = '1.2.51'
 
     repositories {
         google()

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
@@ -70,7 +70,7 @@ class JetpackRestClientTest {
             delay(10)
         }
         successMethodCaptor.lastValue.invoke(JetpackInstallResponse(success))
-        delay(10)
+        delay(50)
 
         checkUrlAndLogin()
         assertThat(jetpackInstalledPayload).isNotNull()
@@ -93,7 +93,7 @@ class JetpackRestClientTest {
             delay(10)
         }
         errorMethodCaptor.lastValue.invoke(WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
-        delay(10)
+        delay(50)
 
         checkUrlAndLogin()
         assertThat(jetpackErrorPayload).isNotNull()

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
@@ -28,7 +28,7 @@ import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstalledPayload
 
 @RunWith(MockitoJUnitRunner::class)
-class ActivityLogRestClientTest {
+class JetpackRestClientTest {
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
     @Mock private lateinit var site: SiteModel

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
@@ -1,0 +1,116 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
+
+import com.android.volley.RequestQueue
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.delay
+import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient.JetpackInstallResponse
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstalledPayload
+
+@RunWith(MockitoJUnitRunner::class)
+class ActivityLogRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var successMethodCaptor: KArgumentCaptor<(JetpackInstallResponse) -> Unit>
+    private lateinit var errorMethodCaptor: KArgumentCaptor<(WPComGsonNetworkError) -> Unit>
+
+    private lateinit var jetpackRestClient: JetpackRestClient
+    private val username = "John Smith"
+    private val password = "password123"
+    private val siteUrl = "http://wordpress.org"
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        successMethodCaptor = argumentCaptor()
+        errorMethodCaptor = argumentCaptor()
+        jetpackRestClient = JetpackRestClient(dispatcher,
+                wpComGsonRequestBuilder,
+                null,
+                requestQueue,
+                accessToken,
+                userAgent)
+    }
+
+    @Test
+    fun `returns success on successful jetpack install`() = runBlocking<Unit> {
+        initRequest()
+        val success = true
+
+        var jetpackInstalledPayload: JetpackInstalledPayload? = null
+        launch { jetpackInstalledPayload = jetpackRestClient.installJetpack(site) }
+        while (successMethodCaptor.allValues.isEmpty()) {
+            delay(10)
+        }
+        successMethodCaptor.lastValue.invoke(JetpackInstallResponse(success))
+        delay(10)
+
+        checkUrlAndLogin()
+        assertThat(jetpackInstalledPayload).isNotNull()
+        assertThat(jetpackInstalledPayload?.success).isEqualTo(success)
+    }
+
+    fun checkUrlAndLogin() {
+        val url = "https://public-api.wordpress.com/rest/v1/jetpack-install/http%3A%2F%2Fwordpress.org/"
+        assertThat(urlCaptor.lastValue).isEqualTo(url)
+        assertThat(paramsCaptor.lastValue).containsEntry("user", username).containsEntry("password", password)
+    }
+
+    @Test
+    fun `returns error with type`() = runBlocking<Unit> {
+        initRequest()
+
+        var jetpackErrorPayload: JetpackInstalledPayload? = null
+        launch { jetpackErrorPayload = jetpackRestClient.installJetpack(site) }
+        while (errorMethodCaptor.allValues.isEmpty()) {
+            delay(10)
+        }
+        errorMethodCaptor.lastValue.invoke(WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
+        delay(10)
+
+        checkUrlAndLogin()
+        assertThat(jetpackErrorPayload).isNotNull()
+        assertThat(jetpackErrorPayload?.success).isEqualTo(false)
+        assertThat(jetpackErrorPayload?.error?.type).isEqualTo(JetpackInstallErrorType.GENERIC_ERROR)
+    }
+
+    fun initRequest() {
+        whenever(site.username).thenReturn(username)
+        whenever(site.password).thenReturn(password)
+        whenever(site.url).thenReturn(siteUrl)
+        whenever(wpComGsonRequestBuilder.buildPostRequest(
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                eq(JetpackInstallResponse::class.java),
+                successMethodCaptor.capture(),
+                errorMethodCaptor.capture()
+        )).thenReturn(mock())
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
@@ -1,0 +1,87 @@
+package org.wordpress.android.fluxc.store
+
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.delay
+import kotlinx.coroutines.experimental.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
+import org.wordpress.android.fluxc.generated.JetpackActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallError
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstalledPayload
+import org.wordpress.android.fluxc.store.JetpackStore.OnJetpackInstalled
+
+@RunWith(MockitoJUnitRunner::class)
+class JetpackStoreTest {
+    @Mock private lateinit var jetpackRestClient: JetpackRestClient
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var site: SiteModel
+    private lateinit var jetpackStore: JetpackStore
+
+    @Before
+    fun setUp() {
+        jetpackStore = JetpackStore(jetpackRestClient, dispatcher)
+    }
+
+    @Test
+    fun `on install triggers rest client and returns success`() = runBlocking {
+        val success = true
+        whenever(jetpackRestClient.installJetpack(site)).thenReturn(JetpackInstalledPayload(site, success))
+
+        val jetpackInstalled = jetpackStore.install(site, INSTALL_JETPACK)
+
+        assertThat(jetpackInstalled.success).isTrue()
+        val expectedChangeEvent = OnJetpackInstalled(success, INSTALL_JETPACK)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
+    @Test
+    fun `on install action triggers rest client and returns success`() = runBlocking {
+        val success = true
+        whenever(jetpackRestClient.installJetpack(site)).thenReturn(JetpackInstalledPayload(site, success))
+
+        jetpackStore.onAction(JetpackActionBuilder.newInstallJetpackAction(site))
+
+        delay(10)
+
+        val expectedChangeEvent = OnJetpackInstalled(success, INSTALL_JETPACK)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
+    @Test
+    fun `on install triggers rest client and returns error`() = runBlocking {
+        val installError = JetpackInstallError(GENERIC_ERROR)
+        val payload = JetpackInstalledPayload(installError, site)
+        whenever(jetpackRestClient.installJetpack(site)).thenReturn(payload)
+
+        val jetpackInstalled = jetpackStore.install(site, INSTALL_JETPACK)
+
+        assertThat(jetpackInstalled.success).isFalse()
+        val expectedChangeEvent = OnJetpackInstalled(installError, INSTALL_JETPACK)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
+    @Test
+    fun `on install action triggers rest client and returns error`() = runBlocking {
+        val installError = JetpackInstallError(GENERIC_ERROR)
+        val payload = JetpackInstalledPayload(installError, site)
+        whenever(jetpackRestClient.installJetpack(site)).thenReturn(payload)
+
+        jetpackStore.onAction(JetpackActionBuilder.newInstallJetpackAction(site))
+
+        delay(10)
+
+        val expectedChangeEvent = OnJetpackInstalled(installError, INSTALL_JETPACK)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+}

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -94,8 +94,8 @@ dependencies {
     compileOnly 'org.glassfish:javax.annotation:10.0-b28'
 
     // Coroutines
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.24.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.24.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.23.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.23.4'
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -94,8 +94,8 @@ dependencies {
     compileOnly 'org.glassfish:javax.annotation:10.0-b28'
 
     // Coroutines
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.23.4'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.23.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.24.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.24.0'
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/JetpackAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/JetpackAction.java
@@ -3,11 +3,10 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.model.SiteModel;
 
 @ActionEnum
 public enum JetpackAction implements IAction {
-    @Action(payloadType = JetpackAction.class)
-    INSTALL_JETPACK,
-    @Action(payloadType = JetpackAction.class)
-    INSTALLED_JETPACK
+    @Action(payloadType = SiteModel.class)
+    INSTALL_JETPACK
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/JetpackAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/JetpackAction.java
@@ -1,0 +1,13 @@
+package org.wordpress.android.fluxc.action;
+
+import org.wordpress.android.fluxc.annotations.Action;
+import org.wordpress.android.fluxc.annotations.ActionEnum;
+import org.wordpress.android.fluxc.annotations.action.IAction;
+
+@ActionEnum
+public enum JetpackAction implements IAction {
+    @Action(payloadType = JetpackAction.class)
+    INSTALL_JETPACK,
+    @Action(payloadType = JetpackAction.class)
+    INSTALLED_JETPACK
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
@@ -165,6 +166,16 @@ public class ReleaseNetworkModule {
                                                               AccessToken token, UserAgent userAgent,
                                                               WPComGsonRequestBuilder wpComGsonRequestBuilder) {
         return new ActivityLogRestClient(dispatcher, wpComGsonRequestBuilder, appContext, requestQueue, token,
+                userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public JetpackRestClient provideJetpackRestClient(Context appContext, Dispatcher dispatcher,
+                                                      @Named("regular") RequestQueue requestQueue,
+                                                      AccessToken token, UserAgent userAgent,
+                                                      WPComGsonRequestBuilder wpComGsonRequestBuilder) {
+        return new JetpackRestClient(dispatcher, wpComGsonRequestBuilder, appContext, requestQueue, token,
                 userAgent);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -1,0 +1,57 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallError
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.AUTHORIZATION_REQUIRED
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.SITE_IS_JETPACK
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.USERNAME_OR_PASSWORD_MISSING
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstalledPayload
+import java.net.URLEncoder
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.suspendCoroutine
+
+@Singleton
+class JetpackRestClient
+constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun installJetpack(site: SiteModel) = suspendCoroutine<JetpackInstalledPayload> { cont ->
+        val url = WPCOMREST.jetpack_install.site(URLEncoder.encode(site.url, "UTF-8")).urlV1
+        val params = mapOf("user" to site.username, "password" to site.password)
+        val request = wpComGsonRequestBuilder.buildPostRequest(
+                url, params, Response::class.java,
+                { response ->
+                    cont.resume(JetpackInstalledPayload(site, response.status))
+                },
+                { networkError ->
+                    val error = when {
+                        networkError.apiError == "SITE_IS_JETPACK" -> SITE_IS_JETPACK
+                        networkError.isGeneric &&
+                                networkError.type == BaseRequest.GenericErrorType.INVALID_RESPONSE -> INVALID_RESPONSE
+                        networkError.apiError == "unauthorized" -> AUTHORIZATION_REQUIRED
+                        networkError.apiError == "INVALID_INPUT" -> USERNAME_OR_PASSWORD_MISSING
+                        else -> GENERIC_ERROR
+                    }
+                    cont.resume(JetpackInstalledPayload(JetpackInstallError(error, networkError.message), site))
+                })
+        add(request)
+    }
+
+    private data class Response(val status: Boolean)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -35,7 +35,7 @@ constructor(
         val url = WPCOMREST.jetpack_install.site(URLEncoder.encode(site.url, "UTF-8")).urlV1
         val params = mapOf("user" to site.username, "password" to site.password)
         val request = wpComGsonRequestBuilder.buildPostRequest(
-                url, params, Response::class.java,
+                url, params, JetpackInstallResponse::class.java,
                 { response ->
                     cont.resume(JetpackInstalledPayload(site, response.status))
                 },
@@ -53,5 +53,5 @@ constructor(
         add(request)
     }
 
-    private data class Response(val status: Boolean)
+    data class JetpackInstallResponse(val status: Boolean)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -1,0 +1,84 @@
+package org.wordpress.android.fluxc.store
+
+import kotlinx.coroutines.experimental.launch
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.action.JetpackAction
+import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class JetpackStore
+@Inject constructor(private val jetpackRestClient: JetpackRestClient, dispatcher: Dispatcher) : Store(dispatcher) {
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>?) {
+        if (action is JetpackAction) {
+            when (action.type) {
+                JetpackAction.INSTALL_JETPACK -> asyncInstall(action.payload as SiteModel, action)
+            }
+        }
+    }
+
+    override fun onRegister() {
+        AppLog.d(T.API, "JetpackStore onRegister")
+    }
+
+    suspend fun install(site: SiteModel, action: JetpackAction = INSTALL_JETPACK): OnJetpackInstalled {
+        val installedPayload = jetpackRestClient.installJetpack(site)
+        return if (!installedPayload.isError) {
+            val onJetpackInstall = OnJetpackInstalled(installedPayload.success, action)
+            emitChange(onJetpackInstall)
+            onJetpackInstall
+        } else {
+            val errorPayload = OnJetpackInstalled(installedPayload.error, action)
+            emitChange(errorPayload)
+            errorPayload
+        }
+    }
+
+    private fun asyncInstall(site: SiteModel, action: JetpackAction) {
+        launch {
+            install(site, action)
+        }
+    }
+
+    class JetpackInstalledPayload(
+        val site: SiteModel,
+        val success: Boolean
+    ) : Payload<JetpackInstallError>() {
+        constructor(
+            error: JetpackInstallError,
+            site: SiteModel
+        ) : this(site = site, success = false) {
+            this.error = error
+        }
+    }
+
+    data class OnJetpackInstalled(
+        val success: Boolean,
+        var causeOfChange: JetpackAction
+    ) : Store.OnChanged<JetpackInstallError>() {
+        constructor(error: JetpackInstallError, causeOfChange: JetpackAction) :
+                this(success = false, causeOfChange = causeOfChange) {
+            this.error = error
+        }
+    }
+
+    enum class JetpackInstallErrorType {
+        GENERIC_ERROR,
+        AUTHORIZATION_REQUIRED,
+        INVALID_RESPONSE,
+        USERNAME_OR_PASSWORD_MISSING,
+        SITE_IS_JETPACK
+    }
+
+    class JetpackInstallError(var type: JetpackInstallErrorType, var message: String? = null) : Store.OnChangedError
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -19,10 +19,11 @@ import javax.inject.Singleton
 class JetpackStore
 @Inject constructor(private val jetpackRestClient: JetpackRestClient, dispatcher: Dispatcher) : Store(dispatcher) {
     @Subscribe(threadMode = ThreadMode.ASYNC)
-    override fun onAction(action: Action<*>?) {
-        if (action is JetpackAction) {
-            when (action.type) {
-                JetpackAction.INSTALL_JETPACK -> asyncInstall(action.payload as SiteModel, action)
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? JetpackAction ?: return
+        when (actionType) {
+            JetpackAction.INSTALL_JETPACK -> {
+                launch { install(action.payload as SiteModel, actionType) }
             }
         }
     }
@@ -41,12 +42,6 @@ class JetpackStore
             val errorPayload = OnJetpackInstalled(installedPayload.error, action)
             emitChange(errorPayload)
             errorPayload
-        }
-    }
-
-    private fun asyncInstall(site: SiteModel, action: JetpackAction) {
-        launch {
-            install(site, action)
         }
     }
 

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -86,3 +86,5 @@
 /users/social/new
 
 /activity-log/$site/rewind/to/$rewind_ID#String
+
+/jetpack-install/$site#String


### PR DESCRIPTION
- add rest client and store for Jetpack to enable remote install
- add interface in both standard event driven arch and coroutines
- bump kotlin
- bump coroutines