### PR TITLE
Fixing Quick Start DB migration

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -309,8 +309,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 37:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("CREATE TABLE QuickStartModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                db.execSQL("DROP TABLE IF EXISTS QuickStartModel");
+                db.execSQL("CREATE TABLE QuickStartTaskModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                            + "SITE_ID INTEGER,TASK_NAME TEXT,IS_DONE INTEGER,IS_SHOWN INTEGER)");
+                db.execSQL("CREATE TABLE QuickStartStatusModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                           + "SITE_ID INTEGER,IS_COMPLETED INTEGER,IS_NOTIFICATION_RECEIVED INTEGER)");
                 oldVersion++;
             case 38:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
@@ -327,9 +330,9 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 39:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("DROP TABLE IF EXISTS QuickStartModel");
-                db.execSQL("CREATE TABLE QuickStartTaskModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                db.execSQL("CREATE TABLE IF NOT EXISTS QuickStartTaskModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                            + "SITE_ID INTEGER,TASK_NAME TEXT,IS_DONE INTEGER,IS_SHOWN INTEGER)");
-                db.execSQL("CREATE TABLE QuickStartStatusModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                db.execSQL("CREATE TABLE IF NOT EXISTS QuickStartStatusModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                            + "SITE_ID INTEGER,IS_COMPLETED INTEGER,IS_NOTIFICATION_RECEIVED INTEGER)");
                 oldVersion++;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 39;
+        return 40;
     }
 
     @Override
@@ -309,11 +309,8 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 37:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("DROP TABLE IF EXISTS QuickStartModel");
-                db.execSQL("CREATE TABLE QuickStartTaskModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                db.execSQL("CREATE TABLE QuickStartModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                            + "SITE_ID INTEGER,TASK_NAME TEXT,IS_DONE INTEGER,IS_SHOWN INTEGER)");
-                db.execSQL("CREATE TABLE QuickStartStatusModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                           + "SITE_ID INTEGER,IS_COMPLETED INTEGER,IS_NOTIFICATION_RECEIVED INTEGER)");
                 oldVersion++;
             case 38:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
@@ -326,6 +323,14 @@ public class WellSqlConfig extends DefaultWellConfig {
                     fluxCPreferences.edit().putString("ACCOUNT_TOKEN_PREF_KEY", token).apply();
                     defaultSharedPrefs.edit().remove("ACCOUNT_TOKEN_PREF_KEY").apply();
                 }
+                oldVersion++;
+            case 39:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS QuickStartModel");
+                db.execSQL("CREATE TABLE QuickStartTaskModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                           + "SITE_ID INTEGER,TASK_NAME TEXT,IS_DONE INTEGER,IS_SHOWN INTEGER)");
+                db.execSQL("CREATE TABLE QuickStartStatusModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                           + "SITE_ID INTEGER,IS_COMPLETED INTEGER,IS_NOTIFICATION_RECEIVED INTEGER)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
This PR fixes the incorrect Quick Start DB migration.

WPAndroid part is [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/885)