### PR TITLE
Activity log coroutines

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -106,7 +106,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnMissingActivityId() = runBlocking{
+    fun fetchActivity_dispatchesErrorOnMissingActivityId() = runBlocking {
         val failingPage = Page(listOf(ACTIVITY_RESPONSE.copy(activity_id = null)))
         val activitiesResponse = ActivitiesResponse(1, "response", failingPage)
         initFetchActivity(activitiesResponse)
@@ -117,7 +117,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnMissingSummary() = runBlocking{
+    fun fetchActivity_dispatchesErrorOnMissingSummary() = runBlocking {
         val failingPage = Page(listOf(ACTIVITY_RESPONSE.copy(summary = null)))
         val activitiesResponse = ActivitiesResponse(1, "response", failingPage)
         initFetchActivity(activitiesResponse)
@@ -128,7 +128,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnMissingContentText() = runBlocking{
+    fun fetchActivity_dispatchesErrorOnMissingContentText() = runBlocking {
         val emptyContent = ActivitiesResponse.Content(null)
         val failingPage = Page(listOf(ACTIVITY_RESPONSE.copy(content = emptyContent)))
         val activitiesResponse = ActivitiesResponse(1, "response", failingPage)
@@ -140,7 +140,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnMissingPublishedDate() = runBlocking{
+    fun fetchActivity_dispatchesErrorOnMissingPublishedDate() = runBlocking {
         val failingPage = Page(listOf(ACTIVITY_RESPONSE.copy(published = null)))
         val activitiesResponse = ActivitiesResponse(1, "response", failingPage)
         initFetchActivity(activitiesResponse)
@@ -151,7 +151,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnFailure() = runBlocking{
+    fun fetchActivity_dispatchesErrorOnFailure() = runBlocking {
         initFetchActivity(error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR)))
 
         val payload = activityRestClient.fetchActivity(site, number, offset)
@@ -183,7 +183,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesGenericErrorOnFailure() = runBlocking{
+    fun fetchActivityRewind_dispatchesGenericErrorOnFailure() = runBlocking {
         initFetchRewindStatus(error = WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
 
         val payload = activityRestClient.fetchActivityRewind(site)
@@ -192,7 +192,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesErrorOnWrongState() = runBlocking{
+    fun fetchActivityRewind_dispatchesErrorOnWrongState() = runBlocking {
         initFetchRewindStatus(REWIND_STATUS_RESPONSE.copy(state = "wrong"))
 
         val payload = activityRestClient.fetchActivityRewind(site)
@@ -201,7 +201,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesErrorOnMissingRestoreId() = runBlocking{
+    fun fetchActivityRewind_dispatchesErrorOnMissingRestoreId() = runBlocking {
         initFetchRewindStatus(REWIND_STATUS_RESPONSE.copy(rewind = REWIND_RESPONSE.copy(rewind_id = null)))
 
         val payload = activityRestClient.fetchActivityRewind(site)
@@ -210,7 +210,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesErrorOnWrongRestoreStatus() = runBlocking{
+    fun fetchActivityRewind_dispatchesErrorOnWrongRestoreStatus() = runBlocking {
         initFetchRewindStatus(REWIND_STATUS_RESPONSE.copy(rewind = REWIND_RESPONSE.copy(status = "wrong")))
 
         val payload = activityRestClient.fetchActivityRewind(site)
@@ -219,7 +219,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun postRewindOperation() = runBlocking{
+    fun postRewindOperation() = runBlocking {
         val restoreId = 10L
         val response = RewindResponse(restoreId, true, null)
         initPostRewind(response)
@@ -230,7 +230,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun postRewindOperationError() = runBlocking{
+    fun postRewindOperationError() = runBlocking {
         initPostRewind(error = WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
 
         val payload = activityRestClient.rewind(site, "rewindId")
@@ -239,7 +239,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun postRewindApiError() = runBlocking{
+    fun postRewindApiError() = runBlocking {
         val restoreId = 10L
         initPostRewind(RewindResponse(restoreId, false, "error"))
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
@@ -13,13 +13,5 @@ public enum ActivityLogAction implements IAction {
     @Action(payloadType = ActivityLogStore.FetchRewindStatePayload.class)
     FETCH_REWIND_STATE,
     @Action(payloadType = ActivityLogStore.RewindPayload.class)
-    REWIND,
-
-    // Remote responses
-    @Action(payloadType = ActivityLogStore.FetchedActivityLogPayload.class)
-    FETCHED_ACTIVITIES,
-    @Action(payloadType = ActivityLogStore.FetchedRewindStatePayload.class)
-    FETCHED_REWIND_STATE,
-    @Action(payloadType = ActivityLogStore.RewindResultPayload.class)
-    REWIND_RESULT
+    REWIND
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
@@ -40,7 +40,7 @@ class WPComGsonRequestBuilder
         url: String,
         params: Map<String, String>,
         clazz: Class<T>
-    ) = suspendCoroutine<Response<T>> {cont ->
+    ) = suspendCoroutine<Response<T>> { cont ->
         restClient.add(WPComGsonRequest.buildGetRequest(url, params, clazz, {
             cont.resume(Success(it))
         }, {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
@@ -29,6 +29,26 @@ class WPComGsonRequestBuilder
     }
 
     /**
+     * Creates a new GET request.
+     * @param restClient rest client that handles the request
+     * @param url the request URL
+     * @param params the parameters to append to the request URL
+     * @param clazz the class defining the expected response
+     */
+    suspend fun <T> syncGetRequest(
+        restClient: BaseWPComRestClient,
+        url: String,
+        params: Map<String, String>,
+        clazz: Class<T>
+    ) = suspendCoroutine<Response<T>> {cont ->
+        restClient.add(WPComGsonRequest.buildGetRequest(url, params, clazz, {
+            cont.resume(Success(it))
+        }, {
+            cont.resume(Error(it))
+        }))
+    }
+
+    /**
      * Creates a new JSON-formatted POST request.
      * @param url the request URL
      * @param body the content body, which will be converted to JSON using [Gson][com.google.gson.Gson]

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -34,7 +34,7 @@ import javax.inject.Singleton
 @Singleton
 class ActivityLogRestClient
 constructor(
-    private val dispatcher: Dispatcher,
+    dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
     requestQueue: RequestQueue,
@@ -47,7 +47,7 @@ constructor(
         val pageNumber = offset / number + 1
         val params = mapOf("page" to pageNumber.toString(), "number" to number.toString())
         val response = wpComGsonRequestBuilder.syncGetRequest(this, url, params, ActivitiesResponse::class.java)
-        return when(response) {
+        return when (response) {
             is Success -> {
                 val activities = response.data.current?.orderedItems ?: listOf()
                 val totalItems = response.data.totalItems ?: 0
@@ -69,7 +69,7 @@ constructor(
     suspend fun fetchActivityRewind(site: SiteModel): FetchedRewindStatePayload {
         val url = WPCOMV2.sites.site(site.siteId).rewind.url
         val response = wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), RewindStatusResponse::class.java)
-        return when(response) {
+        return when (response) {
             is Success -> {
                 buildRewindStatusPayload(response.data, site)
             }
@@ -89,7 +89,7 @@ constructor(
     suspend fun rewind(site: SiteModel, rewindId: String): RewindResultPayload {
         val url = WPCOMREST.activity_log.site(site.siteId).rewind.to.rewind(rewindId).urlV1
         val response = wpComGsonRequestBuilder.syncPostRequest(this, url, mapOf(), RewindResponse::class.java)
-        return when(response) {
+        return when (response) {
             is Success -> {
                 if (response.data.ok != true && (response.data.error != null && response.data.error.isNotEmpty())) {
                     RewindResultPayload(RewindError(API_ERROR, response.data.error), rewindId, site)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.activity
 import android.content.Context
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.ActivityLogActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
 import org.wordpress.android.fluxc.model.SiteModel
@@ -15,6 +14,8 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.ActivityError
@@ -41,75 +42,69 @@ constructor(
     userAgent: UserAgent
 ) :
         BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    fun fetchActivity(site: SiteModel, number: Int, offset: Int) {
+    suspend fun fetchActivity(site: SiteModel, number: Int, offset: Int): FetchedActivityLogPayload {
         val url = WPCOMV2.sites.site(site.siteId).activity.url
         val pageNumber = offset / number + 1
         val params = mapOf("page" to pageNumber.toString(), "number" to number.toString())
-        val request = wpComGsonRequestBuilder.buildGetRequest(
-                url, params, ActivitiesResponse::class.java,
-                { response ->
-                    val activities = response.current?.orderedItems ?: listOf()
-                    val totalItems = response.totalItems ?: 0
-                    val payload = buildActivityPayload(activities, site, totalItems, number, offset)
-                    dispatcher.dispatch(ActivityLogActionBuilder.newFetchedActivitiesAction(payload))
-                },
-                { networkError ->
-                    val errorType = genericToError(
-                            networkError,
-                            ActivityLogErrorType.GENERIC_ERROR,
-                            ActivityLogErrorType.INVALID_RESPONSE,
-                            ActivityLogErrorType.AUTHORIZATION_REQUIRED
-                    )
-                    val error = ActivityError(errorType, networkError.message)
-                    val payload = FetchedActivityLogPayload(error, site, number = number, offset = offset)
-                    dispatcher.dispatch(ActivityLogActionBuilder.newFetchedActivitiesAction(payload))
-                })
-        add(request)
+        val response = wpComGsonRequestBuilder.syncGetRequest(this, url, params, ActivitiesResponse::class.java)
+        return when(response) {
+            is Success -> {
+                val activities = response.data.current?.orderedItems ?: listOf()
+                val totalItems = response.data.totalItems ?: 0
+                buildActivityPayload(activities, site, totalItems, number, offset)
+            }
+            is Error -> {
+                val errorType = genericToError(
+                        response.error,
+                        ActivityLogErrorType.GENERIC_ERROR,
+                        ActivityLogErrorType.INVALID_RESPONSE,
+                        ActivityLogErrorType.AUTHORIZATION_REQUIRED
+                )
+                val error = ActivityError(errorType, response.error.message)
+                FetchedActivityLogPayload(error, site, number = number, offset = offset)
+            }
+        }
     }
 
-    fun fetchActivityRewind(site: SiteModel) {
+    suspend fun fetchActivityRewind(site: SiteModel): FetchedRewindStatePayload {
         val url = WPCOMV2.sites.site(site.siteId).rewind.url
-        val request = wpComGsonRequestBuilder.buildGetRequest(
-                url, mapOf(), RewindStatusResponse::class.java,
-                { response ->
-                    val payload = buildRewindStatusPayload(response, site)
-                    dispatcher.dispatch(ActivityLogActionBuilder.newFetchedRewindStateAction(payload))
-                },
-                { networkError ->
-                    val errorType = genericToError(
-                            networkError,
-                            RewindStatusErrorType.GENERIC_ERROR,
-                            RewindStatusErrorType.INVALID_RESPONSE,
-                            RewindStatusErrorType.AUTHORIZATION_REQUIRED
-                    )
-                    val error = RewindStatusError(errorType, networkError.message)
-                    val payload = FetchedRewindStatePayload(error, site)
-                    dispatcher.dispatch(ActivityLogActionBuilder.newFetchedRewindStateAction(payload))
-                })
-        add(request)
+        val response = wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), RewindStatusResponse::class.java)
+        return when(response) {
+            is Success -> {
+                buildRewindStatusPayload(response.data, site)
+            }
+            is Error -> {
+                val errorType = genericToError(
+                        response.error,
+                        RewindStatusErrorType.GENERIC_ERROR,
+                        RewindStatusErrorType.INVALID_RESPONSE,
+                        RewindStatusErrorType.AUTHORIZATION_REQUIRED
+                )
+                val error = RewindStatusError(errorType, response.error.message)
+                FetchedRewindStatePayload(error, site)
+            }
+        }
     }
 
-    fun rewind(site: SiteModel, rewindId: String) {
+    suspend fun rewind(site: SiteModel, rewindId: String): RewindResultPayload {
         val url = WPCOMREST.activity_log.site(site.siteId).rewind.to.rewind(rewindId).urlV1
-        val request = wpComGsonRequestBuilder.buildPostRequest(url, mapOf(), RewindResponse::class.java,
-                { response ->
-                    if (response.ok != true && (response.error != null && response.error.isNotEmpty())) {
-                        val payload = RewindResultPayload(RewindError(API_ERROR, response.error), rewindId, site)
-                        dispatcher.dispatch(ActivityLogActionBuilder.newRewindResultAction(payload))
-                    } else {
-                        val payload = ActivityLogStore.RewindResultPayload(rewindId, response.restore_id, site)
-                        dispatcher.dispatch(ActivityLogActionBuilder.newRewindResultAction(payload))
-                    }
-                },
-                { networkError ->
-                    val error = ActivityLogStore.RewindError(genericToError(networkError,
-                            RewindErrorType.GENERIC_ERROR,
-                            RewindErrorType.INVALID_RESPONSE,
-                            RewindErrorType.AUTHORIZATION_REQUIRED), networkError.message)
-                    val payload = ActivityLogStore.RewindResultPayload(error, rewindId, site)
-                    dispatcher.dispatch(ActivityLogActionBuilder.newRewindResultAction(payload))
-                })
-        add(request)
+        val response = wpComGsonRequestBuilder.syncPostRequest(this, url, mapOf(), RewindResponse::class.java)
+        return when(response) {
+            is Success -> {
+                if (response.data.ok != true && (response.data.error != null && response.data.error.isNotEmpty())) {
+                    RewindResultPayload(RewindError(API_ERROR, response.data.error), rewindId, site)
+                } else {
+                    ActivityLogStore.RewindResultPayload(rewindId, response.data.restore_id, site)
+                }
+            }
+            is Error -> {
+                val error = ActivityLogStore.RewindError(genericToError(response.error,
+                        RewindErrorType.GENERIC_ERROR,
+                        RewindErrorType.INVALID_RESPONSE,
+                        RewindErrorType.AUTHORIZATION_REQUIRED), response.error.message)
+                ActivityLogStore.RewindResultPayload(error, rewindId, site)
+            }
+        }
     }
 
     private fun buildActivityPayload(


### PR DESCRIPTION
Converting Activity log to coroutines consists of two parts. First one is using new methods that instead of creating a Request and triggering it asynchronously encapsulate it to a suspend function. The result gets converted to a Response object. This makes it much easier to unit test the `RestClient`.
The second part is converting the `ActivityLogStore`. I'm still keeping original `onAction` which should behave exactly the same as before. I'm also making the suspend function public in order of using these in WPAndroid.