### PR TITLE
Making Diff model parcelable

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.dcendents.android-maven'
 
@@ -35,6 +36,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+}
+
+androidExtensions {
+    experimental = true
 }
 
 kotlin { experimental { coroutines 'enable' } }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/Diff.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/Diff.kt
@@ -1,6 +1,10 @@
 package org.wordpress.android.fluxc.model.revisions
 
-class Diff(val operation: DiffOperations, val value: String?) {
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+class Diff(val operation: DiffOperations, val value: String?) : Parcelable{
     override fun equals(other: Any?): Boolean {
         if (this === other) {
             return true

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/Diff.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/Diff.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-class Diff(val operation: DiffOperations, val value: String?) : Parcelable{
+class Diff(val operation: DiffOperations, val value: String?) : Parcelable {
     override fun equals(other: Any?): Boolean {
         if (this === other) {
             return true

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/Diff.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/revisions/Diff.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.fluxc.model.revisions
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 class Diff(val operation: DiffOperations, val value: String?) : Parcelable {
     override fun equals(other: Any?): Boolean {
         if (this === other) {


### PR DESCRIPTION
This PR makes Diff model parseable, so I could be easily passed around in client app.

To test: 
1. Update the reference to Flux-C in [this](https://github.com/wordpress-mobile/WordPress-Android/pull/8457) PR to `d694153be7a62fd56579d0efbfcdbae88d274394`.
2. Minimize the app while at the Revision Details screen.
3. Notice that there is no crash, and navigating back to the app shows revision details.