### PR TITLE
ListStore Part 2: ListStore & ListManager

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
@@ -1,0 +1,220 @@
+package org.wordpress.android.fluxc.list
+
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.mock
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.ListAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.list.ListDescriptor
+import org.wordpress.android.fluxc.model.list.ListItemDataSource
+import org.wordpress.android.fluxc.model.list.ListItemModel
+import org.wordpress.android.fluxc.model.list.ListManager
+import org.wordpress.android.fluxc.model.list.ListType.POST
+import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
+import kotlin.test.assertEquals
+
+@RunWith(MockitoJUnitRunner::class)
+class ListManagerTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var dataSource: ListItemDataSource<PostModel> // should work with any type
+    private lateinit var actionCaptor: KArgumentCaptor<Action<FetchListPayload>>
+
+    // Helpers
+    private val listDescriptor = ListDescriptor(POST)
+    private val numberOfItems = 30
+    private val loadMoreOffset = 10
+    private val indexThatShouldLoadMore: Int = numberOfItems - loadMoreOffset + 1
+
+    @Before
+    fun setup() {
+        actionCaptor = argumentCaptor()
+    }
+
+    /**
+     * Calling refresh on the [ListManager] should dispatch an action to refresh the list if
+     * `isFetchingFirstPage` is false.
+     */
+    @Test
+    fun testRefreshTriggersFetch() {
+        val listManager = setupListManager(
+                isFetchingFirstPage = false,
+                isLoadingMore = false,
+                indexToGet = 11, // doesn't matter
+                remoteItemId = 222L, // doesn't matter
+                remoteItem = PostModel()
+        )
+        listManager.refresh()
+        verify(dispatcher).dispatch(actionCaptor.capture())
+        with(actionCaptor.firstValue) {
+            assertEquals(this.type, ListAction.FETCH_LIST)
+            assertEquals(this.payload.listDescriptor, listDescriptor)
+            assertEquals(this.payload.loadMore, false)
+        }
+    }
+
+    /**
+     * Calling refresh on the [ListManager] should NOT dispatch an action to refresh the list if
+     * `isFetchingFirstPage` is true.
+     */
+    @Test
+    fun testDuplicateRefreshIsIgnored() {
+        val listManager = setupListManager(
+                isFetchingFirstPage = true,
+                isLoadingMore = false,
+                indexToGet = 11, // doesn't matter
+                remoteItemId = 222L, // doesn't matter
+                remoteItem = PostModel()
+        )
+        listManager.refresh()
+        verify(dispatcher, never()).dispatch(actionCaptor.capture())
+    }
+
+    /**
+     * [ListManager.getRemoteItem] should call [ListItemDataSource.fetchItem] if [ListItemDataSource.getItem] returns
+     * `null` and `shouldFetchIfNull` flag is true.
+     */
+    @Test
+    fun testGetRemoteItemTriggersItemFetch() {
+        val indexToGet = 22 // doesn't matter
+        val remoteItemId = 333L // doesn't matter
+        val listManager = setupListManager(
+                isFetchingFirstPage = false,
+                isLoadingMore = false,
+                indexToGet = indexToGet,
+                remoteItemId = remoteItemId,
+                remoteItem = null
+        )
+        listManager.getRemoteItem(indexToGet, shouldFetchIfNull = true)
+        verify(dataSource).fetchItem(listDescriptor, remoteItemId)
+    }
+
+    /**
+     * [ListManager.getRemoteItem] should NOT call [ListItemDataSource.fetchItem] if [ListItemDataSource.getItem]
+     * returns `null`, BUT `shouldFetchIfNull` flag is false.
+     */
+    @Test
+    fun testGetRemoteItemDoesNotTriggerItemFetch() {
+        val indexToGet = 22 // doesn't matter
+        val remoteItemId = 333L // doesn't matter
+        val listManager = setupListManager(
+                isFetchingFirstPage = false,
+                isLoadingMore = false,
+                indexToGet = indexToGet,
+                remoteItemId = remoteItemId,
+                remoteItem = null
+        )
+        listManager.getRemoteItem(indexToGet, shouldFetchIfNull = false)
+        verify(dataSource, never()).fetchItem(listDescriptor, remoteItemId)
+    }
+
+    /**
+     * [ListManager.getRemoteItem] should dispatch an action to load more items if the requested index is closer to the
+     * end of list than the offset, `isLoadingMore` flag is false and `shouldLoadMoreIfNecessary` flag is true.
+     */
+    @Test
+    fun testGetRemoteItemTriggersLoadMore() {
+        val listManager = setupListManager(
+                isFetchingFirstPage = false,
+                isLoadingMore = false,
+                indexToGet = indexThatShouldLoadMore,
+                remoteItemId = 132L,
+                remoteItem = null
+        )
+        listManager.getRemoteItem(indexThatShouldLoadMore, shouldLoadMoreIfNecessary = true)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+        with(actionCaptor.firstValue) {
+            assertEquals(this.type, ListAction.FETCH_LIST)
+            assertEquals(this.payload.listDescriptor, listDescriptor)
+            assertEquals(this.payload.loadMore, true)
+        }
+    }
+
+    /**
+     * [ListManager.getRemoteItem] should NOT dispatch an action to load more items if the requested index is NOT closer
+     * to the end of list than the offset, `isLoadingMore` flag is false and `shouldLoadMoreIfNecessary` flag is true.
+     */
+    @Test
+    fun testGetRemoteItemTriggersLoadMoreDueToIndex() {
+        val listManager = setupListManager(
+                isFetchingFirstPage = false,
+                isLoadingMore = false,
+                indexToGet = 0,
+                remoteItemId = 132L,
+                remoteItem = null
+        )
+        listManager.getRemoteItem(0, shouldLoadMoreIfNecessary = true)
+        verify(dispatcher, never()).dispatch(actionCaptor.capture())
+    }
+
+    /**
+     * [ListManager.getRemoteItem] should NOT dispatch an action to load more items if the requested index is closer to
+     * the end of list than the offset and `isLoadingMore` flag is false, BUT `shouldLoadMoreIfNecessary` flag is false.
+     */
+    @Test
+    fun testGetRemoteItemDoesNotTriggerLoadMoreDueToShouldLoadMoreIfNecessary() {
+        val listManager = setupListManager(
+                isFetchingFirstPage = false,
+                isLoadingMore = false,
+                indexToGet = indexThatShouldLoadMore,
+                remoteItemId = 132L,
+                remoteItem = null
+        )
+        listManager.getRemoteItem(indexThatShouldLoadMore, shouldLoadMoreIfNecessary = false)
+        verify(dispatcher, never()).dispatch(actionCaptor.capture())
+    }
+
+    /**
+     * [ListManager.getRemoteItem] should NOT dispatch an action to load more items if the requested index is closer to
+     * the end of list than the offset and `shouldLoadMoreIfNecessary` flag is true, BUT the `isLoadingMore` flag
+     * is true.
+     */
+    @Test
+    fun testDuplicateLoadMoreIsIgnored() {
+        val listManager = setupListManager(
+                isFetchingFirstPage = false,
+                isLoadingMore = true,
+                indexToGet = indexThatShouldLoadMore,
+                remoteItemId = 132L,
+                remoteItem = null
+        )
+        listManager.getRemoteItem(indexThatShouldLoadMore, shouldLoadMoreIfNecessary = true)
+        verify(dispatcher, never()).dispatch(actionCaptor.capture())
+    }
+
+    /**
+     * Sets up a ListManager with given parameters.
+     *
+     * It'll also assert various common properties for [ListManager] before returning it.
+     */
+    private fun setupListManager(
+        isFetchingFirstPage: Boolean,
+        isLoadingMore: Boolean,
+        indexToGet: Int,
+        remoteItemId: Long,
+        remoteItem: PostModel?
+    ): ListManager<PostModel> {
+        val listItems: List<ListItemModel> = mock()
+        val listItemModel = ListItemModel()
+        listItemModel.remoteItemId = remoteItemId
+
+        `when`(listItems.size).thenReturn(numberOfItems)
+        `when`(listItems[indexToGet]).thenReturn(listItemModel)
+        `when`(dataSource.getItem(listDescriptor, remoteItemId)).thenReturn(remoteItem)
+        val listManager = ListManager(dispatcher, listDescriptor, listItems, dataSource, loadMoreOffset,
+                isFetchingFirstPage, isLoadingMore)
+        assertEquals(isFetchingFirstPage, listManager.isFetchingFirstPage)
+        assertEquals(isLoadingMore, listManager.isLoadingMore)
+        assertEquals(numberOfItems, listManager.size)
+        return listManager
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
@@ -3,11 +3,11 @@ package org.wordpress.android.fluxc.list
 import com.nhaarman.mockito_kotlin.KArgumentCaptor
 import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
@@ -206,10 +206,9 @@ class ListManagerTest {
         val listItems: List<ListItemModel> = mock()
         val listItemModel = ListItemModel()
         listItemModel.remoteItemId = remoteItemId
-
-        `when`(listItems.size).thenReturn(numberOfItems)
-        `when`(listItems[indexToGet]).thenReturn(listItemModel)
-        `when`(dataSource.getItem(listDescriptor, remoteItemId)).thenReturn(remoteItem)
+        whenever(listItems.size).thenReturn(numberOfItems)
+        whenever(listItems[indexToGet]).thenReturn(listItemModel)
+        whenever(dataSource.getItem(listDescriptor, remoteItemId)).thenReturn(remoteItem)
         val listManager = ListManager(dispatcher, listDescriptor, listItems, dataSource, loadMoreOffset,
                 isFetchingFirstPage, isLoadingMore)
         assertEquals(isFetchingFirstPage, listManager.isFetchingFirstPage)

--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListModelTest.kt
@@ -93,11 +93,10 @@ class ListModelTest {
      */
     @Test
     fun testFetchingFirstPage() {
-        val listModel = ListModel()
-        listModel.stateDbValue = ListState.FETCHING_FIRST_PAGE.value
-        assertTrue(listModel.isFetchingFirstPage())
-        assertFalse(listModel.isLoadingMore())
-        assertFalse(listModel.canLoadMore())
+        val listState = ListState.FETCHING_FIRST_PAGE
+        assertTrue(listState.isFetchingFirstPage())
+        assertFalse(listState.isLoadingMore())
+        assertFalse(listState.canLoadMore())
     }
 
     /**
@@ -105,11 +104,10 @@ class ListModelTest {
      */
     @Test
     fun testLoadingMore() {
-        val listModel = ListModel()
-        listModel.stateDbValue = ListState.LOADING_MORE.value
-        assertFalse(listModel.isFetchingFirstPage())
-        assertTrue(listModel.isLoadingMore())
-        assertFalse(listModel.canLoadMore())
+        val listState = ListState.LOADING_MORE
+        assertFalse(listState.isFetchingFirstPage())
+        assertTrue(listState.isLoadingMore())
+        assertFalse(listState.canLoadMore())
     }
 
     /**
@@ -118,12 +116,10 @@ class ListModelTest {
      */
     @Test
     fun testNonSpecialStates() {
-        listOf(NEEDS_REFRESH, FETCHED, ERROR).forEach { state ->
-            val listModel = ListModel()
-            listModel.stateDbValue = state.value
-            assertFalse(listModel.isFetchingFirstPage())
-            assertFalse(listModel.isLoadingMore())
-            assertFalse(listModel.canLoadMore())
+        listOf(NEEDS_REFRESH, FETCHED, ERROR).forEach { listState ->
+            assertFalse(listState.isFetchingFirstPage())
+            assertFalse(listState.isLoadingMore())
+            assertFalse(listState.canLoadMore())
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -5,14 +5,14 @@ import org.wordpress.android.fluxc.annotations.ActionEnum
 import org.wordpress.android.fluxc.annotations.action.IAction
 import org.wordpress.android.fluxc.store.ListStore.DeleteListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
-import org.wordpress.android.fluxc.store.ListStore.UpdateListPayload
+import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 
 @ActionEnum
 enum class ListAction : IAction {
     @Action(payloadType = FetchListPayload::class)
     FETCH_LIST,
-    @Action(payloadType = UpdateListPayload::class)
-    UPDATE_LIST,
+    @Action(payloadType = FetchedListItemsPayload::class)
+    FETCHED_LIST_ITEMS,
     @Action(payloadType = DeleteListItemsPayload::class)
     DELETE_LIST_ITEMS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.fluxc.action
+
+import org.wordpress.android.fluxc.annotations.Action
+import org.wordpress.android.fluxc.annotations.ActionEnum
+import org.wordpress.android.fluxc.annotations.action.IAction
+import org.wordpress.android.fluxc.store.ListStore.DeleteListItemsPayload
+import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
+import org.wordpress.android.fluxc.store.ListStore.UpdateListPayload
+
+@ActionEnum
+enum class ListAction : IAction {
+    @Action(payloadType = FetchListPayload::class)
+    FETCH_LIST,
+    @Action(payloadType = UpdateListPayload::class)
+    UPDATE_LIST,
+    @Action(payloadType = DeleteListItemsPayload::class)
+    DELETE_LIST_ITEMS
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -1,0 +1,114 @@
+package org.wordpress.android.fluxc.model.list
+
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.ListActionBuilder
+import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
+
+/**
+ * This is an immutable class which helps us expose the list details to a client. It's designed to be initiated from
+ * `ListStore`.
+ *
+ * @param dispatcher The dispatcher to be used for FluxC actions
+ * @param listDescriptor The list descriptor that will be used for FluxC actions and comparison with
+ * other [ListManager]s
+ * @param items The [ListItemModel]s which contains the `remoteItemId`s
+ * @param dataSource The data source which knows actions like how to query an item by `remoteItemId` or how to fetch it.
+ * @param loadMoreOffset Tells how many items before last one should trigger loading more data
+ * @param isFetchingFirstPage A helper property to be used to show/hide pull-to-refresh progress bar
+ * @param isLoadingMore A helper property to be used to show/hide load more progress bar
+ *
+ * @property size The number of items in the list
+ *
+ */
+class ListManager<T>(
+    private val dispatcher: Dispatcher,
+    private val listDescriptor: ListDescriptor,
+    private val items: List<ListItemModel>,
+    private val dataSource: ListItemDataSource<T>,
+    private val loadMoreOffset: Int,
+    val isFetchingFirstPage: Boolean,
+    val isLoadingMore: Boolean
+) {
+    val size: Int = items.size
+
+    /**
+     * Returns the item in a given position. It's meant to be used by adapters.
+     *
+     * The [ListItemDataSource.getItem] function will be utilized to get the item by its `remoteItemId`.
+     *
+     * @param position The index of the item
+     * @param shouldFetchIfNull Indicates whether the [ListManager] should initiate a fetch
+     * @param shouldLoadMoreIfNecessary Indicates whether the [ListManager] should dispatch an action to load more data
+     * if the end of the list is closer than the [loadMoreOffset].
+     * if [ListItemDataSource.getItem] returns `null`
+     */
+    fun getRemoteItem(
+        position: Int,
+        shouldFetchIfNull: Boolean = true,
+        shouldLoadMoreIfNecessary: Boolean = true
+    ): T? {
+        if (shouldLoadMoreIfNecessary && position > size - loadMoreOffset) {
+            loadMore()
+        }
+        val listItemModel = items[position]
+        val remoteItemId = listItemModel.remoteItemId
+        val item = dataSource.getItem(listDescriptor, remoteItemId)
+        if (item == null && shouldFetchIfNull) {
+            dataSource.fetchItem(listDescriptor, remoteItemId)
+        }
+        return item
+    }
+
+    /**
+     * Returns the index of an item for [remoteItemId] if it exists. It's meant to be paired up with
+     * `notifyItemChanged(position)` of recycler view (or similar for other list views) when an item [T] is updated
+     * by FluxC.
+     */
+    fun indexOfItem(remoteItemId: Long): Int? {
+        val index = items.indexOfFirst { it.remoteItemId == remoteItemId }
+        return if (index != -1) index else null
+    }
+
+    /**
+     * Dispatches an action to fetch the first page of the list. Since this class is immutable, it'll not update itself.
+     * `OnListChanged` should be used to observe changes to lists and a new instance should be requested from
+     * `ListStore`.
+     *
+     * [isFetchingFirstPage] will be checked before dispatching the action to prevent duplicate requests.
+     *
+     * @return whether the refresh action is dispatched
+     */
+    fun refresh() {
+        if (!isFetchingFirstPage) {
+            dispatcher.dispatch(ListActionBuilder.newFetchListAction(FetchListPayload(listDescriptor)))
+        }
+    }
+
+    /**
+     * Dispatches an action to load the next page of a list. It's auto-managed by [ListManager]. See [getRemoteItem]
+     * for more details.
+     *
+     * [isFetchingFirstPage] will be checked before dispatching the action to prevent duplicate requests.
+     */
+    private fun loadMore() {
+        if (!isLoadingMore) {
+            dispatcher.dispatch(ListActionBuilder.newFetchListAction(FetchListPayload(listDescriptor, true)))
+        }
+    }
+
+    /**
+     * Compares the listDescriptors and remoteItemIds with another [ListManager] and returns the result. It's added
+     * to be used with `OnListChanged` to decide whether to reload the full list or not.
+     *
+     * IMPORTANT: It will NOT compare the contents of items.
+     *
+     * This is likely to be re-worked soon, but for now, it provides a convenient function for what we need.
+     */
+    fun hasDataChanged(otherListManager: ListManager<T>): Boolean {
+        if (listDescriptor != otherListManager.listDescriptor || items.size != otherListManager.items.size)
+            return true
+        return !items.zip(otherListManager.items).fold(true) { result, pair ->
+            result && pair.first.remoteItemId == pair.second.remoteItemId
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListModel.kt
@@ -4,11 +4,6 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
-import org.wordpress.android.fluxc.model.list.ListState.CAN_LOAD_MORE
-import org.wordpress.android.fluxc.model.list.ListState.FETCHING_FIRST_PAGE
-import org.wordpress.android.fluxc.model.list.ListState.LOADING_MORE
-import org.wordpress.android.util.DateTimeUtils
-import java.util.Date
 
 const val LIST_STATE_TIMEOUT = 60 * 1000 // 1 minute
 
@@ -32,39 +27,10 @@ class ListModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     val listDescriptor: ListDescriptor
         get() = ListDescriptor(typeDbValue, localSiteIdDbValue, filterDbValue, orderDbValue)
 
-    private val state: ListState
-        get() {
-            /**
-             * Since we keep the state in the DB, in the case of application being closed during a fetch, it'll carry
-             * over to the next session. To prevent such cases, we use a timeout approach and if it has been a certain
-             * time since the list is last updated, we'll simply ignore the state and return the default state.
-             *
-             * If certain amount of time passed since the state last updated, we should always fetch the first page.
-             * For example, consider the case where we are fetching the first page of a list and the user closes the app.
-             * Since we keep the state in the DB, it'll preserve it until the next session even though there is not
-             * actually any request going on. This kind of check prevents such cases and also makes sure that we have
-             * proper timeout.
-             */
-            if (lastModified != null) {
-                val lastModified = DateTimeUtils.dateUTCFromIso8601(lastModified)
-                val timePassed = (Date().time - lastModified.time)
-                if (timePassed > LIST_STATE_TIMEOUT) {
-                    return ListState.defaultState
-                }
-            }
-            return ListState.values().firstOrNull { it.value == this.stateDbValue }!!
-        }
-
     fun setListDescriptor(listDescriptor: ListDescriptor) {
         typeDbValue = listDescriptor.type.value
         localSiteIdDbValue = listDescriptor.localSiteId
         filterDbValue = listDescriptor.filter?.value
         orderDbValue = listDescriptor.order?.value
     }
-
-    fun canLoadMore() = state == CAN_LOAD_MORE
-
-    fun isFetchingFirstPage() = state == FETCHING_FIRST_PAGE
-
-    fun isLoadingMore() = state == LOADING_MORE
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListState.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListState.kt
@@ -1,5 +1,11 @@
 package org.wordpress.android.fluxc.model.list
 
+/**
+ * This is an enum used by `ListStore` to manage the state of a [ListModel]. It'll be saved to `ListModelTable`.
+ *
+ * IMPORTANT: Because the values are stored in the DB, in case of a change to the enum values a migration needs to
+ * be added!
+ */
 enum class ListState(val value: Int) {
     NEEDS_REFRESH(0),
     CAN_LOAD_MORE(1),
@@ -7,6 +13,12 @@ enum class ListState(val value: Int) {
     FETCHING_FIRST_PAGE(3),
     LOADING_MORE(4),
     ERROR(5);
+
+    fun canLoadMore() = this == CAN_LOAD_MORE
+
+    fun isFetchingFirstPage() = this == FETCHING_FIRST_PAGE
+
+    fun isLoadingMore() = this == LOADING_MORE
 
     companion object {
         val defaultState = ListState.NEEDS_REFRESH

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -22,6 +22,11 @@ import javax.inject.Singleton
 
 const val DEFAULT_LOAD_MORE_OFFSET = 10 // When we should load more data for a list
 
+/**
+ * This Store is responsible for managing lists and their metadata. One of the designs goals for this Store is expose
+ * as little as possible to the consumers and make sure the exposed parts are immutable. This not only moves the
+ * responsibility of mutation to the Store but also makes it much easier to use the exposed data.
+ */
 @Singleton
 class ListStore @Inject constructor(
     private val listSqlUtils: ListSqlUtils,
@@ -33,9 +38,9 @@ class ListStore @Inject constructor(
         val actionType = action.type as? ListAction ?: return
 
         when (actionType) {
-            ListAction.FETCH_LIST -> fetchList(action.payload as FetchListPayload)
-            ListAction.UPDATE_LIST -> updateList(action.payload as UpdateListPayload)
-            ListAction.DELETE_LIST_ITEMS -> listItemsDeleted(action.payload as DeleteListItemsPayload)
+            ListAction.FETCH_LIST -> handleFetchList(action.payload as FetchListPayload)
+            ListAction.FETCHED_LIST_ITEMS -> handleFetchedListItems(action.payload as FetchedListItemsPayload)
+            ListAction.DELETE_LIST_ITEMS -> handleDeleteListItems(action.payload as DeleteListItemsPayload)
         }
     }
 
@@ -43,12 +48,23 @@ class ListStore @Inject constructor(
         AppLog.d(AppLog.T.API, ListStore::class.java.simpleName + " onRegister")
     }
 
+    /**
+     * This is the function that'll be used to consume lists.
+     *
+     * @property listDescriptor List to be consumed
+     * @property dataSource An interface that tells the [ListStore] how to get/fetch items. See [ListItemDataSource]
+     * for more details.
+     * @property loadMoreOffset Indicates when more data for a list should be fetched. It'll be passed to [ListManager].
+     *
+     * @return An immutable list manager that exposes enough information about a list to be used by adapters. See
+     * [ListManager] for more details.
+     */
     fun <T> getListManager(
         listDescriptor: ListDescriptor,
         dataSource: ListItemDataSource<T>,
         loadMoreOffset: Int = DEFAULT_LOAD_MORE_OFFSET
     ): ListManager<T> {
-        val listModel = getListModel(listDescriptor)
+        val listModel = listSqlUtils.getList(listDescriptor)
         val listItems = if (listModel != null) {
             listItemSqlUtils.getListItems(listModel.id)
         } else emptyList()
@@ -63,7 +79,16 @@ class ListStore @Inject constructor(
         )
     }
 
-    private fun fetchList(payload: FetchListPayload) {
+    /**
+     * Handles the [ListAction.FETCH_LIST] action.
+     *
+     * This acts as an intermediary action. It will update the state and emit the change. Afterwards, depending on
+     * the type of the list, another action will be dispatched so the Store for that type can handle the fetch action
+     * and later use the [ListAction.FETCHED_LIST_ITEMS] action to let the [ListStore] know about it.
+     *
+     * See [handleFetchedListItems] for what happens after items are fetched.
+     */
+    private fun handleFetchList(payload: FetchListPayload) {
         val newState = if (payload.loadMore) ListState.LOADING_MORE else ListState.FETCHING_FIRST_PAGE
         listSqlUtils.insertOrUpdateList(payload.listDescriptor, newState)
         emitChange(OnListChanged(payload.listDescriptor, null))
@@ -74,16 +99,26 @@ class ListStore @Inject constructor(
         }
     }
 
-    private fun updateList(payload: UpdateListPayload) {
+    /**
+     * Handles the [ListAction.FETCHED_LIST_ITEMS] action.
+     *
+     * Here is how it works:
+     * 1. If there was an error, update the list's state and emit the change. Otherwise:
+     * 2. If the first page is fetched, delete the existing [ListItemModel]s.
+     * 3. Update the [ListModel]'s state depending on whether there is more data to be fetched
+     * 4. Insert the [ListItemModel]s and emit the change
+     *
+     * See [handleFetchList] to see how items are fetched.
+     */
+    private fun handleFetchedListItems(payload: FetchedListItemsPayload) {
         if (!payload.isError) {
             if (!payload.loadedMore) {
                 deleteListItems(payload.listDescriptor)
             }
             val state = if (payload.canLoadMore) ListState.CAN_LOAD_MORE else ListState.FETCHED
             listSqlUtils.insertOrUpdateList(payload.listDescriptor, state)
-            val listModel = getListModel(payload.listDescriptor)
+            val listModel = listSqlUtils.getList(payload.listDescriptor)
             if (listModel != null) { // Sanity check
-                // Ensure the listId is set correctly for ListItemModels
                 listItemSqlUtils.insertItemList(payload.remoteItemIds.map { remoteItemId ->
                     val listItemModel = ListItemModel()
                     listItemModel.listId = listModel.id
@@ -97,54 +132,89 @@ class ListStore @Inject constructor(
         emitChange(OnListChanged(payload.listDescriptor, payload.error))
     }
 
-    private fun listItemsDeleted(payload: DeleteListItemsPayload) {
+    /**
+     * Handles the [ListAction.DELETE_LIST_ITEMS] action.
+     *
+     * It'll first find every list for the given [ListDescriptor]s and then remove the given items from each one.
+     */
+    private fun handleDeleteListItems(payload: DeleteListItemsPayload) {
         val lists = payload.listDescriptors.mapNotNull { listSqlUtils.getList(it) }
         listItemSqlUtils.deleteItemsFromLists(lists.map { it.id }, payload.remoteItemIds)
     }
 
-    private fun getListModel(listDescriptor: ListDescriptor): ListModel? =
-            listSqlUtils.getList(listDescriptor)
-
+    /**
+     * Deletes all the items for the given [ListDescriptor].
+     */
     private fun deleteListItems(listDescriptor: ListDescriptor) {
-        getListModel(listDescriptor)?.let {
+        listSqlUtils.getList(listDescriptor)?.let {
             listItemSqlUtils.deleteItems(it.id)
         }
     }
 
+    /**
+     * The event to be emitted when there is a change to a [ListModel] or its items.
+     */
     class OnListChanged(
         val listDescriptor: ListDescriptor,
-        error: UpdateListError?
-    ) : Store.OnChanged<UpdateListError>() {
+        error: FetchedListItemsError?
+    ) : Store.OnChanged<FetchedListItemsError>() {
         init {
             this.error = error
         }
     }
 
+    /**
+     * This is the payload for [ListAction.DELETE_LIST_ITEMS]. When an item is deleted, we'll need to remove it from
+     * several lists. It's the caller Stores responsibility to decide which lists an item should be deleted from.
+     *
+     * @property listDescriptors Lists to be deleted from.
+     * @property remoteItemIds Items to delete.
+     */
     class DeleteListItemsPayload(
         val listDescriptors: List<ListDescriptor>,
         val remoteItemIds: List<Long>
     ) : Payload<BaseNetworkError>()
 
+    /**
+     * This is the payload for [ListAction.FETCH_LIST].
+     *
+     * @property listDescriptor List to be fetched
+     * @property loadMore Indicates whether the first page should be fetched or more data should be loaded.
+     */
     class FetchListPayload(
         val listDescriptor: ListDescriptor,
         val loadMore: Boolean = false
     ) : Payload<BaseNetworkError>()
 
-    class UpdateListPayload(
+    /**
+     * This is the payload for [ListAction.FETCHED_LIST_ITEMS].
+     *
+     * @property listDescriptor List descriptor will be provided when the action to fetch items will be dispatched
+     * from other Stores. The same list descriptor will need to be used in this payload so [ListStore] can decide
+     * which list to update.
+     * @property remoteItemIds Fetched item ids
+     * @property loadedMore Indicates whether the first page is fetched or loaded more data
+     * @property canLoadMore Indicates whether there is more data to be loaded from the server. If it's false,
+     * [ListStore] will not trigger any more actions to load more data.
+     */
+    class FetchedListItemsPayload(
         val listDescriptor: ListDescriptor,
         val remoteItemIds: List<Long>,
         val loadedMore: Boolean,
         val canLoadMore: Boolean,
-        error: UpdateListError?
-    ) : Payload<UpdateListError>() {
+        error: FetchedListItemsError?
+    ) : Payload<FetchedListItemsError>() {
         init {
             this.error = error
         }
     }
 
-    class UpdateListError(val type: UpdateListErrorType, val message: String? = null) : Store.OnChangedError
+    class FetchedListItemsError(
+        val type: FetchedListItemsErrorType,
+        val message: String? = null
+    ) : Store.OnChangedError
 
-    enum class UpdateListErrorType {
+    enum class FetchedListItemsErrorType {
         GENERIC_ERROR
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -1,0 +1,150 @@
+package org.wordpress.android.fluxc.store
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.action.ListAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.list.ListDescriptor
+import org.wordpress.android.fluxc.model.list.ListItemDataSource
+import org.wordpress.android.fluxc.model.list.ListItemModel
+import org.wordpress.android.fluxc.model.list.ListManager
+import org.wordpress.android.fluxc.model.list.ListModel
+import org.wordpress.android.fluxc.model.list.ListState
+import org.wordpress.android.fluxc.model.list.ListType
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.persistence.ListItemSqlUtils
+import org.wordpress.android.fluxc.persistence.ListSqlUtils
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+const val DEFAULT_LOAD_MORE_OFFSET = 10 // When we should load more data for a list
+
+@Singleton
+class ListStore @Inject constructor(
+    private val listSqlUtils: ListSqlUtils,
+    private val listItemSqlUtils: ListItemSqlUtils,
+    dispatcher: Dispatcher
+) : Store(dispatcher) {
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? ListAction ?: return
+
+        when (actionType) {
+            ListAction.FETCH_LIST -> fetchList(action.payload as FetchListPayload)
+            ListAction.UPDATE_LIST -> updateList(action.payload as UpdateListPayload)
+            ListAction.DELETE_LIST_ITEMS -> listItemsDeleted(action.payload as DeleteListItemsPayload)
+        }
+    }
+
+    override fun onRegister() {
+        AppLog.d(AppLog.T.API, ListStore::class.java.simpleName + " onRegister")
+    }
+
+    fun <T> getListManager(
+        listDescriptor: ListDescriptor,
+        dataSource: ListItemDataSource<T>,
+        loadMoreOffset: Int = DEFAULT_LOAD_MORE_OFFSET
+    ): ListManager<T> {
+        val listModel = getListModel(listDescriptor)
+        val listItems = if (listModel != null) {
+            listItemSqlUtils.getListItems(listModel.id)
+        } else emptyList()
+        return ListManager(
+                mDispatcher,
+                listDescriptor,
+                listItems,
+                dataSource,
+                loadMoreOffset,
+                listModel?.isFetchingFirstPage() ?: false,
+                listModel?.isLoadingMore() ?: false
+        )
+    }
+
+    private fun fetchList(payload: FetchListPayload) {
+        val newState = if (payload.loadMore) ListState.LOADING_MORE else ListState.FETCHING_FIRST_PAGE
+        listSqlUtils.insertOrUpdateList(payload.listDescriptor, newState)
+        emitChange(OnListChanged(payload.listDescriptor, null))
+
+        when (payload.listDescriptor.type) {
+            ListType.POST -> TODO()
+            ListType.WOO_ORDER -> TODO()
+        }
+    }
+
+    private fun updateList(payload: UpdateListPayload) {
+        if (!payload.isError) {
+            if (!payload.loadedMore) {
+                deleteListItems(payload.listDescriptor)
+            }
+            val state = if (payload.canLoadMore) ListState.CAN_LOAD_MORE else ListState.FETCHED
+            listSqlUtils.insertOrUpdateList(payload.listDescriptor, state)
+            val listModel = getListModel(payload.listDescriptor)
+            if (listModel != null) { // Sanity check
+                // Ensure the listId is set correctly for ListItemModels
+                listItemSqlUtils.insertItemList(payload.remoteItemIds.map { remoteItemId ->
+                    val listItemModel = ListItemModel()
+                    listItemModel.listId = listModel.id
+                    listItemModel.remoteItemId = remoteItemId
+                    return@map listItemModel
+                })
+            }
+        } else {
+            listSqlUtils.insertOrUpdateList(payload.listDescriptor, ListState.ERROR)
+        }
+        emitChange(OnListChanged(payload.listDescriptor, payload.error))
+    }
+
+    private fun listItemsDeleted(payload: DeleteListItemsPayload) {
+        val lists = payload.listDescriptors.mapNotNull { listSqlUtils.getList(it) }
+        listItemSqlUtils.deleteItemsFromLists(lists.map { it.id }, payload.remoteItemIds)
+    }
+
+    private fun getListModel(listDescriptor: ListDescriptor): ListModel? =
+            listSqlUtils.getList(listDescriptor)
+
+    private fun deleteListItems(listDescriptor: ListDescriptor) {
+        getListModel(listDescriptor)?.let {
+            listItemSqlUtils.deleteItems(it.id)
+        }
+    }
+
+    class OnListChanged(
+        val listDescriptor: ListDescriptor,
+        error: UpdateListError?
+    ) : Store.OnChanged<UpdateListError>() {
+        init {
+            this.error = error
+        }
+    }
+
+    class DeleteListItemsPayload(
+        val listDescriptors: List<ListDescriptor>,
+        val remoteItemIds: List<Long>
+    ) : Payload<BaseNetworkError>()
+
+    class FetchListPayload(
+        val listDescriptor: ListDescriptor,
+        val loadMore: Boolean = false
+    ) : Payload<BaseNetworkError>()
+
+    class UpdateListPayload(
+        val listDescriptor: ListDescriptor,
+        val remoteItemIds: List<Long>,
+        val loadedMore: Boolean,
+        val canLoadMore: Boolean,
+        error: UpdateListError?
+    ) : Payload<UpdateListError>() {
+        init {
+            this.error = error
+        }
+    }
+
+    class UpdateListError(val type: UpdateListErrorType, val message: String? = null) : Store.OnChangedError
+
+    enum class UpdateListErrorType {
+        GENERIC_ERROR
+    }
+}


### PR DESCRIPTION
This is the second part of `ListStore` PRs and a follow up to #890. In the previous PR, we added most of the necessary models for the `ListStore`. This PR builds on it by introducing a `ListManager`, which is how the clients will consume the information from `ListStore` and implements the store itself.

**ListManager**

The idea behind `ListManager` is a simple but important one. We want the common list management logic to be extracted from clients as much as possible. We also want to make sure that all consumers of `ListStore` follow the same pattern in its usage. That way we can build on it and make improvements to it without worrying about how the clients will be affected by it.

Most importantly, there is no way to change the values in `ListManager` once they are set from the constructor. The only way to make changes to a list is to dispatch FluxC actions, observe for `OnChanged` events and simply ask for a new version.

**ListManager Gotcha!** _(Please, please, make sure to read this part!)_

There is an important gotcha to how `ListManager` will commonly be consumed. Because `ListStore` only stores the metadata of a list and it doesn't have access to the underlying data, we can't actually provide the actual items in its functions. Instead, it takes a `ListItemDataSource` which tells how to fetch and get items from its own store. The gotcha here is that, although the `ListManager` itself is immutable the actual data you get from it might not be immutable depending on how `getItem` is implemented. This is kind of obvious from the `ListStore.getListManager` (by design), however the implications of that might not be too clear.

One example where this gotcha will make a difference is the usage of `DiffUtil.Callback` in the client side. It's **strongly** discouraged to use this pattern right now because in order to calculate the `areContentsTheSame` of `DiffUtil.Callback`, the client needs to know about the item's contents from before and after the update. Since, we are using the `ListItemDataSource.getItem` to get the actual item, it'll simply return the same data, which means `areContentsTheSame` will always return `true`.

I realize that this is an important gotcha and it's one we will hopefully address soon. I am considering changing `getItem` to `getItems` so `ListManager` will be provided all the items at the start. However, it has a lot of performance implications. It's a risky change to make in the first iteration because we can't profile or optimize it properly (I also don't have enough time now). So, this optimization is left for later. For now, a combination of `notifyItemChanged` is the best way to go.

Another small gotcha, that's again a result of how this is likely to be consumed, is that `getItem` will most likely hit the DB which is really really bad to do in a list. There are ways around that (for example caching the actual objects in the client) but it's important one to keep in mind. The reason it's not addressed yet is the above possible change to `ListManager` which will also fix this issue.

**ListStore**

Aside from providing the `ListManager`, `ListStore`'s job is to handle 3 actions.
1. `FETCH_LIST`: This is an intermediary action and it'll simply dispatch an action to fetch the list from its Store depending on its `ListType`. It'll also change the list's state and emit an `OnListChanged` event.
2. `FETCHED_LIST_ITEMS`: This is the counterpart of `FETCH_LIST`. The stores that handle the `FETCH_LIST` actions will be responsible for dispatching this action when a list is fetched. We'll no longer need to emit events such as `OnPostListChanged`. (just an example, this doesn't exist) `ListStore` will save the items in the DB, manage state and emit an `OnListChanged` event.
3. `DELETE_LIST_ITEMS`: Whenever an item is deleted this action needs to be dispatched telling which lists to be updated using the `ListDescriptor`s. It'll be the actual item's store's responsibility to decide which sites, filters, orders etc should be updated. `ListStore` will remove all items from all the lists and emit an `OnListChanged` event. I am thinking about providing helper functions for this when I implement it for stores. _We could have simply asked for a primary type and delete the item from every list for that type, but that doesn't actually work in every case. For example, consider a remote draft being published; it'll be removed from the drafts, but not the list for all items._

More actions will be added to `ListStore` later on, but these ones should be enough to get us started.

**Questions**
1. I really hate the method name `hasDataChanged` in `ListManager` mostly because it doesn't tell the developer that it doesn't compare actual items. This method might be removed with the changes talked about in the gotcha section, but if there is a better name, even if temporary, I'd really like to change it.
2. This is for later, but I have been thinking about whether the `ListState.NEEDS_REFRESH` should trigger an automatic update. I almost implemented this, but I didn't like the fact that when we call `getListManager` we'll immediately get a callback because the state is changed. I considered not emitting the change even in this case, but that wouldn't be right because we don't know if there is another consumer of that list that needs to update itself.

P.S: Sorry about the long PR description, there is just a lot to mention in this one.

/cc @malinajirka @AmandaRiu 