### PR TITLE
Bump deprecated libraries - gson, kotlin, volley

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.61'
+    ext.kotlinVersion = '1.2.71'
 
     repositories {
         google()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -90,7 +90,7 @@ dependencies {
         exclude group: "com.android.support"
     }
 
-    implementation 'com.google.code.gson:gson:2.8.0'
+    implementation 'com.google.code.gson:gson:2.8.5'
 
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -82,10 +82,10 @@ dependencies {
 
     // External libs
     api 'org.greenrobot:eventbus:3.0.0'
-    api 'com.squareup.okhttp3:okhttp:3.8.1'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.8.1'
-    api 'com.android.volley:volley:1.0.0'
-    implementation 'com.google.code.gson:gson:2.8.0'
+    api 'com.squareup.okhttp3:okhttp:3.11.0'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.11.0'
+    api 'com.android.volley:volley:1.1.1'
+    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-text:1.1'
 
     // Dagger


### PR DESCRIPTION
We were using deprecated version of Volley. The other bumps should be straightforward.
I've tried this updated FluxC with WPAndroid and it seems to work fine.