### PR TITLE
Drop the correct table for AL migration

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -337,7 +337,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 40:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("DROP TABLE IF EXISTS ActivityLogModel");
+                db.execSQL("DROP TABLE IF EXISTS ActivityLog");
                 db.execSQL(
                         "CREATE TABLE ActivityLog (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
                         + "REMOTE_SITE_ID INTEGER,ACTIVITY_ID TEXT NOT NULL,SUMMARY TEXT NOT NULL,FORMATTABLE_CONTENT"


### PR DESCRIPTION
- `ActivityLogModel` doesn't exist. We should be dropping and rebuilding `ActivityLog` instead. This is not released yet so it shouldn't require a more complex fix. The bug was introduced with the FormattableContent and causes migration to fail because we're recreating the same DB table.