### PR TITLE
Support scheme param for magic link e-mail requests

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailError;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
+import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -210,6 +211,12 @@ public class Authenticator {
         params.put("email", payload.emailOrUsername);
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
+
+        AuthEmailPayloadScheme scheme = payload.scheme;
+        if (scheme == null) {
+            scheme = AuthEmailPayloadScheme.WORDPRESS;
+        }
+        params.put("scheme", scheme.toString());
 
         if (payload.flow != null) {
             params.put("flow", payload.flow.toString());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -75,17 +75,40 @@ public class AccountStore extends Store {
     }
 
     public static class AuthEmailPayload extends Payload<BaseNetworkError> {
+        public AuthEmailPayloadScheme scheme;
         public AuthEmailPayloadFlow flow;
         public AuthEmailPayloadSource source;
         public String emailOrUsername;
         public boolean isSignup;
 
         public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailPayloadFlow flow,
-                                AuthEmailPayloadSource source) {
+                                AuthEmailPayloadSource source, AuthEmailPayloadScheme scheme) {
             this.emailOrUsername = emailOrUsername;
             this.isSignup = isSignup;
             this.flow = flow;
             this.source = source;
+            this.scheme = scheme;
+        }
+
+        public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailPayloadFlow flow,
+                                AuthEmailPayloadSource source) {
+            this(emailOrUsername, isSignup, flow, source, null);
+        }
+    }
+
+    public enum AuthEmailPayloadScheme {
+        WORDPRESS("wordpress"),
+        WOOCOMMERCE("woocommerce");
+
+        private final String mString;
+
+        AuthEmailPayloadScheme(final String s) {
+            mString = s;
+        }
+
+        @Override
+        public String toString() {
+            return mString;
         }
     }
 


### PR DESCRIPTION
Closes #834. Adds support for a `scheme` parameter when generating magic link requests, allowing magic links to launch the app that requested them (unlike the current situation, where magic links requested from the WordPress or WooCommerce app will offer to open both apps).

To test:
This should have no effect on the WordPress app (this should be verified) - magic links created from it should open the WordPress app (or offer a choice between release and dev versions if both are installed).

A PR will be opened in the WooCommerce app making use of the `woocommerce` scheme, with more testing information.