### PR TITLE
Introduced Fetch Supported States API

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -30,7 +30,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains;
-import org.wordpress.android.fluxc.store.SiteStore.OnSupportedStatesFetched;
+import org.wordpress.android.fluxc.store.SiteStore.OnDomainSupportedStatesFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnWPComSiteFetched;
 import org.wordpress.android.fluxc.store.SiteStore.PlansErrorType;
@@ -75,7 +75,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         INITIATE_INELIGIBLE_AUTOMATED_TRANSFER,
         AUTOMATED_TRANSFER_NOT_FOUND,
         CHECK_BLACKLISTED_DOMAIN_AVAILABILITY,
-        FETCHED_SUPPORTED_STATES
+        FETCHED_DOMAIN_SUPPORTED_STATES
     }
 
     private TestEvents mNextEvent;
@@ -318,8 +318,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     public void testFetchSupportedStates() throws InterruptedException {
         authenticateUser(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         // Fetch Supported states
-        mDispatcher.dispatch(SiteActionBuilder.newFetchSupportedStatesAction("US"));
-        mNextEvent = TestEvents.FETCHED_SUPPORTED_STATES;
+        mDispatcher.dispatch(SiteActionBuilder.newFetchDomainSupportedStatesAction("US"));
+        mNextEvent = TestEvents.FETCHED_DOMAIN_SUPPORTED_STATES;
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
@@ -505,11 +505,11 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onSupportedStatesFetched(OnSupportedStatesFetched event) {
+    public void onDomainSupportedStatesFetched(OnDomainSupportedStatesFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertEquals(TestEvents.FETCHED_SUPPORTED_STATES, mNextEvent);
+        assertEquals(TestEvents.FETCHED_DOMAIN_SUPPORTED_STATES, mNextEvent);
         assertNotNull(event.supportedStates);
         assertFalse(event.supportedStates.isEmpty());
         mCountDownLatch.countDown();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -325,7 +325,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
- 
+
+    @Test
     public void testFetchSupportedCountries() throws InterruptedException {
         authenticateUser(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         // Fetch supported countries
@@ -526,6 +527,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mCountDownLatch.countDown();
     }
 
+    @SuppressWarnings("unused")
+    @Subscribe
     public void onDomainSupportedCountriesFetched(OnDomainSupportedCountriesFetched event) {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains;
+import org.wordpress.android.fluxc.store.SiteStore.OnSupportedStatesFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnWPComSiteFetched;
 import org.wordpress.android.fluxc.store.SiteStore.PlansErrorType;
@@ -73,7 +74,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         INELIGIBLE_FOR_AUTOMATED_TRANSFER,
         INITIATE_INELIGIBLE_AUTOMATED_TRANSFER,
         AUTOMATED_TRANSFER_NOT_FOUND,
-        CHECK_BLACKLISTED_DOMAIN_AVAILABILITY
+        CHECK_BLACKLISTED_DOMAIN_AVAILABILITY,
+        FETCHED_SUPPORTED_STATES
     }
 
     private TestEvents mNextEvent;
@@ -312,6 +314,16 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
+    public void testFetchSupportedStates() throws InterruptedException {
+        authenticateUser(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+        // Fetch Supported states
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSupportedStatesAction("US"));
+        mNextEvent = TestEvents.FETCHED_SUPPORTED_STATES;
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
@@ -488,6 +500,18 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         assertEquals(TestEvents.CHECK_BLACKLISTED_DOMAIN_AVAILABILITY, mNextEvent);
         assertEquals(event.status, DomainAvailabilityStatus.BLACKLISTED_DOMAIN);
         assertEquals(event.mappable, DomainMappabilityStatus.BLACKLISTED_DOMAIN);
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onSupportedStatesFetched(OnSupportedStatesFetched event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(TestEvents.FETCHED_SUPPORTED_STATES, mNextEvent);
+        assertNotNull(event.supportedStates);
+        assertFalse(event.supportedStates.isEmpty());
         mCountDownLatch.countDown();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.SupportedStatesResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponsePayload;
 
 @ActionEnum
 public enum SiteAction implements IAction {
@@ -65,7 +65,7 @@ public enum SiteAction implements IAction {
     @Action(payloadType = String.class)
     CHECK_DOMAIN_AVAILABILITY,
     @Action(payloadType = String.class)
-    FETCH_SUPPORTED_STATES,
+    FETCH_DOMAIN_SUPPORTED_STATES,
 
     // Remote responses
     @Action(payloadType = SiteModel.class)
@@ -98,8 +98,8 @@ public enum SiteAction implements IAction {
     FETCHED_PLANS,
     @Action(payloadType = DomainAvailabilityResponsePayload.class)
     CHECKED_DOMAIN_AVAILABILITY,
-    @Action(payloadType = SupportedStatesResponsePayload.class)
-    FETCHED_SUPPORTED_STATES,
+    @Action(payloadType = DomainSupportedStatesResponsePayload.class)
+    FETCHED_DOMAIN_SUPPORTED_STATES,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.SupportedStatesResponsePayload;
 
 @ActionEnum
 public enum SiteAction implements IAction {
@@ -63,6 +64,8 @@ public enum SiteAction implements IAction {
     FETCH_PLANS,
     @Action(payloadType = String.class)
     CHECK_DOMAIN_AVAILABILITY,
+    @Action(payloadType = String.class)
+    FETCH_SUPPORTED_STATES,
 
     // Remote responses
     @Action(payloadType = SiteModel.class)
@@ -95,6 +98,8 @@ public enum SiteAction implements IAction {
     FETCHED_PLANS,
     @Action(payloadType = DomainAvailabilityResponsePayload.class)
     CHECKED_DOMAIN_AVAILABILITY,
+    @Action(payloadType = SupportedStatesResponsePayload.class)
+    FETCHED_SUPPORTED_STATES,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -47,6 +47,8 @@ import org.wordpress.android.fluxc.store.SiteStore.DomainMappabilityStatus;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesError;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesError;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
@@ -62,8 +64,6 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesError;
-import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesError;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesErrorType;
 import org.wordpress.android.util.AppLog;
@@ -583,6 +583,8 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 DomainSupportedStatesResponsePayload payload =
                                         new DomainSupportedStatesResponsePayload(response);
                                 mDispatcher.dispatch(SiteActionBuilder.newFetchedDomainSupportedStatesAction(payload));
+                            }
+                        },
                         new WPComErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
@@ -595,7 +597,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                         });
         add(request);
     }
-                              
+
     /**
      * Performs an HTTP GET call to v1.1 /domains/supported-countries/ endpoint. Upon receiving a response
      * (success or error) a {@link SiteAction#FETCHED_DOMAIN_SUPPORTED_COUNTRIES} action is dispatched with a

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -58,6 +58,9 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.SupportedStatesError;
+import org.wordpress.android.fluxc.store.SiteStore.SupportedStatesErrorType;
+import org.wordpress.android.fluxc.store.SiteStore.SupportedStatesResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesError;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesErrorType;
 import org.wordpress.android.util.AppLog;
@@ -554,6 +557,39 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 DomainAvailabilityResponsePayload payload =
                                         new DomainAvailabilityResponsePayload(domainAvailabilityError);
                                 mDispatcher.dispatch(SiteActionBuilder.newCheckedDomainAvailabilityAction(payload));
+                            }
+                        });
+        add(request);
+    }
+
+    /**
+     * Performs an HTTP GET call to v1.1 /domains/supported-states/$countryCode endpoint. Upon receiving a response
+     * (success or error) a {@link SiteAction#FETCHED_SUPPORTED_STATES} action is dispatched with a
+     * payload of type {@link SupportedStatesResponsePayload}.
+     *
+     * {@link SupportedStatesResponsePayload#isError()} can be used to check the request result.
+     */
+    public void fetchSupportedStates(@NonNull final String countryCode) {
+        String url = WPCOMREST.domains.supported_states.countryCode(countryCode).getUrlV1_1();
+        final WPComGsonRequest<List<SupportedStatesResponse>> request =
+                WPComGsonRequest.buildGetRequest(url, null,
+                        new TypeToken<ArrayList<SupportedStatesResponse>>() {}.getType(),
+                        new Listener<List<SupportedStatesResponse>>() {
+                            @Override
+                            public void onResponse(List<SupportedStatesResponse> response) {
+                                SupportedStatesResponsePayload payload =
+                                        new SupportedStatesResponsePayload(response);
+                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedStatesAction(payload));
+                            }
+                        },
+                        new WPComErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                                SupportedStatesError supportedStatesError = new SupportedStatesError(
+                                        SupportedStatesErrorType.fromString(error.apiError), error.message);
+                                SupportedStatesResponsePayload payload =
+                                        new SupportedStatesResponsePayload(supportedStatesError);
+                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedStatesAction(payload));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -42,6 +42,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityError;
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
@@ -58,9 +59,8 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.SupportedStatesError;
-import org.wordpress.android.fluxc.store.SiteStore.SupportedStatesErrorType;
-import org.wordpress.android.fluxc.store.SiteStore.SupportedStatesResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesError;
+import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesError;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesErrorType;
 import org.wordpress.android.util.AppLog;
@@ -564,32 +564,32 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     /**
      * Performs an HTTP GET call to v1.1 /domains/supported-states/$countryCode endpoint. Upon receiving a response
-     * (success or error) a {@link SiteAction#FETCHED_SUPPORTED_STATES} action is dispatched with a
-     * payload of type {@link SupportedStatesResponsePayload}.
+     * (success or error) a {@link SiteAction#FETCHED_DOMAIN_SUPPORTED_STATES} action is dispatched with a
+     * payload of type {@link DomainSupportedStatesResponsePayload}.
      *
-     * {@link SupportedStatesResponsePayload#isError()} can be used to check the request result.
+     * {@link DomainSupportedStatesResponsePayload#isError()} can be used to check the request result.
      */
     public void fetchSupportedStates(@NonNull final String countryCode) {
         String url = WPCOMREST.domains.supported_states.countryCode(countryCode).getUrlV1_1();
-        final WPComGsonRequest<List<SupportedStatesResponse>> request =
+        final WPComGsonRequest<List<SupportedStateResponse>> request =
                 WPComGsonRequest.buildGetRequest(url, null,
-                        new TypeToken<ArrayList<SupportedStatesResponse>>() {}.getType(),
-                        new Listener<List<SupportedStatesResponse>>() {
+                        new TypeToken<ArrayList<SupportedStateResponse>>() {}.getType(),
+                        new Listener<List<SupportedStateResponse>>() {
                             @Override
-                            public void onResponse(List<SupportedStatesResponse> response) {
-                                SupportedStatesResponsePayload payload =
-                                        new SupportedStatesResponsePayload(response);
-                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedStatesAction(payload));
+                            public void onResponse(List<SupportedStateResponse> response) {
+                                DomainSupportedStatesResponsePayload payload =
+                                        new DomainSupportedStatesResponsePayload(response);
+                                mDispatcher.dispatch(SiteActionBuilder.newFetchedDomainSupportedStatesAction(payload));
                             }
                         },
                         new WPComErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                                SupportedStatesError supportedStatesError = new SupportedStatesError(
-                                        SupportedStatesErrorType.fromString(error.apiError), error.message);
-                                SupportedStatesResponsePayload payload =
-                                        new SupportedStatesResponsePayload(supportedStatesError);
-                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSupportedStatesAction(payload));
+                                DomainSupportedStatesError domainSupportedStatesError = new DomainSupportedStatesError(
+                                        DomainSupportedStatesErrorType.fromString(error.apiError), error.message);
+                                DomainSupportedStatesResponsePayload payload =
+                                        new DomainSupportedStatesResponsePayload(domainSupportedStatesError);
+                                mDispatcher.dispatch(SiteActionBuilder.newFetchedDomainSupportedStatesAction(payload));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SupportedStateResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SupportedStateResponse.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site
 
-class SupportedStatesResponse(
+class SupportedStateResponse(
     val code: String?,
     val name: String?
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SupportedStatesResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SupportedStatesResponse.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site
+
+class SupportedStatesResponse(
+    val code: String?,
+    val name: String?
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -29,7 +29,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.Export
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.FetchWPComSiteResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPComResponsePayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
-import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStatesResponse;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
@@ -238,14 +238,14 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class SupportedStatesResponsePayload extends Payload<SupportedStatesError> {
-        public @Nullable List<SupportedStatesResponse> supportedStates;
+    public static class DomainSupportedStatesResponsePayload extends Payload<DomainSupportedStatesError> {
+        public @Nullable List<SupportedStateResponse> supportedStates;
 
-        public SupportedStatesResponsePayload(@Nullable List<SupportedStatesResponse> supportedStates) {
+        public DomainSupportedStatesResponsePayload(@Nullable List<SupportedStateResponse> supportedStates) {
             this.supportedStates = supportedStates;
         }
 
-        public SupportedStatesResponsePayload(@NonNull SupportedStatesError error) {
+        public DomainSupportedStatesResponsePayload(@NonNull DomainSupportedStatesError error) {
             this.error = error;
         }
     }
@@ -345,16 +345,16 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class SupportedStatesError implements OnChangedError {
-        @NonNull public SupportedStatesErrorType type;
+    public static class DomainSupportedStatesError implements OnChangedError {
+        @NonNull public DomainSupportedStatesErrorType type;
         @Nullable public String message;
 
-        public SupportedStatesError(@NonNull SupportedStatesErrorType type, @Nullable String message) {
+        public DomainSupportedStatesError(@NonNull DomainSupportedStatesErrorType type, @Nullable String message) {
             this.type = type;
             this.message = message;
         }
 
-        public SupportedStatesError(@NonNull SupportedStatesErrorType type) {
+        public DomainSupportedStatesError(@NonNull DomainSupportedStatesErrorType type) {
             this.type = type;
         }
     }
@@ -527,11 +527,11 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class OnSupportedStatesFetched extends OnChanged<SupportedStatesError> {
-        public @Nullable List<SupportedStatesResponse> supportedStates;
+    public static class OnDomainSupportedStatesFetched extends OnChanged<DomainSupportedStatesError> {
+        public @Nullable List<SupportedStateResponse> supportedStates;
 
-        public OnSupportedStatesFetched(@Nullable List<SupportedStatesResponse> supportedStates,
-                                        @Nullable SupportedStatesError error) {
+        public OnDomainSupportedStatesFetched(@Nullable List<SupportedStateResponse> supportedStates,
+                                              @Nullable DomainSupportedStatesError error) {
             this.supportedStates = supportedStates;
             this.error = error;
         }
@@ -738,14 +738,14 @@ public class SiteStore extends Store {
         GENERIC_ERROR
     }
 
-    public enum SupportedStatesErrorType {
+    public enum DomainSupportedStatesErrorType {
         INVALID_COUNTRY_CODE,
         INVALID_QUERY,
         GENERIC_ERROR;
 
-        public static SupportedStatesErrorType fromString(String type) {
+        public static DomainSupportedStatesErrorType fromString(String type) {
             if (!TextUtils.isEmpty(type)) {
-                for (SupportedStatesErrorType v : SupportedStatesErrorType.values()) {
+                for (DomainSupportedStatesErrorType v : DomainSupportedStatesErrorType.values()) {
                     if (type.equalsIgnoreCase(v.name())) {
                         return v;
                     }
@@ -1176,11 +1176,11 @@ public class SiteStore extends Store {
             case CHECKED_DOMAIN_AVAILABILITY:
                 handleCheckedDomainAvailability((DomainAvailabilityResponsePayload) action.getPayload());
                 break;
-            case FETCH_SUPPORTED_STATES:
+            case FETCH_DOMAIN_SUPPORTED_STATES:
                 fetchSupportedStates((String) action.getPayload());
                 break;
-            case FETCHED_SUPPORTED_STATES:
-                handleFetchedSupportedStates((SupportedStatesResponsePayload) action.getPayload());
+            case FETCHED_DOMAIN_SUPPORTED_STATES:
+                handleFetchedSupportedStates((DomainSupportedStatesResponsePayload) action.getPayload());
                 break;
             // Automated Transfer
             case CHECK_AUTOMATED_TRANSFER_ELIGIBILITY:
@@ -1496,15 +1496,15 @@ public class SiteStore extends Store {
 
     private void fetchSupportedStates(String countryCode) {
         if (TextUtils.isEmpty(countryCode)) {
-            SupportedStatesError error = new SupportedStatesError(SupportedStatesErrorType.INVALID_COUNTRY_CODE);
-            handleFetchedSupportedStates(new SupportedStatesResponsePayload(error));
+            DomainSupportedStatesError error = new DomainSupportedStatesError(DomainSupportedStatesErrorType.INVALID_COUNTRY_CODE);
+            handleFetchedSupportedStates(new DomainSupportedStatesResponsePayload(error));
         } else {
             mSiteRestClient.fetchSupportedStates(countryCode);
         }
     }
 
-    private void handleFetchedSupportedStates(SupportedStatesResponsePayload payload) {
-        emitChange(new OnSupportedStatesFetched(payload.supportedStates, payload.error));
+    private void handleFetchedSupportedStates(DomainSupportedStatesResponsePayload payload) {
+        emitChange(new OnDomainSupportedStatesFetched(payload.supportedStates, payload.error));
     }
 
     // Automated Transfers

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1499,6 +1499,7 @@ public class SiteStore extends Store {
             SupportedStatesError error = new SupportedStatesError(SupportedStatesErrorType.INVALID_COUNTRY_CODE);
             handleFetchedSupportedStates(new SupportedStatesResponsePayload(error));
         } else {
+            mSiteRestClient.fetchSupportedStates(countryCode);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -371,7 +371,7 @@ public class SiteStore extends Store {
             this.type = type;
         }
     }
-  
+
     public static class DomainSupportedCountriesError implements OnChangedError {
         @NonNull public DomainSupportedCountriesErrorType type;
         @Nullable public String message;
@@ -1220,6 +1220,7 @@ public class SiteStore extends Store {
                 break;
             case FETCHED_DOMAIN_SUPPORTED_STATES:
                 handleFetchedSupportedStates((DomainSupportedStatesResponsePayload) action.getPayload());
+                break;
             case FETCH_DOMAIN_SUPPORTED_COUNTRIES:
                 mSiteRestClient.fetchSupportedCountries();
                 break;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1496,7 +1496,8 @@ public class SiteStore extends Store {
 
     private void fetchSupportedStates(String countryCode) {
         if (TextUtils.isEmpty(countryCode)) {
-            DomainSupportedStatesError error = new DomainSupportedStatesError(DomainSupportedStatesErrorType.INVALID_COUNTRY_CODE);
+            DomainSupportedStatesError error =
+                    new DomainSupportedStatesError(DomainSupportedStatesErrorType.INVALID_COUNTRY_CODE);
             handleFetchedSupportedStates(new DomainSupportedStatesResponsePayload(error));
         } else {
             mSiteRestClient.fetchSupportedStates(countryCode);

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -27,6 +27,7 @@
 /read/site/$site#String/post_email_subscriptions/update
 
 /domains/suggestions
+/domains/supported-states/$countryCode#String
 /domains/$domainName#String/is-available
 
 /meta/external-media/pexels


### PR DESCRIPTION
This is an API required for implementing [custom domain association](https://github.com/wordpress-mobile/WordPress-Android/issues/7923) feature.

When User associates a custom domain, they have to input and confirm basic information about themselves.
In this screen, they will be required to select one of the supported states for a countries.

This API provides a list of supported states for a specific country from which User can select.