### PR TITLE
Add page reload to jetpack install

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
@@ -75,7 +75,7 @@ class JetpackRestClientTest {
     fun `returns error with type`() = runBlocking<Unit> {
         initRequest(Error(WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR))))
 
-        val jetpackErrorPayload= jetpackRestClient.installJetpack(site)
+        val jetpackErrorPayload = jetpackRestClient.installJetpack(site)
 
         checkUrlAndLogin()
         assertThat(jetpackErrorPayload).isNotNull()

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
@@ -4,10 +4,7 @@ import com.android.volley.RequestQueue
 import com.nhaarman.mockito_kotlin.KArgumentCaptor
 import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
-import kotlinx.coroutines.experimental.delay
-import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -22,10 +19,11 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient.JetpackInstallResponse
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType
-import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstalledPayload
 
 @RunWith(MockitoJUnitRunner::class)
 class JetpackRestClientTest {
@@ -37,8 +35,6 @@ class JetpackRestClientTest {
     @Mock private lateinit var userAgent: UserAgent
     private lateinit var urlCaptor: KArgumentCaptor<String>
     private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
-    private lateinit var successMethodCaptor: KArgumentCaptor<(JetpackInstallResponse) -> Unit>
-    private lateinit var errorMethodCaptor: KArgumentCaptor<(WPComGsonNetworkError) -> Unit>
 
     private lateinit var jetpackRestClient: JetpackRestClient
     private val username = "John Smith"
@@ -49,8 +45,6 @@ class JetpackRestClientTest {
     fun setUp() {
         urlCaptor = argumentCaptor()
         paramsCaptor = argumentCaptor()
-        successMethodCaptor = argumentCaptor()
-        errorMethodCaptor = argumentCaptor()
         jetpackRestClient = JetpackRestClient(dispatcher,
                 wpComGsonRequestBuilder,
                 null,
@@ -61,20 +55,14 @@ class JetpackRestClientTest {
 
     @Test
     fun `returns success on successful jetpack install`() = runBlocking<Unit> {
-        initRequest()
+        initRequest(Success(JetpackInstallResponse(true)))
         val success = true
 
-        var jetpackInstalledPayload: JetpackInstalledPayload? = null
-        launch { jetpackInstalledPayload = jetpackRestClient.installJetpack(site) }
-        while (successMethodCaptor.allValues.isEmpty()) {
-            delay(10)
-        }
-        successMethodCaptor.lastValue.invoke(JetpackInstallResponse(success))
-        delay(50)
+        val jetpackInstalledPayload = jetpackRestClient.installJetpack(site)
 
         checkUrlAndLogin()
         assertThat(jetpackInstalledPayload).isNotNull()
-        assertThat(jetpackInstalledPayload?.success).isEqualTo(success)
+        assertThat(jetpackInstalledPayload.success).isEqualTo(success)
     }
 
     fun checkUrlAndLogin() {
@@ -85,32 +73,25 @@ class JetpackRestClientTest {
 
     @Test
     fun `returns error with type`() = runBlocking<Unit> {
-        initRequest()
+        initRequest(Error(WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR))))
 
-        var jetpackErrorPayload: JetpackInstalledPayload? = null
-        launch { jetpackErrorPayload = jetpackRestClient.installJetpack(site) }
-        while (errorMethodCaptor.allValues.isEmpty()) {
-            delay(10)
-        }
-        errorMethodCaptor.lastValue.invoke(WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
-        delay(50)
+        val jetpackErrorPayload= jetpackRestClient.installJetpack(site)
 
         checkUrlAndLogin()
         assertThat(jetpackErrorPayload).isNotNull()
-        assertThat(jetpackErrorPayload?.success).isEqualTo(false)
-        assertThat(jetpackErrorPayload?.error?.type).isEqualTo(JetpackInstallErrorType.GENERIC_ERROR)
+        assertThat(jetpackErrorPayload.success).isEqualTo(false)
+        assertThat(jetpackErrorPayload.error?.type).isEqualTo(JetpackInstallErrorType.GENERIC_ERROR)
     }
 
-    fun initRequest() {
+    suspend fun initRequest(response: WPComGsonRequestBuilder.Response<JetpackInstallResponse>) {
         whenever(site.username).thenReturn(username)
         whenever(site.password).thenReturn(password)
         whenever(site.url).thenReturn(siteUrl)
-        whenever(wpComGsonRequestBuilder.buildPostRequest(
+        whenever(wpComGsonRequestBuilder.syncPostRequest(
+                eq(jetpackRestClient),
                 urlCaptor.capture(),
                 paramsCaptor.capture(),
-                eq(JetpackInstallResponse::class.java),
-                successMethodCaptor.capture(),
-                errorMethodCaptor.capture()
-        )).thenReturn(mock())
+                eq(JetpackInstallResponse::class.java)
+        )).thenReturn(response)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -45,6 +45,8 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import kotlin.coroutines.experimental.CoroutineContext;
+import kotlinx.coroutines.experimental.CommonPool;
 import okhttp3.OkHttpClient;
 
 @Module
@@ -177,6 +179,12 @@ public class ReleaseNetworkModule {
                                                       WPComGsonRequestBuilder wpComGsonRequestBuilder) {
         return new JetpackRestClient(dispatcher, wpComGsonRequestBuilder, appContext, requestQueue, token,
                 userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public CoroutineContext provideCoroutineContext() {
+        return CommonPool.INSTANCE;
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
@@ -66,8 +66,8 @@ class WPComGsonRequestBuilder
         }))
     }
 
-    sealed class Response<T>{
-        data class Success<T>(val data: T): Response<T>()
-        data class Error<T>(val error: WPComGsonNetworkError): Response<T>()
+    sealed class Response<T> {
+        data class Success<T>(val data: T) : Response<T>()
+        data class Error<T>(val error: WPComGsonNetworkError) : Response<T>()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
@@ -1,8 +1,11 @@
 package org.wordpress.android.fluxc.network.rest.wpcom
 
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.experimental.suspendCoroutine
 
 @Singleton
 class WPComGsonRequestBuilder
@@ -41,5 +44,30 @@ class WPComGsonRequestBuilder
         errorListener: (WPComGsonNetworkError) -> Unit
     ): WPComGsonRequest<T> {
         return WPComGsonRequest.buildPostRequest(url, body, clazz, listener, errorListener)
+    }
+
+    /**
+     * Creates a new JSON-formatted POST request, triggers it and awaits results synchronously.
+     * @param restClient rest client that handles the request
+     * @param url the request URL
+     * @param body the content body, which will be converted to JSON using [Gson][com.google.gson.Gson]
+     * @param clazz the class defining the expected response
+     */
+    suspend fun <T> syncPostRequest(
+        restClient: BaseWPComRestClient,
+        url: String,
+        body: Map<String, Any>,
+        clazz: Class<T>
+    ) = suspendCoroutine<Response<T>> { cont ->
+        restClient.add(WPComGsonRequest.buildPostRequest(url, body, clazz, {
+            cont.resume(Success(it))
+        }, {
+            cont.resume(Error(it))
+        }))
+    }
+
+    sealed class Response<T>{
+        data class Success<T>(val data: T): Response<T>()
+        data class Error<T>(val error: WPComGsonNetworkError): Response<T>()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -39,7 +39,7 @@ constructor(
                 url,
                 params,
                 JetpackInstallResponse::class.java)
-        return when(response) {
+        return when (response) {
             is Success -> JetpackInstalledPayload(site, response.data.status)
             is WPComGsonRequestBuilder.Response.Error -> {
                 val error = when {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallError
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.AUTHORIZATION_REQUIRED
@@ -19,7 +20,6 @@ import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.US
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstalledPayload
 import java.net.URLEncoder
 import javax.inject.Singleton
-import kotlin.coroutines.experimental.suspendCoroutine
 
 @Singleton
 class JetpackRestClient
@@ -31,26 +31,28 @@ constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    suspend fun installJetpack(site: SiteModel) = suspendCoroutine<JetpackInstalledPayload> { cont ->
+    suspend fun installJetpack(site: SiteModel): JetpackInstalledPayload {
         val url = WPCOMREST.jetpack_install.site(URLEncoder.encode(site.url, "UTF-8")).urlV1
         val params = mapOf("user" to site.username, "password" to site.password)
-        val request = wpComGsonRequestBuilder.buildPostRequest(
-                url, params, JetpackInstallResponse::class.java,
-                { response ->
-                    cont.resume(JetpackInstalledPayload(site, response.status))
-                },
-                { networkError ->
-                    val error = when {
-                        networkError.apiError == "SITE_IS_JETPACK" -> SITE_IS_JETPACK
-                        networkError.isGeneric &&
-                                networkError.type == BaseRequest.GenericErrorType.INVALID_RESPONSE -> INVALID_RESPONSE
-                        networkError.apiError == "unauthorized" -> AUTHORIZATION_REQUIRED
-                        networkError.apiError == "INVALID_INPUT" -> USERNAME_OR_PASSWORD_MISSING
-                        else -> GENERIC_ERROR
-                    }
-                    cont.resume(JetpackInstalledPayload(JetpackInstallError(error, networkError.message), site))
-                })
-        add(request)
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                params,
+                JetpackInstallResponse::class.java)
+        return when(response) {
+            is Success -> JetpackInstalledPayload(site, response.data.status)
+            is WPComGsonRequestBuilder.Response.Error -> {
+                val error = when {
+                    response.error.apiError == "SITE_IS_JETPACK" -> SITE_IS_JETPACK
+                    response.error.isGeneric &&
+                            response.error.type == BaseRequest.GenericErrorType.INVALID_RESPONSE -> INVALID_RESPONSE
+                    response.error.apiError == "unauthorized" -> AUTHORIZATION_REQUIRED
+                    response.error.apiError == "INVALID_INPUT" -> USERNAME_OR_PASSWORD_MISSING
+                    else -> GENERIC_ERROR
+                }
+                JetpackInstalledPayload(JetpackInstallError(error, response.error.message), site)
+            }
+        }
     }
 
     data class JetpackInstallResponse(val status: Boolean)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -61,7 +61,7 @@ class JetpackStore
     }
 
     private suspend fun reloadSite(site: SiteModel) = suspendCoroutine<Unit> { cont ->
-        launch {
+        launch(CommonPool) {
             delay(5000)
             if (siteContinuation != null && siteContinuation == cont) {
                 siteContinuation?.resume(Unit)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.fluxc.store
 
+import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.delay
 import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -8,16 +11,25 @@ import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.JetpackAction
 import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
 import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.experimental.Continuation
+import kotlin.coroutines.experimental.suspendCoroutine
 
 @Singleton
 class JetpackStore
-@Inject constructor(private val jetpackRestClient: JetpackRestClient, dispatcher: Dispatcher) : Store(dispatcher) {
+@Inject constructor(
+    private val jetpackRestClient: JetpackRestClient,
+    private val siteStore: SiteStore,
+    dispatcher: Dispatcher
+) : Store(dispatcher) {
+    private var siteContinuation: Continuation<Unit>? = null
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? JetpackAction ?: return
@@ -32,10 +44,13 @@ class JetpackStore
         AppLog.d(T.API, "JetpackStore onRegister")
     }
 
-    suspend fun install(site: SiteModel, action: JetpackAction = INSTALL_JETPACK): OnJetpackInstalled {
+    suspend fun install(site: SiteModel, action: JetpackAction = INSTALL_JETPACK) = withContext(CommonPool) {
         val installedPayload = jetpackRestClient.installJetpack(site)
-        return if (!installedPayload.isError) {
-            val onJetpackInstall = OnJetpackInstalled(installedPayload.success, action)
+        reloadSite(site)
+        val reloadedSite = siteStore.getSiteByLocalId(site.id)
+        return@withContext if (!installedPayload.isError || reloadedSite.isJetpackInstalled) {
+            val onJetpackInstall = OnJetpackInstalled(installedPayload.success ||
+                    reloadedSite.isJetpackInstalled, action)
             emitChange(onJetpackInstall)
             onJetpackInstall
         } else {
@@ -43,6 +58,18 @@ class JetpackStore
             emitChange(errorPayload)
             errorPayload
         }
+    }
+
+    private suspend fun reloadSite(site: SiteModel) = suspendCoroutine<Unit> { cont ->
+        launch {
+            delay(5000)
+            if (siteContinuation != null && siteContinuation == cont) {
+                siteContinuation?.resume(Unit)
+                siteContinuation = null
+            }
+        }
+        siteStore.onAction(SiteActionBuilder.newFetchSiteAction(site))
+        siteContinuation = cont
     }
 
     class JetpackInstalledPayload(
@@ -76,4 +103,12 @@ class JetpackStore
     }
 
     class JetpackInstallError(var type: JetpackInstallErrorType, var message: String? = null) : Store.OnChangedError
+
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    fun onSiteChanged(event: OnSiteChanged) {
+        if (event.rowsAffected > 0) {
+            siteContinuation?.resume(Unit)
+            siteContinuation = null
+        }
+    }
 }


### PR DESCRIPTION
- The Jetpack store installs Jetpack to self-hosted sites remotely. This PR adds a step to the flow that refetches the SiteModel after the install call. It's necessary in order to let the app know that the field `isJetpackInstalled` is now updated. 
- I'm using advantages of coroutines - merging these two operations together and returning the result once both are done instead of sending events. 
- To test: there is nothing to test here until the related WPAndroid PR is done