### PR TITLE
Issue/974 restore post action

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPComEndpointTest.java
@@ -20,6 +20,7 @@ public class WPComEndpointTest {
         assertEquals("/sites/56/posts/", WPCOMREST.sites.site(56).posts.getEndpoint());
         assertEquals("/sites/56/posts/78/", WPCOMREST.sites.site(56).posts.post(78).getEndpoint());
         assertEquals("/sites/56/posts/78/delete/", WPCOMREST.sites.site(56).posts.post(78).delete.getEndpoint());
+        assertEquals("/sites/56/posts/78/restore/", WPCOMREST.sites.site(56).posts.post(78).restore.getEndpoint());
         assertEquals("/sites/56/posts/new/", WPCOMREST.sites.site(56).posts.new_.getEndpoint());
         assertEquals("/sites/56/posts/slug:fluxc/", WPCOMREST.sites.site(56).posts.slug("fluxc").getEndpoint());
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -28,6 +28,8 @@ public enum PostAction implements IAction {
     PUSH_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETE_POST,
+    @Action(payloadType = RemotePostPayload.class)
+    RESTORE_POST,
     @Action(payloadType = FetchRevisionsPayload.class)
     FETCH_REVISIONS,
 
@@ -42,6 +44,8 @@ public enum PostAction implements IAction {
     PUSHED_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETED_POST,
+    @Action(payloadType = RemotePostPayload.class)
+    RESTORED_POST,
     @Action(payloadType = FetchRevisionsResponsePayload.class)
     FETCHED_REVISIONS,
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.model
 
 sealed class CauseOfOnPostChanged {
     class DeletePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
+    class RestorePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
     object FetchPages : CauseOfOnPostChanged()
     object FetchPosts : CauseOfOnPostChanged()
     object RemoveAllPosts : CauseOfOnPostChanged()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -329,9 +329,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         params.add(post.getRemotePostId());
         params.add(contentStruct);
 
-        final XMLRPC method = XMLRPC.EDIT_POST;
-
-        final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), method, params,
+        final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.EDIT_POST, params,
                 new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
@@ -365,45 +363,6 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         request.disableRetries();
         add(request);
-//
-//
-//        List<Object> params = new ArrayList<>(4);
-//        params.add(site.getSelfHostedSiteId());
-//        params.add(site.getUsername());
-//        params.add(site.getPassword());
-//        params.add(post.getRemotePostId());
-//
-//        final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.UNTRASH_POST, params,
-//                new Listener<Object>() {
-//                    @Override
-//                    public void onResponse(Object response) {
-//                        RemotePostPayload payload = new RemotePostPayload(post, site);
-//                        mDispatcher.dispatch(PostActionBuilder.newRestoredPostAction(payload));
-//                    }
-//                },
-//                new BaseErrorListener() {
-//                    @Override
-//                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-//                        // Possible non-generic errors:
-//                        // 404 - "Invalid post ID."
-//                        RemotePostPayload payload = new RemotePostPayload(post, site);
-//                        // TODO: Check the error message and flag this as UNKNOWN_POST if applicable
-//                        // Convert GenericErrorType to PostErrorType where applicable
-//                        PostError postError;
-//                        switch (error.type) {
-//                            case AUTHORIZATION_REQUIRED:
-//                                postError = new PostError(PostErrorType.UNAUTHORIZED, error.message);
-//                                break;
-//                            default:
-//                                postError = new PostError(PostErrorType.GENERIC_ERROR, error.message);
-//                        }
-//                        payload.error = postError;
-//                        mDispatcher.dispatch(PostActionBuilder.newRestoredPostAction(payload));
-//                    }
-//                });
-//
-//        request.disableRetries();
-//        add(request);
     }
 
     private @NotNull List<PostListItem> postListItemsFromPostsResponse(@Nullable Object[] response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -245,6 +245,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                         }
                         post.setIsLocalDraft(false);
                         post.setIsLocallyChanged(false);
+
                         RemotePostPayload payload = new RemotePostPayload(post, site);
                         mDispatcher.dispatch(UploadActionBuilder.newPushedPostAction(payload));
                     }
@@ -341,10 +342,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                     @Override
                     public void onErrorResponse(@NonNull BaseNetworkError error) {
                         // Possible non-generic errors:
-                        // 403 - "Invalid post type"
-                        // 403 - "Invalid term ID" (invalid category or tag id)
                         // 404 - "Invalid post ID." (editing only)
-                        // 404 - "Invalid attachment ID." (invalid featured image)
                         RemotePostPayload payload = new RemotePostPayload(post, site);
                         // TODO: Check the error message and flag this as one of the above specific errors if applicable
                         // Convert GenericErrorType to PostErrorType where applicable

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -660,7 +660,7 @@ public class PostStore extends Store {
 
     private void handleRestorePostCompleted(RemotePostPayload payload) {
         OnPostChanged event = new OnPostChanged(
-                new CauseOfOnPostChanged.RestoredPost(payload.post.getId(), payload.post.getRemotePostId()), 0);
+                new CauseOfOnPostChanged.RestorePost(payload.post.getId(), payload.post.getRemotePostId()), 0);
 
         if (payload.isError()) {
             event.error = payload.error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -709,7 +709,7 @@ public class PostStore extends Store {
                 event.error = payload.error;
                 emitChange(event);
             } else {
-                restorePost(payload);
+                restorePostLocally(payload.post);
             }
             return;
         }
@@ -756,7 +756,7 @@ public class PostStore extends Store {
             if (payload.site.isUsingWpComRestApi()) {
                 // The WP.COM REST API response contains the modified post, so we're already in sync with the server
                 // All we need to do is store it and emit OnPostChanged
-                restorePost(payload.post);
+                restorePostLocally(payload.post);
             } else {
                 // XML-RPC does not respond to new/edit post calls with the modified post
                 // Update the post locally to reflect its uploaded status, but also request a fresh copy
@@ -789,7 +789,7 @@ public class PostStore extends Store {
                 new ListItemsChangedPayload(PostListDescriptor.calculateTypeIdentifier(post.getLocalSiteId()))));
     }
 
-    private void restorePost(PostModel post) {
+    private void restorePostLocally(PostModel post) {
         int rowsAffected = PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(post);
         CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.RestorePost(post.getId(), post.getRemotePostId());
         OnPostChanged onPostChanged = new OnPostChanged(causeOfChange, rowsAffected);

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -74,7 +74,6 @@
 /sites/$site/posts/$post_ID/restore/
 /sites/$site/posts/$post_ID/replies/new
 /sites/$site/posts/new/
-/sites/$site/posts/restore/
 /sites/$site/posts/slug:$post_slug#String/
 
 /sites/$site/stats/visits

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -71,8 +71,10 @@
 /sites/$site/posts/
 /sites/$site/posts/$post_ID/
 /sites/$site/posts/$post_ID/delete/
+/sites/$site/posts/$post_ID/restore/
 /sites/$site/posts/$post_ID/replies/new
 /sites/$site/posts/new/
+/sites/$site/posts/restore/
 /sites/$site/posts/slug:$post_slug#String/
 
 /sites/$site/stats/visits

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -9,6 +9,7 @@ wp.getPosts
 wp.newPost
 wp.editPost
 wp.deletePost
+wp.untrashPost
 wp.getTerm
 wp.getTerms
 wp.newTerm

--- a/fluxc/src/main/tools/xmlrpc-endpoints.txt
+++ b/fluxc/src/main/tools/xmlrpc-endpoints.txt
@@ -9,7 +9,6 @@ wp.getPosts
 wp.newPost
 wp.editPost
 wp.deletePost
-wp.untrashPost
 wp.getTerm
 wp.getTerms
 wp.newTerm


### PR DESCRIPTION
Fixes #974 

This PR adds a `RESTORE_POST` action that allows us to restore trashed remote posts. I this as an opportunity to learn about XmlRpc and recent changes to Post list. I hope understood everything correctly, but please let me know if I missed something. I added comments to a couple of places I'm not 100% sure about.

Notes:
I went with the separate `CauseOfChange` for post-restoration, which should make life a bit easier on a client side.

XmlRpc client is using `EDIT_POST` endpoint, and then fetches updated post from the server before emitting a successful event.  The process is really similar to on in post updater flow, so there is a bit of code duplication.

There is catch with statuses of restored posts on the self-hosted websites - we have do not know the status of a post before it was trashed, so all the restore post will become published. I'm not a fan of this approach, and wonder, maybe we can set the status of restored posts to `private` and notify user about this in a client?