### PR TITLE
Device Connection Monitoring

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
@@ -2,17 +2,29 @@ package org.wordpress.android.fluxc.example
 
 import android.app.Activity
 import android.app.Application
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.os.Bundle
 import com.yarolegovich.wellsql.WellSql
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasActivityInjector
 import org.wordpress.android.fluxc.example.di.AppComponent
 import org.wordpress.android.fluxc.example.di.DaggerAppComponent
+import org.wordpress.android.fluxc.network.ConnectionChangeReceiver
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import java.util.Timer
+import java.util.TimerTask
 import javax.inject.Inject
 
 open class ExampleApp : Application(), HasActivityInjector {
+    companion object {
+        var sAppIsInTheBackground = true
+    }
     @Inject lateinit var activityInjector: DispatchingAndroidInjector<Activity>
+    @Inject lateinit var connectionReceiver: ConnectionChangeReceiver
 
     protected open val component: AppComponent by lazy {
         DaggerAppComponent.builder()
@@ -25,7 +37,96 @@ open class ExampleApp : Application(), HasActivityInjector {
         component.inject(this)
         val wellSqlConfig = WellSqlConfig(applicationContext, WellSqlConfig.ADDON_WOOCOMMERCE)
         WellSql.init(wellSqlConfig)
+
+        val lifecycleMonitor = ApplicationLifecycleMonitor(connectionReceiver)
+        registerActivityLifecycleCallbacks(lifecycleMonitor)
     }
 
     override fun activityInjector(): AndroidInjector<Activity> = activityInjector
+
+    /**
+     * Monitors the lifecycle of this application.
+     *
+     * The two methods ([startActivityTransitionTimer] and [stopActivityTransitionTimer])
+     * are used to track when the app goes to background.
+     *
+     * Our implementation uses [onActivityPaused] and [onActivityResumed] of this [ApplicationLifecycleMonitor]
+     * to start and stop the timer that detects when the app goes to background.
+     *
+     * So when the user is simply navigating between the activities, the [onActivityPaused]
+     * calls [startActivityTransitionTimer] and starts the timer, but almost immediately the new activity being
+     * entered, the [ApplicationLifecycleMonitor] cancels the timer in its [onActivityResumed] method, that in order
+     * calls [stopActivityTransitionTimer] and so mIsInBackground would be false.
+     *
+     * In the case the app is sent to background, the [TimerTask] is instead executed, and the code that handles all
+     * the background logic is run.
+     */
+    inner class ApplicationLifecycleMonitor(
+        val connectionReceiver: ConnectionChangeReceiver
+    ) : Application.ActivityLifecycleCallbacks {
+        private val MAX_ACTIVITY_TRANSITION_TIME_MS: Long = 2000
+        private var connectionReceiverRegistered = false
+        private var activityTransitionTimer: Timer? = null
+        private var activityTransitionTimerTask: TimerTask? = null
+
+        private fun onAppGoesToBackground() {
+            AppLog.i(T.MAIN, "App goes to background")
+
+            // Methods onAppComesFromBackground / onAppGoesToBackground are only workarounds to track when the
+            // app goes to or comes from background, but they are not 100% reliable, we should avoid unregistering
+            // the receiver twice.
+            if (connectionReceiverRegistered) {
+                connectionReceiverRegistered = false
+                unregisterReceiver(connectionReceiver)
+            }
+        }
+
+        private fun onAppComesFromBackground() {
+            AppLog.i(T.MAIN, "App goes to foreground")
+            if (!connectionReceiverRegistered) {
+                connectionReceiverRegistered = true
+                registerReceiver(connectionReceiver, IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION))
+            }
+        }
+
+        private fun startActivityTransitionTimer() {
+            this.activityTransitionTimer = Timer()
+            this.activityTransitionTimerTask = object : TimerTask() {
+                override fun run() {
+                    onAppGoesToBackground()
+                }
+            }
+
+            this.activityTransitionTimer?.schedule(activityTransitionTimerTask, MAX_ACTIVITY_TRANSITION_TIME_MS)
+        }
+
+        private fun stopActivityTransitionTimer() {
+            this.activityTransitionTimerTask?.cancel()
+            this.activityTransitionTimer?.cancel()
+
+            sAppIsInTheBackground = false
+        }
+
+        override fun onActivityPaused(activity: Activity?) {
+            startActivityTransitionTimer()
+        }
+
+        override fun onActivityResumed(activity: Activity?) {
+            if (sAppIsInTheBackground) {
+                onAppComesFromBackground()
+            }
+            stopActivityTransitionTimer()
+            sAppIsInTheBackground = false
+        }
+
+        override fun onActivityStarted(activity: Activity?) {}
+
+        override fun onActivityDestroyed(activity: Activity?) {}
+
+        override fun onActivitySaveInstanceState(activity: Activity?, outState: Bundle?) {}
+
+        override fun onActivityStopped(activity: Activity?) {}
+
+        override fun onActivityCreated(activity: Activity?, savedInstanceState: Bundle?) {}
+    }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.example.ThreeEditTextDialog.Listener
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.network.ConnectionChangeReceiver.OnNetworkStatusChanged
 import org.wordpress.android.fluxc.network.HTTPAuthManager
 import org.wordpress.android.fluxc.network.MemorizingTrustManager
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryError
@@ -314,6 +315,15 @@ class MainFragment : Fragment() {
             val firstSite = siteStore.sites[0]
             prependToLog("First site name: " + firstSite.name + " - Total sites: " + siteStore.sitesCount +
                     " - rowsAffected: " + event.rowsAffected)
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onNetworkStatusChanged(event: OnNetworkStatusChanged) {
+        when (event.isConnected) {
+            true -> prependToLog("Connected to the Internet :)")
+            else -> prependToLog("Not connected to the Internet!")
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/ConnectionChangeReceiver.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/ConnectionChangeReceiver.kt
@@ -1,0 +1,43 @@
+package org.wordpress.android.fluxc.network
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.NetworkUtils
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Global network connection change receiver - The implementing Application must register this receiver in either it's
+ * Application class (if it wants to manage connectivity status globally, or inside the activity that wishes to
+ * monitor connectivity.
+ */
+@Singleton
+class ConnectionChangeReceiver @Inject constructor(val dispatcher: Dispatcher) : BroadcastReceiver() {
+    companion object {
+        private var isFirstReceive = true
+        private var wasConnected = true
+    }
+
+    class OnNetworkStatusChanged(var isConnected: Boolean)
+
+    /**
+     * Listens for device connection changes.
+     *
+     * This method is called whenever something about the device connection has changed, not just
+     * it's network connectivity. Only dispatch a [OnNetworkStatusChanged] event
+     * when connection availability has changed.
+     */
+    override fun onReceive(context: Context, intent: Intent) {
+        val isConnected = NetworkUtils.isNetworkAvailable(context)
+        if (isFirstReceive || isConnected != wasConnected) {
+            AppLog.i(T.MAIN, "Connection Changed to $isConnected")
+            wasConnected = isConnected
+            isFirstReceive = false
+            dispatcher.emitChange(OnNetworkStatusChanged(isConnected))
+        }
+    }
+}


### PR DESCRIPTION
Added a new broadcast receiver to listen for changes in device connectivity. The logic has been borrowed from the current WordPress-Android app and has been consolidated to a single class in FluxC named `ConnectionChangeReceiver`. The App using this functionality would need to register this receiver to get connection updates. This can be done globally in the `Application` class, or in a single `Activity`. I've added it globally to the Example App for example implementation and testing purposes.

When a change in network status that effects the previously known network availability, a new `OnNetworkStatusChanged` event will be dispatched. 

### Design notes
I added this feature to FluxC instead of the Woo App for two reasons:
1. FluxC is responsible for the network and database layer of the Woo App already. 
2. To make use of the existing `Dispatcher` pattern and it's implementation of the `EventBus`. Since this feature does not make use of a database table or take incoming actions, I did not add it to FluxC as a store. 

I added the feature to core so it can be used across any app utilizing fluxC. The WordPress-Android app has a similar implementation already, but that would not be affected since the class being registered is different. They could eventually cut over to using this one however. 

### To Test
1. Make sure the device is connected to the internet.
2. Open the Example App - the current connectivity status will appear in the log section.
3. Put the device in Airplane mode - the updated connectivity status will appear in the log section

<img width="473" alt="screen shot 2018-08-13 at 5 51 12 pm" src="https://user-images.githubusercontent.com/5810477/44062506-420e7c50-9f22-11e8-8e3e-61310320a9ea.png">

cc: @aforcier @nbradbury 