### PR TITLE
Quick Start api

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -19,7 +19,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartCompletedResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.QuickStartCompletedResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
@@ -71,7 +71,7 @@ public enum SiteAction implements IAction {
     @Action
     FETCH_DOMAIN_SUPPORTED_COUNTRIES,
     @Action(payloadType = SiteModel.class)
-    COMPLETE_MOBILE_QUICK_START,
+    COMPLETE_QUICK_START,
 
     // Remote responses
     @Action(payloadType = SiteModel.class)
@@ -108,8 +108,8 @@ public enum SiteAction implements IAction {
     FETCHED_DOMAIN_SUPPORTED_STATES,
     @Action(payloadType = DomainSupportedCountriesResponsePayload.class)
     FETCHED_DOMAIN_SUPPORTED_COUNTRIES,
-    @Action(payloadType = MobileQuickStartCompletedResponsePayload.class)
-    COMPLETED_MOBILE_QUICK_START,
+    @Action(payloadType = QuickStartCompletedResponsePayload.class)
+    COMPLETED_QUICK_START,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -67,6 +67,8 @@ public enum SiteAction implements IAction {
     CHECK_DOMAIN_AVAILABILITY,
     @Action
     FETCH_DOMAIN_SUPPORTED_COUNTRIES,
+    @Action(payloadType = SiteModel.class)
+    COMPLETE_MOBILE_QUICK_START,
 
     // Remote responses
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartCompletedResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
@@ -100,6 +101,8 @@ public enum SiteAction implements IAction {
     CHECKED_DOMAIN_AVAILABILITY,
     @Action(payloadType = DomainSupportedCountriesResponsePayload.class)
     FETCHED_DOMAIN_SUPPORTED_COUNTRIES,
+    @Action(payloadType = MobileQuickStartCompletedResponsePayload.class)
+    COMPLETED_MOBILE_QUICK_START,
 
     // Local actions
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/MobileQuickStartCompletedResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/MobileQuickStartCompletedResponse.java
@@ -1,0 +1,8 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import com.google.gson.annotations.SerializedName;
+
+public class MobileQuickStartCompletedResponse {
+    @SerializedName("status")
+    public boolean status;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/MobileQuickStartCompletedResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/MobileQuickStartCompletedResponse.java
@@ -3,6 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.site;
 import com.google.gson.annotations.SerializedName;
 
 public class MobileQuickStartCompletedResponse {
-    @SerializedName("status")
-    public boolean status;
+    @SerializedName("success")
+    public boolean success;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/QuickStartCompletedResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/QuickStartCompletedResponse.java
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.site;
 
 import com.google.gson.annotations.SerializedName;
 
-public class MobileQuickStartCompletedResponse {
+public class QuickStartCompletedResponse {
     @SerializedName("success")
     public boolean success;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -732,7 +732,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                             @Override
                             public void onResponse(MobileQuickStartCompletedResponse response) {
                                 mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(
-                                         new MobileQuickStartCompletedResponsePayload(response.status)));
+                                         new MobileQuickStartCompletedResponsePayload(response.success)));
                             }
                         },
                         new WPComErrorListener() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -55,6 +55,8 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartCompletedResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartError;
+import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.PlansError;
@@ -736,9 +738,12 @@ public class SiteRestClient extends BaseWPComRestClient {
                         new WPComErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
+                                MobileQuickStartError error = new MobileQuickStartError(
+                                        MobileQuickStartErrorType.GENERIC_ERROR, networkError.message);
+
                                 MobileQuickStartCompletedResponsePayload payload =
                                         new MobileQuickStartCompletedResponsePayload(false);
-                                payload.error = networkError;
+                                payload.error = error;
 
                                 mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(payload));
                             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -689,7 +689,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         String url = WPCOMREST.sites.site(site.getSiteId()).mobile_quick_start.getUrlV1_1();
 
         final WPComGsonRequest<MobileQuickStartCompletedResponse> request = WPComGsonRequest
-                .buildGetRequest(url, null, MobileQuickStartCompletedResponse.class,
+                .buildPostRequest(url, null, MobileQuickStartCompletedResponse.class,
                         new Listener<MobileQuickStartCompletedResponse>() {
                             @Override
                             public void onResponse(MobileQuickStartCompletedResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -694,7 +694,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                             @Override
                             public void onResponse(MobileQuickStartCompletedResponse response) {
                                 mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(
-                                        new MobileQuickStartCompletedResponsePayload(response.status)));
+                                         new MobileQuickStartCompletedResponsePayload(response.status)));
                             }
                         },
                         new WPComErrorListener() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -51,6 +51,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartCompletedResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.PlansError;
@@ -679,6 +680,28 @@ public class SiteRestClient extends BaseWPComRestClient {
                                         networkError.apiError, networkError.message);
                                 mDispatcher.dispatch(SiteActionBuilder.newCheckedAutomatedTransferStatusAction(
                                         new AutomatedTransferStatusResponsePayload(site, error)));
+                            }
+                        });
+        add(request);
+    }
+
+    public void completeMobileQuickStart(@NonNull final SiteModel site) {
+        String url = WPCOMREST.sites.site(site.getSiteId()).mobile_quick_start.getUrlV1_1();
+
+        final WPComGsonRequest<MobileQuickStartCompletedResponse> request = WPComGsonRequest
+                .buildGetRequest(url, null, MobileQuickStartCompletedResponse.class,
+                        new Listener<MobileQuickStartCompletedResponse>() {
+                            @Override
+                            public void onResponse(MobileQuickStartCompletedResponse response) {
+                                mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(
+                                        new MobileQuickStartCompletedResponsePayload(response.status)));
+                            }
+                        },
+                        new WPComErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
+                                mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(
+                                        new MobileQuickStartCompletedResponsePayload(false)));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -732,7 +732,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                             @Override
                             public void onResponse(MobileQuickStartCompletedResponse response) {
                                 mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(
-                                         new MobileQuickStartCompletedResponsePayload(response.success)));
+                                         new MobileQuickStartCompletedResponsePayload(site, response.success)));
                             }
                         },
                         new WPComErrorListener() {
@@ -742,7 +742,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                                         MobileQuickStartErrorType.GENERIC_ERROR, networkError.message);
 
                                 MobileQuickStartCompletedResponsePayload payload =
