### PR TITLE
Replace runBlocking in unit tests with a new function called test

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/CoroutinesTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/CoroutinesTestUtils.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc
+
+import kotlinx.coroutines.experimental.CoroutineScope
+import kotlinx.coroutines.experimental.runBlocking
+import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.experimental.EmptyCoroutineContext
+
+fun <T> test(context: CoroutineContext = EmptyCoroutineContext, block: suspend CoroutineScope.() -> T) {
+    runBlocking(context, block)
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
-import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -36,6 +35,7 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.ActivityLogErrorType
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedRewindStatePayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusErrorType
+import org.wordpress.android.fluxc.test
 
 @RunWith(MockitoJUnitRunner::class)
 class ActivityLogRestClientTest {
@@ -65,7 +65,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_passesCorrectParamToBuildRequest() = runBlocking {
+    fun fetchActivity_passesCorrectParamToBuildRequest() = test {
         initFetchActivity()
 
         activityRestClient.fetchActivity(site, number, offset)
@@ -78,7 +78,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesResponseOnSuccess() = runBlocking {
+    fun fetchActivity_dispatchesResponseOnSuccess() = test {
         val response = ActivitiesResponse(1, "response", ACTIVITY_RESPONSE_PAGE)
         initFetchActivity(response)
 
@@ -106,7 +106,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnMissingActivityId() = runBlocking {
+    fun fetchActivity_dispatchesErrorOnMissingActivityId() = test {
         val failingPage = Page(listOf(ACTIVITY_RESPONSE.copy(activity_id = null)))
         val activitiesResponse = ActivitiesResponse(1, "response", failingPage)
         initFetchActivity(activitiesResponse)
@@ -117,7 +117,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnMissingSummary() = runBlocking {
+    fun fetchActivity_dispatchesErrorOnMissingSummary() = test {
         val failingPage = Page(listOf(ACTIVITY_RESPONSE.copy(summary = null)))
         val activitiesResponse = ActivitiesResponse(1, "response", failingPage)
         initFetchActivity(activitiesResponse)
@@ -128,7 +128,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnMissingContentText() = runBlocking {
+    fun fetchActivity_dispatchesErrorOnMissingContentText() = test {
         val emptyContent = ActivitiesResponse.Content(null)
         val failingPage = Page(listOf(ACTIVITY_RESPONSE.copy(content = emptyContent)))
         val activitiesResponse = ActivitiesResponse(1, "response", failingPage)
@@ -140,7 +140,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnMissingPublishedDate() = runBlocking {
+    fun fetchActivity_dispatchesErrorOnMissingPublishedDate() = test {
         val failingPage = Page(listOf(ACTIVITY_RESPONSE.copy(published = null)))
         val activitiesResponse = ActivitiesResponse(1, "response", failingPage)
         initFetchActivity(activitiesResponse)
@@ -151,7 +151,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivity_dispatchesErrorOnFailure() = runBlocking {
+    fun fetchActivity_dispatchesErrorOnFailure() = test {
         initFetchActivity(error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR)))
 
         val payload = activityRestClient.fetchActivity(site, number, offset)
@@ -160,7 +160,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesResponseOnSuccess() = runBlocking<Unit> {
+    fun fetchActivityRewind_dispatchesResponseOnSuccess() = test {
         val state = RewindStatusModel.State.ACTIVE
         val rewindResponse = REWIND_STATUS_RESPONSE.copy(state = state.value)
         initFetchRewindStatus(rewindResponse)
@@ -183,7 +183,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesGenericErrorOnFailure() = runBlocking {
+    fun fetchActivityRewind_dispatchesGenericErrorOnFailure() = test {
         initFetchRewindStatus(error = WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
 
         val payload = activityRestClient.fetchActivityRewind(site)
@@ -192,7 +192,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesErrorOnWrongState() = runBlocking {
+    fun fetchActivityRewind_dispatchesErrorOnWrongState() = test {
         initFetchRewindStatus(REWIND_STATUS_RESPONSE.copy(state = "wrong"))
 
         val payload = activityRestClient.fetchActivityRewind(site)
@@ -201,7 +201,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesErrorOnMissingRestoreId() = runBlocking {
+    fun fetchActivityRewind_dispatchesErrorOnMissingRestoreId() = test {
         initFetchRewindStatus(REWIND_STATUS_RESPONSE.copy(rewind = REWIND_RESPONSE.copy(rewind_id = null)))
 
         val payload = activityRestClient.fetchActivityRewind(site)
@@ -210,7 +210,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun fetchActivityRewind_dispatchesErrorOnWrongRestoreStatus() = runBlocking {
+    fun fetchActivityRewind_dispatchesErrorOnWrongRestoreStatus() = test {
         initFetchRewindStatus(REWIND_STATUS_RESPONSE.copy(rewind = REWIND_RESPONSE.copy(status = "wrong")))
 
         val payload = activityRestClient.fetchActivityRewind(site)
@@ -219,7 +219,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun postRewindOperation() = runBlocking {
+    fun postRewindOperation() = test {
         val restoreId = 10L
         val response = RewindResponse(restoreId, true, null)
         initPostRewind(response)
@@ -230,7 +230,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun postRewindOperationError() = runBlocking {
+    fun postRewindOperationError() = test {
         initPostRewind(error = WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
 
         val payload = activityRestClient.rewind(site, "rewindId")
@@ -239,7 +239,7 @@ class ActivityLogRestClientTest {
     }
 
     @Test
-    fun postRewindApiError() = runBlocking {
+    fun postRewindApiError() = test {
         val restoreId = 10L
         initPostRewind(RewindResponse(restoreId, false, "error"))
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockito_kotlin.KArgumentCaptor
 import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.whenever
-import kotlinx.coroutines.experimental.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -24,6 +23,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient.JetpackInstallResponse
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType
+import org.wordpress.android.fluxc.test
 
 @RunWith(MockitoJUnitRunner::class)
 class JetpackRestClientTest {
@@ -54,7 +54,7 @@ class JetpackRestClientTest {
     }
 
     @Test
-    fun `returns success on successful jetpack install`() = runBlocking<Unit> {
+    fun `returns success on successful jetpack install`() = test {
         initRequest(Success(JetpackInstallResponse(true)))
         val success = true
 
@@ -72,7 +72,7 @@ class JetpackRestClientTest {
     }
 
     @Test
-    fun `returns error with type`() = runBlocking<Unit> {
+    fun `returns error with type`() = test {
         initRequest(Error(WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR))))
 
         val jetpackErrorPayload = jetpackRestClient.installJetpack(site)

--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
@@ -22,10 +22,6 @@ import org.wordpress.android.fluxc.action.PostAction.FETCH_PAGES
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.PageStore
-import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
-import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.model.page.PageStatus.DRAFT
@@ -33,9 +29,14 @@ import org.wordpress.android.fluxc.model.page.PageStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.page.PageStatus.SCHEDULED
 import org.wordpress.android.fluxc.model.page.PageStatus.TRASHED
 import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PageStore
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNKNOWN_POST
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
+import org.wordpress.android.fluxc.test
 import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
@@ -141,7 +142,7 @@ class PageStoreTest {
     }
 
     @Test
-    fun requestPagesFetchesFromServerAndReturnsEvent() = runBlocking {
+    fun requestPagesFetchesFromServerAndReturnsEvent() = test {
         val expected = OnPostChanged(5, false)
         expected.causeOfChange = FETCH_PAGES
         var event: OnPostChanged? = null
@@ -158,7 +159,7 @@ class PageStoreTest {
     }
 
     @Test
-    fun requestPagesFetchesPaginatedFromServerAndReturnsSecondEvent() = runBlocking<Unit> {
+    fun requestPagesFetchesPaginatedFromServerAndReturnsSecondEvent() = test {
         val firstEvent = OnPostChanged(5, true)
         val lastEvent = OnPostChanged(5, false)
         firstEvent.causeOfChange = FETCH_PAGES
@@ -185,7 +186,7 @@ class PageStoreTest {
     }
 
     @Test
-    fun deletePageTest() = runBlocking<Unit> {
+    fun deletePageTest() = test {
         val post = pageHierarchy[0]
         whenever(postStore.getPostByLocalPostId(post.id)).thenReturn(post)
         val event = OnPostChanged(0)
@@ -208,7 +209,7 @@ class PageStoreTest {
     }
 
     @Test
-    fun deletePageWithErrorTest() = runBlocking<Unit> {
+    fun deletePageWithErrorTest() = test {
         val post = pageHierarchy[0]
         whenever(postStore.getPostByLocalPostId(post.id)).thenReturn(null)
         val event = OnPostChanged(0)
@@ -226,7 +227,7 @@ class PageStoreTest {
     }
 
     @Test
-    fun requestPagesAndVerifyAllPageTypesPresent() = runBlocking<Unit> {
+    fun requestPagesAndVerifyAllPageTypesPresent() = test {
         val event = OnPostChanged(4, false)
         event.causeOfChange = FETCH_PAGES
         launch {
@@ -260,7 +261,7 @@ class PageStoreTest {
     }
 
     @Test
-    fun getTopLevelPageByLocalId() = runBlocking {
+    fun getTopLevelPageByLocalId() = test {
         doAnswer { invocation -> pageHierarchy.firstOrNull { it.id == invocation.arguments.first() } }
                 .`when`(postStore).getPostByLocalPostId(any())
 
@@ -273,7 +274,7 @@ class PageStoreTest {
     }
 
     @Test
-    fun getChildPageByRemoteId() = runBlocking {
+    fun getChildPageByRemoteId() = test {
         doAnswer { invocation -> pageHierarchy.firstOrNull { it.remotePostId == invocation.arguments.first() } }
                 .`when`(postStore).getPostByRemotePostId(any(), any())
 
@@ -292,7 +293,7 @@ class PageStoreTest {
     }
 
     @Test
-    fun getPages() = runBlocking<Unit> {
+    fun getPages() = test {
         whenever(postStore.getPagesForSite(site)).thenReturn(pageHierarchy)
 
         val pages = store.getPagesFromDb(site)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import com.yarolegovich.wellsql.SelectQuery
 import kotlinx.coroutines.experimental.Unconfined
-import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -27,6 +26,7 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.FetchActivityLogPayloa
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchRewindStatePayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindPayload
+import org.wordpress.android.fluxc.test
 
 @RunWith(MockitoJUnitRunner::class)
 class ActivityLogStoreTest {
@@ -42,7 +42,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun onFetchActivityLogFirstPageActionCleanupDbAndCallRestClient() = runBlocking<Unit> {
+    fun onFetchActivityLogFirstPageActionCleanupDbAndCallRestClient() = test {
         val number = 10
         val offset = 0
 
@@ -54,7 +54,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun onFetchActivityLogNextActionReadCurrentDataAndCallRestClient() = runBlocking<Unit> {
+    fun onFetchActivityLogNextActionReadCurrentDataAndCallRestClient() = test {
         val number = 10
 
         val existingActivities = listOf<ActivityLogModel>(mock())
@@ -69,7 +69,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun onFetchRewindStatusActionCallRestClient() = runBlocking<Unit> {
+    fun onFetchRewindStatusActionCallRestClient() = test {
         val payload = ActivityLogStore.FetchRewindStatePayload(siteModel)
         val action = ActivityLogActionBuilder.newFetchRewindStateAction(payload)
         activityLogStore.onAction(action)
@@ -78,7 +78,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun onRewindActionCallRestClient() = runBlocking<Unit> {
+    fun onRewindActionCallRestClient() = test {
         val rewindId = "rewindId"
         val payload = ActivityLogStore.RewindPayload(siteModel, rewindId)
         val action = ActivityLogActionBuilder.newRewindAction(payload)
@@ -88,7 +88,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun storeFetchedActivityLogToDbAndSetsLoadMoreToFalse() = runBlocking<Unit> {
+    fun storeFetchedActivityLogToDbAndSetsLoadMoreToFalse() = test {
         val rowsAffected = 1
         val activityModels = listOf<ActivityLogModel>(mock())
 
@@ -105,7 +105,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun cannotLoadMoreWhenResponseEmpty() = runBlocking {
+    fun cannotLoadMoreWhenResponseEmpty() = test {
         val rowsAffected = 0
         val activityModels = listOf<ActivityLogModel>(mock())
 
@@ -120,7 +120,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun setsLoadMoreToTrueOnMoreItems() = runBlocking {
+    fun setsLoadMoreToTrueOnMoreItems() = test {
         val rowsAffected = 1
         val activityModels = listOf<ActivityLogModel>(mock())
 
@@ -148,7 +148,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun storeFetchedRewindStatusToDb() = runBlocking {
+    fun storeFetchedRewindStatusToDb() = test {
         val rewindStatusModel = mock<RewindStatusModel>()
         val payload = ActivityLogStore.FetchedRewindStatePayload(rewindStatusModel, siteModel)
         whenever(activityLogRestClient.fetchActivityRewind(siteModel)).thenReturn(payload)
@@ -174,7 +174,7 @@ class ActivityLogStoreTest {
     }
 
     @Test
-    fun emitsRewindResult() = runBlocking {
+    fun emitsRewindResult() = test {
         val rewindId = "rewindId"
         val restoreId = 10L
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import kotlinx.coroutines.experimental.Unconfined
 import kotlinx.coroutines.experimental.launch
-import kotlinx.coroutines.experimental.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -22,6 +21,7 @@ import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.GE
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstalledPayload
 import org.wordpress.android.fluxc.store.JetpackStore.OnJetpackInstalled
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.test
 
 @RunWith(MockitoJUnitRunner::class)
 class JetpackStoreTest {
@@ -40,7 +40,7 @@ class JetpackStoreTest {
     }
 
     @Test
-    fun `on install triggers rest client and returns success`() = runBlocking {
+    fun `on install triggers rest client and returns success`() = test {
         val success = true
         whenever(jetpackRestClient.installJetpack(site)).thenReturn(JetpackInstalledPayload(site, success))
 
@@ -55,7 +55,7 @@ class JetpackStoreTest {
     }
 
     @Test
-    fun `on install action triggers rest client and returns success`() = runBlocking {
+    fun `on install action triggers rest client and returns success`() = test {
         val success = true
         whenever(jetpackRestClient.installJetpack(site)).thenReturn(JetpackInstalledPayload(site, success))
 
@@ -68,7 +68,7 @@ class JetpackStoreTest {
     }
 
     @Test
-    fun `on install triggers rest client and returns error`() = runBlocking {
+    fun `on install triggers rest client and returns error`() = test {
         val installError = JetpackInstallError(GENERIC_ERROR)
         val payload = JetpackInstalledPayload(installError, site)
         whenever(jetpackRestClient.installJetpack(site)).thenReturn(payload)
@@ -84,7 +84,7 @@ class JetpackStoreTest {
     }
 
     @Test
-    fun `on install action triggers rest client and returns error`() = runBlocking {
+    fun `on install action triggers rest client and returns error`() = test {
         val installError = JetpackInstallError(GENERIC_ERROR)
         val payload = JetpackInstalledPayload(installError, site)
         whenever(jetpackRestClient.installJetpack(site)).thenReturn(payload)


### PR DESCRIPTION
When you run a test that's testing a suspended function, coroutines (in the current version) require you to wrap the test in `runBlocking`. Since `runBlocking` might return a result, the test only works when it doesn't return any value. Otherwise you have to use `runBlocking<Unit>`. I felt like this is unnecessary so I'm creating here a helper function that replaces both of these calls with a simpler `test` one. This way you don't have to worry about any return value and the meaning is clear. The method is introduced only in `CoroutineTestUtils` in tests so it's not visible from production code.

Let me know if the method name works for you.