### PR TITLE
Remove error when posts empty

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.xmlrpc.post;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.android.volley.RequestQueue;
@@ -67,8 +68,8 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                 new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
-                        if (response != null && response instanceof Map) {
-                            PostModel postModel = postResponseObjectToPostModel(response, site);
+                        if (response instanceof Map) {
+                            PostModel postModel = postResponseObjectToPostModel((Map) response, site);
                             FetchPostResponsePayload payload;
                             if (postModel != null) {
                                 if (origin == PostAction.PUSH_POST) {
@@ -277,32 +278,30 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    private PostsModel postsResponseToPostsModel(Object[] response, SiteModel site) {
-        List<Map<?, ?>> postsList = new ArrayList<>();
+    private PostsModel postsResponseToPostsModel(@Nullable Object[] response, SiteModel site) {
+        List<PostModel> postArray = new ArrayList<>();
+        if (response == null) {
+            return null;
+        }
+        if (response.length == 0) {
+            return new PostsModel(postArray);
+        }
         for (Object responseObject : response) {
             Map<?, ?> postMap = (Map<?, ?>) responseObject;
-            postsList.add(postMap);
-        }
-
-        List<PostModel> postArray = new ArrayList<>();
-        PostModel post;
-
-        for (Object postObject : postsList) {
-            post = postResponseObjectToPostModel(postObject, site);
+            PostModel post = postResponseObjectToPostModel(postMap, site);
             if (post != null) {
                 postArray.add(post);
             }
         }
 
-        return new PostsModel(postArray);
-    }
-
-    private static PostModel postResponseObjectToPostModel(Object postObject, SiteModel site) {
-        // Sanity checks
-        if (!(postObject instanceof Map)) {
+        if (postArray.isEmpty()) {
             return null;
         }
 
+        return new PostsModel(postArray);
+    }
+
+    private static PostModel postResponseObjectToPostModel(@NonNull Map postObject, SiteModel site) {
         Map<?, ?> postMap = (Map<?, ?>) postObject;
         PostModel post = new PostModel();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -294,10 +294,6 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             }
         }
 
-        if (postArray.isEmpty()) {
-            return null;
-        }
-
         return new PostsModel(postArray);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/8377

We're currently showing a "Pages cannot be refreshed at the moment" error in the app when the Self-hosted site doesn't have any posts. I'm changing the code so we return an empty list instead of null as the `PostsModel` mapped response. The next check was transforming `null` `PostsModel` into `INVALID_RESPONSE` error.

I've reshuffled the code a bit to increase readability. The other functionality should not be changed. 