### PR TITLE
Issue/fixing quick start flags reset

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/QuickStartSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/QuickStartSqlUtilsTest.kt
@@ -72,4 +72,23 @@ class QuickStartSqlUtilsTest {
         quickStartSqlUtils.setShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE, false)
         assertFalse(quickStartSqlUtils.hasShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
     }
+
+    @Test
+    fun testTaskMultipleStatuses() {
+        assertFalse(quickStartSqlUtils.hasShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+        assertFalse(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+
+        quickStartSqlUtils.setShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE, true)
+        quickStartSqlUtils.setDoneTask(testLocalSiteId, QuickStartTask.CREATE_SITE, true)
+        assertTrue(quickStartSqlUtils.hasShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+        assertTrue(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+
+        quickStartSqlUtils.setShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE, false)
+        assertFalse(quickStartSqlUtils.hasShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+        assertTrue(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+
+        quickStartSqlUtils.setDoneTask(testLocalSiteId, QuickStartTask.CREATE_SITE, false)
+        assertFalse(quickStartSqlUtils.hasShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+        assertFalse(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
@@ -58,7 +58,7 @@ class QuickStartSqlUtils
     }
 
     fun setDoneTask(siteId: Long, task: QuickStartTask, isDone: Boolean) {
-        val model = QuickStartModel()
+        val model = getTask(siteId, task) ?: QuickStartModel()
         model.siteId = siteId
         model.taskName = task.toString()
         model.isDone = isDone
@@ -66,7 +66,7 @@ class QuickStartSqlUtils
     }
 
     fun setShownTask(siteId: Long, task: QuickStartTask, isShown: Boolean) {
-        val model = QuickStartModel()
+        val model = getTask(siteId, task) ?: QuickStartModel()
         model.siteId = siteId
         model.taskName = task.toString()
         model.isShown = isShown


### PR DESCRIPTION
This PR fixes issue in QuickStartSqlUtils that reset the `isDone` flag to false when setting `isShown` flag and vice-versa.