-                                        new MobileQuickStartCompletedResponsePayload(false);
+                                        new MobileQuickStartCompletedResponsePayload(site, false);
                                 payload.error = error;
 
                                 mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -736,8 +736,11 @@ public class SiteRestClient extends BaseWPComRestClient {
                         new WPComErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
-                                mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(
-                                        new MobileQuickStartCompletedResponsePayload(false)));
+                                MobileQuickStartCompletedResponsePayload payload =
+                                        new MobileQuickStartCompletedResponsePayload(false);
+                                payload.error = networkError;
+
+                                mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(payload));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -54,9 +54,9 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartCompletedResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartError;
-import org.wordpress.android.fluxc.store.SiteStore.MobileQuickStartErrorType;
+import org.wordpress.android.fluxc.store.SiteStore.QuickStartCompletedResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.QuickStartError;
+import org.wordpress.android.fluxc.store.SiteStore.QuickStartErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.PlansError;
@@ -723,29 +723,29 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void completeMobileQuickStart(@NonNull final SiteModel site) {
+    public void completeQuickStart(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).mobile_quick_start.getUrlV1_1();
 
-        final WPComGsonRequest<MobileQuickStartCompletedResponse> request = WPComGsonRequest
-                .buildPostRequest(url, null, MobileQuickStartCompletedResponse.class,
-                        new Listener<MobileQuickStartCompletedResponse>() {
+        final WPComGsonRequest<QuickStartCompletedResponse> request = WPComGsonRequest
+                .buildPostRequest(url, null, QuickStartCompletedResponse.class,
+                        new Listener<QuickStartCompletedResponse>() {
                             @Override
-                            public void onResponse(MobileQuickStartCompletedResponse response) {
-                                mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(
-                                         new MobileQuickStartCompletedResponsePayload(site, response.success)));
+                            public void onResponse(QuickStartCompletedResponse response) {
+                                mDispatcher.dispatch(SiteActionBuilder.newCompletedQuickStartAction(
+                                         new QuickStartCompletedResponsePayload(site, response.success)));
                             }
                         },
                         new WPComErrorListener() {
                             @Override
                             public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
-                                MobileQuickStartError error = new MobileQuickStartError(
-                                        MobileQuickStartErrorType.GENERIC_ERROR, networkError.message);
+                                QuickStartError error = new QuickStartError(
+                                        QuickStartErrorType.GENERIC_ERROR, networkError.message);
 
-                                MobileQuickStartCompletedResponsePayload payload =
-                                        new MobileQuickStartCompletedResponsePayload(site, false);
+                                QuickStartCompletedResponsePayload payload =
+                                        new QuickStartCompletedResponsePayload(site, false);
                                 payload.error = error;
 
-                                mDispatcher.dispatch(SiteActionBuilder.newCompletedMobileQuickStartAction(payload));
+                                mDispatcher.dispatch(SiteActionBuilder.newCompletedQuickStartAction(payload));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -643,18 +643,18 @@ public class SiteStore extends Store {
     }
 
     public static class MobileQuickStartCompletedResponsePayload extends OnChanged<MobileQuickStartError> {
-        public boolean status;
+        public boolean success;
 
         public MobileQuickStartCompletedResponsePayload(boolean status) {
-            this.status = status;
+            this.success = status;
         }
     }
 
     public static class OnMobileQuickStartCompleted extends OnChanged<MobileQuickStartError> {
-        public boolean status;
+        public boolean success;
 
         OnMobileQuickStartCompleted(boolean status) {
-            this.status = status;
+            this.success = status;
         }
     }
 
@@ -1634,7 +1634,7 @@ public class SiteStore extends Store {
     }
 
     private void handleMobileQuickStartCompleted(MobileQuickStartCompletedResponsePayload payload) {
-        OnMobileQuickStartCompleted event = new OnMobileQuickStartCompleted(payload.status);
+        OnMobileQuickStartCompleted event = new OnMobileQuickStartCompleted(payload.success);
         event.error = payload.error;
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -384,6 +384,16 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class MobileQuickStartError implements OnChangedError {
+        @NonNull public MobileQuickStartErrorType type;
+        @Nullable public String message;
+
+        public MobileQuickStartError(@NonNull MobileQuickStartErrorType type, @Nullable String message) {
+            this.type = type;
+            this.message = message;
+        }
+    }
+
     // OnChanged Events
     public static class OnProfileFetched extends OnChanged<SiteError> {
         public SiteModel site;
@@ -632,7 +642,7 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class MobileQuickStartCompletedResponsePayload extends Payload<BaseNetworkError> {
+    public static class MobileQuickStartCompletedResponsePayload extends OnChanged<MobileQuickStartError> {
         public boolean status;
 
         public MobileQuickStartCompletedResponsePayload(boolean status) {
@@ -640,7 +650,7 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class OnMobileQuickStartCompleted extends Payload<BaseNetworkError> {
+    public static class OnMobileQuickStartCompleted extends OnChanged<MobileQuickStartError> {
         public boolean status;
 
         OnMobileQuickStartCompleted(boolean status) {
@@ -807,6 +817,10 @@ public class SiteStore extends Store {
       }
 
     public enum DomainSupportedCountriesErrorType {
+        GENERIC_ERROR
+    }
+
+    public enum MobileQuickStartErrorType {
         GENERIC_ERROR
     }
 
@@ -1621,6 +1635,7 @@ public class SiteStore extends Store {
 
     private void handleMobileQuickStartCompleted(MobileQuickStartCompletedResponsePayload payload) {
         OnMobileQuickStartCompleted event = new OnMobileQuickStartCompleted(payload.status);
+        event.error = payload.error;
         emitChange(event);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -595,6 +595,22 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class MobileQuickStartCompletedResponsePayload extends OnChanged<SiteError> {
+        public boolean status;
+
+        public MobileQuickStartCompletedResponsePayload(boolean status) {
+            this.status = status;
+        }
+    }
+
+    public static class OnMobileQuickStartCompleted extends OnChanged<SiteError> {
+        public boolean status;
+
+        public OnMobileQuickStartCompleted(boolean status) {
+            this.status = status;
+        }
+    }
+
     public static class UpdateSitesResult {
         public int rowsAffected = 0;
         public boolean duplicateSiteFound = false;
@@ -1187,6 +1203,9 @@ public class SiteStore extends Store {
             case CHECKED_AUTOMATED_TRANSFER_STATUS:
                 handleCheckedAutomatedTransferStatus((AutomatedTransferStatusResponsePayload) action.getPayload());
                 break;
+            case COMPLETED_MOBILE_QUICK_START:
+                handleMobileQuickStartCompleted((MobileQuickStartCompletedResponsePayload) action.getPayload());
+                break;
         }
     }
 
@@ -1516,6 +1535,15 @@ public class SiteStore extends Store {
         } else {
             event = new OnAutomatedTransferStatusChecked(payload.site, payload.error);
         }
+        emitChange(event);
+    }
+
+    private void completeMobileQuickStart(@NonNull SiteModel site) {
+        mSiteRestClient.completeMobileQuickStart(site);
+    }
+
+    private void handleMobileQuickStartCompleted(MobileQuickStartCompletedResponsePayload payload) {
+        OnMobileQuickStartCompleted event = new OnMobileQuickStartCompleted(payload.status);
         emitChange(event);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -643,17 +643,21 @@ public class SiteStore extends Store {
     }
 
     public static class MobileQuickStartCompletedResponsePayload extends OnChanged<MobileQuickStartError> {
+        public @NonNull SiteModel site;
         public boolean success;
 
-        public MobileQuickStartCompletedResponsePayload(boolean status) {
+        public MobileQuickStartCompletedResponsePayload(@NonNull SiteModel site, boolean status) {
+            this.site = site;
             this.success = status;
         }
     }
 
     public static class OnMobileQuickStartCompleted extends OnChanged<MobileQuickStartError> {
+        public @NonNull SiteModel site;
         public boolean success;
 
-        OnMobileQuickStartCompleted(boolean status) {
+        OnMobileQuickStartCompleted(@NonNull SiteModel site, boolean status) {
+            this.site = site;
             this.success = status;
         }
     }
@@ -1634,7 +1638,7 @@ public class SiteStore extends Store {
     }
 
     private void handleMobileQuickStartCompleted(MobileQuickStartCompletedResponsePayload payload) {
-        OnMobileQuickStartCompleted event = new OnMobileQuickStartCompleted(payload.success);
+        OnMobileQuickStartCompleted event = new OnMobileQuickStartCompleted(payload.site, payload.success);
         event.error = payload.error;
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -632,7 +632,7 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class MobileQuickStartCompletedResponsePayload extends OnChanged<SiteError> {
+    public static class MobileQuickStartCompletedResponsePayload extends Payload<BaseNetworkError> {
         public boolean status;
 
         public MobileQuickStartCompletedResponsePayload(boolean status) {
@@ -640,10 +640,10 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class OnMobileQuickStartCompleted extends OnChanged<SiteError> {
+    public static class OnMobileQuickStartCompleted extends Payload<BaseNetworkError> {
         public boolean status;
 
-        public OnMobileQuickStartCompleted(boolean status) {
+        OnMobileQuickStartCompleted(boolean status) {
             this.status = status;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1203,6 +1203,9 @@ public class SiteStore extends Store {
             case CHECKED_AUTOMATED_TRANSFER_STATUS:
                 handleCheckedAutomatedTransferStatus((AutomatedTransferStatusResponsePayload) action.getPayload());
                 break;
+            case COMPLETE_MOBILE_QUICK_START:
+                completeMobileQuickStart((SiteModel) action.getPayload());
+                break;
             case COMPLETED_MOBILE_QUICK_START:
                 handleMobileQuickStartCompleted((MobileQuickStartCompletedResponsePayload) action.getPayload());
                 break;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -384,11 +384,11 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class MobileQuickStartError implements OnChangedError {
-        @NonNull public MobileQuickStartErrorType type;
+    public static class QuickStartError implements OnChangedError {
+        @NonNull public QuickStartErrorType type;
         @Nullable public String message;
 
-        public MobileQuickStartError(@NonNull MobileQuickStartErrorType type, @Nullable String message) {
+        public QuickStartError(@NonNull QuickStartErrorType type, @Nullable String message) {
             this.type = type;
             this.message = message;
         }
@@ -642,21 +642,21 @@ public class SiteStore extends Store {
         }
     }
 
-    public static class MobileQuickStartCompletedResponsePayload extends OnChanged<MobileQuickStartError> {
+    public static class QuickStartCompletedResponsePayload extends OnChanged<QuickStartError> {
         public @NonNull SiteModel site;
         public boolean success;
 
-        public MobileQuickStartCompletedResponsePayload(@NonNull SiteModel site, boolean status) {
+        public QuickStartCompletedResponsePayload(@NonNull SiteModel site, boolean status) {
             this.site = site;
             this.success = status;
         }
     }
 
-    public static class OnMobileQuickStartCompleted extends OnChanged<MobileQuickStartError> {
+    public static class OnQuickStartCompleted extends OnChanged<QuickStartError> {
         public @NonNull SiteModel site;
         public boolean success;
 
-        OnMobileQuickStartCompleted(@NonNull SiteModel site, boolean status) {
+        OnQuickStartCompleted(@NonNull SiteModel site, boolean status) {
             this.site = site;
             this.success = status;
         }
@@ -824,7 +824,7 @@ public class SiteStore extends Store {
         GENERIC_ERROR
     }
 
-    public enum MobileQuickStartErrorType {
+    public enum QuickStartErrorType {
         GENERIC_ERROR
     }
 
@@ -1281,11 +1281,11 @@ public class SiteStore extends Store {
             case CHECKED_AUTOMATED_TRANSFER_STATUS:
                 handleCheckedAutomatedTransferStatus((AutomatedTransferStatusResponsePayload) action.getPayload());
                 break;
-            case COMPLETE_MOBILE_QUICK_START:
-                completeMobileQuickStart((SiteModel) action.getPayload());
+            case COMPLETE_QUICK_START:
+                completeQuickStart((SiteModel) action.getPayload());
                 break;
-            case COMPLETED_MOBILE_QUICK_START:
-                handleMobileQuickStartCompleted((MobileQuickStartCompletedResponsePayload) action.getPayload());
+            case COMPLETED_QUICK_START:
+                handleQuickStartCompleted((QuickStartCompletedResponsePayload) action.getPayload());
                 break;
         }
     }
@@ -1633,12 +1633,12 @@ public class SiteStore extends Store {
         emitChange(event);
     }
 
-    private void completeMobileQuickStart(@NonNull SiteModel site) {
-        mSiteRestClient.completeMobileQuickStart(site);
+    private void completeQuickStart(@NonNull SiteModel site) {
+        mSiteRestClient.completeQuickStart(site);
     }
 
-    private void handleMobileQuickStartCompleted(MobileQuickStartCompletedResponsePayload payload) {
-        OnMobileQuickStartCompleted event = new OnMobileQuickStartCompleted(payload.site, payload.success);
+    private void handleQuickStartCompleted(QuickStartCompletedResponsePayload payload) {
+        OnQuickStartCompleted event = new OnQuickStartCompleted(payload.site, payload.success);
         event.error = payload.error;
         emitChange(event);
     }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -83,6 +83,8 @@
 
 /sites/$siteUrl#String
 
+/sites/$site/mobile-quick-start
+
 /users/new/
 /users/social/new
 


### PR DESCRIPTION
This PR adds a mobile quick start API that is used to notify the server that mobile quick start is completed for a specific site, and that completion notification should be sent to the client.

There is no special errors and responses returns either `{success:true}` or `{success:false}`.