### PR TITLE
Adds getRemoteItemId to ListManager

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListManager.kt
@@ -82,6 +82,13 @@ class ListManager<T>(
     }
 
     /**
+     * Returns the remote item id for the given position if it's a remote item and `null` otherwise.
+     */
+    fun getRemoteItemId(position: Int): Long? {
+        return (items[position] as? RemoteItem)?.remoteItemId
+    }
+
+    /**
      * Dispatches an action to fetch the first page of the list. Since this class is immutable, it'll not update itself.
      * `OnListChanged` should be used to observe changes to lists and a new instance should be requested from
      * `ListStore`.


### PR DESCRIPTION
This PR adds `getRemoteItemId` to `ListManager` to make it possible to compare ids when both items are `null` (not yet fetched) for calculating diff purposes. It is used to fix the weird disappear/reappear animation in this gif in WPAndroid: https://cloudup.com/cMczJcqe_T4