### PR TITLE
Woocommerce: Fetch single order API access

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -141,6 +141,38 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
+    fun testFetchSingleOrderSuccess() {
+        val remoteOrderId = 88L
+        interceptor.respondWith("wc-fetch-order-response-success.json")
+        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteOrderPayload
+        with(payload) {
+            assertNull(error)
+            assertEquals(remoteOrderId, order.remoteOrderId)
+        }
+    }
+
+    @Test
+    fun testFetchSingleOrderError() {
+        val remoteOrderId = 88L
+
+        interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
+        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteOrderPayload
+        assertNotNull(payload.error)
+    }
+
+    @Test
     fun testOrderStatusUpdateSuccess() {
         val originalOrder = WCOrderModel().apply {
             id = 8

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -11,12 +11,14 @@ import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import java.util.concurrent.CountDownLatch
@@ -29,6 +31,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         NONE,
         FETCHED_ORDERS,
         FETCHED_ORDERS_COUNT,
+        FETCHED_SINGLE_ORDER,
         FETCHED_ORDER_NOTES,
         FETCHED_HAS_ORDERS,
         POST_ORDER_NOTE,
@@ -122,6 +125,25 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
 
     @Throws(InterruptedException::class)
     @Test
+    fun testFetchSingleOrder() {
+        // Fetch a single order
+        nextEvent = TestEvent.FETCHED_SINGLE_ORDER
+        mCountDownLatch = CountDownLatch(1)
+        mDispatcher.dispatch(WCOrderActionBuilder
+                .newFetchSingleOrderAction(FetchSingleOrderPayload(sSite, orderModel.remoteOrderId)))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        // Verify results
+        val fetchedOrder = orderStore.getOrderByIdentifier(OrderIdentifier(
+                WCOrderModel().apply {
+                    remoteOrderId = orderModel.remoteOrderId
+                    localSiteId = sSite.id
+                }))
+        assertTrue(fetchedOrder != null && fetchedOrder.remoteOrderId == orderModel.remoteOrderId)
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
     fun testFetchOrderNotes() {
         // Grab a list of orders
         nextEvent = TestEvent.FETCHED_ORDERS
@@ -198,6 +220,10 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
             }
             WCOrderAction.POST_ORDER_NOTE -> {
                 assertEquals(TestEvent.POST_ORDER_NOTE, nextEvent)
+                mCountDownLatch.countDown()
+            }
+            WCOrderAction.FETCH_SINGLE_ORDER -> {
+                assertEquals(TestEvent.FETCHED_SINGLE_ORDER, nextEvent)
                 mCountDownLatch.countDown()
             }
             else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)

--- a/example/src/androidTest/resources/wc-fetch-order-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-order-response-success.json
@@ -1,0 +1,123 @@
+{
+  "data": {
+    "id": 88,
+    "parent_id": 0,
+    "number": "88",
+    "order_key": "wc_order_5a77766b88986",
+    "created_via": "checkout",
+    "version": "3.3.5",
+    "status": "refunded",
+    "currency": "USD",
+    "date_created": "2018-02-04T21:08:59",
+    "date_created_gmt": "2018-02-04T21:08:59",
+    "date_modified": "2018-04-11T18:58:54",
+    "date_modified_gmt": "2018-04-11T18:58:54",
+    "discount_total": "0.00",
+    "discount_tax": "0.00",
+    "shipping_total": "0.00",
+    "shipping_tax": "0.00",
+    "cart_tax": "0.00",
+    "total": "15.00",
+    "total_tax": "0.00",
+    "prices_include_tax": false,
+    "customer_id": 0,
+    "customer_ip_address": "101.164.14.22",
+    "customer_user_agent": "mozilla\/5.0 (macintosh; intel mac os x 10.13; rv:58.0) gecko\/20100101 firefox\/58.0",
+    "customer_note": "",
+    "billing": {
+      "first_name": "John",
+      "last_name": "Quail",
+      "company": "",
+      "address_1": "Somewhere 55",
+      "address_2": "",
+      "city": "Place",
+      "state": "AK",
+      "postcode": "42532",
+      "country": "US",
+      "email": "place2153216321532152@thing.com",
+      "phone": "2332532"
+    },
+    "shipping": {
+      "first_name": "John",
+      "last_name": "Quail",
+      "company": "",
+      "address_1": "Somewhere 55",
+      "address_2": "",
+      "city": "Place",
+      "state": "AK",
+      "postcode": "42532",
+      "country": "US"
+    },
+    "payment_method": "cheque",
+    "payment_method_title": "Check payments",
+    "transaction_id": "",
+    "date_paid": "2018-04-11T18:58:54",
+    "date_paid_gmt": "2018-04-11T18:58:54",
+    "date_completed": null,
+    "date_completed_gmt": null,
+    "cart_hash": "3bc7aa78f62c9f30f8852fba6914694d",
+    "meta_data": [
+      {
+        "id": 671,
+        "key": "mailchimp_woocommerce_is_subscribed",
+        "value": "0"
+      },
+      {
+        "id": 677,
+        "key": "_shipping_phone",
+        "value": "2332532"
+      }
+    ],
+    "line_items": [
+      {
+        "id": 3,
+        "name": "Product",
+        "product_id": 58,
+        "variation_id": 0,
+        "quantity": 1,
+        "tax_class": "",
+        "subtotal": "15.00",
+        "subtotal_tax": "0.00",
+        "total": "15.00",
+        "total_tax": "0.00",
+        "taxes": [],
+        "meta_data": [],
+        "sku": "",
+        "price": 15
+      }
+    ],
+    "tax_lines": [],
+    "shipping_lines": [
+      {
+        "id": 4,
+        "method_title": "Free shipping",
+        "method_id": "free_shipping:1",
+        "total": "0.00",
+        "total_tax": "0.00",
+        "taxes": [],
+        "meta_data": [
+          {
+            "id": 28,
+            "key": "Items",
+            "value": "Product &times; 1"
+          }
+        ]
+      }
+    ],
+    "fee_lines": [],
+    "coupon_lines": [],
+    "refunds": [],
+    "_links": {
+      "self": [
+        {
+          "href": "https:\/\/alexforcier-test-store-1.blog\/wp-json\/wc\/v2\/orders\/88"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https:\/\/alexforcier-test-store-1.blog\/wp-json\/wc\/v2\/orders"
+        }
+      ]
+    }
+  }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_SINGLE_ORDER
 import org.wordpress.android.fluxc.action.WCOrderAction.POST_ORDER_NOTE
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.action.WCStatsAction
@@ -24,12 +25,14 @@ import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
@@ -55,6 +58,7 @@ class WooCommerceFragment : Fragment() {
     private var pendingNotesOrderModel: WCOrderModel? = null
     private var pendingFetchOrdersFilter: List<String>? = null
     private var pendingFetchCompletedOrders: Boolean = false
+    private var pendingFetchSingleOrderRemoteId: Long? = null
 
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
@@ -96,6 +100,20 @@ class WooCommerceFragment : Fragment() {
 
                     val payload = FetchOrdersCountPayload(site, statusFilter)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersCountAction(payload))
+                }
+            }
+        }
+
+        fetch_single_order.setOnClickListener {
+            getFirstWCSite()?.let { site ->
+                showSingleLineDialog(activity, "Enter the remoteOrderId of order to fetch:") { editText ->
+                    pendingFetchSingleOrderRemoteId = editText.text.toString().toLongOrNull()
+                    pendingFetchSingleOrderRemoteId?.let { id ->
+                        prependToLog("Submitting request to fetch order by remoteOrderID" +
+                                ": $pendingFetchSingleOrderRemoteId")
+                        val payload = FetchSingleOrderPayload(site, id)
+                        dispatcher.dispatch(WCOrderActionBuilder.newFetchSingleOrderAction(payload))
+                    } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
                 }
             }
         }
@@ -268,6 +286,9 @@ class WooCommerceFragment : Fragment() {
                             prependToLog("Fetched ${completedOrders.size} completed orders from ${site.name}")
                         } else {
                             prependToLog("Fetched ${event.rowsAffected} orders from: ${site.name}")
+                            prependToLog("printing the first 5 remoteOrderId's from result:")
+                            val orders = wcOrderStore.getOrdersForSite(site)
+                            orders.take(5).forEach { prependToLog("- remoteOrderId [${it.remoteOrderId}]") }
                         }
                     }
                     FETCH_ORDERS_COUNT -> {
@@ -275,6 +296,19 @@ class WooCommerceFragment : Fragment() {
                         event.statusFilter?.let {
                             prependToLog("Count of $it orders: ${event.rowsAffected}$append")
                         } ?: prependToLog("Count of all orders: ${event.rowsAffected}$append")
+                    }
+                    FETCH_SINGLE_ORDER -> {
+                        pendingFetchSingleOrderRemoteId?.let { remoteId ->
+                            pendingFetchSingleOrderRemoteId = null
+                            wcOrderStore.getOrderByIdentifier(OrderIdentifier(
+                                    WCOrderModel().apply {
+                                        remoteOrderId = remoteId
+                                        localSiteId = site.id
+                                    })
+                            )?.let {
+                                prependToLog("Single order fetched successfully!")
+                            } ?: prependToLog("WARNING: Fetched order not found in the local database!")
+                        }
                     }
                     FETCH_HAS_ORDERS -> {
                         val hasOrders = event.rowsAffected > 0

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -29,6 +29,12 @@
             android:text="Fetch Orders Count"/>
 
         <Button
+            android:id="@+id/fetch_single_order"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fetch Single Order"/>
+
+        <Button
             android:id="@+id/fetch_has_orders"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload;
@@ -23,6 +24,8 @@ public enum WCOrderAction implements IAction {
     FETCH_ORDERS,
     @Action(payloadType = FetchOrdersCountPayload.class)
     FETCH_ORDERS_COUNT,
+    @Action(payloadType = FetchSingleOrderPayload.class)
+    FETCH_SINGLE_ORDER,
     @Action(payloadType = UpdateOrderStatusPayload.class)
     UPDATE_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesPayload.class)
@@ -37,6 +40,8 @@ public enum WCOrderAction implements IAction {
     FETCHED_ORDERS,
     @Action(payloadType = FetchOrdersCountResponsePayload.class)
     FETCHED_ORDERS_COUNT,
+    @Action(payloadType = RemoteOrderPayload.class)
+    FETCHED_SINGLE_ORDER,
     @Action(payloadType = RemoteOrderPayload.class)
     UPDATED_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesResponsePayload.class)


### PR DESCRIPTION
Fixes #932 

Adds the events required to fetch a single order from the remote api and save it to the local device database.

## Example App
A new button labeled **FETCH SINGLE ORDER** as been added to the Woo page of the example app. I also tweaked the log to print out the `remoteOrderId`'s of the first 5 orders fetched during the **FETCH ORDERS** test so one can be plucked to use for this new test.

Note in this screenshot the new button, as well as the log window displaying the results from clicking **FETCH ORDERS**:

<img width="405" alt="screen shot 2018-10-17 at 5 18 34 pm" src="https://user-images.githubusercontent.com/5810477/47117002-2f15fa00-d231-11e8-89eb-e75d5dce18a2.png">

Clicking **FETCH SINGLE ORDER** will open a dialog window where a single `remoteOrderId` can be entered:

<img width="404" alt="screen shot 2018-10-17 at 5 18 51 pm" src="https://user-images.githubusercontent.com/5810477/47117007-31785400-d231-11e8-8a4a-e14e4ee5eacb.png">

Successful test result

<img width="407" alt="screen shot 2018-10-17 at 5 19 07 pm" src="https://user-images.githubusercontent.com/5810477/47117014-363d0800-d231-11e8-8325-29b8a49db20f.png">

## Instrumentation Tests
Added tests to:
- MockedStack_WCOrdersTest.kt
- ReleaseStack_WCOrdersTest.kt
