### PR TITLE
Show XMLRPC error when it's broken

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -452,8 +452,6 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
     @Test
     public void testXMLRPCMissingMethodDiscovery() throws InterruptedException {
         mUrl = BuildConfig.TEST_WPORG_URL_SH_MISSING_METHODS;
-        mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_MISSING_METHODS;
-        mPassword = BuildConfig.TEST_WPORG_PASSWORD_SH_MISSING_METHODS;
 
         mNextEvent = TestEvents.MISSING_XMLRPC_METHOD;
         mCountDownLatch = new CountDownLatch(1);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -435,10 +435,8 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
     }
 
     @Test
-    public void testXMLRPCForbiddenDiscoveryOnSelfHostedSiteWithMovedPhpFile() throws InterruptedException {
+    public void testXMLRPCDeletedXmlrpcFileDiscovery() throws InterruptedException {
         mUrl = BuildConfig.TEST_WPORG_URL_DELETED_XMLRPC_PHP;
-        mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_FORBIDDEN;
-        mPassword = BuildConfig.TEST_WPORG_PASSWORD_SH_FORBIDDEN;
 
         mNextEvent = TestEvents.MISSING_XMLRPC_METHOD;
         mCountDownLatch = new CountDownLatch(1);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -435,6 +435,21 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
     }
 
     @Test
+    public void testXMLRPCForbiddenDiscoveryOnSelfHostedSiteWithMovedPhpFile() throws InterruptedException {
+        mUrl = BuildConfig.TEST_WPORG_URL_DELETED_XMLRPC_PHP;
+        mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_FORBIDDEN;
+        mPassword = BuildConfig.TEST_WPORG_PASSWORD_SH_FORBIDDEN;
+
+        mNextEvent = TestEvents.MISSING_XMLRPC_METHOD;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
+
+        // Wait for a network response / onChanged event
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
     public void testXMLRPCMissingMethodDiscovery() throws InterruptedException {
         mUrl = BuildConfig.TEST_WPORG_URL_SH_MISSING_METHODS;
         mUsername = BuildConfig.TEST_WPORG_USERNAME_SH_MISSING_METHODS;

--- a/example/tests.properties-example
+++ b/example/tests.properties-example
@@ -142,6 +142,9 @@ TEST_WPORG_PASSWORD_SH_WORDPRESS_4_3 = FIXME
 TEST_WPORG_URL_SH_WORDPRESS_4_3 = FIXME
 TEST_WPORG_URL_SH_WORDPRESS_4_3_ENDPOINT = FIXME
 
+# Self Hosted - Deleted xmlrpc.php file
+TEST_WPORG_URL_DELETED_XMLRPC_PHP = FIXME
+
 ## Jetpack
 
 # WP.com - Account with only one site, which is Jetpack

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -38,7 +38,7 @@ public class SelfHostedEndpointFinder {
         GENERIC_ERROR
     }
 
-    static class DiscoveryException extends Exception {
+    public static class DiscoveryException extends Exception {
         public final DiscoveryError discoveryError;
         public final String failedUrl;
 
@@ -204,6 +204,7 @@ public class SelfHostedEndpointFinder {
         AppLog.i(AppLog.T.NUX, "Running RSD discovery process on the following URLs: " + urlsToTry);
 
         String xmlrpcUrl = null;
+        boolean isWpSite = false;
         for (String currentURL : urlsToTry) {
             if (!URLUtil.isValidUrl(currentURL)) {
                 continue;
@@ -230,6 +231,8 @@ public class SelfHostedEndpointFinder {
                     xmlrpcUrl = UrlUtils.addUrlSchemeIfNeeded(DiscoveryUtils.getXMLRPCApiLink(responseHTML), false);
                 }
             } else {
+                // If the site contains RSD link, it is WP.org site
+                isWpSite = true;
                 AppLog.i(AppLog.T.NUX, "RSD endpoint found at the following address: " + rsdUrl);
                 AppLog.i(AppLog.T.NUX, "Downloading the RSD document...");
                 String rsdEndpointDocument = mDiscoveryXMLRPCClient.getResponse(rsdUrl);
@@ -256,8 +259,11 @@ public class SelfHostedEndpointFinder {
                 return xmlrpcUrl;
             }
         }
-
-        throw new DiscoveryException(DiscoveryError.NO_SITE_ERROR, xmlrpcUrl);
+        if (!isWpSite) {
+            throw new DiscoveryException(DiscoveryError.NO_SITE_ERROR, xmlrpcUrl);
+        } else {
+            throw new DiscoveryException(DiscoveryError.MISSING_XMLRPC_METHOD, xmlrpcUrl);
+        }
     }
 
     /**


### PR DESCRIPTION
Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/8459

This PR is adding one additional case when we're returning the `MISSING_XMLRPC_METHOD`. When we were able to scrape it from the the site, we already know the the site is wporg. In that case we shouldn't show the `NO_SITE_ERROR` because it is not true. 