### PR TITLE
Improvements for ListStore and its integration for post list

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/PostListConnectedTestHelper.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/PostListConnectedTestHelper.kt
@@ -16,6 +16,8 @@ import org.wordpress.android.fluxc.model.list.ListManager
 import org.wordpress.android.fluxc.model.list.PostListDescriptor
 import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged
+import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChange.FIRST_PAGE_FETCHED
+import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChange.LOADED_MORE
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.FetchPostListPayload
 import java.util.concurrent.CountDownLatch
@@ -142,6 +144,21 @@ class PostListConnectedTestHelper(
     fun onListChanged(event: OnListChanged) {
         event.error?.let {
             throw AssertionError("OnListChanged has error: " + it.type)
+        }
+        when {
+            event.causeOfChange == FIRST_PAGE_FETCHED -> assertEquals(
+                    "Expected event was fetching the first page",
+                    TestEvent.FETCHED_FIRST_PAGE,
+                    nextEvent
+            )
+            event.causeOfChange == LOADED_MORE -> assertEquals(
+                    "Expected event was the loading more pages",
+                    TestEvent.LOADED_MORE,
+                    nextEvent
+            )
+            else -> {
+                assertEquals("Expected event was state change", TestEvent.LIST_STATE_CHANGED, nextEvent)
+            }
         }
         countDownLatch.countDown()
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/PostListConnectedTestHelper.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/PostListConnectedTestHelper.kt
@@ -64,7 +64,7 @@ class PostListConnectedTestHelper(
     ): ListManager<PostModel> {
         // Get the initial ListManager from ListStore and assert that everything is as expected
         val listManagerBefore = runBlocking {
-            listStore.getListManager(postListDescriptor, null, dataSource)
+            listStore.getListManager(postListDescriptor, dataSource)
         }
         assertEquals("List should be empty at first", 0, listManagerBefore.size)
         assertFalse("List shouldn't be fetching first page initially", listManagerBefore.isFetchingFirstPage)
@@ -86,7 +86,7 @@ class PostListConnectedTestHelper(
         )
         // Retrieve the updated ListManager from ListStore and assert that we have data and the state is as expected
         val listManagerAfter = runBlocking {
-            listStore.getListManager(postListDescriptor, null, dataSource)
+            listStore.getListManager(postListDescriptor, dataSource)
         }
         assertFalse("List shouldn't be empty after fetch", listManagerAfter.size == 0)
         assertFalse("List shouldn't be fetching first page anymore", listManagerAfter.isFetchingFirstPage)
@@ -130,7 +130,7 @@ class PostListConnectedTestHelper(
         )
         // Retrieve the updated ListManager from ListStore and assert that we have more data than before
         val listManagerAfter = runBlocking {
-            listStore.getListManager(postListDescriptor, null, dataSource)
+            listStore.getListManager(postListDescriptor, dataSource)
         }
         assertTrue("More data should be loaded after loadMore", listManagerAfter.size > listManagerBefore.size)
         assertFalse("List shouldn't be fetching first page anymore", listManagerAfter.isFetchingFirstPage)

--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
@@ -280,7 +280,7 @@ class ListManagerTest {
     }
 
     /**
-     * Simple test for the [ListManager.findIndexedNotNull].
+     * Simple test for [ListManager.findWithIndex].
      */
     @Test
     fun testFindIndexedNotNull() {
@@ -297,7 +297,7 @@ class ListManagerTest {
                 fetchItem = {},
                 fetchList = fetchList
         )
-        val result = listManager.findIndexedNotNull { it.contains("remote") }
+        val result = listManager.findWithIndex { it.contains("remote") }
         assertEquals(1, result.size)
         assertEquals(Pair(1, "remoteItem"), result[0])
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
@@ -264,19 +264,42 @@ class ListManagerTest {
         val localItems = listOf(LocalItem("localItem1"), LocalItem("localItem2"))
         val fetchList = { _: ListDescriptor, _: Int -> }
         val listManager = ListManager(
-                dispatcher,
-                listDescriptor,
-                localItems,
-                10,
-                false,
-                false,
-                false,
+                dispatcher = dispatcher,
+                listDescriptor = listDescriptor,
+                items = localItems,
+                loadMoreOffset = 10,
+                isFetchingFirstPage = false,
+                isLoadingMore = false,
+                canLoadMore = false,
                 fetchItem = {},
                 fetchList = fetchList
         )
         localItems.forEachIndexed { index, item ->
             assertEquals(listManager.getItem(index), item.value)
         }
+    }
+
+    /**
+     * Simple test for the [ListManager.findIndexedNotNull].
+     */
+    @Test
+    fun testFindIndexedNotNull() {
+        val items = listOf(LocalItem("localItem"), RemoteItem(123L, "remoteItem"))
+        val fetchList = { _: ListDescriptor, _: Int -> }
+        val listManager = ListManager(
+                dispatcher = dispatcher,
+                listDescriptor = listDescriptor,
+                items = items,
+                loadMoreOffset = 10,
+                isFetchingFirstPage = false,
+                isLoadingMore = false,
+                canLoadMore = false,
+                fetchItem = {},
+                fetchList = fetchList
+        )
+        val result = listManager.findIndexedNotNull { it.contains("remote") }
+        assertEquals(1, result.size)
+        assertEquals(Pair(1, "remoteItem"), result[0])
     }
 
     /**

--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
@@ -52,8 +52,6 @@ class ListManagerTest {
     /**
      * Calling refresh on the [ListManager] should dispatch an action to refresh the list if
      * `isFetchingFirstPage` is false and it's the first call of [ListManager.refresh].
-     *
-     * The second call of [ListManager.refresh] should be ignored.
      */
     @Test
     fun testRefreshTriggersFetch() {
@@ -68,7 +66,6 @@ class ListManagerTest {
                 fetchList = fetchList
         )
         assertTrue(listManager.refresh())
-        assertFalse(listManager.refresh())
         verify(dispatcher, times(1)).dispatch(actionCaptor.capture())
         with(actionCaptor.firstValue) {
             assertEquals(this.type, ListAction.FETCH_LIST)
@@ -179,8 +176,6 @@ class ListManagerTest {
     /**
      * Tests [ListManager.getItem] triggering load more when the requested index is closer to the end of the list
      * than the offset.
-     *
-     * Calling [ListManager.getItem] a second time should not dispatch a second action.
      */
     @Test
     fun testGetItemTriggersLoadMore() {
@@ -194,7 +189,6 @@ class ListManagerTest {
                 remoteItem = null,
                 fetchList = fetchList
         )
-        listManager.getItem(indexThatShouldLoadMore, shouldLoadMoreIfNecessary = true)
         listManager.getItem(indexThatShouldLoadMore, shouldLoadMoreIfNecessary = true)
         verify(dispatcher, times(1)).dispatch(actionCaptor.capture())
         with(actionCaptor.firstValue) {

--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListManagerTest.kt
@@ -20,9 +20,11 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.list.ListDescriptor
 import org.wordpress.android.fluxc.model.list.ListItemModel
 import org.wordpress.android.fluxc.model.list.ListManager
+import org.wordpress.android.fluxc.model.list.ListManagerItem
+import org.wordpress.android.fluxc.model.list.ListManagerItem.LocalItem
+import org.wordpress.android.fluxc.model.list.ListManagerItem.RemoteItem
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForRestSite
 import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
-import java.util.Collections
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -259,14 +261,12 @@ class ListManagerTest {
      */
     @Test
     fun testGetLocalItem() {
-        val localItems = listOf("localItem1", "localItem2")
+        val localItems = listOf(LocalItem("localItem1"), LocalItem("localItem2"))
         val fetchList = { _: ListDescriptor, _: Int -> }
         val listManager = ListManager(
                 dispatcher,
                 listDescriptor,
                 localItems,
-                emptyList(),
-                emptyMap(),
                 10,
                 false,
                 false,
@@ -275,7 +275,7 @@ class ListManagerTest {
                 fetchList = fetchList
         )
         localItems.forEachIndexed { index, item ->
-            assertEquals(listManager.getItem(index), item)
+            assertEquals(listManager.getItem(index), item.value)
         }
     }
 
@@ -294,16 +294,24 @@ class ListManagerTest {
         fetchItem: ((Long) -> Unit)? = null,
         fetchList: ((ListDescriptor, Int) -> Unit)? = null
     ): ListManager<PostModel> {
-        val listItems: List<ListItemModel> = mock()
+        val listItems: List<ListManagerItem<PostModel>> = mock()
         val listItemModel = ListItemModel()
         listItemModel.remoteItemId = remoteItemId
         whenever(listItems.size).thenReturn(numberOfItems)
-        whenever(listItems[indexToGet]).thenReturn(listItemModel)
-        val listData = if (remoteItem != null) mapOf(Pair(remoteItemId, remoteItem)) else Collections.emptyMap()
+        whenever(listItems[indexToGet]).thenReturn(RemoteItem(remoteItemId, remoteItem))
         val fetchItemFunction = fetchItem ?: {}
         val fetchListFunction = fetchList ?: { _: ListDescriptor, _: Int -> }
-        val listManager = ListManager(dispatcher, listDescriptor, null, listItems, listData, loadMoreOffset,
-                isFetchingFirstPage, isLoadingMore, canLoadMore, fetchItemFunction, fetchListFunction)
+        val listManager = ListManager(
+                dispatcher = dispatcher,
+                listDescriptor = listDescriptor,
+                items = listItems,
+                loadMoreOffset = loadMoreOffset,
+                isFetchingFirstPage = isFetchingFirstPage,
+                isLoadingMore = isLoadingMore,
+                canLoadMore = canLoadMore,
+                fetchItem = fetchItemFunction,
+                fetchList = fetchListFunction
+        )
         assertEquals(isFetchingFirstPage, listManager.isFetchingFirstPage)
         assertEquals(isLoadingMore, listManager.isLoadingMore)
         assertEquals(numberOfItems, listManager.size)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListItemDataSource.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListItemDataSource.kt
@@ -18,4 +18,25 @@ interface ListItemDataSource<T> {
      * Should return the items available for the given [ListDescriptor] and [remoteItemIds].
      */
     fun getItems(listDescriptor: ListDescriptor, remoteItemIds: List<Long>): Map<Long, T>
+
+    /**
+     * Optional function to return the ordered local items to be shown at the top of the list
+     */
+    fun localItems(listDescriptor: ListDescriptor): List<T>? = null
+
+    /**
+     * Optional function to return list of remote items ids that must be included in the list. If they are not in the
+     * list they'll be added in between local items and the remote items.
+     *
+     * This is used for a workaround where local items become remote items after a network request but the remote ids
+     * of those items are not yet added to the list.
+     */
+    fun remoteItemIdsToInclude(listDescriptor: ListDescriptor): List<Long>? = null
+
+    /**
+     * Optional function to return list of remote item ids that must not be included in the list.
+     *
+     * This is used to be able to temporarily hide items in the list to show the user an undo action.
+     */
+    fun remoteItemsToHide(listDescriptor: ListDescriptor): List<Long>? = null
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -9,8 +9,8 @@ import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
  * A sealed class to make it easier to manage local and remote items together.
  */
 sealed class ListManagerItem<T>(val value: T?) {
-    class LocalItem<T>(value: T): ListManagerItem<T>(value)
-    class RemoteItem<T>(val remoteItemId: Long, value: T?): ListManagerItem<T>(value)
+    class LocalItem<T>(value: T) : ListManagerItem<T>(value)
+    class RemoteItem<T>(val remoteItemId: Long, value: T?) : ListManagerItem<T>(value)
 }
 
 /**
@@ -68,7 +68,7 @@ class ListManager<T>(
         shouldFetchIfNull: Boolean = true,
         shouldLoadMoreIfNecessary: Boolean = true
     ): T? {
-        assert(position in 1..(size - 1)) {
+        assert(position in 0..(size - 1)) {
             "Position is out of bounds!"
         }
         if (shouldLoadMoreIfNecessary && position > size - loadMoreOffset) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -152,20 +152,15 @@ class ListManager<T>(
         return false
     }
 
-    fun positionOfLocalItem(predicate: (T) -> Boolean): Int? {
-        localItems?.let { localItems ->
-            val index = localItems.indexOfFirst(predicate)
-            return if (index == -1) null else index
-        }
-        return null
-    }
-
-    fun positionOfRemoteItem(remoteItemId: Long): Int? {
-        val index = items.indexOfFirst { it.remoteItemId == remoteItemId }
-        if (index == -1) {
-            return null
-        }
-        return localItemSize + index
+    fun findIndices(predicate: (T) -> Boolean): List<Int> {
+        val localIndices = localItems?.mapIndexedNotNull { index, localItem ->
+            if (predicate(localItem)) index else null
+        } ?: emptyList()
+        val remoteIndices = items.asSequence().mapIndexedNotNull { index, listItem ->
+            val item = listData[listItem.remoteItemId] ?: return@mapIndexedNotNull null
+            if (predicate(item)) index else null
+        }.map { it + localItemSize }.toList()
+        return localIndices.plus(remoteIndices)
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -152,6 +152,22 @@ class ListManager<T>(
         return false
     }
 
+    fun positionOfLocalItem(predicate: (T) -> Boolean): Int? {
+        localItems?.let { localItems ->
+            val index = localItems.indexOfFirst(predicate)
+            return if (index == -1) null else index
+        }
+        return null
+    }
+
+    fun positionOfRemoteItem(remoteItemId: Long): Int? {
+        val index = items.indexOfFirst { it.remoteItemId == remoteItemId }
+        if (index == -1) {
+            return null
+        }
+        return localItemSize + index
+    }
+
     /**
      * Dispatches an action to load the next page of a list. It's auto-managed by [ListManager].
      *

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -102,7 +102,7 @@ class ListManager<T>(
     /**
      * Returns a list containing results of applying the given [predicate] function to each non-null element.
      */
-    fun findIndexedNotNull(predicate: (T) -> Boolean): List<Pair<Int, T>> {
+    fun findWithIndex(predicate: (T) -> Boolean): List<Pair<Int, T>> {
         return items.mapIndexedNotNull { index, item ->
             if (item.value != null && predicate(item.value)) Pair(index, item.value) else null
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -152,6 +152,10 @@ class ListManager<T>(
         return false
     }
 
+    fun hasRemoteItem(remoteItemId: Long): Boolean {
+        return items.any { it.remoteItemId == remoteItemId }
+    }
+
     fun findIndices(predicate: (T) -> Boolean): List<Int> {
         val localIndices = localItems?.mapIndexedNotNull { index, localItem ->
             if (predicate(localItem)) index else null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -2,7 +2,16 @@ package org.wordpress.android.fluxc.model.list
 
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.ListActionBuilder
+import org.wordpress.android.fluxc.model.list.ListManagerItem.RemoteItem
 import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
+
+/**
+ * A sealed class to make it easier to manage local and remote items together.
+ */
+sealed class ListManagerItem<T>(val value: T?) {
+    class LocalItem<T>(value: T): ListManagerItem<T>(value)
+    class RemoteItem<T>(val remoteItemId: Long, value: T?): ListManagerItem<T>(value)
+}
 
 /**
  * This is a helper class by which FluxC communicates a list's data and its state with its clients. It's designed to be
@@ -11,9 +20,7 @@ import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
  * @param dispatcher The dispatcher to be used for FluxC actions
  * @param listDescriptor The list descriptor that will be used for FluxC actions and comparison with
  * other [ListManager]s
- * @param localItems The list of ordered local items that should be shown at the top of the list
- * @param items The [ListItemModel]s which contains the `remoteItemId`s
- * @param listData The map that holds the items as values for the `remoteItemId`s as keys
+ * @param items List of items to manage
  * @param loadMoreOffset The offset from the end of list that'll be used to fetch the next page
  * @param isFetchingFirstPage A helper property to be used to show/hide pull-to-refresh progress bar
  * @param isLoadingMore A helper property to be used to show/hide load more progress bar
@@ -28,9 +35,7 @@ import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
 class ListManager<T>(
     private val dispatcher: Dispatcher,
     private val listDescriptor: ListDescriptor,
-    private val localItems: List<T>?,
-    private val items: List<ListItemModel>,
-    private val listData: Map<Long, T>,
+    private val items: List<ListManagerItem<T>>,
     private val loadMoreOffset: Int,
     val isFetchingFirstPage: Boolean,
     val isLoadingMore: Boolean,
@@ -38,66 +43,16 @@ class ListManager<T>(
     private val fetchItem: (Long) -> Unit,
     private val fetchList: (ListDescriptor, Int) -> Unit
 ) {
-    companion object {
-        /**
-         * A helper function to calculate whether two items from two different [ListManager]s are the same. Since
-         * [ListManager] supports local items, we can't always rely on the `remoteItemId` to compare two different
-         * items. This function tries to compare `remoteItemId`s of the items if both of them are remote items. If at
-         * least one of them is a local item, it'll use the [areItemsTheSame] to defer the comparison to the caller.
-         *
-         * Here is the full set of rules:
-         *
-         * 1. Check if both items are remote items, if so compare their `remoteItemId`s and return the result.
-         * 2. Get the items from the [listData] and check if both of them are null. If so, for our intents these are
-         * the same items, since no other data about them are exposed.
-         * 3. Check if either item is null in which case it means that the items are different since we know both of
-         * them can't be null due to step 2.
-         * 4. Defer the comparison of the items to the caller. The caller should most likely use the local ids.
-         *
-         * @param new The new [ListManager]
-         * @param old The old [ListManager]
-         * @param newPosition The position of the item in the new [ListManager]
-         * @param oldPosition The position of the item in the old [ListManager]
-         * @param areItemsTheSame A function to compare the two items which should not compare the contents of them.
-         *
-         * @return whether two items are the same regardless of their contents.
-         */
-        fun <T> areItemsTheSame(
-            new: ListManager<T>,
-            old: ListManager<T>,
-            newPosition: Int,
-            oldPosition: Int,
-            areItemsTheSame: (T, T) -> Boolean
-        ): Boolean {
-            if (newPosition >= new.localItemSize && oldPosition >= old.localItemSize) {
-                return new.remoteItemId(newPosition - new.localItemSize) ==
-                        old.remoteItemId(oldPosition - old.localItemSize)
-            }
-            val oldItem = old.getItem(oldPosition, false)
-            val newItem = new.getItem(newPosition, false)
-            if (oldItem == null && newItem == null) {
-                return true
-            }
-            if (oldItem == null || newItem == null) {
-                return false
-            }
-            return areItemsTheSame(oldItem, newItem)
-        }
+    val size: Int by lazy {
+        items.size
     }
-
-    private val localItemSize: Int = localItems?.size ?: 0
-    val size: Int = items.size + localItemSize
     /**
-     * These three private properties help us prevent duplicate requests within short time frames. Since [ListManager]
+     * This property help us prevent duplicate requests within short time frames. Since [ListManager]
      * instances are meant to be short lived, this will not actually prevent duplicate requests and it's not actually
      * its job to do so. However, since its instances will be used by adapters, it can dispatch a lot of unnecessary
      * actions.
      */
     private val fetchRemoteItemSet = HashSet<Long>()
-
-    private fun remoteItemId(remoteItemIndex: Int): Long {
-        return items[remoteItemIndex].remoteItemId
-    }
 
     /**
      * Returns the item in a given position if it's available.
@@ -116,18 +71,11 @@ class ListManager<T>(
         if (shouldLoadMoreIfNecessary && position > size - loadMoreOffset) {
             loadMore()
         }
-        localItems?.let {
-            if (position < it.size) {
-                return it[position]
-            }
+        val item = items[position]
+        if (item is RemoteItem && item.value == null && shouldFetchIfNull) {
+            fetchItemIfNecessary(item.remoteItemId)
         }
-        val remoteItemIndex = position - localItemSize
-        val remoteItemId = items[remoteItemIndex].remoteItemId
-        val item = listData[remoteItemId]
-        if (item == null && shouldFetchIfNull) {
-            fetchItemIfNecessary(remoteItemId)
-        }
-        return item
+        return item.value
     }
 
     /**
@@ -148,19 +96,13 @@ class ListManager<T>(
         return false
     }
 
-    fun hasRemoteItem(remoteItemId: Long): Boolean {
-        return items.any { it.remoteItemId == remoteItemId }
-    }
-
-    fun findIndices(predicate: (T) -> Boolean): List<Int> {
-        val localIndices = localItems?.mapIndexedNotNull { index, localItem ->
-            if (predicate(localItem)) index else null
-        } ?: emptyList()
-        val remoteIndices = items.asSequence().mapIndexedNotNull { index, listItem ->
-            val item = listData[listItem.remoteItemId] ?: return@mapIndexedNotNull null
-            if (predicate(item)) index else null
-        }.map { it + localItemSize }.toList()
-        return localIndices.plus(remoteIndices)
+    /**
+     * Returns a list containing results of applying the given [predicate] function to each non-null element.
+     */
+    fun findIndexedNotNull(predicate: (T) -> Boolean): List<Pair<Int, T>> {
+        return items.mapIndexedNotNull { index, item ->
+            if (item.value != null && predicate(item.value)) Pair(index, item.value) else null
+        }
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -93,8 +93,6 @@ class ListManager<T>(
      * its job to do so. However, since its instances will be used by adapters, it can dispatch a lot of unnecessary
      * actions.
      */
-    private var dispatchedRefreshAction = false
-    private var dispatchedLoadMoreAction = false
     private val fetchRemoteItemSet = HashSet<Long>()
 
     private fun remoteItemId(remoteItemIndex: Int): Long {
@@ -137,16 +135,14 @@ class ListManager<T>(
      * `OnListChanged` should be used to observe changes to lists and a new instance should be requested from
      * `ListStore`.
      *
-     * [isFetchingFirstPage] & [dispatchedRefreshAction] will be checked before dispatching the action to prevent
-     * duplicate requests.
+     * [isFetchingFirstPage] will be checked before dispatching the action.
      *
      * @return whether the refresh action is dispatched
      */
     fun refresh(): Boolean {
-        if (!isFetchingFirstPage && !dispatchedRefreshAction) {
+        if (!isFetchingFirstPage) {
             val fetchListPayload = FetchListPayload(listDescriptor, false, fetchList)
             dispatcher.dispatch(ListActionBuilder.newFetchListAction(fetchListPayload))
-            dispatchedRefreshAction = true
             return true
         }
         return false
@@ -170,12 +166,11 @@ class ListManager<T>(
     /**
      * Dispatches an action to load the next page of a list. It's auto-managed by [ListManager].
      *
-     * [canLoadMore] & [dispatchedLoadMoreAction] will be checked before dispatching the action.
+     * [canLoadMore] will be checked before dispatching the action.
      */
     private fun loadMore() {
-        if (canLoadMore && !dispatchedLoadMoreAction) {
+        if (canLoadMore) {
             dispatcher.dispatch(ListActionBuilder.newFetchListAction(FetchListPayload(listDescriptor, true, fetchList)))
-            dispatchedLoadMoreAction = true
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -68,6 +68,9 @@ class ListManager<T>(
         shouldFetchIfNull: Boolean = true,
         shouldLoadMoreIfNecessary: Boolean = true
     ): T? {
+        assert(position in 1..(size - 1)) {
+            "Position is out of bounds!"
+        }
         if (shouldLoadMoreIfNecessary && position > size - loadMoreOffset) {
             loadMore()
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -18,7 +18,7 @@ sealed class PostListDescriptor(
             is PostListDescriptorForRestSite -> {
                 val statusStr = statusList.asSequence().map { it.name }.joinToString(separator = ",")
                 ListDescriptorUniqueIdentifier(
-                        ("rest-site-post-list-$site.id-st$statusStr-o${order.value}-ob${orderBy.value}" +
+                        ("rest-site-post-list-${site.id}-st$statusStr-o${order.value}-ob${orderBy.value}" +
                                 "-sq$searchQuery").hashCode()
                 )
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.model.list
 
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PostStore.DEFAULT_POST_STATUS_LIST
 
 private const val PAGE_SIZE = 100
 
@@ -14,8 +16,9 @@ sealed class PostListDescriptor(
         // TODO: need a better hashing algorithm, preferably a perfect hash
         when (this) {
             is PostListDescriptorForRestSite -> {
+                val statusStr = statusList.asSequence().map { it.name }.joinToString(separator = ",")
                 ListDescriptorUniqueIdentifier(
-                        ("rest-site-post-list-$site.id-st${status.value}-o${order.value}-ob${orderBy.value}" +
+                        ("rest-site-post-list-$site.id-st$statusStr-o${order.value}-ob${orderBy.value}" +
                                 "-sq$searchQuery").hashCode()
                 )
             }
@@ -52,28 +55,12 @@ sealed class PostListDescriptor(
 
     class PostListDescriptorForRestSite(
         site: SiteModel,
-        val status: PostStatusForRestSite = PostStatusForRestSite.PUBLISH,
+        val statusList: List<PostStatus> = DEFAULT_POST_STATUS_LIST,
         order: ListOrder = ListOrder.DESC,
         orderBy: PostListOrderBy = PostListOrderBy.DATE,
         val searchQuery: String? = null,
         pageSize: Int = PAGE_SIZE
-    ) : PostListDescriptor(site, orderBy, order, pageSize) {
-        enum class PostStatusForRestSite(val value: String) {
-            ANY("any"),
-            DRAFT("draft"),
-            PUBLISH("publish"),
-            PRIVATE("private"),
-            PENDING("pending"),
-            FUTURE("future"),
-            TRASH("trash");
-
-            companion object {
-                fun fromValue(value: String): PostStatusForRestSite? {
-                    return values().firstOrNull { it.value.toLowerCase() == value.toLowerCase() }
-                }
-            }
-        }
-    }
+    ) : PostListDescriptor(site, orderBy, order, pageSize)
 
     class PostListDescriptorForXmlRpcSite(
         site: SiteModel,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -100,7 +100,7 @@ public class PostRestClient extends BaseWPComRestClient {
 
         String fields = "ID,modified";
         Map<String, String> params = getFetchPostListParameters(false, offset, listDescriptor.getPageSize(),
-                listDescriptor.getStatus().getValue(), fields, listDescriptor.getOrder().getValue(),
+                listDescriptor.getStatusList(), fields, listDescriptor.getOrder().getValue(),
                 listDescriptor.getOrderBy().getValue(), listDescriptor.getSearchQuery());
 
         final boolean loadedMore = offset > 0;
@@ -139,8 +139,7 @@ public class PostRestClient extends BaseWPComRestClient {
         String url = WPCOMREST.sites.site(site.getSiteId()).posts.getUrlV1_1();
 
         Map<String, String> params =
-                getFetchPostListParameters(getPages, offset, number, PostStatus.postStatusListToString(statusList),
-                        null, null, null, null);
+                getFetchPostListParameters(getPages, offset, number, statusList, null, null, null, null);
 
         final WPComGsonRequest<PostsResponse> request = WPComGsonRequest.buildGetRequest(url, params,
                 PostsResponse.class,
@@ -475,7 +474,7 @@ public class PostRestClient extends BaseWPComRestClient {
     private Map<String, String> getFetchPostListParameters(final boolean getPages,
                                                            final int offset,
                                                            final int number,
-                                                           @Nullable final String status,
+                                                           @Nullable final List<PostStatus> statusList,
                                                            @Nullable final String fields,
                                                            @Nullable final String order,
                                                            @Nullable final String orderBy,
@@ -495,8 +494,8 @@ public class PostRestClient extends BaseWPComRestClient {
         if (!TextUtils.isEmpty(orderBy)) {
             params.put("order_by", orderBy);
         }
-        if (!TextUtils.isEmpty(status)) {
-            params.put("status", status);
+        if (statusList != null && statusList.size() > 0) {
+            params.put("status", PostStatus.postStatusListToString(statusList));
         }
         if (!TextUtils.isEmpty(searchQuery)) {
             params.put("search", searchQuery);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -324,6 +324,7 @@ class ListStore @Inject constructor(
     ) : Store.OnChangedError
 
     enum class ListErrorType {
-        GENERIC_ERROR
+        GENERIC_ERROR,
+        PERMISSION_ERROR
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -75,11 +75,12 @@ class ListStore @Inject constructor(
         localItems: List<T>?,
         dataSource: ListItemDataSource<T>,
         remoteItemIdsToInclude: List<Long>? = null,
+        remoteItemsToHide: List<Long>? = null,
         loadMoreOffset: Int = DEFAULT_LOAD_MORE_OFFSET
     ): ListManager<T> = withContext(Dispatchers.Default) {
         val listModel = listSqlUtils.getList(listDescriptor)
         val itemsFromDb = if (listModel != null) {
-            listItemSqlUtils.getListItems(listModel.id)
+            listItemSqlUtils.getListItems(listModel.id).filter { remoteItemsToHide?.contains(it.remoteItemId) != true }
         } else emptyList()
         val initialItems = remoteItemIdsToInclude?.let { remoteIdsToInclude ->
             val dbRemoteItemIds = itemsFromDb.map { it.remoteItemId }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -489,10 +489,10 @@ public class PostStore extends Store {
 
         switch ((PostAction) actionType) {
             case FETCH_POST_LIST:
-                fetchPostList((FetchPostListPayload) action.getPayload());
+                handleFetchPostList((FetchPostListPayload) action.getPayload());
                 break;
             case FETCHED_POST_LIST:
-                fetchedPostList((FetchPostListResponsePayload) action.getPayload());
+                handleFetchedPostList((FetchPostListResponsePayload) action.getPayload());
                 break;
             case FETCH_POSTS:
                 fetchPosts((FetchPostsPayload) action.getPayload(), false);
@@ -557,7 +557,7 @@ public class PostStore extends Store {
         }
     }
 
-    private void fetchPostList(FetchPostListPayload payload) {
+    private void handleFetchPostList(FetchPostListPayload payload) {
         if (payload.listDescriptor instanceof PostListDescriptorForRestSite) {
             PostListDescriptorForRestSite descriptor = (PostListDescriptorForRestSite) payload.listDescriptor;
             mPostRestClient.fetchPostList(descriptor, payload.offset);
@@ -567,12 +567,13 @@ public class PostStore extends Store {
         }
     }
 
-    private void fetchedPostList(FetchPostListResponsePayload payload) {
+    private void handleFetchedPostList(FetchPostListResponsePayload payload) {
         ListError fetchedListItemsError = null;
         List<Long> postIds;
         if (payload.isError()) {
-            fetchedListItemsError =
-                    new ListError(ListErrorType.GENERIC_ERROR, payload.error.message);
+            ListErrorType errorType = payload.error.type == PostErrorType.UNAUTHORIZED ? ListErrorType.PERMISSION_ERROR
+                    : ListErrorType.GENERIC_ERROR;
+            fetchedListItemsError = new ListError(errorType, payload.error.message);
             postIds = Collections.emptyList();
         } else {
             postIds = new ArrayList<>(payload.postListItems.size());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.list.ListOrder;
 import org.wordpress.android.fluxc.model.list.PostListDescriptor;
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForRestSite;
-import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForRestSite.PostStatusForRestSite;
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForXmlRpcSite;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.model.revisions.Diff;
@@ -441,9 +440,8 @@ public class PostStore extends Store {
         if (postListDescriptor instanceof PostListDescriptorForRestSite) {
             PostListDescriptorForRestSite descriptor = (PostListDescriptorForRestSite) postListDescriptor;
             searchQuery = descriptor.getSearchQuery();
-            if (!(descriptor.getStatus() == PostStatusForRestSite.ANY
-                  || descriptor.getStatus() == PostStatusForRestSite.DRAFT)) {
-                // Any other status shouldn't be in the local drafts results
+            if (!(descriptor.getStatusList().contains(PostStatus.DRAFT))) {
+                // Drafts should not be included
                 return Collections.emptyList();
             }
         }


### PR DESCRIPTION
This PR is a combination of improvements made to `ListStore`, its components, tests and the integration of it for post lists. Changes should be pretty straightforward and easy to follow, but I'll add a list of it below for easy reference.

### ListItemDataSource
`ListItemDataSource` is now responsible for supplying local items, remote item ids that must be included in the list and remote item ids that must be hidden.

`remoteItemIdsToInclude` is a workaround for when a local object becomes a remote one but it's not yet reflected in the list. This workaround is currently necessary as without it, the item disappears until the next refresh completes. I am pretty disappointed by this workaround, but combining local and remote items is hard when you don't have all the information about a remote item and I couldn't find a better way to solve this yet.

`remoteItemIdsToHide` is there to support the current behavior of the post list's delete action where we delay the deletion of a post to be able to show an undo snackbar. I was initially not very happy to add this ability, but thinking about it, this kind of requirement can be pretty common and it should be possible to handle temporary changes like this with this component.

### ListManager Changes

`ListManager` has been greatly simplified in this iteration. I think `ListManager` was simply trying to do too much even though its main responsibility is very basic.

It no longer takes `localItems`, `items` and `listData` and wrangle all of it. Instead, `ListStore` is responsible for providing a list of `ListManagerItem`s which is a very basic representation of local and remote items.

It'll also no longer provide a companion function for `areItemsTheSame`. I didn't find this as useful as I thought it'd be and a better approach to this would be to introduce a helper for `DiffUtil.Callback`s for `ListManager`s in the client.

Finally, it'll no longer keep track of whether the instance itself dispatched a fetch first page or load more action. This responsibility is moved to `ListStore` as it can reliably check the latest state. We still try to keep track of the actions we dispatch for fetching individual items, but I do want to remove this out eventually. I just don't have a setup to handle this elsewhere yet. I also want to manage state in memory instead of the DB, but that's not a priority right now.

Aside from the simplifications, I also added a `findWithIndex` function for the clients to use when they need to find the index of an item to refresh that row. Even though we handle the item fetches in the ListStore, we can't handle sub item fetches, such as a featured image being loaded. So, this function provides an easy way to handle those situations without worrying about local items, remote items or loading states. (null items)

### PostListDescriptor Changes

`PostStatusForRestSite` has been removed and the existing `PostStatus` is reused for rest sites. We don't even utilize this field yet, I have no idea why I introduced a different enum for this in the first place.

I also updated `status` field to be a list to match the current behavior and set the default status list to the same list we were using in WPAndroid.

---

I think this covers all the important changes. @malinajirka please let me know if you have any questions!

/cc @AmandaRiu