### PR TITLE
Move All time insights to live data

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedToolsModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedToolsModule.java
@@ -5,12 +5,8 @@ import android.support.v4.util.LruCache;
 
 import com.android.volley.toolbox.ImageLoader.ImageCache;
 
-import javax.inject.Singleton;
-
 import dagger.Module;
 import dagger.Provides;
-import kotlin.coroutines.experimental.CoroutineContext;
-import kotlinx.coroutines.experimental.Dispatchers;
 
 @Module
 public class MockedToolsModule {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedToolsModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedToolsModule.java
@@ -5,8 +5,12 @@ import android.support.v4.util.LruCache;
 
 import com.android.volley.toolbox.ImageLoader.ImageCache;
 
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
+import kotlin.coroutines.experimental.CoroutineContext;
+import kotlinx.coroutines.experimental.Dispatchers;
 
 @Module
 public class MockedToolsModule {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/TestCoroutineModule.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/TestCoroutineModule.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.module
+
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.experimental.Dispatchers
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
+
+@Module
+class TestCoroutineModule {
+    @Singleton
+    @Provides
+    fun provideCoroutineContext(): CoroutineContext {
+        return Dispatchers.Unconfined
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 import org.wordpress.android.fluxc.module.ReleaseWCNetworkModule;
+import org.wordpress.android.fluxc.module.TestCoroutineModule;
 
 import javax.inject.Singleton;
 
@@ -23,7 +24,8 @@ import dagger.Component;
         ReleaseNetworkModule.class,
         ReleaseWCNetworkModule.class,
         ReleaseToolsModule.class,
-        MockedToolsModule.class
+        MockedToolsModule.class,
+        TestCoroutineModule.class
 })
 public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_AccountTest test);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.experimental.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
@@ -14,7 +15,8 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.persistence.ActivityLogSqlUtils
+import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
@@ -37,7 +39,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     @Inject lateinit var insightsStore: InsightsStore
     @Inject internal lateinit var siteStore: SiteStore
     @Inject internal lateinit var accountStore: AccountStore
-    @Inject internal lateinit var activityLogSqlUtils: ActivityLogSqlUtils
+    @Inject internal lateinit var statsSqlUtils: StatsSqlUtils
 
     private var nextEvent: TestEvents? = null
 
@@ -63,6 +65,10 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     fun testFetchAllTimeInsights() {
         val site = authenticate()
 
+        var liveAllTimeInsights: InsightsAllTimeModel? = null
+        insightsStore.liveAllTimeInsights(site).observeForever { liveAllTimeInsights = it }
+        assertNull(liveAllTimeInsights)
+
         val fetchedInsights = runBlocking { insightsStore.fetchAllTimeInsights(site) }
 
         assertNotNull(fetchedInsights)
@@ -71,6 +77,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         val insightsFromDb = insightsStore.getAllTimeInsights(site)
 
         assertEquals(fetchedInsights.model, insightsFromDb)
+        assertEquals(fetchedInsights.model, liveAllTimeInsights)
     }
 
     @Test

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -102,8 +102,8 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.1'
 
-    implementation 'android.arch.lifecycle:livedata-core:1.1.1'
-    implementation 'android.arch.lifecycle:extensions:1.1.1'
+    implementation 'android.arch.lifecycle:livedata-core:1.1.0'
+    implementation 'android.arch.lifecycle:extensions:1.1.0'
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -101,6 +101,9 @@ dependencies {
     // Coroutines
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.1'
+
+    implementation 'android.arch.lifecycle:livedata-core:1.1.1'
+    implementation 'android.arch.lifecycle:extensions:1.1.1'
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/CoroutineModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/CoroutineModule.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.module
+
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.experimental.Dispatchers
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
+
+@Module
+class CoroutineModule {
+    @Singleton
+    @Provides
+    fun provideCoroutineContext(): CoroutineContext {
+        return Dispatchers.Default
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -53,8 +53,6 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
-import kotlin.coroutines.experimental.CoroutineContext;
-import kotlinx.coroutines.experimental.Dispatchers;
 import okhttp3.OkHttpClient;
 
 @Module
@@ -205,12 +203,6 @@ public class ReleaseNetworkModule {
                                                       WPComGsonRequestBuilder wpComGsonRequestBuilder) {
         return new JetpackRestClient(dispatcher, wpComGsonRequestBuilder, appContext, requestQueue, token,
                 userAgent);
-    }
-
-    @Singleton
-    @Provides
-    public CoroutineContext provideCoroutineContext() {
-        return Dispatchers.Default;
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.persistence
 
+import android.arch.lifecycle.LiveData
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.AllTimeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.MostPopularResponse
@@ -33,6 +34,10 @@ class InsightsSqlUtils
 
     fun selectAllTimeInsights(site: SiteModel): AllTimeResponse? {
         return statsSqlUtils.select(site, ALL_TIME_INSIGHTS, AllTimeResponse::class.java)
+    }
+
+    fun allTimeInsightsLiveData(site: SiteModel): LiveData<AllTimeResponse> {
+        return statsSqlUtils.liveData(site, ALL_TIME_INSIGHTS, AllTimeResponse::class.java)
     }
 
     fun selectMostPopularInsights(site: SiteModel): MostPopularResponse? {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.persistence
 
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
 import com.google.gson.Gson
 import com.wellsql.generated.StatsBlockTable
 import com.yarolegovich.wellsql.WellSql
@@ -7,22 +9,32 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.android.Main
+import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
 
 @Singleton
 class StatsSqlUtils
-@Inject constructor(private val gson: Gson) {
+@Inject constructor(private val gson: Gson, private val coroutineContext: CoroutineContext) {
+    private val liveData = mutableMapOf<Key, MutableLiveData<*>>()
     fun <T> insert(site: SiteModel, type: Key, item: T) {
         val json = gson.toJson(item)
         WellSql.delete(StatsBlockBuilder::class.java)
-                    .where()
-                    .equals(StatsBlockTable.TYPE, type.name)
-                    .endWhere()
-                    .execute()
+                .where()
+                .equals(StatsBlockTable.TYPE, type.name)
+                .endWhere()
+                .execute()
         WellSql.insert(StatsBlockBuilder(localSiteId = site.id, type = type.name, json = json))
-                    .execute()
+                .execute()
+        GlobalScope.launch(Dispatchers.Main) {
+            liveData.getOrPutAndCast<T>(type).value = item
+        }
     }
 
     fun <T> select(site: SiteModel, type: Key, classOfT: Class<T>): T? {
@@ -31,11 +43,24 @@ class StatsSqlUtils
                 .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
                 .equals(StatsBlockTable.TYPE, type.name)
                 .endWhere().asModel.firstOrNull()
-        if (model != null) {
-            return gson.fromJson(model.json, classOfT)
-        }
-        return null
+        return model?.let { gson.fromJson(model.json, classOfT) }
     }
+
+    fun <T> liveData(site: SiteModel, type: Key, classOfT: Class<T>): LiveData<T> {
+        if (!liveData.containsKey(type)) {
+            val mutableLiveData = liveData.getOrPutAndCast<T>(type)
+            GlobalScope.launch(coroutineContext) {
+                val data = select(site, type, classOfT)
+                withContext(Dispatchers.Main) {
+                    mutableLiveData.value = data
+                }
+            }
+        }
+        return liveData.getOrPutAndCast<T>(type)
+    }
+
+    private fun <T> MutableMap<Key, MutableLiveData<*>>.getOrPutAndCast(type: Key) =
+            this.getOrPut(type) { MutableLiveData<T>() } as MutableLiveData<T>
 
     @Table(name = "StatsBlock")
     data class StatsBlockBuilder(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/InsightsStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import android.arch.lifecycle.LiveData
 import kotlinx.coroutines.experimental.withContext
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.model.SiteModel
@@ -13,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.P
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
 import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.utils.map
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.CoroutineContext
@@ -39,6 +41,10 @@ class InsightsStore
 
     fun getAllTimeInsights(site: SiteModel): InsightsAllTimeModel? {
         return sqlUtils.selectAllTimeInsights(site)?.toDomainModel(site)
+    }
+
+    fun liveAllTimeInsights(site: SiteModel): LiveData<InsightsAllTimeModel> {
+        return sqlUtils.allTimeInsightsLiveData(site).map { it.toDomainModel(site)  }
     }
 
     private fun AllTimeResponse.toDomainModel(site: SiteModel): InsightsAllTimeModel {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/LiveDataUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/LiveDataUtils.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.utils
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.Transformations
+
+fun <T, O> LiveData<T>.map(mapper: (T) -> O): LiveData<O> {
+    return Transformations.map(this) { item ->
+        if (item != null) {
+            mapper(item)
+        } else {
+            null
+        }
+    }
+}

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppComponent.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppComponent.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.instaflux;
 
 import org.wordpress.android.fluxc.module.AppContextModule;
+import org.wordpress.android.fluxc.module.CoroutineModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
@@ -15,7 +16,8 @@ import dagger.Component;
         AppConfigModule.class,
         ReleaseOkHttpClientModule.class,
         ReleaseBaseModule.class,
-        ReleaseNetworkModule.class
+        ReleaseNetworkModule.class,
+        CoroutineModule.class
 })
 public interface AppComponent {
     void inject(InstafluxApp application);


### PR DESCRIPTION
This is adding Live data as an additional endpoint to the `StatsSqlUtils`. The solutions should scale well and we could use it for all the other endpoints. Let me know what you think @0nko 

I'm not sure at the moment how to update the LiveData value (it should be done on the main thread).