### PR TITLE
Ignore duplicate rows in ListItemModelTable

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListItemModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListItemModel.kt
@@ -9,7 +9,7 @@ import com.yarolegovich.wellsql.core.annotation.Table
 @Table
 @RawConstraints(
         "FOREIGN KEY(LIST_ID) REFERENCES ListModel(_id) ON DELETE CASCADE",
-        "UNIQUE(LIST_ID, REMOTE_ITEM_ID)"
+        "UNIQUE(LIST_ID, REMOTE_ITEM_ID) ON CONFLICT IGNORE"
 )
 class ListItemModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     constructor(listId: Int, remoteItemId: Long): this() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 44;
+        return 45;
     }
 
     @Override
@@ -370,6 +370,13 @@ public class WellSqlConfig extends DefaultWellConfig {
                            + "_id INTEGER PRIMARY KEY AUTOINCREMENT,FOREIGN KEY(LIST_ID) REFERENCES ListModel(_id) "
                            + "ON DELETE CASCADE,UNIQUE(LIST_ID, REMOTE_ITEM_ID))");
                 db.execSQL("ALTER TABLE PostModel ADD LAST_MODIFIED TEXT");
+                oldVersion++;
+            case 44:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS ListItemModel");
+                db.execSQL("CREATE TABLE ListItemModel (LIST_ID INTEGER,REMOTE_ITEM_ID INTEGER,_id INTEGER PRIMARY KEY "
+                           + "AUTOINCREMENT,FOREIGN KEY(LIST_ID) REFERENCES ListModel(_id) ON DELETE CASCADE,"
+                           + "UNIQUE(LIST_ID, REMOTE_ITEM_ID) ON CONFLICT IGNORE)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
In some rare cases, I am getting the crash below in WPAndroid, this PR fixes that crash.

When I added the `unique` constraint to `ListItemModel`, I've written a unit test for it, but it looked like it was passing no matter what, so I assumed the default behavior was to ignore duplicate rows which turns out not to be true. I've tried it again today and it's still passing the unit test. What's more weird is that, if I replicate the issue by manually inserting duplicate rows in connected tests, the issue does show up in the logs but it doesn't crash the test and the test still succeeds. I am a bit baffled by why it the tests don't crash, but at the end of the day, we do need an `ON CONFLICT` clause for the unique constraint which this PR adds. Unfortunately, since the code is merged in WPAndroid, we need a migration to fix the issue 🤦‍♂️ 

To test:
1. Checkout the current `develop`
2. In `ListItemSqlUtils.insertItemList` duplicate the insert clause to easily test the issue
3. Run the `ReleaseStack_PostListTestWpCom.testFetchFirstPageForDefaultDescriptor` and verify that you see the unique constraint error in the logs
4. Checkout this branch, redo the step 2 and verify that it doesn't happen anymore.

Since the tests don't seem to report this issue as it should, I am not adding a test for it. Good news is this issue should never happen again after the `ON CONFLICT IGNORE` addition. So, the test wouldn't have been very useful anyway.

```
2018-10-29 01:11:44.355 7301-7557/org.wordpress.android.beta E/SQLiteDatabase: Error inserting LIST_ID=1 REMOTE_ITEM_ID=313
    android.database.sqlite.SQLiteConstraintException: UNIQUE constraint failed: ListItemModel.LIST_ID, ListItemModel.REMOTE_ITEM_ID (code 2067)
        at android.database.sqlite.SQLiteConnection.nativeExecuteForLastInsertedRowId(Native Method)
        at android.database.sqlite.SQLiteConnection.executeForLastInsertedRowId(SQLiteConnection.java:782)
        at android.database.sqlite.SQLiteSession.executeForLastInsertedRowId(SQLiteSession.java:788)
        at android.database.sqlite.SQLiteStatement.executeInsert(SQLiteStatement.java:86)
        at android.database.sqlite.SQLiteDatabase.insertWithOnConflict(SQLiteDatabase.java:1474)
        at android.database.sqlite.SQLiteDatabase.insert(SQLiteDatabase.java:1343)
        at com.yarolegovich.wellsql.InsertQuery.execute(InsertQuery.java:61)
        at org.wordpress.android.fluxc.persistence.ListItemSqlUtils.insertItemList(ListItemSqlUtils.kt:21)
        at org.wordpress.android.fluxc.store.ListStore.handleFetchedListItems(ListStore.kt:180)
        at org.wordpress.android.fluxc.store.ListStore.onAction(ListStore.kt:60)
        at java.lang.reflect.Method.invoke(Native Method)
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:485)
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:479)
        at org.greenrobot.eventbus.AsyncPoster.run(AsyncPoster.java:46)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
```