### PR TITLE
Add stats today endpoint

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -101,6 +101,20 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         assertEquals(fetchedInsights.model, insightsFromDb)
     }
 
+    @Test
+    fun testTodayInsights() {
+        val site = authenticate()
+
+        val fetchedInsights = runBlocking { insightsStore.fetchTodayInsights(site) }
+
+        assertNotNull(fetchedInsights)
+        assertNotNull(fetchedInsights.model)
+
+        val insightsFromDb = insightsStore.getTodayInsights(site)
+
+        assertEquals(fetchedInsights.model, insightsFromDb)
+    }
+
     private fun authenticate(): SiteModel {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY)

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.fluxc.model.stats
+
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.ALL_TIME_RESPONSE
+import org.wordpress.android.fluxc.store.COMMENT_COUNT
+import org.wordpress.android.fluxc.store.FIRST_DAY
+import org.wordpress.android.fluxc.store.FIRST_DAY_VIEWS
+import org.wordpress.android.fluxc.store.LATEST_POST
+import org.wordpress.android.fluxc.store.LIKE_COUNT
+import org.wordpress.android.fluxc.store.MOST_POPULAR_RESPONSE
+import org.wordpress.android.fluxc.store.POST_COUNT
+import org.wordpress.android.fluxc.store.POST_STATS_RESPONSE
+import org.wordpress.android.fluxc.store.REBLOG_COUNT
+import org.wordpress.android.fluxc.store.SECOND_DAY
+import org.wordpress.android.fluxc.store.SECOND_DAY_VIEWS
+import org.wordpress.android.fluxc.store.VIEWS
+import org.wordpress.android.fluxc.store.VISITS_DATE
+import org.wordpress.android.fluxc.store.VISITS_RESPONSE
+
+@RunWith(MockitoJUnitRunner::class)
+class InsightsMapperTest {
+    @Mock lateinit var site: SiteModel
+    private lateinit var mapper: InsightsMapper
+    private val siteId = 3L
+    @Before
+    fun setUp() {
+        mapper = InsightsMapper()
+        whenever(site.siteId).thenReturn(siteId)
+    }
+
+    @Test
+    fun `maps all time response`() {
+        val model = mapper.map(ALL_TIME_RESPONSE, site)
+
+        assertThat(model.siteId).isEqualTo(siteId)
+        assertThat(model.date).isEqualTo(ALL_TIME_RESPONSE.date)
+        assertThat(model.visitors).isEqualTo(ALL_TIME_RESPONSE.stats.visitors)
+        assertThat(model.views).isEqualTo(ALL_TIME_RESPONSE.stats.views)
+        assertThat(model.posts).isEqualTo(ALL_TIME_RESPONSE.stats.posts)
+        assertThat(model.viewsBestDay).isEqualTo(ALL_TIME_RESPONSE.stats.viewsBestDay)
+        assertThat(model.viewsBestDayTotal).isEqualTo(ALL_TIME_RESPONSE.stats.viewsBestDayTotal)
+    }
+
+    @Test
+    fun `maps most popular response`() {
+        val model = mapper.map(MOST_POPULAR_RESPONSE, site)
+
+        assertThat(model.siteId).isEqualTo(siteId)
+        assertThat(model.highestDayOfWeek).isEqualTo(MOST_POPULAR_RESPONSE.highestDayOfWeek)
+        assertThat(model.highestHour).isEqualTo(MOST_POPULAR_RESPONSE.highestHour)
+        assertThat(model.highestDayPercent).isEqualTo(MOST_POPULAR_RESPONSE.highestDayPercent)
+        assertThat(model.highestHourPercent).isEqualTo(MOST_POPULAR_RESPONSE.highestHourPercent)
+    }
+
+    @Test
+    fun `maps latest posts response`() {
+        val model = mapper.map(LATEST_POST, POST_STATS_RESPONSE, site)
+
+        assertThat(model.siteId).isEqualTo(siteId)
+        assertThat(model.postTitle).isEqualTo(LATEST_POST.title)
+        assertThat(model.postURL).isEqualTo(LATEST_POST.url)
+        assertThat(model.postDate).isEqualTo(LATEST_POST.date)
+        assertThat(model.postId).isEqualTo(LATEST_POST.id)
+        assertThat(model.postCommentCount).isEqualTo(COMMENT_COUNT)
+        assertThat(model.postViewsCount).isEqualTo(VIEWS)
+        assertThat(model.postLikeCount).isEqualTo(LIKE_COUNT)
+        assertThat(model.dayViews).containsOnly(FIRST_DAY to FIRST_DAY_VIEWS, SECOND_DAY to SECOND_DAY_VIEWS)
+    }
+
+    @Test
+    fun `maps visits response`() {
+        val model = mapper.map(VISITS_RESPONSE)
+
+        assertThat(model.period).isEqualTo(VISITS_DATE)
+        assertThat(model.comments).isEqualTo(COMMENT_COUNT)
+        assertThat(model.likes).isEqualTo(LIKE_COUNT)
+        assertThat(model.posts).isEqualTo(POST_COUNT)
+        assertThat(model.reblogs).isEqualTo(REBLOG_COUNT)
+        assertThat(model.views).isEqualTo(VIEWS)
+        assertThat(model.visitors).isEqualTo(org.wordpress.android.fluxc.store.VISITORS)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsFixtures.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.M
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostStatsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse.Discussion
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.VisitResponse
 import java.util.Date
 
 val DATE = Date(10)
@@ -42,3 +43,20 @@ const val SECOND_DAY_VIEWS = 11
 val DATA = listOf(listOf(FIRST_DAY, FIRST_DAY_VIEWS.toString()), listOf(SECOND_DAY, SECOND_DAY_VIEWS.toString()))
 
 val POST_STATS_RESPONSE = PostStatsResponse(0, 0, 0, VIEWS, null, DATA, FIELDS, listOf(), mapOf(), mapOf())
+
+const val REBLOG_COUNT = 13
+const val POST_COUNT = 17
+val VISITS_FIELDS = listOf("period", "views", "visitors", "likes", "reblogs", "comments", "posts")
+const val VISITS_DATE = "2018-11-02"
+val VISITS_DATA = listOf(
+        VISITS_DATE,
+        "$VIEWS",
+        "$VISITORS",
+        "$LIKE_COUNT",
+        "$REBLOG_COUNT",
+        "$COMMENT_COUNT",
+        "$POST_COUNT"
+)
+val VISITS_RESPONSE = VisitResponse(
+        FIRST_DAY, "day", VISITS_FIELDS, listOf(VISITS_DATA)
+)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.store
 
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
-import kotlinx.coroutines.experimental.Unconfined
+import kotlinx.coroutines.experimental.Dispatchers.Unconfined
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -11,6 +13,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
+import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.InsightsMostPopularModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.AllTimeResponse
@@ -33,12 +36,11 @@ class InsightsStoreTest {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var insightsRestClient: InsightsRestClient
     @Mock lateinit var sqlUtils: InsightsSqlUtils
+    @Mock lateinit var mapper: InsightsMapper
     private lateinit var store: InsightsStore
-    private val siteId = 3L
     @Before
     fun setUp() {
-        store = InsightsStore(insightsRestClient, sqlUtils, Unconfined)
-        whenever(site.siteId).thenReturn(siteId)
+        store = InsightsStore(insightsRestClient, sqlUtils, mapper, Unconfined)
     }
 
     @Test
@@ -48,10 +50,12 @@ class InsightsStoreTest {
         )
         val forced = true
         whenever(insightsRestClient.fetchAllTimeInsights(site, forced)).thenReturn(fetchInsightsPayload)
+        val model = mock<InsightsAllTimeModel>()
+        whenever(mapper.map(ALL_TIME_RESPONSE, site)).thenReturn(model)
 
         val allTimeInsights = store.fetchAllTimeInsights(site, forced)
 
-        assertAllTimeInsights(allTimeInsights.model)
+        assertThat(allTimeInsights.model).isEqualTo(model)
         verify(sqlUtils).insert(site, ALL_TIME_RESPONSE)
     }
 
@@ -74,22 +78,12 @@ class InsightsStoreTest {
     @Test
     fun `returns all time insights from db`() {
         whenever(sqlUtils.selectAllTimeInsights(site)).thenReturn(ALL_TIME_RESPONSE)
+        val model = mock<InsightsAllTimeModel>()
+        whenever(mapper.map(ALL_TIME_RESPONSE, site)).thenReturn(model)
 
         val result = store.getAllTimeInsights(site)
 
-        assertAllTimeInsights(result)
-    }
-
-    private fun assertAllTimeInsights(model: InsightsAllTimeModel?) {
-        assertNotNull(model)
-        model?.let {
-            assertEquals(DATE, model.date)
-            assertEquals(VISITORS, model.visitors)
-            assertEquals(VIEWS, model.views)
-            assertEquals(POSTS, model.posts)
-            assertEquals(VIEWS_BEST_DAY, model.viewsBestDay)
-            assertEquals(VIEWS_BEST_DAY_TOTAL, model.viewsBestDayTotal)
-        }
+        assertThat(result).isEqualTo(model)
     }
 
     @Test
@@ -99,10 +93,13 @@ class InsightsStoreTest {
         )
         val forced = true
         whenever(insightsRestClient.fetchMostPopularInsights(site, forced)).thenReturn(fetchInsightsPayload)
+        val model = mock<InsightsMostPopularModel>()
+        whenever(mapper.map(MOST_POPULAR_RESPONSE, site)).thenReturn(model)
+
 
         val allTimeInsights = store.fetchMostPopularInsights(site, forced)
 
-        assertMostPopularInsights(allTimeInsights.model)
+        assertThat(allTimeInsights.model).isEqualTo(model)
         verify(sqlUtils).insert(site, MOST_POPULAR_RESPONSE)
     }
 
@@ -125,28 +122,21 @@ class InsightsStoreTest {
     @Test
     fun `returns most popular insights from db`() {
         whenever(sqlUtils.selectMostPopularInsights(site)).thenReturn(MOST_POPULAR_RESPONSE)
+        val model = mock<InsightsMostPopularModel>()
+        whenever(mapper.map(MOST_POPULAR_RESPONSE, site)).thenReturn(model)
 
         val result = store.getMostPopularInsights(site)
 
-        assertMostPopularInsights(result)
-    }
-
-    private fun assertMostPopularInsights(model: InsightsMostPopularModel?) {
-        assertNotNull(model)
-        model?.let {
-            assertEquals(HIGHEST_DAY_OF_WEEK, model.highestDayOfWeek)
-            assertEquals(HIGHEST_HOUR, model.highestHour)
-            assertEquals(HIGHEST_DAY_PERCENT, model.highestDayPercent)
-            assertEquals(HIGHEST_HOUR_PERCENT, model.highestHourPercent)
-        }
+        assertThat(result).isEqualTo(model)
     }
 
     @Test
     fun `returns latest post insights per site`() = test {
+        val postsResponse = PostsResponse(
+                POSTS_FOUND, listOf(LATEST_POST)
+        )
         val fetchInsightsPayload = FetchInsightsPayload(
-                PostsResponse(
-                        POSTS_FOUND, listOf(LATEST_POST)
-                )
+                postsResponse
         )
         val forced = true
         whenever(insightsRestClient.fetchLatestPostForInsights(site, forced)).thenReturn(fetchInsightsPayload)
@@ -156,10 +146,12 @@ class InsightsStoreTest {
                         viewsResponse
                 )
         )
+        val model = mock<InsightsLatestPostModel>()
+        whenever(mapper.map(LATEST_POST, POST_STATS_RESPONSE, site)).thenReturn(model)
 
         val allTimeInsights = store.fetchLatestPostInsights(site, forced)
 
-        assertLatestPostInsights(allTimeInsights.model)
+        assertThat(allTimeInsights.model).isEqualTo(model)
         verify(sqlUtils).insert(site, LATEST_POST)
         verify(sqlUtils).insert(site, viewsResponse)
     }
@@ -168,10 +160,12 @@ class InsightsStoreTest {
     fun `returns latest post insights from db`() {
         whenever(sqlUtils.selectLatestPostDetail(site)).thenReturn(LATEST_POST)
         whenever(sqlUtils.selectLatestPostStats(site)).thenReturn(POST_STATS_RESPONSE)
+        val model = mock<InsightsLatestPostModel>()
+        whenever(mapper.map(LATEST_POST, POST_STATS_RESPONSE, site)).thenReturn(model)
 
         val result = store.getLatestPostInsights(site)
 
-        assertLatestPostInsights(result)
+        assertThat(result).isEqualTo(model)
     }
 
     @Test
@@ -188,22 +182,6 @@ class InsightsStoreTest {
         val error = allTimeInsights.error!!
         assertEquals(type, error.type)
         assertEquals(message, error.message)
-    }
-
-    private fun assertLatestPostInsights(model: InsightsLatestPostModel?) {
-        assertNotNull(model)
-        model?.let {
-            assertEquals(COMMENT_COUNT, model.postCommentCount)
-            assertEquals(LIKE_COUNT, model.postLikeCount)
-            assertEquals(VIEWS, model.postViewsCount)
-            assertEquals(DATE, model.postDate)
-            assertEquals(ID, model.postId)
-            assertEquals(TITLE, model.postTitle)
-            assertEquals(URL, model.postURL)
-            assertEquals(siteId, model.siteId)
-            assertEquals(model.dayViews.size, 2)
-            assertEquals(model.dayViews, listOf(FIRST_DAY to FIRST_DAY_VIEWS, SECOND_DAY to SECOND_DAY_VIEWS))
-        }
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
@@ -103,7 +103,6 @@ class InsightsStoreTest {
         val model = mock<InsightsMostPopularModel>()
         whenever(mapper.map(MOST_POPULAR_RESPONSE, site)).thenReturn(model)
 
-
         val responseModel = store.fetchMostPopularInsights(site, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
@@ -228,10 +227,11 @@ class InsightsStoreTest {
                 VISITS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchTimePeriodStats(site, DAYS, currentDate, forced)).thenReturn(fetchInsightsPayload)
+        whenever(insightsRestClient.fetchTimePeriodStats(site, DAYS, currentDate, forced)).thenReturn(
+                fetchInsightsPayload
+        )
         val model = mock<VisitsModel>()
         whenever(mapper.map(VISITS_RESPONSE)).thenReturn(model)
-
 
         val responseModel = store.fetchTodayInsights(site, forced)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.InsightsMostPopularModel
+import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.AllTimeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.MostPopularResponse
@@ -22,11 +23,14 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.P
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse.Discussion
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.VisitResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
 import org.wordpress.android.fluxc.store.InsightsStore.FetchInsightsPayload
 import org.wordpress.android.fluxc.store.InsightsStore.StatsError
 import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -37,10 +41,13 @@ class InsightsStoreTest {
     @Mock lateinit var insightsRestClient: InsightsRestClient
     @Mock lateinit var sqlUtils: InsightsSqlUtils
     @Mock lateinit var mapper: InsightsMapper
+    @Mock lateinit var timeProvider: CurrentTimeProvider
     private lateinit var store: InsightsStore
+    private val currentDate = Date(10)
     @Before
     fun setUp() {
-        store = InsightsStore(insightsRestClient, sqlUtils, mapper, Unconfined)
+        store = InsightsStore(insightsRestClient, sqlUtils, mapper, timeProvider, Unconfined)
+        whenever(timeProvider.currentDate).thenReturn(currentDate)
     }
 
     @Test
@@ -53,9 +60,9 @@ class InsightsStoreTest {
         val model = mock<InsightsAllTimeModel>()
         whenever(mapper.map(ALL_TIME_RESPONSE, site)).thenReturn(model)
 
-        val allTimeInsights = store.fetchAllTimeInsights(site, forced)
+        val responseModel = store.fetchAllTimeInsights(site, forced)
 
-        assertThat(allTimeInsights.model).isEqualTo(model)
+        assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, ALL_TIME_RESPONSE)
     }
 
@@ -67,10 +74,10 @@ class InsightsStoreTest {
         val forced = true
         whenever(insightsRestClient.fetchAllTimeInsights(site, forced)).thenReturn(errorPayload)
 
-        val allTimeInsights = store.fetchAllTimeInsights(site, forced)
+        val responseModel = store.fetchAllTimeInsights(site, forced)
 
-        assertNotNull(allTimeInsights.error)
-        val error = allTimeInsights.error!!
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
         assertEquals(type, error.type)
         assertEquals(message, error.message)
     }
@@ -97,9 +104,9 @@ class InsightsStoreTest {
         whenever(mapper.map(MOST_POPULAR_RESPONSE, site)).thenReturn(model)
 
 
-        val allTimeInsights = store.fetchMostPopularInsights(site, forced)
+        val responseModel = store.fetchMostPopularInsights(site, forced)
 
-        assertThat(allTimeInsights.model).isEqualTo(model)
+        assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, MOST_POPULAR_RESPONSE)
     }
 
@@ -111,10 +118,10 @@ class InsightsStoreTest {
         val forced = true
         whenever(insightsRestClient.fetchMostPopularInsights(site, forced)).thenReturn(errorPayload)
 
-        val allTimeInsights = store.fetchMostPopularInsights(site, forced)
+        val responseModel = store.fetchMostPopularInsights(site, forced)
 
-        assertNotNull(allTimeInsights.error)
-        val error = allTimeInsights.error!!
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
         assertEquals(type, error.type)
         assertEquals(message, error.message)
     }
@@ -149,9 +156,9 @@ class InsightsStoreTest {
         val model = mock<InsightsLatestPostModel>()
         whenever(mapper.map(LATEST_POST, POST_STATS_RESPONSE, site)).thenReturn(model)
 
-        val allTimeInsights = store.fetchLatestPostInsights(site, forced)
+        val responseModel = store.fetchLatestPostInsights(site, forced)
 
-        assertThat(allTimeInsights.model).isEqualTo(model)
+        assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, LATEST_POST)
         verify(sqlUtils).insert(site, viewsResponse)
     }
@@ -176,10 +183,10 @@ class InsightsStoreTest {
         val forced = true
         whenever(insightsRestClient.fetchLatestPostForInsights(site, forced)).thenReturn(errorPayload)
 
-        val allTimeInsights = store.fetchLatestPostInsights(site, forced)
+        val responseModel = store.fetchLatestPostInsights(site, forced)
 
-        assertNotNull(allTimeInsights.error)
-        val error = allTimeInsights.error!!
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
         assertEquals(type, error.type)
         assertEquals(message, error.message)
     }
@@ -207,10 +214,54 @@ class InsightsStoreTest {
         val errorPayload = FetchInsightsPayload<PostStatsResponse>(StatsError(type, message))
         whenever(insightsRestClient.fetchPostStats(site, id, forced)).thenReturn(errorPayload)
 
-        val allTimeInsights = store.fetchLatestPostInsights(site, forced)
+        val responseModel = store.fetchLatestPostInsights(site, forced)
 
-        assertNotNull(allTimeInsights.error)
-        val error = allTimeInsights.error!!
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns today stats per site`() = test {
+        val fetchInsightsPayload = FetchInsightsPayload(
+                VISITS_RESPONSE
+        )
+        val forced = true
+        whenever(insightsRestClient.fetchTimePeriodStats(site, DAYS, currentDate, forced)).thenReturn(fetchInsightsPayload)
+        val model = mock<VisitsModel>()
+        whenever(mapper.map(VISITS_RESPONSE)).thenReturn(model)
+
+
+        val responseModel = store.fetchTodayInsights(site, forced)
+
+        assertThat(responseModel.model).isEqualTo(model)
+        verify(sqlUtils).insert(site, VISITS_RESPONSE)
+    }
+
+    @Test
+    fun `returns today stats from db`() {
+        whenever(sqlUtils.selectTodayInsights(site)).thenReturn(VISITS_RESPONSE)
+        val model = mock<VisitsModel>()
+        whenever(mapper.map(VISITS_RESPONSE)).thenReturn(model)
+
+        val result = store.getTodayInsights(site)
+
+        assertThat(result).isEqualTo(model)
+    }
+
+    @Test
+    fun `returns error when today stats call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchInsightsPayload<VisitResponse>(StatsError(type, message))
+        val forced = true
+        whenever(insightsRestClient.fetchTimePeriodStats(site, DAYS, currentDate, forced)).thenReturn(errorPayload)
+
+        val responseModel = store.fetchTodayInsights(site, forced)
+
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
         assertEquals(type, error.type)
         assertEquals(message, error.message)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.fluxc.model.stats
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.AllTimeResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.MostPopularResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostStatsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.VisitResponse
+import javax.inject.Inject
+
+private const val PERIOD = "period"
+private const val VIEWS = "views"
+private const val VISITORS = "visitors"
+private const val LIKES = "likes"
+private const val REBLOGS = "reblogs"
+private const val COMMENTS = "comments"
+private const val POSTS = "posts"
+
+class InsightsMapper
+@Inject constructor() {
+    fun map(response: AllTimeResponse, site: SiteModel): InsightsAllTimeModel {
+        val stats = response.stats
+        return InsightsAllTimeModel(
+                site.siteId,
+                response.date,
+                stats.visitors,
+                stats.views,
+                stats.posts,
+                stats.viewsBestDay,
+                stats.viewsBestDayTotal
+        )
+    }
+
+    fun map(response: MostPopularResponse, site: SiteModel): InsightsMostPopularModel {
+        return InsightsMostPopularModel(
+                site.siteId,
+                response.highestDayOfWeek,
+                response.highestHour,
+                response.highestDayPercent,
+                response.highestHourPercent
+        )
+    }
+
+    fun map(
+        postResponse: PostResponse,
+        postStatsResponse: PostStatsResponse,
+        site: SiteModel
+    ): InsightsLatestPostModel {
+        val daysViews = if (postStatsResponse.fields.size > 1 &&
+                postStatsResponse.fields[0] == "period" &&
+                postStatsResponse.fields[1] == "views") {
+            postStatsResponse.data.map { list -> list[0] to list[1].toInt() }
+        } else {
+            listOf()
+        }
+        val viewsCount = postStatsResponse.views
+        val commentCount = postResponse.discussion?.commentCount ?: 0
+        return InsightsLatestPostModel(
+                site.siteId,
+                postResponse.title,
+                postResponse.url,
+                postResponse.date,
+                postResponse.id,
+                viewsCount,
+                commentCount,
+                postResponse.likeCount,
+                daysViews
+        )
+    }
+
+    fun map(response: VisitResponse): VisitsModel {
+        val result: Map<String, String> = response.fields.mapIndexed { index, value ->
+            value to response.data[0][index]
+        }.toMap()
+        return VisitsModel(
+                result[PERIOD] ?: "",
+                result[VIEWS]?.toInt() ?: 0,
+                result[VISITORS]?.toInt() ?: 0,
+                result[LIKES]?.toInt() ?: 0,
+                result[REBLOGS]?.toInt() ?: 0,
+                result[COMMENTS]?.toInt() ?: 0,
+                result[POSTS]?.toInt() ?: 0
+        )
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -46,7 +46,9 @@ class InsightsMapper
         postStatsResponse: PostStatsResponse,
         site: SiteModel
     ): InsightsLatestPostModel {
-        val daysViews = if (postStatsResponse.fields.size > 1 &&
+        val daysViews = if (postStatsResponse.fields != null &&
+                postStatsResponse.data != null &&
+                postStatsResponse.fields.size > 1 &&
                 postStatsResponse.fields[0] == "period" &&
                 postStatsResponse.fields[1] == "views") {
             postStatsResponse.data.map { list -> list[0] to list[1].toInt() }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/VisitsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/VisitsModel.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.model.stats
+
+data class VisitsModel(
+        val period: String,
+        val views: Int,
+        val visitors: Int,
+        val likes: Int,
+        val reblogs: Int,
+        val comments: Int,
+        val posts: Int
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/VisitsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/VisitsModel.kt
@@ -1,11 +1,11 @@
 package org.wordpress.android.fluxc.model.stats
 
 data class VisitsModel(
-        val period: String,
-        val views: Int,
-        val visitors: Int,
-        val likes: Int,
-        val reblogs: Int,
-        val comments: Int,
-        val posts: Int
+    val period: String,
+    val views: Int,
+    val visitors: Int,
+    val likes: Int,
+    val reblogs: Int,
+    val comments: Int,
+    val posts: Int
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom;
 
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.android.volley.Response.Listener;
 import com.android.volley.toolbox.HttpHeaderParser;
@@ -113,6 +114,7 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
             try {
                 jsonString = new String(error.volleyError.networkResponse.data,
                         HttpHeaderParser.parseCharset(error.volleyError.networkResponse.headers));
+                Log.e("wp_com_gson_request", "Response: " + jsonString);
             } catch (UnsupportedEncodingException e) {
                 jsonString = "";
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/DateStatsUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/DateStatsUtils.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.network.utils
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.utils.SiteUtils
+import java.util.Date
+
+const val DATE_FORMAT_DAY = "yyyy-MM-dd"
+const val DATE_FORMAT_WEEK = "yyyy-'W'ww"
+const val DATE_FORMAT_MONTH = "yyyy-MM"
+const val DATE_FORMAT_YEAR = "yyyy"
+
+enum class StatsGranularity {
+    DAYS, WEEKS, MONTHS, YEARS;
+}
+
+fun getFormattedDate(site: SiteModel, date: Date, granularity: StatsGranularity): String {
+    return when (granularity) {
+        StatsGranularity.DAYS -> SiteUtils.getDateTimeForSite(site, DATE_FORMAT_DAY, date)
+        StatsGranularity.WEEKS -> SiteUtils.getDateTimeForSite(site, DATE_FORMAT_WEEK, date)
+        StatsGranularity.MONTHS -> SiteUtils.getDateTimeForSite(site, DATE_FORMAT_MONTH, date)
+        StatsGranularity.YEARS -> SiteUtils.getDateTimeForSite(site, DATE_FORMAT_YEAR, date)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -5,10 +5,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.A
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.MostPopularResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostStatsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.PostsResponse.PostResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.VisitResponse
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.Key.ALL_TIME_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.Key.LATEST_POST_DETAIL_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.Key.LATEST_POST_STATS_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.Key.MOST_POPULAR_INSIGHTS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.Key.TODAYS_INSIGHTS
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,6 +33,10 @@ class InsightsSqlUtils
         statsSqlUtils.insert(site, LATEST_POST_STATS_INSIGHTS, data)
     }
 
+    fun insert(site: SiteModel, data: VisitResponse) {
+        statsSqlUtils.insert(site, TODAYS_INSIGHTS, data)
+    }
+
     fun selectAllTimeInsights(site: SiteModel): AllTimeResponse? {
         return statsSqlUtils.select(site, ALL_TIME_INSIGHTS, AllTimeResponse::class.java)
     }
@@ -45,5 +51,9 @@ class InsightsSqlUtils
 
     fun selectLatestPostStats(site: SiteModel): PostStatsResponse? {
         return statsSqlUtils.select(site, LATEST_POST_STATS_INSIGHTS, PostStatsResponse::class.java)
+    }
+
+    fun selectTodayInsights(site: SiteModel): VisitResponse? {
+        return statsSqlUtils.select(site, TODAYS_INSIGHTS, VisitResponse::class.java)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -17,12 +17,12 @@ class StatsSqlUtils
     fun <T> insert(site: SiteModel, type: Key, item: T) {
         val json = gson.toJson(item)
         WellSql.delete(StatsBlockBuilder::class.java)
-                    .where()
-                    .equals(StatsBlockTable.TYPE, type.name)
-                    .endWhere()
-                    .execute()
+                .where()
+                .equals(StatsBlockTable.TYPE, type.name)
+                .endWhere()
+                .execute()
         WellSql.insert(StatsBlockBuilder(localSiteId = site.id, type = type.name, json = json))
-                    .execute()
+                .execute()
     }
 
     fun <T> select(site: SiteModel, type: Key, classOfT: Class<T>): T? {
@@ -54,6 +54,10 @@ class StatsSqlUtils
     }
 
     enum class Key {
-        ALL_TIME_INSIGHTS, MOST_POPULAR_INSIGHTS, LATEST_POST_DETAIL_INSIGHTS, LATEST_POST_STATS_INSIGHTS
+        ALL_TIME_INSIGHTS,
+        MOST_POPULAR_INSIGHTS,
+        LATEST_POST_DETAIL_INSIGHTS,
+        LATEST_POST_STATS_INSIGHTS,
+        TODAYS_INSIGHTS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/InsightsStore.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
 import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.INVALID_RESPONSE
-import java.util.Date
+import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.CoroutineContext
@@ -23,6 +23,7 @@ class InsightsStore
     private val restClient: InsightsRestClient,
     private val sqlUtils: InsightsSqlUtils,
     private val insightsMapper: InsightsMapper,
+    private val timeProvider: CurrentTimeProvider,
     private val coroutineContext: CoroutineContext
 ) {
     // All time insights
@@ -99,7 +100,7 @@ class InsightsStore
 
     // Time period stats
     suspend fun fetchTodayInsights(siteModel: SiteModel, forced: Boolean = false) = withContext(coroutineContext) {
-        val response = restClient.fetchTimePeriodStats(siteModel, DAYS, Date(), forced)
+        val response = restClient.fetchTimePeriodStats(siteModel, DAYS, timeProvider.currentDate, forced)
         return@withContext when {
             response.isError -> { OnInsightsFetched(response.error) }
             response.response != null -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CurrentTimeProvider.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CurrentTimeProvider.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.utils
+
+import java.util.Date
+import javax.inject.Inject
+
+class CurrentTimeProvider
+@Inject constructor() {
+    val currentDate = Date()
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -15,7 +15,7 @@ public class SiteUtils {
     /**
      * Given a {@link SiteModel} and a {@link String} compatible with {@link SimpleDateFormat},
      * returns a formatted date that accounts for the site's timezone setting.
-     *
+     * <p>
      * Imported from WordPress-Android with some modifications.
      */
     public static @NonNull String getCurrentDateTimeForSite(@NonNull SiteModel site, @NonNull String pattern) {
@@ -24,13 +24,36 @@ public class SiteUtils {
     }
 
     /**
+     * Given a {@link SiteModel}, {@link String} and a {@link Date} compatible with {@link SimpleDateFormat},
+     * returns a formatted date that accounts for the site's timezone setting.
+     */
+    public static @NonNull String getDateTimeForSite(@NonNull SiteModel site,
+                                                     @NonNull String pattern,
+                                                     @NonNull Date date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(pattern, Locale.ROOT);
+        return getDateTimeForSite(site, dateFormat, date);
+    }
+
+    /**
      * Given a {@link SiteModel} and a {@link SimpleDateFormat},
      * returns a formatted date that accounts for the site's timezone setting.
-     *
+     * <p>
      * Imported from WordPress-Android with some modifications.
      */
     public static @NonNull String getCurrentDateTimeForSite(@NonNull SiteModel site,
                                                             @NonNull SimpleDateFormat dateFormat) {
+        Date date = new Date();
+        return getDateTimeForSite(site, dateFormat, date);
+    }
+
+
+    /**
+     * Given a {@link SiteModel}, {@link SimpleDateFormat} and a {@link Date},
+     * returns a formatted date that accounts for the site's timezone setting.
+     */
+    private static @NonNull String getDateTimeForSite(@NonNull SiteModel site,
+                                                      @NonNull SimpleDateFormat dateFormat,
+                                                      @NonNull Date date) {
         String wpTimeZone = site.getTimezone();
 
         /*
@@ -73,6 +96,6 @@ public class SiteUtils {
         }
 
         dateFormat.setTimeZone(TimeZone.getTimeZone(timezoneNormalized));
-        return dateFormat.format(new Date());
+        return dateFormat.format(date);
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -15,12 +15,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchVisitorStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import javax.inject.Singleton

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -15,12 +15,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchVisitorStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import javax.inject.Singleton


### PR DESCRIPTION
Fixes #967

This PR is adding an endpoint to load today's stats for the Insights screen. 

I've extracted the domain model mapper from the InsightsStore because the store was doing too much. The tests are not more explicit and simpler.

I've included some renaming and unification in tests. The logic should still be the same.

The WPAndroid part has already been tested and merged so the functionality should be alright 