### PR TITLE
Add fixed list of stats

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.COMMENTS
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.FOLLOWERS
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.LATEST_POST_SUMMARY
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.MOST_POPULAR_DAY_AND_HOUR
-import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.PUBLICISE
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.PUBLICIZE
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.TAGS_AND_CATEGORIES
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.TODAY_STATS
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.AUTHORS
@@ -33,7 +33,7 @@ class StatsStore
                 COMMENTS,
                 TAGS_AND_CATEGORIES,
                 FOLLOWERS,
-                PUBLICISE
+                PUBLICIZE
         )
     }
 
@@ -61,7 +61,7 @@ class StatsStore
         FOLLOWERS,
         TODAY_STATS,
         POSTING_ACTIVITY,
-        PUBLICISE
+        PUBLICIZE
     }
 
     enum class TimeStatsTypes {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.fluxc.store
+
+import kotlinx.coroutines.experimental.withContext
+import org.wordpress.android.fluxc.store.StatsStore.StatsType.ALL_TIME_STATS
+import org.wordpress.android.fluxc.store.StatsStore.StatsType.COMMENTS
+import org.wordpress.android.fluxc.store.StatsStore.StatsType.FOLLOWERS
+import org.wordpress.android.fluxc.store.StatsStore.StatsType.LATEST_POST_SUMMARY
+import org.wordpress.android.fluxc.store.StatsStore.StatsType.MOST_POPULAR_DAY_AND_HOUR
+import org.wordpress.android.fluxc.store.StatsStore.StatsType.PUBLICISE
+import org.wordpress.android.fluxc.store.StatsStore.StatsType.TAGS_AND_CATEGORIES
+import org.wordpress.android.fluxc.store.StatsStore.StatsType.TODAY_STATS
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
+
+@Singleton
+class StatsStore
+@Inject constructor(private val coroutineContext: CoroutineContext) {
+    suspend fun getStatsTypes(): List<StatsType> = withContext(coroutineContext){
+        return@withContext listOf(
+                LATEST_POST_SUMMARY,
+                TODAY_STATS,
+                ALL_TIME_STATS,
+                MOST_POPULAR_DAY_AND_HOUR,
+                COMMENTS,
+                TAGS_AND_CATEGORIES,
+                FOLLOWERS,
+                PUBLICISE)
+    }
+
+    enum class StatsType {
+        LATEST_POST_SUMMARY,
+        MOST_POPULAR_DAY_AND_HOUR,
+        ALL_TIME_STATS,
+        FOLLOWER_TOTALS,
+        TAGS_AND_CATEGORIES,
+        ANNUAL_SITE_STATS,
+        COMMENTS,
+        FOLLOWERS,
+        TODAY_STATS,
+        POSTING_ACTIVITY,
+        PUBLICISE
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.experimental.CoroutineContext
 @Singleton
 class StatsStore
 @Inject constructor(private val coroutineContext: CoroutineContext) {
-    suspend fun getInsights(): List<InsightsTypes> = withContext(coroutineContext){
+    suspend fun getInsights(): List<InsightsTypes> = withContext(coroutineContext) {
         return@withContext listOf(
                 LATEST_POST_SUMMARY,
                 TODAY_STATS,
@@ -33,10 +33,11 @@ class StatsStore
                 COMMENTS,
                 TAGS_AND_CATEGORIES,
                 FOLLOWERS,
-                PUBLICISE)
+                PUBLICISE
+        )
     }
 
-    suspend fun getTimeStatsTypes() :List<TimeStatsTypes> = withContext(coroutineContext) {
+    suspend fun getTimeStatsTypes(): List<TimeStatsTypes> = withContext(coroutineContext) {
         return@withContext listOf(
                 OVERVIEW,
                 POSTS_AND_PAGES,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -1,14 +1,22 @@
 package org.wordpress.android.fluxc.store
 
 import kotlinx.coroutines.experimental.withContext
-import org.wordpress.android.fluxc.store.StatsStore.StatsType.ALL_TIME_STATS
-import org.wordpress.android.fluxc.store.StatsStore.StatsType.COMMENTS
-import org.wordpress.android.fluxc.store.StatsStore.StatsType.FOLLOWERS
-import org.wordpress.android.fluxc.store.StatsStore.StatsType.LATEST_POST_SUMMARY
-import org.wordpress.android.fluxc.store.StatsStore.StatsType.MOST_POPULAR_DAY_AND_HOUR
-import org.wordpress.android.fluxc.store.StatsStore.StatsType.PUBLICISE
-import org.wordpress.android.fluxc.store.StatsStore.StatsType.TAGS_AND_CATEGORIES
-import org.wordpress.android.fluxc.store.StatsStore.StatsType.TODAY_STATS
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.ALL_TIME_STATS
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.COMMENTS
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.FOLLOWERS
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.LATEST_POST_SUMMARY
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.MOST_POPULAR_DAY_AND_HOUR
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.PUBLICISE
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.TAGS_AND_CATEGORIES
+import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.TODAY_STATS
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.AUTHORS
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.CLICKS
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.COUNTRIES
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.OVERVIEW
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.POSTS_AND_PAGES
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.REFERRERS
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.SEARCH_TERMS
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.VIDEOS
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.CoroutineContext
@@ -16,7 +24,7 @@ import kotlin.coroutines.experimental.CoroutineContext
 @Singleton
 class StatsStore
 @Inject constructor(private val coroutineContext: CoroutineContext) {
-    suspend fun getStatsTypes(): List<StatsType> = withContext(coroutineContext){
+    suspend fun getInsights(): List<InsightsTypes> = withContext(coroutineContext){
         return@withContext listOf(
                 LATEST_POST_SUMMARY,
                 TODAY_STATS,
@@ -28,7 +36,20 @@ class StatsStore
                 PUBLICISE)
     }
 
-    enum class StatsType {
+    suspend fun getTimeStatsTypes() :List<TimeStatsTypes> = withContext(coroutineContext) {
+        return@withContext listOf(
+                OVERVIEW,
+                POSTS_AND_PAGES,
+                REFERRERS,
+                CLICKS,
+                AUTHORS,
+                COUNTRIES,
+                SEARCH_TERMS,
+                VIDEOS
+        )
+    }
+
+    enum class InsightsTypes {
         LATEST_POST_SUMMARY,
         MOST_POPULAR_DAY_AND_HOUR,
         ALL_TIME_STATS,
@@ -40,5 +61,17 @@ class StatsStore
         TODAY_STATS,
         POSTING_ACTIVITY,
         PUBLICISE
+    }
+
+    enum class TimeStatsTypes {
+        OVERVIEW,
+        POSTS_AND_PAGES,
+        REFERRERS,
+        CLICKS,
+        AUTHORS,
+        COUNTRIES,
+        SEARCH_TERMS,
+        PUBLISHED,
+        VIDEOS
     }
 }


### PR DESCRIPTION
- this PR is introducing a `StatsStore` which now returns a fixed list of Insights types for the insights screen in Stats and a list of block types for the Day/Week/Month/Year screen. 
- As a next step we'll replace this with a user selected list of types in a custom order. 