### PR TITLE
Feature/splitting quick start taks and status models

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/QuickStartSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/QuickStartSqlUtilsTest.kt
@@ -8,7 +8,8 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
-import org.wordpress.android.fluxc.model.QuickStartModel
+import org.wordpress.android.fluxc.model.QuickStartStatusModel
+import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.fluxc.persistence.QuickStartSqlUtils
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import kotlin.test.assertFalse
@@ -22,7 +23,8 @@ class QuickStartSqlUtilsTest {
     @Before
     fun setUp() {
         val appContext = RuntimeEnvironment.application.applicationContext
-        val config = SingleStoreWellSqlConfigForTests(appContext, QuickStartModel::class.java)
+        val config = SingleStoreWellSqlConfigForTests(appContext,
+                listOf(QuickStartTaskModel::class.java, QuickStartStatusModel::class.java), "")
         WellSql.init(config)
         config.reset()
 
@@ -90,5 +92,27 @@ class QuickStartSqlUtilsTest {
         quickStartSqlUtils.setDoneTask(testLocalSiteId, QuickStartTask.CREATE_SITE, false)
         assertFalse(quickStartSqlUtils.hasShownTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
         assertFalse(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.CREATE_SITE))
+    }
+
+    @Test
+    fun testQuickStartCompletedStatus() {
+        assertFalse(quickStartSqlUtils.getQuickStartCompleted(testLocalSiteId))
+
+        quickStartSqlUtils.setQuickStartCompleted(testLocalSiteId, true)
+        assertTrue(quickStartSqlUtils.getQuickStartCompleted(testLocalSiteId))
+
+        quickStartSqlUtils.setQuickStartCompleted(testLocalSiteId, false)
+        assertFalse(quickStartSqlUtils.getQuickStartCompleted(testLocalSiteId))
+    }
+
+    @Test
+    fun testQuickStartNotificationReceivedStatus() {
+        assertFalse(quickStartSqlUtils.getQuickStartNotificationReceived(testLocalSiteId))
+
+        quickStartSqlUtils.setQuickStartNotificationReceived(testLocalSiteId, true)
+        assertTrue(quickStartSqlUtils.getQuickStartNotificationReceived(testLocalSiteId))
+
+        quickStartSqlUtils.setQuickStartNotificationReceived(testLocalSiteId, false)
+        assertFalse(quickStartSqlUtils.getQuickStartNotificationReceived(testLocalSiteId))
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/QuickStartStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/QuickStartStatusModel.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+
+@Table
+class QuickStartStatusModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var siteId: Long = 0
+    @Column var isCompleted: Boolean = false
+        @JvmName("setIsCompleted")
+        set
+    @Column var isNotificationReceived: Boolean = false
+        @JvmName("setIsNotificationReceived")
+        set
+
+    override fun getId(): Int {
+        return this.id
+    }
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/QuickStartTaskModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/QuickStartTaskModel.kt
@@ -4,10 +4,9 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
-import java.io.Serializable
 
 @Table
-class QuickStartModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable, Serializable {
+class QuickStartTaskModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var siteId: Long = 0
     @Column var taskName: String? = null
     @Column var isDone: Boolean = false

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.persistence
 
-import com.wellsql.generated.QuickStartModelTable
+import com.wellsql.generated.QuickStartStatusModelTable
+import com.wellsql.generated.QuickStartTaskModelTable
 import com.yarolegovich.wellsql.WellSql
-import org.wordpress.android.fluxc.model.QuickStartModel
+import org.wordpress.android.fluxc.model.QuickStartStatusModel
+import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -11,30 +13,41 @@ import javax.inject.Singleton
 class QuickStartSqlUtils
 @Inject constructor() {
     fun getDoneCount(siteId: Long): Int {
-        return WellSql.select(QuickStartModel::class.java)
+        return WellSql.select(QuickStartTaskModel::class.java)
                 .where().beginGroup()
-                .equals(QuickStartModelTable.SITE_ID, siteId)
-                .equals(QuickStartModelTable.IS_DONE, true)
+                .equals(QuickStartTaskModelTable.SITE_ID, siteId)
+                .equals(QuickStartTaskModelTable.IS_DONE, true)
                 .endGroup().endWhere()
                 .asModel.size
     }
 
     fun getShownCount(siteId: Long): Int {
-        return WellSql.select(QuickStartModel::class.java)
+        return WellSql.select(QuickStartTaskModel::class.java)
                 .where().beginGroup()
-                .equals(QuickStartModelTable.SITE_ID, siteId)
-                .equals(QuickStartModelTable.IS_SHOWN, true)
+                .equals(QuickStartTaskModelTable.SITE_ID, siteId)
+                .equals(QuickStartTaskModelTable.IS_SHOWN, true)
                 .endGroup().endWhere()
                 .asModel.size
     }
 
-    private fun getTask(siteId: Long, task: QuickStartTask): QuickStartModel? {
-        return WellSql.select(QuickStartModel::class.java)
+    private fun getTask(siteId: Long, task: QuickStartTask): QuickStartTaskModel? {
+        return WellSql.select(QuickStartTaskModel::class.java)
                 .where().beginGroup()
-                .equals(QuickStartModelTable.SITE_ID, siteId)
-                .equals(QuickStartModelTable.TASK_NAME, task.toString())
+                .equals(QuickStartTaskModelTable.SITE_ID, siteId)
+                .equals(QuickStartTaskModelTable.TASK_NAME, task.toString())
                 .endGroup().endWhere()
                 .asModel.firstOrNull()
+    }
+
+    private fun getQuickStartStatus(siteId: Long): QuickStartStatusModel? {
+        return WellSql.select(QuickStartStatusModel::class.java)
+                .where()
+                .beginGroup()
+                .equals(QuickStartStatusModelTable.SITE_ID, siteId)
+                .endGroup()
+                .endWhere()
+                .asModel
+                .firstOrNull()
     }
 
     fun hasDoneTask(siteId: Long, task: QuickStartTask): Boolean {
@@ -45,20 +58,32 @@ class QuickStartSqlUtils
         return getTask(siteId, task)?.isShown ?: false
     }
 
-    private fun insertOrUpdateQuickStartModel(newModel: QuickStartModel) {
-        val oldModel = getTask(newModel.siteId, QuickStartTask.fromString(newModel.taskName))
+    private fun insertOrUpdateQuickStartModel(newTaskModel: QuickStartTaskModel) {
+        val oldModel = getTask(newTaskModel.siteId, QuickStartTask.fromString(newTaskModel.taskName))
         oldModel?.let {
-            WellSql.update(QuickStartModel::class.java)
+            WellSql.update(QuickStartTaskModel::class.java)
                     .whereId(it.id)
-                    .put(newModel, UpdateAllExceptId(QuickStartModel::class.java))
+                    .put(newTaskModel, UpdateAllExceptId(QuickStartTaskModel::class.java))
                     .execute()
             return
         }
-        WellSql.insert(newModel).execute()
+        WellSql.insert(newTaskModel).execute()
+    }
+
+    private fun insertOrUpdateQuickStartStatusModel(newQuickStartStatus: QuickStartStatusModel) {
+        val oldModel = getQuickStartStatus(newQuickStartStatus.siteId)
+        oldModel?.let {
+            WellSql.update(QuickStartStatusModel::class.java)
+                    .whereId(it.id)
+                    .put(newQuickStartStatus, UpdateAllExceptId(QuickStartStatusModel::class.java))
+                    .execute()
+            return
+        }
+        WellSql.insert(newQuickStartStatus).execute()
     }
 
     fun setDoneTask(siteId: Long, task: QuickStartTask, isDone: Boolean) {
-        val model = getTask(siteId, task) ?: QuickStartModel()
+        val model = getTask(siteId, task) ?: QuickStartTaskModel()
         model.siteId = siteId
         model.taskName = task.toString()
         model.isDone = isDone
@@ -66,10 +91,32 @@ class QuickStartSqlUtils
     }
 
     fun setShownTask(siteId: Long, task: QuickStartTask, isShown: Boolean) {
-        val model = getTask(siteId, task) ?: QuickStartModel()
+        val model = getTask(siteId, task) ?: QuickStartTaskModel()
         model.siteId = siteId
         model.taskName = task.toString()
         model.isShown = isShown
         insertOrUpdateQuickStartModel(model)
+    }
+
+    fun setQuickStartCompleted(siteId: Long, isCompleted: Boolean) {
+        val model = getQuickStartStatus(siteId) ?: QuickStartStatusModel()
+        model.siteId = siteId
+        model.isCompleted = isCompleted
+        insertOrUpdateQuickStartStatusModel(model)
+    }
+
+    fun getQuickStartCompleted(siteId: Long): Boolean {
+        return getQuickStartStatus(siteId)?.isCompleted ?: false
+    }
+
+    fun setQuickStartNotificationReceived(siteId: Long, isReceived: Boolean) {
+        val model = getQuickStartStatus(siteId) ?: QuickStartStatusModel()
+        model.siteId = siteId
+        model.isNotificationReceived = isReceived
+        insertOrUpdateQuickStartStatusModel(model)
+    }
+
+    fun getQuickStartNotificationReceived(siteId: Long): Boolean {
+        return getQuickStartStatus(siteId)?.isNotificationReceived ?: false
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
@@ -41,13 +41,10 @@ class QuickStartSqlUtils
 
     private fun getQuickStartStatus(siteId: Long): QuickStartStatusModel? {
         return WellSql.select(QuickStartStatusModel::class.java)
-                .where()
-                .beginGroup()
+                .where().beginGroup()
                 .equals(QuickStartStatusModelTable.SITE_ID, siteId)
-                .endGroup()
-                .endWhere()
-                .asModel
-                .firstOrNull()
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
     }
 
     fun hasDoneTask(siteId: Long, task: QuickStartTask): Boolean {
@@ -58,7 +55,7 @@ class QuickStartSqlUtils
         return getTask(siteId, task)?.isShown ?: false
     }
 
-    private fun insertOrUpdateQuickStartModel(newTaskModel: QuickStartTaskModel) {
+    private fun insertOrUpdateQuickStartTaskModel(newTaskModel: QuickStartTaskModel) {
         val oldModel = getTask(newTaskModel.siteId, QuickStartTask.fromString(newTaskModel.taskName))
         oldModel?.let {
             WellSql.update(QuickStartTaskModel::class.java)
@@ -87,7 +84,7 @@ class QuickStartSqlUtils
         model.siteId = siteId
         model.taskName = task.toString()
         model.isDone = isDone
-        insertOrUpdateQuickStartModel(model)
+        insertOrUpdateQuickStartTaskModel(model)
     }
 
     fun setShownTask(siteId: Long, task: QuickStartTask, isShown: Boolean) {
@@ -95,7 +92,7 @@ class QuickStartSqlUtils
         model.siteId = siteId
         model.taskName = task.toString()
         model.isShown = isShown
-        insertOrUpdateQuickStartModel(model)
+        insertOrUpdateQuickStartTaskModel(model)
     }
 
     fun setQuickStartCompleted(siteId: Long, isCompleted: Boolean) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -309,8 +309,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 37:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("CREATE TABLE QuickStartModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                db.execSQL("DROP TABLE IF EXISTS QuickStartModel");
+                db.execSQL("CREATE TABLE QuickStartTaskModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                            + "SITE_ID INTEGER,TASK_NAME TEXT,IS_DONE INTEGER,IS_SHOWN INTEGER)");
+                db.execSQL("CREATE TABLE QuickStartStatusModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                           + "SITE_ID INTEGER,IS_COMPLETED INTEGER,IS_NOTIFICATION_RECEIVED INTEGER)");
                 oldVersion++;
             case 38:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
@@ -69,4 +69,20 @@ constructor(private val quickStartSqlUtils: QuickStartSqlUtils, dispatcher: Disp
     fun setShownTask(siteId: Long, task: QuickStartTask, isShown: Boolean) {
         quickStartSqlUtils.setShownTask(siteId, task, isShown)
     }
+
+    fun setQuickStartCompleted(siteId: Long, isCompleted: Boolean) {
+        quickStartSqlUtils.setQuickStartCompleted(siteId, isCompleted)
+    }
+
+    fun getQuickStartCompleted(siteId: Long): Boolean {
+        return quickStartSqlUtils.getQuickStartCompleted(siteId)
+    }
+
+    fun setQuickStartNotificationReceived(siteId: Long, isReceived: Boolean) {
+        quickStartSqlUtils.setQuickStartNotificationReceived(siteId, isReceived)
+    }
+
+    fun getQuickStartNotificationReceived(siteId: Long): Boolean {
+        return quickStartSqlUtils.getQuickStartNotificationReceived(siteId)
+    }
 }


### PR DESCRIPTION
This PR adds a separate Quick Start table to track a status of Quick Start related events on a per-site basis.