### PR TITLE
Remove unused search post/page action from PostStore

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
@@ -18,19 +18,14 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
-import org.wordpress.android.fluxc.store.PostStore.OnPostsSearched
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
-import org.wordpress.android.fluxc.store.PostStore.SearchPostsPayload
 import org.wordpress.android.fluxc.store.SiteStore
-import java.util.Collections
 import javax.inject.Inject
 
 class PostsFragment : Fragment() {
     @Inject internal lateinit var siteStore: SiteStore
     @Inject internal lateinit var postStore: PostStore
     @Inject internal lateinit var dispatcher: Dispatcher
-
-    private var searchOffset = 0
 
     override fun onAttach(context: Context?) {
         AndroidInjection.inject(this)
@@ -60,14 +55,12 @@ class PostsFragment : Fragment() {
         delete_a_post_from_first_site.setOnClickListener {
             val firstSite = getFirstSite()
             val posts = postStore.getPostsForSite(firstSite)
-            Collections.sort(posts) { lhs, rhs -> (rhs.remotePostId - lhs.remotePostId).toInt() }
+            posts.sortWith(Comparator { lhs, rhs -> (rhs.remotePostId - lhs.remotePostId).toInt() })
             if (!posts.isEmpty()) {
                 val payload = RemotePostPayload(posts[0], firstSite)
                 dispatcher.dispatch(PostActionBuilder.newDeletePostAction(payload))
             }
         }
-
-        search_posts.setOnClickListener { searchPosts(search_posts_query.text.toString(), 0) }
     }
 
     override fun onStart() {
@@ -102,32 +95,6 @@ class PostsFragment : Fragment() {
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onPostUploaded(event: OnPostUploaded) {
         prependToLog("Post uploaded! Remote post id: " + event.post.remotePostId)
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onPostsSearched(event: OnPostsSearched) {
-        if (event.isError) {
-            prependToLog("Error searching posts: " + event.error.type)
-            return
-        }
-
-        val results = if (event.searchResults != null) event.searchResults.posts else null
-        val resultCount = results?.size ?: 0
-        prependToLog("Found $resultCount posts from the search.")
-
-        if (event.canLoadMore) {
-            prependToLog("Can search more posts, dispatching...")
-            searchOffset += resultCount
-            searchPosts(event.searchTerm, searchOffset)
-        } else {
-            searchOffset = 0
-        }
-    }
-
-    private fun searchPosts(searchQuery: String, offset: Int) {
-        val payload = SearchPostsPayload(getFirstSite(), searchQuery, offset)
-        dispatcher.dispatch(PostActionBuilder.newSearchPostsAction(payload))
     }
 
     private fun getFirstSite(): SiteModel = siteStore.sites[0]

--- a/example/src/main/res/layout/fragment_posts.xml
+++ b/example/src/main/res/layout/fragment_posts.xml
@@ -23,16 +23,4 @@
         android:layout_height="wrap_content"
         android:text="Delete a post from first site" />
 
-    <EditText
-        android:id="@+id/search_posts_query"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="Search query" />
-
-    <Button
-        android:id="@+id/search_posts"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Search" />
-
 </LinearLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -6,8 +6,6 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
-import org.wordpress.android.fluxc.store.PostStore.SearchPostsPayload;
-import org.wordpress.android.fluxc.store.PostStore.SearchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 
@@ -24,10 +22,6 @@ public enum PostAction implements IAction {
     PUSH_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETE_POST,
-    @Action(payloadType = SearchPostsPayload.class)
-    SEARCH_POSTS,
-    @Action(payloadType = SearchPostsPayload.class)
-    SEARCH_PAGES,
 
     // Remote responses
     @Action(payloadType = FetchPostsResponsePayload.class)
@@ -38,8 +32,6 @@ public enum PostAction implements IAction {
     PUSHED_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETED_POST,
-    @Action(payloadType = SearchPostsResponsePayload.class)
-    SEARCHED_POSTS,
 
     // Local actions
     @Action(payloadType = PostModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -31,7 +31,6 @@ import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
-import org.wordpress.android.fluxc.store.PostStore.SearchPostsResponsePayload;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
@@ -213,55 +212,6 @@ public class PostRestClient extends BaseWPComRestClient {
         request.addQueryParameter("context", "edit");
 
         request.disableRetries();
-        add(request);
-    }
-
-    public void searchPosts(final SiteModel site, final String searchTerm, final boolean pages, final int offset) {
-        String url = WPCOMREST.sites.site(site.getSiteId()).posts.getUrlV1_1();
-
-        Map<String, String> params = new HashMap<>();
-
-        if (pages) {
-            params.put("type", "page");
-        }
-        params.put("number", String.valueOf(PostStore.NUM_POSTS_PER_FETCH));
-        params.put("offset", String.valueOf(offset));
-        params.put("search", searchTerm);
-        params.put("status", "any");
-
-        final WPComGsonRequest<PostsResponse> request = WPComGsonRequest.buildGetRequest(url, params,
-                PostsResponse.class,
-                new Listener<PostsResponse>() {
-                    @Override
-                    public void onResponse(PostsResponse response) {
-                        List<PostModel> postArray = new ArrayList<>();
-                        PostModel post;
-                        for (PostWPComRestResponse postResponse : response.posts) {
-                            post = postResponseToPostModel(postResponse);
-                            post.setLocalSiteId(site.getId());
-                            postArray.add(post);
-                        }
-
-                        boolean loadedMore = offset > 0;
-                        boolean canLoadMore = postArray.size() == PostStore.NUM_POSTS_PER_FETCH;
-                        PostsModel postsModel = new PostsModel(postArray);
-
-                        SearchPostsResponsePayload payload = new SearchPostsResponsePayload(
-                                postsModel, site, searchTerm, pages, loadedMore, canLoadMore);
-                        mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
-                    }
-                },
-                new WPComErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                        PostError postError = new PostError(error.apiError, error.message);
-                        SearchPostsResponsePayload payload =
-                                new SearchPostsResponsePayload(site, searchTerm, pages, postError);
-                        mDispatcher.dispatch(PostActionBuilder.newSearchedPostsAction(payload));
-                    }
-                }
-        );
-
         add(request);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -61,48 +61,6 @@ public class PostStore extends Store {
         }
     }
 
-    public static class SearchPostsPayload extends Payload<BaseNetworkError> {
-        public SiteModel site;
-        public String searchTerm;
-        public int offset;
-
-        public SearchPostsPayload(SiteModel site, String searchTerm) {
-            this.site = site;
-            this.searchTerm = searchTerm;
-        }
-
-        public SearchPostsPayload(SiteModel site, String searchTerm, int offset) {
-            this(site, searchTerm);
-            this.offset = offset;
-        }
-    }
-
-    public static class SearchPostsResponsePayload extends Payload<PostError> {
-        public PostsModel posts;
-        public SiteModel site;
-        public String searchTerm;
-        public boolean isPages;
-        public boolean loadedMore;
-        public boolean canLoadMore;
-
-        public SearchPostsResponsePayload(PostsModel posts, SiteModel site, String searchTerm, boolean isPages,
-                                          boolean loadedMore, boolean canLoadMore) {
-            this.posts = posts;
-            this.site = site;
-            this.searchTerm = searchTerm;
-            this.isPages = isPages;
-            this.loadedMore = loadedMore;
-            this.canLoadMore = canLoadMore;
-        }
-
-        public SearchPostsResponsePayload(SiteModel site, String searchTerm, boolean isPages, PostError error) {
-            this.site = site;
-            this.searchTerm = searchTerm;
-            this.isPages = isPages;
-            this.error = error;
-        }
-    }
-
     public static class FetchPostsResponsePayload extends Payload<PostError> {
         public PostsModel posts;
         public SiteModel site;
@@ -183,18 +141,6 @@ public class PostStore extends Store {
 
         public OnPostUploaded(PostModel post) {
             this.post = post;
-        }
-    }
-
-    public static class OnPostsSearched extends OnChanged<PostError> {
-        public String searchTerm;
-        public PostsModel searchResults;
-        public boolean canLoadMore;
-
-        public OnPostsSearched(String searchTerm, PostsModel searchResults, boolean canLoadMore) {
-            this.searchTerm = searchTerm;
-            this.searchResults = searchResults;
-            this.canLoadMore = canLoadMore;
         }
     }
 
@@ -408,15 +354,6 @@ public class PostStore extends Store {
             case REMOVE_ALL_POSTS:
                 removeAllPosts();
                 break;
-            case SEARCH_POSTS:
-                searchPosts((SearchPostsPayload) action.getPayload(), false);
-                break;
-            case SEARCH_PAGES:
-                searchPosts((SearchPostsPayload) action.getPayload(), true);
-                break;
-            case SEARCHED_POSTS:
-                handleSearchPostsCompleted((SearchPostsResponsePayload) action.getPayload());
-                break;
         }
     }
 
@@ -449,19 +386,6 @@ public class PostStore extends Store {
         } else {
             // TODO: check for WP-REST-API plugin and use it here
             mPostXMLRPCClient.fetchPosts(payload.site, pages, offset);
-        }
-    }
-
-    private void searchPosts(SearchPostsPayload payload, boolean pages) {
-        if (payload.site.isUsingWpComRestApi()) {
-            mPostRestClient.searchPosts(payload.site, payload.searchTerm, pages, payload.offset);
-        } else {
-            // TODO: check for WP-REST-API plugin and use it here
-            PostError error =
-                    new PostError(PostErrorType.UNSUPPORTED_ACTION, "Search only supported on .com/Jetpack sites");
-            OnPostsSearched onPostsSearched = new OnPostsSearched(payload.searchTerm, null, false);
-            onPostsSearched.error = error;
-            emitChange(onPostsSearched);
         }
     }
 
@@ -507,20 +431,6 @@ public class PostStore extends Store {
         }
 
         emitChange(onPostChanged);
-    }
-
-    private void handleSearchPostsCompleted(SearchPostsResponsePayload payload) {
-        OnPostsSearched onPostsSearched = new OnPostsSearched(payload.searchTerm, payload.posts, payload.canLoadMore);
-
-        if (payload.isError()) {
-            onPostsSearched.error = payload.error;
-        } else if (payload.posts.getPosts() != null && payload.posts.getPosts().size() > 0) {
-            for (PostModel post : payload.posts.getPosts()) {
-                PostSqlUtils.insertOrUpdatePostKeepingLocalChanges(post);
-            }
-        }
-
-        emitChange(onPostsSearched);
     }
 
     private void handleFetchSinglePostCompleted(FetchPostResponsePayload payload) {


### PR DESCRIPTION
We implemented post search a long time ago and never used it in the clients because of the pagination issues it'd have cost us. Since the post pagination project provides a different framework for list management, I'm removing the currently unused search functionality. Whenever we implement search again, we can use bits and pieces from this PR, but for now it'll make my life easier to cleanup the PostStore as much as possible. This is the first of those PRs and more will be coming.

/cc @aforcier & @AmandaRiu Just in case you're using this in Woo. I doubt that's the case, but better to be sure :)