### PR TITLE
Add additional error info to jetpack remote install

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.store
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
-import kotlinx.coroutines.experimental.Unconfined
+import kotlinx.coroutines.experimental.Dispatchers
 import kotlinx.coroutines.experimental.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -33,7 +33,7 @@ class JetpackStoreTest {
 
     @Before
     fun setUp() {
-        jetpackStore = JetpackStore(jetpackRestClient, siteStore, Unconfined, dispatcher)
+        jetpackStore = JetpackStore(jetpackRestClient, siteStore, Dispatchers.Unconfined, dispatcher)
         val siteId = 1
         whenever(site.id).thenReturn(siteId)
         whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
@@ -45,7 +45,7 @@ class JetpackStoreTest {
         whenever(jetpackRestClient.installJetpack(site)).thenReturn(JetpackInstalledPayload(site, success))
 
         var result: OnJetpackInstalled? = null
-        launch(Unconfined) { result = jetpackStore.install(site, INSTALL_JETPACK) }
+        launch(Dispatchers.Unconfined) { result = jetpackStore.install(site, INSTALL_JETPACK) }
 
         jetpackStore.onSiteChanged(OnSiteChanged(1))
 
@@ -74,7 +74,7 @@ class JetpackStoreTest {
         whenever(jetpackRestClient.installJetpack(site)).thenReturn(payload)
 
         var result: OnJetpackInstalled? = null
-        launch(Unconfined) { result = jetpackStore.install(site, INSTALL_JETPACK) }
+        launch(Dispatchers.Unconfined) { result = jetpackStore.install(site, INSTALL_JETPACK) }
 
         jetpackStore.onSiteChanged(OnSiteChanged(1))
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -50,7 +50,7 @@ constructor(
                     response.error.apiError == "INVALID_INPUT" -> USERNAME_OR_PASSWORD_MISSING
                     else -> GENERIC_ERROR
                 }
-                JetpackInstalledPayload(JetpackInstallError(error, response.error.message), site)
+                JetpackInstalledPayload(JetpackInstallError(error, response.error.apiError, response.error.message), site)
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -50,7 +50,10 @@ constructor(
                     response.error.apiError == "INVALID_INPUT" -> USERNAME_OR_PASSWORD_MISSING
                     else -> GENERIC_ERROR
                 }
-                JetpackInstalledPayload(JetpackInstallError(error, response.error.apiError, response.error.message), site)
+                JetpackInstalledPayload(
+                        JetpackInstallError(error, response.error.apiError, response.error.message),
+                        site
+                )
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -54,8 +54,10 @@ class JetpackStore
         reloadSite(site)
         val reloadedSite = siteStore.getSiteByLocalId(site.id)
         return@withContext if (!installedPayload.isError || reloadedSite.isJetpackInstalled) {
-            val onJetpackInstall = OnJetpackInstalled(installedPayload.success ||
-                    reloadedSite.isJetpackInstalled, action)
+            val onJetpackInstall = OnJetpackInstalled(
+                    installedPayload.success ||
+                            reloadedSite.isJetpackInstalled, action
+            )
             emitChange(onJetpackInstall)
             onJetpackInstall
         } else {
@@ -107,7 +109,11 @@ class JetpackStore
         SITE_IS_JETPACK
     }
 
-    class JetpackInstallError(var type: JetpackInstallErrorType, var message: String? = null) : Store.OnChangedError
+    class JetpackInstallError(
+        val type: JetpackInstallErrorType,
+        val apiError: String? = null,
+        val message: String? = null
+    ) : Store.OnChangedError
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     fun onSiteChanged(event: OnSiteChanged) {


### PR DESCRIPTION
- we're seeing plenty of failures in JRI. Adding this additional API error type might give us some clarity as to why the flow is failing.