### PR TITLE
Use correct property for last modified date of xml-rpc posts

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -118,7 +118,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchPostList(final PostListDescriptorForXmlRpcSite listDescriptor, final int offset) {
         SiteModel site = listDescriptor.getSite();
-        List<String> fields = Arrays.asList("post_id", "post_modified");
+        List<String> fields = Arrays.asList("post_id", "post_modified_gmt");
         List<Object> params =
                 createFetchPostListParameters(site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(), false,
                         offset, listDescriptor.getPageSize(), listDescriptor.getStatusList(), fields,
@@ -325,7 +325,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         for (Object responseObject : response) {
             Map<?, ?> postMap = (Map<?, ?>) responseObject;
             String postID = MapUtils.getMapStr(postMap, "post_id");
-            Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified");
+            Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified_gmt");
             String lastModifiedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(lastModifiedGmt);
 
             postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601));
@@ -374,7 +374,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         String dateCreatedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(dateCreatedGmt);
         post.setDateCreated(dateCreatedAsIso8601);
 
-        Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified");
+        Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified_gmt");
         String lastModifiedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(lastModifiedGmt);
         post.setLastModified(lastModifiedAsIso8601);
 


### PR DESCRIPTION
This is a follow up to #964 per @malinajirka's comment [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/964#issuecomment-434987286). It updates the last modified property used for xml-rpc posts to `post_modified_gmt`. As far as I can tell, `post_modified` and `post_modified_gmt` return the same value, but there is no reason to use the `post_modified` one if our logic depends on gmt version, so this PR updates that.

While working on this PR, I also figured out why we have false negative tests for post lists from time to time. It was a race condition. I've explained it in the commit comment and copying it over here for easy reference:

> Previously, we were tracking state change, first page fetched and loaded more events and verifying them. This caused some race conditions and depending on how fast the events were dispatched, sometimes the flag would be updated before we could verify it resulting in false negative tests. Since this architecture doesn't depend on the order of events at all, this commit simplifies those tests to avoid the issue entirely.

To test:

* Run the tests in `ReleaseStack_PostListTestXMLRPC` and `ReleaseStack_PostListTestWpCom`
* It'd be good to put breakpoints in `PostXMLRPCClient` for the modified lines and verify the last modified date we get is correct. `ReleaseStack_PostListTestXMLRPC.testFetchFirstPageForDefaultDescriptor` and `ReleaseStack_PostTestXMLRPC.testFetchPosts` could be used to trigger those breakpoints.
