### PR TITLE
Fixing inconsistency between equals and hashCode methods of RevisionModel

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostRevisionModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostRevisionModelTest.kt
@@ -66,9 +66,11 @@ class PostRevisionModelTest {
         val sampleRevision2 = PostTestUtils.generateSamplePostRevision()
 
         assertEquals(sampleRevision1, sampleRevision2)
+        assertEquals(sampleRevision1.hashCode(), sampleRevision2.hashCode())
 
         sampleRevision1.titleDiffs[0] = Diff(DiffOperations.COPY, "wrong value")
         assertNotEquals(sampleRevision1, sampleRevision2)
+        assertNotEquals(sampleRevision1.hashCode(), sampleRevision2.hashCode())
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/RevisionModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/RevisionModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model.revisions
 
 import java.util.ArrayList
+import java.util.Arrays
 
 class RevisionModel(
     var revisionId: Long,
@@ -84,6 +85,8 @@ class RevisionModel(
         result = 31 * result + (postDateGmt?.hashCode() ?: 0)
         result = 31 * result + (postModifiedGmt?.hashCode() ?: 0)
         result = 31 * result + (postAuthorId?.hashCode() ?: 0)
+        result = 31 * result + (Arrays.hashCode(contentDiffs.toArray()))
+        result = 31 * result + (Arrays.hashCode(titleDiffs.toArray()))
         return result
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/RevisionModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/RevisionModel.kt
@@ -66,8 +66,9 @@ class RevisionModel(
 
         return revisionId == other.revisionId && diffFromVersion == other.diffFromVersion &&
                 totalAdditions == other.totalAdditions && totalDeletions == other.totalDeletions &&
-                postContent == other.postContent && postExcerpt == other.postExcerpt && postTitle == other.postTitle &&
-                postAuthorId == other.postAuthorId &&
+                postContent == other.postContent && postExcerpt == other.postExcerpt &&
+                postTitle == other.postTitle && postAuthorId == other.postAuthorId &&
+                postDateGmt == other.postDateGmt && postModifiedGmt == other.postModifiedGmt &&
                 titleDiffs.toArray() contentDeepEquals other.titleDiffs.toArray() &&
                 contentDiffs.toArray() contentDeepEquals other.contentDiffs.toArray()
     }


### PR DESCRIPTION
Thanks to @malinajirka for pointing inconsistency in `equals` and `hashCode` methods of `RevisionModel`.
This PR addresses the issue and makes sure that the `equals` and `hashCode` behave symmetrically.