### PR TITLE
Issue/882 detect woo empty store

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
@@ -309,6 +310,21 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertNotNull(error)
             assertEquals(OrderErrorType.INVALID_ID, error.type)
         }
+    }
+
+    @Test
+    fun testHasAnyOrders() {
+        interceptor.respondWith("wc-has-orders-response-success.json")
+        orderRestClient.fetchHasOrders(siteModel, filterByStatus = null)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_HAS_ORDERS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchHasOrdersResponsePayload
+        assertNull(payload.error)
+        assertTrue(payload.hasOrders)
+        assertNull(payload.statusFilter)
     }
 
     @Suppress("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
@@ -29,6 +30,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         FETCHED_ORDERS,
         FETCHED_ORDERS_COUNT,
         FETCHED_ORDER_NOTES,
+        FETCHED_HAS_ORDERS,
         POST_ORDER_NOTE,
         POSTED_ORDER_NOTE
     }
@@ -159,6 +161,15 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         assertTrue(fetchedNotes.isNotEmpty())
     }
 
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchHasOrders() {
+        nextEvent = TestEvent.FETCHED_HAS_ORDERS
+        mCountDownLatch = CountDownLatch(1)
+        mDispatcher.dispatch(WCOrderActionBuilder.newFetchHasOrdersAction(FetchHasOrdersPayload(sSite)))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+    }
+
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onOrderChanged(event: OnOrderChanged) {
@@ -179,6 +190,10 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
             }
             WCOrderAction.FETCH_ORDER_NOTES -> {
                 assertEquals(TestEvent.FETCHED_ORDER_NOTES, nextEvent)
+                mCountDownLatch.countDown()
+            }
+            WCOrderAction.FETCH_HAS_ORDERS -> {
+                assertEquals(TestEvent.FETCHED_HAS_ORDERS, nextEvent)
                 mCountDownLatch.countDown()
             }
             WCOrderAction.POST_ORDER_NOTE -> {

--- a/example/src/androidTest/resources/wc-has-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-has-orders-response-success.json
@@ -1,0 +1,135 @@
+{
+  "data": [
+    {
+      "id": 949,
+      "parent_id": 0,
+      "number": "949",
+      "order_key": "wc_order_5ac244e370297",
+      "created_via": "checkout",
+      "version": "3.3.4",
+      "status": "processing",
+      "currency": "USD",
+      "date_created": "2018-04-02T10:57:39",
+      "date_created_gmt": "2018-04-02T14:57:39",
+      "date_modified": "2018-04-02T10:57:43",
+      "date_modified_gmt": "2018-04-02T14:57:43",
+      "discount_total": "0.00",
+      "discount_tax": "0.00",
+      "shipping_total": "4.00",
+      "shipping_tax": "0.00",
+      "cart_tax": "0.00",
+      "total": "44.00",
+      "total_tax": "0.00",
+      "prices_include_tax": false,
+      "customer_id": 1,
+      "customer_ip_address": "100.2.138.170",
+      "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10_13_3) applewebkit\/537.36 (khtml, like gecko) chrome\/65.0.3325.162 safari\/537.36",
+      "customer_note": "",
+      "billing": {
+        "first_name": "Jake",
+        "last_name": "Jakeson",
+        "company": "The DeLorean Shop",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Hill Valley",
+        "state": "CA",
+        "postcode": "95420",
+        "country": "US",
+        "email": "jake.jakeson@totallyrealemail.com",
+        "phone": "333-333-3333"
+      },
+      "shipping": {
+        "first_name": "Jake",
+        "last_name": "Jakeson",
+        "company": "The DeLorean Shop",
+        "address_1": "9303 Lyon Drive",
+        "address_2": "",
+        "city": "Hill Valley",
+        "state": "CA",
+        "postcode": "95420",
+        "country": "US"
+      },
+      "payment_method": "stripe",
+      "payment_method_title": "Credit Card (Stripe)",
+      "transaction_id": "ch_abcdef123456",
+      "date_paid": "2018-04-02T10:57:43",
+      "date_paid_gmt": "2018-04-02T14:57:43",
+      "date_completed": null,
+      "date_completed_gmt": null,
+      "cart_hash": "437b930db84b8079c2dd804a71936b5f",
+      "meta_data": [],
+      "line_items": [
+        {
+          "id": 879,
+          "name": "PDF Doc (Downloadable Product)",
+          "product_id": 290,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "10.00",
+          "subtotal_tax": "0.00",
+          "total": "10.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "",
+          "price": 10
+        },
+        {
+          "id": 880,
+          "name": "Black T-shirt (H&M)",
+          "product_id": 373,
+          "variation_id": 0,
+          "quantity": 1,
+          "tax_class": "",
+          "subtotal": "30.00",
+          "subtotal_tax": "0.00",
+          "total": "30.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [],
+          "sku": "111-111-111",
+          "price": 30
+        }
+      ],
+      "tax_lines": [],
+      "shipping_lines": [
+        {
+          "id": 881,
+          "method_title": "Flat rate",
+          "method_id": "flat_rate:31",
+          "total": "4.00",
+          "total_tax": "0.00",
+          "taxes": [],
+          "meta_data": [
+            {
+              "id": 6426,
+              "key": "Items",
+              "value": "Black T-shirt (H&M) &times; 1"
+            }
+          ]
+        }
+      ],
+      "fee_lines": [],
+      "coupon_lines": [],
+      "refunds": [],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders\/949"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/orders"
+          }
+        ],
+        "customer": [
+          {
+            "href": "https:\/\/example.com\/wp-json\/wc\/v2\/customers\/1"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -11,6 +11,7 @@ import kotlinx.android.synthetic.main.fragment_woocommerce.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
@@ -25,6 +26,7 @@ import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
@@ -94,6 +96,13 @@ class WooCommerceFragment : Fragment() {
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersCountAction(payload))
                 }
             }
+        }
+
+        fetch_has_orders.setOnClickListener {
+            getFirstWCSite()?.let {
+                val payload = FetchHasOrdersPayload(it)
+                dispatcher.dispatch(WCOrderActionBuilder.newFetchHasOrdersAction(payload))
+            } ?: showNoWCSitesToast()
         }
 
         fetch_orders_by_status.setOnClickListener {
@@ -248,6 +257,10 @@ class WooCommerceFragment : Fragment() {
                         event.statusFilter?.let {
                             prependToLog("Count of $it orders: ${event.rowsAffected}$append")
                         } ?: prependToLog("Count of all orders: ${event.rowsAffected}$append")
+                    }
+                    FETCH_HAS_ORDERS -> {
+                        val hasOrders = event.rowsAffected > 0
+                        prependToLog("Store has orders: ${hasOrders}")
                     }
                     FETCH_ORDER_NOTES -> {
                         val notes = wcOrderStore.getOrderNotesForOrder(pendingNotesOrderModel!!)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -260,7 +260,7 @@ class WooCommerceFragment : Fragment() {
                     }
                     FETCH_HAS_ORDERS -> {
                         val hasOrders = event.rowsAffected > 0
-                        prependToLog("Store has orders: ${hasOrders}")
+                        prependToLog("Store has orders: $hasOrders")
                     }
                     FETCH_ORDER_NOTES -> {
                         val notes = wcOrderStore.getOrderNotesForOrder(pendingNotesOrderModel!!)

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -29,6 +29,12 @@
             android:text="Fetch Orders Count"/>
 
         <Button
+            android:id="@+id/fetch_has_orders"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fetch Has Orders"/>
+
+        <Button
             android:id="@+id/fetch_orders_by_status"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -3,6 +3,8 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload;
@@ -27,6 +29,8 @@ public enum WCOrderAction implements IAction {
     FETCH_ORDER_NOTES,
     @Action(payloadType = PostOrderNotePayload.class)
     POST_ORDER_NOTE,
+    @Action(payloadType = FetchHasOrdersPayload.class)
+    FETCH_HAS_ORDERS,
 
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
@@ -38,5 +42,7 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = FetchOrderNotesResponsePayload.class)
     FETCHED_ORDER_NOTES,
     @Action(payloadType = RemoteOrderNotePayload.class)
-    POSTED_ORDER_NOTE
+    POSTED_ORDER_NOTE,
+    @Action(payloadType = FetchHasOrdersResponsePayload.class)
+    FETCHED_HAS_ORDERS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -112,7 +112,7 @@ class OrderRestClient(
                     val orderModels = response?.map {
                         orderResponseToOrderModel(it).apply { localSiteId = site.id }
                     }.orEmpty()
-                    val hasOrders = orderModels.size > 0
+                    val hasOrders = orderModels.isNotEmpty()
                     val payload = FetchHasOrdersResponsePayload(
                             site, filterByStatus, hasOrders)
                     mDispatcher.dispatch(WCOrderActionBuilder.newFetchedHasOrdersAction(payload))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -263,7 +263,11 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         val onOrderChanged = if (payload.isError) {
             OnOrderChanged(0).also { it.error = payload.error }
         } else {
-            with(payload) { OnOrderChanged(1, statusFilter) }
+            with(payload) {
+                // set 'rowsAffected' to non-zerp if there are orders, otherwise set to zero
+                val rowsAffected = if (payload.hasOrders) 1 else 0
+                OnOrderChanged(rowsAffected, statusFilter)
+            }
         }.also { it.causeOfChange = FETCH_HAS_ORDERS }
         emitChange(onOrderChanged)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -185,7 +185,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
             WCOrderAction.FETCHED_ORDER_NOTES ->
                 handleFetchOrderNotesCompleted(action.payload as FetchOrderNotesResponsePayload)
             WCOrderAction.POSTED_ORDER_NOTE -> handlePostOrderNoteCompleted(action.payload as RemoteOrderNotePayload)
-            WCOrderAction.FETCHED_HAS_ORDERS -> handleFetchHasOrdersCompleted(action.payload as FetchHasOrdersResponsePayload)
+            WCOrderAction.FETCHED_HAS_ORDERS -> handleFetchHasOrdersCompleted(
+                    action.payload as FetchHasOrdersResponsePayload)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -263,7 +263,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         val onOrderChanged = if (payload.isError) {
             OnOrderChanged(0).also { it.error = payload.error }
         } else {
-            with(payload) { OnOrderChanged(1, statusFilter, false) }
+            with(payload) { OnOrderChanged(1, statusFilter) }
         }.also { it.causeOfChange = FETCH_HAS_ORDERS }
         emitChange(onOrderChanged)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -264,7 +264,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
             OnOrderChanged(0).also { it.error = payload.error }
         } else {
             with(payload) {
-                // set 'rowsAffected' to non-zerp if there are orders, otherwise set to zero
+                // set 'rowsAffected' to non-zero if there are orders, otherwise set to zero
                 val rowsAffected = if (payload.hasOrders) 1 else 0
                 OnOrderChanged(rowsAffected, statusFilter)
             }


### PR DESCRIPTION
Resolves #882 - uses `GET /wc/v2/orders` to request a single order of a specific type (or any type) to determine whether any orders exist.