### PR TITLE
Revert OkHttp to last working version for self-signed SSL site support

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -82,8 +82,8 @@ dependencies {
 
     // External libs
     api 'org.greenrobot:eventbus:3.0.0'
-    api 'com.squareup.okhttp3:okhttp:3.11.0'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.11.0'
+    api 'com.squareup.okhttp3:okhttp:3.9.0'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.9.0'
     api 'com.android.volley:volley:1.1.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-text:1.1'


### PR DESCRIPTION
It looks like the version updates in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/916 ended up breaking support for self-signed SSL self-hosted sites - at least, our own example self-signed SSL site is no longer accessible.

The deprecated volley version wasn't the problem, it turns out that this breaks as of [OkHttp 3.9.1](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-391). Nothing in the changelog in that version suggests to me why it would break anything, though perhaps the changelog is wrong and some of the `3.10.0` changes made it into `3.9.1`.

In any case, for now we should revert back to the last working version of OkHttp so we don't abruptly drop support for self-signed SSL users. With that done, we can investigate what needs to happen to maintain self-signed SSL support and update OkHttp.

**To test**
1. Build current develop, and run the `ReleaseStack_DiscoveryTest` connected test class
2. Note that `testXMLRPCSelfSignedSSLFetchSites` fails
3. Build this branch
4. Run `ReleaseStack_DiscoveryTest`  (and `ReleaseStack_SiteTestXMLRPC` for good measure)
5. Verify all tests pass