### PR TITLE
Post the initial isEmpty value for PagedListWrapper

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListFactory.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListFactory.kt
@@ -74,9 +74,9 @@ private class PagedListPositionalDataSource<T, R>(
     private val internalItems: List<InternalItem<T>> by lazy {
         val localItems = dataStore.localItems(listDescriptor).map { InternalLocalItem(it) }
         val remoteItemIdsToHide = dataStore.getItemIdsToHide(listDescriptor).mapNotNull { it.second }
-        val remoteItems = getList(listDescriptor).filter {
+        val remoteItems = getList(listDescriptor).asSequence().filter {
             !remoteItemIdsToHide.contains(it)
-        }.map { InternalRemoteItem<T>(it) }
+        }.map { InternalRemoteItem<T>(it) }.toList()
         val actualItems = localItems.plus(remoteItems)
         // We only want to show the end list indicator if the list is fully fetched and it's not empty
         if (isListFullyFetched(listDescriptor) && actualItems.isNotEmpty()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListItemType.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListItemType.kt
@@ -1,7 +1,21 @@
 package org.wordpress.android.fluxc.model.list
 
+/**
+ * These are the different type of items that will be returned by the `PagedList` from `ListStore.getList`.
+ */
 sealed class PagedListItemType<T> {
+    /**
+     * Indicates the end of the list is reached.
+     */
     class EndListIndicatorItem<T> : PagedListItemType<T>()
+
+    /**
+     * Indicates the item doesn't exist in the DB and will be loaded.
+     */
     class LoadingItem<T>(val remoteItemId: Long) : PagedListItemType<T>()
+
+    /**
+     * Indicates the item is available in the DB and ready to be used.
+     */
     class ReadyItem<T>(val item: T) : PagedListItemType<T>()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
@@ -53,6 +53,9 @@ class PagedListWrapper<T>(
     init {
         dispatcher.register(this)
         lifecycle.addObserver(this)
+
+        // We need to update the initial value for isEmpty, so we can immediately hide/show the empty view
+        updateIsEmpty()
     }
 
     /**


### PR DESCRIPTION
This is a very small PR that fixes an issue where the `isEmpty` value is not available initially. This causes an issue for the empty list to be shown even if there are items and it's especially apparent if the connection is slow.

It also adds documentation to `PagedListItemType` as requested [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/977#discussion_r232562107).