### PR TITLE
Lower the number of orders returned per fetch from 50 to 25

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -30,7 +30,7 @@ import javax.inject.Singleton
 class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrderRestClient: OrderRestClient)
     : Store(dispatcher) {
     companion object {
-        const val NUM_ORDERS_PER_FETCH = 50
+        const val NUM_ORDERS_PER_FETCH = 25
     }
 
     class FetchOrdersPayload(


### PR DESCRIPTION
Fixes #897 by lowering the number of orders returned per fetch and therefore avoiding the jetpack tunnel timeout.