### PR TITLE
Adds support for status list to PostListDescriptorForXmlRpcSite

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestWpCom.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestWpCom.kt
@@ -1,7 +1,11 @@
 package org.wordpress.android.fluxc.release
 
 import org.junit.Test
+import org.wordpress.android.fluxc.model.list.ListOrder
+import org.wordpress.android.fluxc.model.list.PostListDescriptor
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForRestSite
+import org.wordpress.android.fluxc.model.list.PostListOrderBy
+import org.wordpress.android.fluxc.model.post.PostStatus
 
 class ReleaseStack_PostListTestWpCom : ReleaseStack_WPComBase() {
     @Throws(Exception::class)
@@ -13,17 +17,54 @@ class ReleaseStack_PostListTestWpCom : ReleaseStack_WPComBase() {
 
     @Throws(InterruptedException::class)
     @Test
-    fun fetchFirstPage() {
-        val postListConnectedTestHelper = PostListConnectedTestHelper(mDispatcher, mReleaseStackAppComponent)
-        val postListDescriptor = PostListDescriptorForRestSite(sSite)
-        postListConnectedTestHelper.fetchFirstPageHelper(postListDescriptor)
+    fun testFetchFirstPageForDefaultDescriptor() {
+        fetchFirstPage(PostListDescriptorForRestSite(sSite))
     }
 
     @Throws(InterruptedException::class)
     @Test
-    fun loadMore() {
+    fun testLoadMoreForDefaultDescriptor() {
+        loadMore(PostListDescriptorForRestSite(sSite, pageSize = 10))
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchPublishedPosts() {
+        fetchFirstPage(PostListDescriptorForRestSite(sSite, statusList = listOf(PostStatus.PUBLISHED)))
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchDraftsOrderedByTitle() {
+        fetchFirstPage(
+                PostListDescriptorForRestSite(
+                        site = sSite,
+                        statusList = listOf(PostStatus.DRAFT),
+                        orderBy = PostListOrderBy.TITLE
+                )
+        )
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchTrashedPostsOrderedByIdInDescendingOrder() {
+        fetchFirstPage(
+                PostListDescriptorForRestSite(
+                        site = sSite,
+                        statusList = listOf(PostStatus.TRASHED),
+                        orderBy = PostListOrderBy.ID,
+                        order = ListOrder.DESC
+                )
+        )
+    }
+
+    private fun fetchFirstPage(listDescriptor: PostListDescriptor) {
         val postListConnectedTestHelper = PostListConnectedTestHelper(mDispatcher, mReleaseStackAppComponent)
-        val postListDescriptor = PostListDescriptorForRestSite(sSite, pageSize = 10)
-        postListConnectedTestHelper.loadMoreHelper(postListDescriptor)
+        postListConnectedTestHelper.fetchFirstPageHelper(listDescriptor)
+    }
+
+    private fun loadMore(listDescriptor: PostListDescriptor) {
+        val postListConnectedTestHelper = PostListConnectedTestHelper(mDispatcher, mReleaseStackAppComponent)
+        postListConnectedTestHelper.loadMoreHelper(listDescriptor)
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestXMLRPC.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestXMLRPC.kt
@@ -1,7 +1,11 @@
 package org.wordpress.android.fluxc.release
 
 import org.junit.Test
+import org.wordpress.android.fluxc.model.list.ListOrder
+import org.wordpress.android.fluxc.model.list.PostListDescriptor
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForXmlRpcSite
+import org.wordpress.android.fluxc.model.list.PostListOrderBy
+import org.wordpress.android.fluxc.model.post.PostStatus
 
 class ReleaseStack_PostListTestXMLRPC : ReleaseStack_XMLRPCBase() {
     @Throws(Exception::class)
@@ -12,17 +16,54 @@ class ReleaseStack_PostListTestXMLRPC : ReleaseStack_XMLRPCBase() {
 
     @Throws(InterruptedException::class)
     @Test
-    fun fetchFirstPage() {
-        val postListConnectedTestHelper = PostListConnectedTestHelper(mDispatcher, mReleaseStackAppComponent)
-        val postListDescriptor = PostListDescriptorForXmlRpcSite(sSite)
-        postListConnectedTestHelper.fetchFirstPageHelper(postListDescriptor)
+    fun testFetchFirstPageForDefaultDescriptor() {
+        fetchFirstPage(PostListDescriptorForXmlRpcSite(sSite))
     }
 
     @Throws(InterruptedException::class)
     @Test
-    fun loadMore() {
+    fun testLoadMoreForDefaultDescriptor() {
+        loadMore(PostListDescriptorForXmlRpcSite(sSite, pageSize = 10))
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchPublishedPosts() {
+        fetchFirstPage(PostListDescriptorForXmlRpcSite(sSite, statusList = listOf(PostStatus.PUBLISHED)))
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchDraftsOrderedByTitle() {
+        fetchFirstPage(
+                PostListDescriptorForXmlRpcSite(
+                        site = sSite,
+                        statusList = listOf(PostStatus.DRAFT),
+                        orderBy = PostListOrderBy.TITLE
+                )
+        )
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testFetchTrashedPostsOrderedByIdInDescendingOrder() {
+        fetchFirstPage(
+                PostListDescriptorForXmlRpcSite(
+                        site = sSite,
+                        statusList = listOf(PostStatus.TRASHED),
+                        orderBy = PostListOrderBy.ID,
+                        order = ListOrder.DESC
+                )
+        )
+    }
+
+    private fun fetchFirstPage(listDescriptor: PostListDescriptor) {
         val postListConnectedTestHelper = PostListConnectedTestHelper(mDispatcher, mReleaseStackAppComponent)
-        val postListDescriptor = PostListDescriptorForXmlRpcSite(sSite, pageSize = 10)
-        postListConnectedTestHelper.loadMoreHelper(postListDescriptor)
+        postListConnectedTestHelper.fetchFirstPageHelper(listDescriptor)
+    }
+
+    private fun loadMore(listDescriptor: PostListDescriptor) {
+        val postListConnectedTestHelper = PostListConnectedTestHelper(mDispatcher, mReleaseStackAppComponent)
+        postListConnectedTestHelper.loadMoreHelper(listDescriptor)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -25,7 +25,7 @@ sealed class PostListDescriptor(
             }
             is PostListDescriptorForXmlRpcSite -> {
                 ListDescriptorUniqueIdentifier(
-                        "xml-rpc-site-post-list-${site.id}-o${order.value}-ob${orderBy.value}".hashCode()
+                        "xml-rpc-site-post-list-${site.id}-st$statusStr-o${order.value}-ob${orderBy.value}".hashCode()
                 )
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -8,15 +8,16 @@ private const val PAGE_SIZE = 100
 
 sealed class PostListDescriptor(
     val site: SiteModel,
-    val orderBy: PostListOrderBy,
+    val statusList: List<PostStatus>,
     val order: ListOrder,
+    val orderBy: PostListOrderBy,
     val pageSize: Int
 ) : ListDescriptor {
     override val uniqueIdentifier: ListDescriptorUniqueIdentifier by lazy {
         // TODO: need a better hashing algorithm, preferably a perfect hash
+        val statusStr = statusList.asSequence().map { it.name }.joinToString(separator = ",")
         when (this) {
             is PostListDescriptorForRestSite -> {
-                val statusStr = statusList.asSequence().map { it.name }.joinToString(separator = ",")
                 ListDescriptorUniqueIdentifier(
                         ("rest-site-post-list-${site.id}-st$statusStr-o${order.value}-ob${orderBy.value}" +
                                 "-sq$searchQuery").hashCode()
@@ -55,19 +56,20 @@ sealed class PostListDescriptor(
 
     class PostListDescriptorForRestSite(
         site: SiteModel,
-        val statusList: List<PostStatus> = DEFAULT_POST_STATUS_LIST,
+        statusList: List<PostStatus> = DEFAULT_POST_STATUS_LIST,
         order: ListOrder = ListOrder.DESC,
         orderBy: PostListOrderBy = PostListOrderBy.DATE,
-        val searchQuery: String? = null,
-        pageSize: Int = PAGE_SIZE
-    ) : PostListDescriptor(site, orderBy, order, pageSize)
+        pageSize: Int = PAGE_SIZE,
+        val searchQuery: String? = null
+    ) : PostListDescriptor(site, statusList, order, orderBy, pageSize)
 
     class PostListDescriptorForXmlRpcSite(
         site: SiteModel,
+        statusList: List<PostStatus> = DEFAULT_POST_STATUS_LIST,
         order: ListOrder = ListOrder.DESC,
         orderBy: PostListOrderBy = PostListOrderBy.DATE,
         pageSize: Int = PAGE_SIZE
-    ) : PostListDescriptor(site, orderBy, order, pageSize)
+    ) : PostListDescriptor(site, statusList, order, orderBy, pageSize)
 }
 
 enum class PostListOrderBy(val value: String) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -122,7 +122,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         fields.add("post_modified");
         List<Object> params =
                 createFetchPostListParameters(site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(), false,
-                        offset, listDescriptor.getPageSize(), Collections.<PostStatus>emptyList(), fields,
+                        offset, listDescriptor.getPageSize(), listDescriptor.getStatusList(), fields,
                         listDescriptor.getOrderBy().getValue(), listDescriptor.getOrder().getValue());
         final boolean loadedMore = offset > 0;
 


### PR DESCRIPTION
This is a very small PR that adds support for status to list `PostListDescriptorForXmlRpcSite`. I haven't added this support previously because the statuses in xml-rpc sites could be altered by the user, see @malinajirka's question [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/922#discussion_r224690636). However, due to #941 and subsequent conversation we had with @aerych, I don't think there is any reason not to have it here as well.

I wanted to take this opportunity to build on the connected tests for post lists and added several more tests for both xml-rpc and .com sites in which we test more complicated `PostListDescriptor`s.

Note that I have merged `develop` into the master branch `feature/post-pagination-master` just before this PR during which I had to make small changes to `PostXMLRPCClient` to resolve a conflict. I have tested the merge in both FluxC and WPAndroid. Specifically, we didn't have `Collections.<PostStatus>emptyList()` in `PostXMLRPCClient` previous to this merge. _There is nothing the reviewer needs to do about this, just making a note of it here._

To test:

* Run the connected tests in `ReleaseStack_PostListTestXMLRPC` and `ReleaseStack_PostListTestWpCom`

Note that the xml-rpc tests might sometimes fail due to server errors, this is not new to this PR, but because the network requests are fairly fast, it might happen more often for them. If that happens to be the case, I'll add a delay in between tests. I didn't want to do that to avoid unnecessary waiting time unless it was necessary.

