### PR TITLE
Replace native fragments with support ones in example app

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     compileOnly 'org.glassfish:javax.annotation:10.0-b28'
-    implementation "com.google.dagger:dagger-android:$daggerVersion"
+    implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
     testImplementation 'junit:junit:4.12'

--- a/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/AccountFragment.kt
@@ -1,14 +1,14 @@
 package org.wordpress.android.fluxc.example
 
 import android.app.AlertDialog
-import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
+import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
-import dagger.android.AndroidInjection
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_account.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -25,14 +25,14 @@ class AccountFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
 
     override fun onAttach(context: Context?) {
-        AndroidInjection.inject(this)
+        AndroidSupportInjection.inject(this)
         super.onAttach(context)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_account, container, false)
 
-    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         account_settings.setOnClickListener { changeAccountSettings() }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -1,8 +1,9 @@
 package org.wordpress.android.fluxc.example;
 
-import android.app.Fragment;
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -30,7 +31,7 @@ import java.util.Random;
 
 import javax.inject.Inject;
 
-import dagger.android.AndroidInjection;
+import dagger.android.support.AndroidSupportInjection;
 
 public class CommentsFragment extends Fragment {
     @Inject SiteStore mSiteStore;
@@ -39,12 +40,12 @@ public class CommentsFragment extends Fragment {
 
     @Override
     public void onAttach(Context context) {
-        AndroidInjection.inject(this);
+        AndroidSupportInjection.inject(this);
         super.onAttach(context);
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_comments, container, false);

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
@@ -1,17 +1,17 @@
 package org.wordpress.android.fluxc.example
 
-import android.app.Activity
-import android.app.Fragment
 import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentActivity
 import android.text.method.ScrollingMovementMethod
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
-import dagger.android.HasFragmentInjector
+import dagger.android.support.HasSupportFragmentInjector
 import kotlinx.android.synthetic.main.activity_example.*
 import javax.inject.Inject
 
-class MainExampleActivity : Activity(), HasFragmentInjector {
+class MainExampleActivity : FragmentActivity(), HasSupportFragmentInjector {
     @Inject lateinit var fragmentInjector: DispatchingAndroidInjector<Fragment>
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,7 +22,7 @@ class MainExampleActivity : Activity(), HasFragmentInjector {
 
         if (savedInstanceState == null) {
             val mf = MainFragment()
-            fragmentManager.beginTransaction().add(R.id.fragment_container, mf).commit()
+            supportFragmentManager.beginTransaction().add(R.id.fragment_container, mf).commit()
         }
         log.movementMethod = ScrollingMovementMethod()
         prependToLog("I'll log stuff here.")
@@ -33,5 +33,5 @@ class MainExampleActivity : Activity(), HasFragmentInjector {
         log.text = output
     }
 
-    override fun fragmentInjector(): AndroidInjector<Fragment> = fragmentInjector
+    override fun supportFragmentInjector(): AndroidInjector<Fragment> = fragmentInjector
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -1,14 +1,14 @@
 package org.wordpress.android.fluxc.example
 
-import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
+import android.support.v4.app.Fragment
 import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnClickListener
 import android.view.ViewGroup
-import dagger.android.AndroidInjection
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_main.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -49,7 +49,7 @@ class MainFragment : Fragment() {
     private var authenticatePayload: AuthenticatePayload? = null
 
     override fun onAttach(context: Context?) {
-        AndroidInjection.inject(this)
+        AndroidSupportInjection.inject(this)
         super.onAttach(context)
     }
 
@@ -66,7 +66,7 @@ class MainFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_main, container, false)
 
-    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         sign_in_fetch_sites_button.setOnClickListener { showSigninDialog() }
@@ -74,10 +74,10 @@ class MainFragment : Fragment() {
         signout.setOnClickListener { signOut() }
 
         signed_out_actions.setOnClickListener {
-            fragmentManager.beginTransaction()
-                    .replace(R.id.fragment_container, SignedOutActionsFragment())
-                    .addToBackStack(null)
-                    .commit()
+            fragmentManager?.beginTransaction()
+                    ?.replace(R.id.fragment_container, SignedOutActionsFragment())
+                    ?.addToBackStack(null)
+                    ?.commit()
         }
 
         account.setOnClickListener(getOnClickListener(AccountFragment()))
@@ -100,14 +100,14 @@ class MainFragment : Fragment() {
             ToastUtils.showToast(activity, "You must be logged in")
             return
         }
-        fragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, fragment)
-                .addToBackStack(null)
-                .commit()
+        fragmentManager?.beginTransaction()
+                ?.replace(R.id.fragment_container, fragment)
+                ?.addToBackStack(null)
+                ?.commit()
     }
 
     private fun showSSLWarningDialog(certifString: String) {
-        val ft = fragmentManager.beginTransaction()
+        val ft = fragmentManager?.beginTransaction()
         val newFragment = SSLWarningDialog.newInstance(
                 { dialog, which ->
                     // Add the certificate to our list
@@ -121,7 +121,7 @@ class MainFragment : Fragment() {
     }
 
     private fun showSigninDialog() {
-        val ft = fragmentManager.beginTransaction()
+        val ft = fragmentManager?.beginTransaction()
         val newFragment = ThreeEditTextDialog.newInstance(object : Listener {
             @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
             override fun onClick(username: String, password: String, url: String) {
@@ -132,7 +132,7 @@ class MainFragment : Fragment() {
     }
 
     private fun show2faDialog() {
-        val ft = fragmentManager.beginTransaction()
+        val ft = fragmentManager?.beginTransaction()
         val newFragment = ThreeEditTextDialog.newInstance(object : Listener {
             override fun onClick(text1: String, text2: String, text3: String) {
                 if (TextUtils.isEmpty(text3)) {
@@ -151,7 +151,7 @@ class MainFragment : Fragment() {
     }
 
     private fun showHTTPAuthDialog(url: String) {
-        val ft = fragmentManager.beginTransaction()
+        val ft = fragmentManager?.beginTransaction()
         val newFragment = ThreeEditTextDialog.newInstance(object : Listener {
             @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
             override fun onClick(username: String, password: String, unused: String) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -1,12 +1,12 @@
 package org.wordpress.android.fluxc.example;
 
-import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -38,7 +38,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import dagger.android.AndroidInjection;
+import dagger.android.support.AndroidSupportInjection;
 
 import static android.app.Activity.RESULT_OK;
 
@@ -59,7 +59,7 @@ public class MediaFragment extends Fragment {
 
     @Override
     public void onAttach(Context context) {
-        AndroidInjection.inject(this);
+        AndroidSupportInjection.inject(this);
         super.onAttach(context);
         if (mSiteStore.hasSite()) {
             mSite = mSiteStore.getSites().get(0);
@@ -67,7 +67,7 @@ public class MediaFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_media, container, false);

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
@@ -1,12 +1,12 @@
 package org.wordpress.android.fluxc.example
 
-import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
+import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import dagger.android.AndroidInjection
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_posts.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -29,14 +29,14 @@ class PostsFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
 
     override fun onAttach(context: Context?) {
-        AndroidInjection.inject(this)
+        AndroidSupportInjection.inject(this)
         super.onAttach(context)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_posts, container, false)
 
-    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         fetch_first_site_posts.setOnClickListener {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SSLWarningDialog.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SSLWarningDialog.java
@@ -1,12 +1,12 @@
 package org.wordpress.android.fluxc.example;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
-import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.fluxc.example;
 
 import android.app.AlertDialog;
-import android.app.DialogFragment;
-import android.app.Fragment;
-import android.app.FragmentTransaction;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -35,7 +35,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
 
 import javax.inject.Inject;
 
-import dagger.android.AndroidInjection;
+import dagger.android.support.AndroidSupportInjection;
 
 
 public class SignedOutActionsFragment extends Fragment {
@@ -44,7 +44,7 @@ public class SignedOutActionsFragment extends Fragment {
 
     @Override
     public void onAttach(Context context) {
-        AndroidInjection.inject(this);
+        AndroidSupportInjection.inject(this);
         super.onAttach(context);
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.fluxc.example;
 
-import android.app.DialogFragment;
-import android.app.Fragment;
-import android.app.FragmentTransaction;
 import android.content.Context;
 import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -30,7 +30,7 @@ import org.wordpress.android.util.AppLog.T;
 
 import javax.inject.Inject;
 
-import dagger.android.AndroidInjection;
+import dagger.android.support.AndroidSupportInjection;
 
 public class SitesFragment extends Fragment {
     @Inject SiteStore mSiteStore;
@@ -38,7 +38,7 @@ public class SitesFragment extends Fragment {
 
     @Override
     public void onAttach(Context context) {
-        AndroidInjection.inject(this);
+        AndroidSupportInjection.inject(this);
         super.onAttach(context);
     }
 
@@ -143,7 +143,7 @@ public class SitesFragment extends Fragment {
     }
 
     private void showNewSiteDialog() {
-        FragmentTransaction ft = getActivity().getFragmentManager().beginTransaction();
+        FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
         DialogFragment newFragment = ThreeEditTextDialog.newInstance(new Listener() {
             @Override
             public void onClick(String name, String title, String unused) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.example;
 
-import android.app.Fragment;
 import android.content.Context;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -27,7 +27,7 @@ import java.util.Random;
 
 import javax.inject.Inject;
 
-import dagger.android.AndroidInjection;
+import dagger.android.support.AndroidSupportInjection;
 
 public class TaxonomiesFragment extends Fragment {
     @Inject SiteStore mSiteStore;
@@ -36,7 +36,7 @@ public class TaxonomiesFragment extends Fragment {
 
     @Override
     public void onAttach(Context context) {
-        AndroidInjection.inject(this);
+        AndroidSupportInjection.inject(this);
         super.onAttach(context);
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -1,14 +1,14 @@
 package org.wordpress.android.fluxc.example
 
-import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
+import android.support.v4.app.Fragment
 import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import dagger.android.AndroidInjection
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_themes.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -32,7 +32,7 @@ class ThemeFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
 
     override fun onAttach(context: Context?) {
-        AndroidInjection.inject(this)
+        AndroidSupportInjection.inject(this)
         super.onAttach(context)
     }
 
@@ -49,7 +49,7 @@ class ThemeFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_themes, container, false)
 
-    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         activate_theme_wpcom.setOnClickListener {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThreeEditTextDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThreeEditTextDialog.kt
@@ -1,9 +1,9 @@
 package org.wordpress.android.fluxc.example
 
-import android.app.AlertDialog
 import android.app.Dialog
-import android.app.DialogFragment
 import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.support.v7.app.AlertDialog
 import android.text.TextUtils
 import android.view.View
 import android.widget.EditText
@@ -27,31 +27,34 @@ class ThreeEditTextDialog : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val builder = AlertDialog.Builder(activity)
-        val inflater = activity.layoutInflater
-        val view = inflater.inflate(R.layout.signin_dialog, null)
-        editText1 = view.findViewById(R.id.text1) as EditText
-        editText2 = view.findViewById(R.id.text2) as EditText
-        editText3 = view.findViewById(R.id.text3) as EditText
+        activity?.let {
+            val builder = AlertDialog.Builder(it)
+            val inflater = it.layoutInflater
+            val view = inflater.inflate(R.layout.signin_dialog, null)
+            editText1 = view.findViewById(R.id.text1) as EditText
+            editText2 = view.findViewById(R.id.text2) as EditText
+            editText3 = view.findViewById(R.id.text3) as EditText
 
-        editText1.hint = hint1
-        editText2.hint = hint2
-        editText3.hint = hint3
-        if (TextUtils.isEmpty(hint1)) {
-            editText1.visibility = View.GONE
-        }
-        if (TextUtils.isEmpty(hint2)) {
-            editText2.visibility = View.GONE
-        }
-        if (TextUtils.isEmpty(hint3)) {
-            editText3.visibility = View.GONE
-        }
-        builder.setView(view)
-                .setPositiveButton(android.R.string.ok) { dialog, id ->
-                    listener?.onClick(editText1.text.toString(), editText2.text.toString(), editText3.text.toString())
-                }
-                .setNegativeButton(android.R.string.cancel, null)
-        return builder.create()
+            editText1.hint = hint1
+            editText2.hint = hint2
+            editText3.hint = hint3
+            if (TextUtils.isEmpty(hint1)) {
+                editText1.visibility = View.GONE
+            }
+            if (TextUtils.isEmpty(hint2)) {
+                editText2.visibility = View.GONE
+            }
+            if (TextUtils.isEmpty(hint3)) {
+                editText3.visibility = View.GONE
+            }
+            builder.setView(view)
+                    .setPositiveButton(android.R.string.ok) { dialog, id ->
+                        listener?.onClick(editText1.text.toString(), editText2.text.toString(),
+                                editText3.text.toString())
+                    }
+                    .setNegativeButton(android.R.string.cancel, null)
+            return builder.create()
+        } ?: throw IllegalStateException("Not attached to an activity!")
     }
 
     companion object {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/UploadsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/UploadsFragment.java
@@ -1,12 +1,12 @@
 package org.wordpress.android.fluxc.example;
 
-import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -37,7 +37,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import dagger.android.AndroidInjection;
+import dagger.android.support.AndroidSupportInjection;
 
 import static android.app.Activity.RESULT_OK;
 
@@ -58,7 +58,7 @@ public class UploadsFragment extends Fragment {
 
     @Override
     public void onAttach(Context context) {
-        AndroidInjection.inject(this);
+        AndroidSupportInjection.inject(this);
         super.onAttach(context);
         if (mSiteStore.hasSite()) {
             mSite = mSiteStore.getSites().get(0);

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -1,12 +1,12 @@
 package org.wordpress.android.fluxc.example
 
-import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
+import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import dagger.android.AndroidInjection
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woocommerce.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -57,14 +57,14 @@ class WooCommerceFragment : Fragment() {
     private var pendingFetchCompletedOrders: Boolean = false
 
     override fun onAttach(context: Context?) {
-        AndroidInjection.inject(this)
+        AndroidSupportInjection.inject(this)
         super.onAttach(context)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woocommerce, container, false)
 
-    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         log_sites.setOnClickListener {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppComponent.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppComponent.kt
@@ -3,8 +3,8 @@ package org.wordpress.android.fluxc.example.di
 import android.app.Application
 import dagger.BindsInstance
 import dagger.Component
-import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
+import dagger.android.support.AndroidSupportInjectionModule
 import org.wordpress.android.fluxc.example.ExampleApp
 import org.wordpress.android.fluxc.module.ReleaseBaseModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 @Singleton
 @Component(modules = arrayOf(
-        AndroidInjectionModule::class,
+        AndroidSupportInjectionModule::class,
         ApplicationModule::class,
         AppConfigModule::class,
         ReleaseOkHttpClientModule::class,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
@@ -1,12 +1,13 @@
 package org.wordpress.android.fluxc.example.utils
 
-import android.app.Activity
-import android.app.AlertDialog
+import android.support.v4.app.FragmentActivity
+import android.support.v7.app.AlertDialog
 import android.widget.EditText
 
 typealias AlertTextListener = (EditText) -> Unit
 
-fun showSingleLineDialog(activity: Activity, message: String, alertTextListener: AlertTextListener) {
+fun showSingleLineDialog(activity: FragmentActivity?, message: String, alertTextListener: AlertTextListener) {
+    if (activity == null) return
     val alert = AlertDialog.Builder(activity)
     val editText = EditText(activity)
     editText.setSingleLine()


### PR DESCRIPTION
Closes #816, replacing the native fragments in the example app with support ones.

This became somewhat more urgent since WPAndroid now has a checkstyle rule against use of native fragments, so FluxC was failing checkstyle when I consolidated the style rules across the projects. The update style rules for FluxC are coming in a follow-up PR.