### PR TITLE
Fixes FetchPostsPayload constructor and a minor issue in PageStoreTest

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
@@ -17,15 +17,12 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.PostAction
 import org.wordpress.android.fluxc.action.PostAction.DELETE_POST
 import org.wordpress.android.fluxc.action.PostAction.FETCH_PAGES
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.PageStore
-import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
-import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.model.page.PageStatus.DRAFT
@@ -33,6 +30,10 @@ import org.wordpress.android.fluxc.model.page.PageStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.page.PageStatus.SCHEDULED
 import org.wordpress.android.fluxc.model.page.PageStatus.TRASHED
 import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PageStore
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNKNOWN_POST
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
@@ -212,14 +213,13 @@ class PageStoreTest {
         val post = pageHierarchy[0]
         whenever(postStore.getPostByLocalPostId(post.id)).thenReturn(null)
         val event = OnPostChanged(0)
+        event.causeOfChange = PostAction.DELETE_POST
         event.error = PostError(UNKNOWN_POST)
         val page = createPageFromPost(post, site, null)
         var result: OnPostChanged? = null
         launch {
             result = store.deletePageFromServer(page)
         }
-        delay(10)
-        store.onPostChanged(event)
         delay(10)
 
         assertThat(result?.error?.type).isEqualTo(event.error.type)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -47,7 +47,7 @@ public class PostStore extends Store {
         public List<PostStatus> statusTypes;
 
         public FetchPostsPayload(SiteModel site) {
-            this.site = site;
+            this(site, false);
         }
 
         public FetchPostsPayload(SiteModel site, boolean loadMore) {


### PR DESCRIPTION
This PR contains 2 small unrelated fixes.

1. `FetchPostsPayload`s first constructor wasn't setting the `statusTypes` which leads to a crash. It looks like this constructor wasn't being used by WPAndroid, so the crash doesn't affect anything in release. In order to test this crash, go into `Posts` fragment in the example app and fetch the first page.
2. I found the other "issue" while working on a completely unrelated change. I was originally going to ask this as part of my next PR, but it'd be much easier to discuss separately. I think the `PostStoreTest.deletePageWithErrorTest` was lacking the `causeOfChange` field (which is what my PR is about) which doesn't seem to be affecting anything at the moment, so I added that. I also found that, `OnPostChanged` event was already being emitted by `PageStore.deletePageFromServer` function. So, I don't think we need the `store.onPostChanged(event)` call in that test. After the changes I made to the `causeOfChange` that line was failing for me, because of the double `OnPostChange` event.

@0nko Do you mind reviewing this PR as it looks like you worked on these changes recently? It'd be great if you can prioritize it as my changes depend on these fixes and the PR is very small. Thanks!