### PR TITLE
Remove list actions for ListStore

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListSqlUtilsTest.kt
@@ -85,8 +85,8 @@ class ListSqlUtilsTest {
     fun testDeleteExpiredLists() {
         val listDescriptors1 = (1..5).map { PostListDescriptorForRestSite(testSite(it)) }
         val listDescriptors2 = (6..10).map { PostListDescriptorForXmlRpcSite(testSite(it)) }
-        val sleepDuration = 1000L
-        val expirationDuration = sleepDuration - 300L // 300 ms seems to be enough for this test
+        val sleepDuration = 2000L
+        val expirationDuration = sleepDuration - 500L // 500 ms seems to be enough for this test
 
         /**
          * 1. Insert 5 lists, wait for 600 ms, so the [ListModel.lastModified] is different, then insert another 5 lists

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -17,5 +17,7 @@ enum class ListAction : IAction {
     @Action(payloadType = ListItemsChangedPayload::class)
     LIST_ITEMS_CHANGED,
     @Action(payloadType = ListItemsRemovedPayload::class)
-    LIST_ITEMS_REMOVED
+    LIST_ITEMS_REMOVED,
+    @Action
+    REMOVE_ALL_LISTS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.store.ListStore.FetchListPayload
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.ListItemsChangedPayload
 import org.wordpress.android.fluxc.store.ListStore.ListItemsRemovedPayload
+import org.wordpress.android.fluxc.store.ListStore.RemoveExpiredListsPayload
 
 @ActionEnum
 enum class ListAction : IAction {
@@ -18,6 +19,8 @@ enum class ListAction : IAction {
     LIST_ITEMS_CHANGED,
     @Action(payloadType = ListItemsRemovedPayload::class)
     LIST_ITEMS_REMOVED,
+    @Action(payloadType = RemoveExpiredListsPayload::class)
+    REMOVE_EXPIRED_LISTS,
     @Action
     REMOVE_ALL_LISTS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListDescriptor.kt
@@ -3,6 +3,41 @@ package org.wordpress.android.fluxc.model.list
 data class ListDescriptorTypeIdentifier(val value: Int)
 data class ListDescriptorUniqueIdentifier(val value: Int)
 
+/**
+ * This is the interface every list descriptor needs to implement for it to work with `ListStore`. It can be used to
+ * describe which site a list belongs to, which filters it has, how to order it or anything and everything else a
+ * feature might need.
+ *
+ * This presents an interesting challenge because if every list can be different, how do we use a generic interface
+ * to save it in the DB and more importantly how do we query it back from it. In a traditional solution, one approach
+ * would be to separate each list descriptor and save them in the DB in separate tables, and another approach would be
+ * to add common fields in one table and try to work off of it. Neither approach is very flexible.
+ *
+ * `ListStore` takes a completely different approach to this problem by shying away from using lists directly and
+ * tying everything to [ListDescriptor]s. For example, there is no way to access a list by its id, `ListSqlUtils`
+ * ensures this. That means, we don't necessarily need to save every bit of information about a list in the DB,
+ * as long as there is a way to identify it. That's where the [uniqueIdentifier] property comes in.
+ * By using a unique identifier, we can save them in the DB and then retrieve them from it as long as we can calculate
+ * the exact same identifier. This also means that we erase the information about a list, and we can no longer access it
+ * even if we queried the list in some other way. However, as previously stated, all the components in `ListStore` is
+ * designed in a way to work with that constraint.
+ *
+ * There is another interesting challenge this decision brings. What if we want to be able to identify lists that
+ * has a certain "type". For example, let's say we are dealing with several post lists all belonging to the same site.
+ * If a post in that site is updated, we'd expect all the post lists for that site to be notified of this change.
+ * That's where the [typeIdentifier] comes in. It gives the class that's implementing this interface a way to group
+ * them so the changes for the items in them notifies all of them together.
+ *
+ * TODO: Please note that "type" is not the correct term for this and should be renamed.
+ *
+ * @property uniqueIdentifier is a globally unique value for the described list. The responsibility of calculating a
+ * unique value for the described list relies on the developer implementing this interface. If there is ever a collision
+ * between two identifiers, incorrect items could be shown.
+ *
+ * @property typeIdentifier is an identifier used to describe lists belonging to the same "type". For example, post
+ * lists belonging to the same site, would have the same [typeIdentifier]. Whereas, comments for that site, or posts
+ * of another site would have a different identifier.
+ */
 interface ListDescriptor {
     val uniqueIdentifier: ListDescriptorUniqueIdentifier
     val typeIdentifier: ListDescriptorTypeIdentifier

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
@@ -62,6 +62,9 @@ class ListSqlUtils @Inject constructor() {
                 .firstOrNull()
     }
 
+    /**
+     * This function returns all [ListModel] records that matches the given [ListDescriptorTypeIdentifier].
+     */
     fun getListsWithTypeIdentifier(descriptorTypeIdentifier: ListDescriptorTypeIdentifier): List<ListModel> {
         return WellSql.select(ListModel::class.java)
                 .where()
@@ -80,5 +83,12 @@ class ListSqlUtils @Inject constructor() {
         existing?.let {
             WellSql.delete(ListModel::class.java).whereId(it.id)
         }
+    }
+
+    /**
+     * This function deletes all [ListModel] records from the DB.
+     */
+    fun deleteAllLists() {
+        WellSql.delete(ListModel::class.java).execute()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListSqlUtils.kt
@@ -86,6 +86,23 @@ class ListSqlUtils @Inject constructor() {
     }
 
     /**
+     * This function deletes [ListModel] records that hasn't been updated for the given [expirationDuration].
+     */
+    fun deleteExpiredLists(expirationDuration: Long) {
+        val allLists = WellSql.select(ListModel::class.java).asModel
+        val cutOffDate = Date(System.currentTimeMillis() - expirationDuration)
+        // Find the ids of lists that are expired
+        val listIdsToDelete = allLists.asSequence().filter {
+            DateTimeUtils.dateFromIso8601(it.lastModified).before(cutOffDate)
+        }.map { it.id }.toList()
+        if (listIdsToDelete.isNotEmpty()) {
+            WellSql.delete(ListModel::class.java)
+                    .where().isIn(ListModelTable.ID, listIdsToDelete).endWhere()
+                    .execute()
+        }
+    }
+
+    /**
      * This function deletes all [ListModel] records from the DB.
      */
     fun deleteAllLists() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.action.ListAction.FETCH_LIST
 import org.wordpress.android.fluxc.action.ListAction.LIST_ITEMS_CHANGED
 import org.wordpress.android.fluxc.action.ListAction.LIST_ITEMS_REMOVED
 import org.wordpress.android.fluxc.action.ListAction.REMOVE_ALL_LISTS
+import org.wordpress.android.fluxc.action.ListAction.REMOVE_EXPIRED_LISTS
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.list.LIST_STATE_TIMEOUT
 import org.wordpress.android.fluxc.model.list.ListDescriptor
@@ -34,7 +35,10 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 
-const val DEFAULT_LOAD_MORE_OFFSET = 10 // When we should load more data for a list
+// How long a list should stay in DB if it hasn't been updated
+const val DEFAULT_EXPIRATION_DURATION = 1000L * 60 * 60 * 24 * 7
+// When we should load more data for a list
+const val DEFAULT_LOAD_MORE_OFFSET = 10
 
 /**
  * This Store is responsible for managing lists and their metadata. One of the designs goals for this Store is expose
@@ -56,6 +60,7 @@ class ListStore @Inject constructor(
             FETCHED_LIST_ITEMS -> handleFetchedListItems(action.payload as FetchedListItemsPayload)
             LIST_ITEMS_CHANGED -> handleListItemsChanged(action.payload as ListItemsChangedPayload)
             LIST_ITEMS_REMOVED -> handleListItemsRemoved(action.payload as ListItemsRemovedPayload)
+            REMOVE_EXPIRED_LISTS -> handleRemoveExpiredLists(action.payload as RemoveExpiredListsPayload)
             REMOVE_ALL_LISTS -> handleRemoveAllLists()
         }
     }
@@ -212,6 +217,15 @@ class ListStore @Inject constructor(
     }
 
     /**
+     * Handles the [ListAction.REMOVE_EXPIRED_LISTS] action.
+     *
+     * It deletes [ListModel]s that hasn't been updated for the given [RemoveExpiredListsPayload.expirationDuration].
+     */
+    private fun handleRemoveExpiredLists(payload: RemoveExpiredListsPayload) {
+        listSqlUtils.deleteExpiredLists(payload.expirationDuration)
+    }
+
+    /**
      * Handles the [ListAction.REMOVE_ALL_LISTS] action.
      *
      * It simply deletes every [ListModel] in the DB.
@@ -337,6 +351,13 @@ class ListStore @Inject constructor(
             this.error = error
         }
     }
+
+    /**
+     * This is the payload for [ListAction.REMOVE_EXPIRED_LISTS].
+     *
+     * @property expirationDuration Tells how long a list should be kept in the DB if it hasn't been updated
+     */
+    class RemoveExpiredListsPayload(val expirationDuration: Long = DEFAULT_EXPIRATION_DURATION)
 
     class ListError(
         val type: ListErrorType,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.action.ListAction.FETCHED_LIST_ITEMS
 import org.wordpress.android.fluxc.action.ListAction.FETCH_LIST
 import org.wordpress.android.fluxc.action.ListAction.LIST_ITEMS_CHANGED
 import org.wordpress.android.fluxc.action.ListAction.LIST_ITEMS_REMOVED
+import org.wordpress.android.fluxc.action.ListAction.REMOVE_ALL_LISTS
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.list.LIST_STATE_TIMEOUT
 import org.wordpress.android.fluxc.model.list.ListDescriptor
@@ -55,6 +56,7 @@ class ListStore @Inject constructor(
             FETCHED_LIST_ITEMS -> handleFetchedListItems(action.payload as FetchedListItemsPayload)
             LIST_ITEMS_CHANGED -> handleListItemsChanged(action.payload as ListItemsChangedPayload)
             LIST_ITEMS_REMOVED -> handleListItemsRemoved(action.payload as ListItemsRemovedPayload)
+            REMOVE_ALL_LISTS -> handleRemoveAllLists()
         }
     }
 
@@ -207,6 +209,15 @@ class ListStore @Inject constructor(
         val lists = listSqlUtils.getListsWithTypeIdentifier(payload.type)
         listItemSqlUtils.deleteItemsFromLists(lists.map { it.id }, payload.remoteItemIds)
         emitChange(OnListItemsChanged(payload.type, error = null))
+    }
+
+    /**
+     * Handles the [ListAction.REMOVE_ALL_LISTS] action.
+     *
+     * It simply deletes every [ListModel] in the DB.
+     */
+    private fun handleRemoveAllLists() {
+        listSqlUtils.deleteAllLists()
     }
 
     /**


### PR DESCRIPTION
This PR implements `REMOVE_EXPIRED_LISTS` and `REMOVE_ALL_LISTS` actions in `ListStore`. Note that #947 needs to be merged before this PR is reviewed since it contains changes from that PR.

When we start utilizing filters for different lists, we might end up inserting a lot of `ListModel`s into the DB. Although they wouldn't take much space, it can still get out of hand especially with searching. `REMOVE_EXPIRED_LISTS` deals with this issue by deleting lists that has not been modified in the last week (by default) when this action is dispatched. The clients are responsible for calling this action when appropriate. A good candidate would be to do this when application is launched.

I have been thinking whether it makes sense to have an action to remove all lists, but at the end, decided to include it in `REMOVE_ALL_LISTS`. I _think_ our lists will be tied to an account, so logging out or removing all the sites should be a trigger for this event. If we do end up implementing lists that needs to be preserved when the user logs out, we'll re-visit this implementation. I just don't want a complicated solution if there is no need for it.

To test:

* Run the newly added unit tests in `ListSqlUtilsTest`

