### PR TITLE
Add Insight endpoints tests

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -1,0 +1,239 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.AllTimeResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.MostPopularResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse
+import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(MockitoJUnitRunner::class)
+class InsightsRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var insightsRestClient: InsightsRestClient
+    private val siteId: Long = 12
+    private val postId: Long = 1
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        insightsRestClient = InsightsRestClient(
+                dispatcher,
+                wpComGsonRequestBuilder,
+                null,
+                requestQueue,
+                accessToken,
+                userAgent
+        )
+    }
+
+    @Test
+    fun `returns all time success response`() = test {
+        val response = mock<AllTimeResponse>()
+        initAllTimeResponse(response)
+
+        val allTimeInsights = insightsRestClient.fetchAllTimeInsights(site, false)
+
+        assertNotNull(allTimeInsights.response)
+        assertEquals(response, allTimeInsights.response)
+        assertEquals("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/", urlCaptor.lastValue)
+    }
+
+    @Test
+    fun `returns all time error response`() = test {
+        val errorMessage = "message"
+        initAllTimeResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val allTimeInsights = insightsRestClient.fetchAllTimeInsights(site, false)
+
+        assertNotNull(allTimeInsights.error)
+        assertEquals(API_ERROR, allTimeInsights.error.type)
+        assertEquals(errorMessage, allTimeInsights.error.message)
+    }
+
+    @Test
+    fun `returns most popular success response`() = test {
+        val response = mock<MostPopularResponse>()
+        initMostPopularResponse(response)
+
+        val allTimeInsights = insightsRestClient.fetchMostPopularInsights(site, false)
+
+        assertNotNull(allTimeInsights.response)
+        assertEquals(response, allTimeInsights.response)
+        assertEquals("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/insights/", urlCaptor.lastValue)
+    }
+
+    @Test
+    fun `returns most popular error response`() = test {
+        val errorMessage = "message"
+        initMostPopularResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val allTimeInsights = insightsRestClient.fetchMostPopularInsights(site, false)
+
+        assertNotNull(allTimeInsights.error)
+        assertEquals(API_ERROR, allTimeInsights.error.type)
+        assertEquals(errorMessage, allTimeInsights.error.message)
+    }
+
+    @Test
+    fun `returns latest post success response`() = test {
+        val response = mock<PostsResponse>()
+        initLatestPostResponse(response)
+
+        val allTimeInsights = insightsRestClient.fetchLatestPostForInsights(site, false)
+
+        assertNotNull(allTimeInsights.response)
+        assertEquals(response, allTimeInsights.response)
+        assertEquals("https://public-api.wordpress.com/rest/v1.1/sites/12/posts/", urlCaptor.lastValue)
+    }
+
+    @Test
+    fun `returns latest post error response`() = test {
+        val errorMessage = "message"
+        initLatestPostResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val allTimeInsights = insightsRestClient.fetchLatestPostForInsights(site, false)
+
+        assertNotNull(allTimeInsights.error)
+        assertEquals(API_ERROR, allTimeInsights.error.type)
+        assertEquals(errorMessage, allTimeInsights.error.message)
+    }
+
+    @Test
+    fun `returns posts view success response`() = test {
+        val response = mock<PostViewsResponse>()
+        initPostsViewResponse(response)
+
+        val allTimeInsights = insightsRestClient.fetchPostViewsForInsights(site, postId, false)
+
+        assertNotNull(allTimeInsights.response)
+        assertEquals(response, allTimeInsights.response)
+        assertEquals("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/post/1/", urlCaptor.lastValue)
+    }
+
+    @Test
+    fun `returns posts view error response`() = test {
+        val errorMessage = "message"
+        initPostsViewResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val allTimeInsights = insightsRestClient.fetchPostViewsForInsights(site, postId, false)
+
+        assertNotNull(allTimeInsights.error)
+        assertEquals(API_ERROR, allTimeInsights.error.type)
+        assertEquals(errorMessage, allTimeInsights.error.message)
+    }
+
+    private suspend fun initAllTimeResponse(
+        data: AllTimeResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<AllTimeResponse> {
+        return initResponse(AllTimeResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initMostPopularResponse(
+        data: MostPopularResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<MostPopularResponse> {
+        return initResponse(MostPopularResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initLatestPostResponse(
+        data: PostsResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<PostsResponse> {
+        return initResponse(PostsResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initPostsViewResponse(
+        data: PostViewsResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<PostViewsResponse> {
+        return initResponse(PostViewsResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun <T> initResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null
+    ): Response<T> {
+        val response = if (error != null) Response.Error<T>(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncGetRequest(
+                        eq(insightsRestClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        eq(kclass),
+                        eq(true),
+                        any(),
+                        eq(false)
+                )
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
@@ -1,0 +1,205 @@
+package org.wordpress.android.fluxc.store
+
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.Unconfined
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.AllTimeResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.AllTimeResponse.StatsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.MostPopularResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse.Discussion
+import org.wordpress.android.fluxc.store.InsightsStore.FetchInsightsPayload
+import org.wordpress.android.fluxc.store.InsightsStore.StatsError
+import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(MockitoJUnitRunner::class)
+class InsightsStoreTest {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var insightsRestClient: InsightsRestClient
+    private lateinit var store: InsightsStore
+    private val siteId = 3L
+    @Before
+    fun setUp() {
+        store = InsightsStore(insightsRestClient, Unconfined)
+        whenever(site.siteId).thenReturn(siteId)
+    }
+
+    @Test
+    fun `returns all time insights per site`() = test {
+        val date = "1970"
+        val visitors = 10
+        val views = 15
+        val posts = 20
+        val viewsBestDay = "Monday"
+        val viewsBestDayTotal = 25
+        val fetchInsightsPayload = FetchInsightsPayload(
+                AllTimeResponse(
+                        date,
+                        StatsResponse(visitors, views, posts, viewsBestDay, viewsBestDayTotal)
+                )
+        )
+        val forced = true
+        whenever(insightsRestClient.fetchAllTimeInsights(site, forced)).thenReturn(fetchInsightsPayload)
+
+        val allTimeInsights = store.fetchAllTimeInsights(site, forced)
+
+        assertNotNull(allTimeInsights.model)
+        val model = allTimeInsights.model!!
+        assertEquals(date, model.date)
+        assertEquals(visitors, model.visitors)
+        assertEquals(views, model.views)
+        assertEquals(posts, model.posts)
+        assertEquals(viewsBestDay, model.viewsBestDay)
+        assertEquals(viewsBestDayTotal, model.viewsBestDayTotal)
+    }
+
+    @Test
+    fun `returns error when all time insights call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchInsightsPayload<AllTimeResponse>(StatsError(type, message))
+        val forced = true
+        whenever(insightsRestClient.fetchAllTimeInsights(site, forced)).thenReturn(errorPayload)
+
+        val allTimeInsights = store.fetchAllTimeInsights(site, forced)
+
+        assertNotNull(allTimeInsights.error)
+        val error = allTimeInsights.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns most popular insights per site`() = test {
+        val highestDayOfWeek = 10
+        val highestHour = 15
+        val highestDayPercent = 2.0
+        val highestHourPercent = 5.0
+        val fetchInsightsPayload = FetchInsightsPayload(
+                MostPopularResponse(
+                        highestDayOfWeek, highestHour, highestDayPercent, highestHourPercent
+                )
+        )
+        val forced = true
+        whenever(insightsRestClient.fetchMostPopularInsights(site, forced)).thenReturn(fetchInsightsPayload)
+
+        val allTimeInsights = store.fetchMostPopularInsights(site, forced)
+
+        assertNotNull(allTimeInsights.model)
+        val model = allTimeInsights.model!!
+        assertEquals(highestDayOfWeek, model.highestDayOfWeek)
+        assertEquals(highestHour, model.highestHour)
+        assertEquals(highestDayPercent, model.highestDayPercent)
+        assertEquals(highestHourPercent, model.highestHourPercent)
+    }
+
+    @Test
+    fun `returns error when most popular insights call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchInsightsPayload<MostPopularResponse>(StatsError(type, message))
+        val forced = true
+        whenever(insightsRestClient.fetchMostPopularInsights(site, forced)).thenReturn(errorPayload)
+
+        val allTimeInsights = store.fetchMostPopularInsights(site, forced)
+
+        assertNotNull(allTimeInsights.error)
+        val error = allTimeInsights.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns latest post insights per site`() = test {
+        val postsFound = 15
+        val id: Long = 2
+        val title = "title"
+        val date = "date"
+        val url = "url"
+        val likeCount = 5
+        val commentCount = 10
+        val views = 20
+        val latestPost = PostResponse(id, title, date, url, likeCount, Discussion(commentCount))
+        val fetchInsightsPayload = FetchInsightsPayload(
+                PostsResponse(
+                        postsFound, listOf(latestPost)
+                )
+        )
+        val forced = true
+        whenever(insightsRestClient.fetchLatestPostForInsights(site, forced)).thenReturn(fetchInsightsPayload)
+        whenever(insightsRestClient.fetchPostViewsForInsights(site, id, forced)).thenReturn(FetchInsightsPayload(
+                PostViewsResponse(views)
+        ))
+
+        val allTimeInsights = store.fetchLatestPostInsights(site, forced)
+
+        assertNotNull(allTimeInsights.model)
+        val model = allTimeInsights.model!!
+        assertEquals(commentCount, model.postCommentCount)
+        assertEquals(likeCount, model.postLikeCount)
+        assertEquals(views, model.postViewsCount)
+        assertEquals(date, model.postDate)
+        assertEquals(id, model.postID)
+        assertEquals(title, model.postTitle)
+        assertEquals(url, model.postURL)
+        assertEquals(siteId, model.siteId)
+    }
+
+    @Test
+    fun `returns error when latest post insights call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchInsightsPayload<PostsResponse>(StatsError(type, message))
+        val forced = true
+        whenever(insightsRestClient.fetchLatestPostForInsights(site, forced)).thenReturn(errorPayload)
+
+        val allTimeInsights = store.fetchLatestPostInsights(site, forced)
+
+        assertNotNull(allTimeInsights.error)
+        val error = allTimeInsights.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns error when latest post views insights call fail`() = test {
+        val postsFound = 15
+        val id: Long = 2
+        val title = "title"
+        val date = "date"
+        val url = "url"
+        val likeCount = 5
+        val commentCount = 10
+        val latestPost = PostResponse(id, title, date, url, likeCount, Discussion(commentCount))
+        val fetchInsightsPayload = FetchInsightsPayload(
+                PostsResponse(
+                        postsFound, listOf(latestPost)
+                )
+        )
+        val forced = true
+        whenever(insightsRestClient.fetchLatestPostForInsights(site, forced)).thenReturn(fetchInsightsPayload)
+
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchInsightsPayload<PostViewsResponse>(StatsError(type, message))
+        whenever(insightsRestClient.fetchPostViewsForInsights(site, id, forced)).thenReturn(errorPayload)
+
+        val allTimeInsights = store.fetchLatestPostInsights(site, forced)
+
+        assertNotNull(allTimeInsights.error)
+        val error = allTimeInsights.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
@@ -151,7 +151,7 @@ class InsightsStoreTest {
         assertEquals(likeCount, model.postLikeCount)
         assertEquals(views, model.postViewsCount)
         assertEquals(date, model.postDate)
-        assertEquals(id, model.postID)
+        assertEquals(id, model.postId)
         assertEquals(title, model.postTitle)
         assertEquals(url, model.postURL)
         assertEquals(siteId, model.siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.InsightsStore.FetchInsightsPayload
 import org.wordpress.android.fluxc.store.InsightsStore.StatsError
 import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -37,7 +38,7 @@ class InsightsStoreTest {
 
     @Test
     fun `returns all time insights per site`() = test {
-        val date = "1970"
+        val date = Date(10)
         val visitors = 10
         val views = 15
         val posts = 20
@@ -125,7 +126,7 @@ class InsightsStoreTest {
         val postsFound = 15
         val id: Long = 2
         val title = "title"
-        val date = "date"
+        val date = Date(10)
         val url = "url"
         val likeCount = 5
         val commentCount = 10
@@ -177,7 +178,7 @@ class InsightsStoreTest {
         val postsFound = 15
         val id: Long = 2
         val title = "title"
-        val date = "date"
+        val date = Date(10)
         val url = "url"
         val likeCount = 5
         val commentCount = 10

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/InsightsStore.kt
@@ -67,21 +67,25 @@ class InsightsStore
         val posts = responsePost.response?.posts
         return@withContext if (postsFound != null && postsFound > 0 && posts != null && posts.isNotEmpty()) {
             val latestPost = posts[0]
-            val postViews = insightsRestClient.fetchPostViewsForInsights(site, latestPost.id, forced)
             val commentCount = latestPost.discussion?.commentCount ?: 0
-            val viewsCount = postViews.response?.views ?: 0
-            OnInsightsFetched(
-                    InsightsLatestPostModel(
-                            site.siteId,
-                            latestPost.title,
-                            latestPost.url,
-                            latestPost.date,
-                            latestPost.id,
-                            viewsCount,
-                            commentCount,
-                            latestPost.likeCount
-                    )
-            )
+            val postViews = insightsRestClient.fetchPostViewsForInsights(site, latestPost.id, forced)
+            if (postViews.isError) {
+                OnInsightsFetched(postViews.error)
+            } else {
+                val viewsCount = postViews.response?.views ?: 0
+                OnInsightsFetched(
+                        InsightsLatestPostModel(
+                                site.siteId,
+                                latestPost.title,
+                                latestPost.url,
+                                latestPost.date,
+                                latestPost.id,
+                                viewsCount,
+                                commentCount,
+                                latestPost.likeCount
+                        )
+                )
+            }
         } else if (responsePost.isError) {
             OnInsightsFetched(responsePost.error)
         } else {


### PR DESCRIPTION
- add unit test for InsightsRestClient and InsightsStore
- simple coverage of the basic usecases, I expect them to grow once we add DB caching
- Instead of setting views to 0 the store now returns a failure if the second call to Post views fails on the Latest post insights