### PR TITLE
Add PageSize parameter to the store calls that need a page size

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -117,12 +117,13 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     fun testWpComFollowersInsights() {
         val site = authenticate()
 
-        val fetchedInsights = runBlocking { insightsStore.fetchWpComFollowers(site) }
+        val pageSize = 5
+        val fetchedInsights = runBlocking { insightsStore.fetchWpComFollowers(site, pageSize) }
 
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = insightsStore.getWpComFollowers(site)
+        val insightsFromDb = insightsStore.getWpComFollowers(site, pageSize)
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }
@@ -131,12 +132,13 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     fun testEmailFollowersInsights() {
         val site = authenticate()
 
-        val fetchedInsights = runBlocking { insightsStore.fetchEmailFollowers(site) }
+        val pageSize = 5
+        val fetchedInsights = runBlocking { insightsStore.fetchEmailFollowers(site, pageSize) }
 
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = insightsStore.getEmailFollowers(site)
+        val insightsFromDb = insightsStore.getEmailFollowers(site, pageSize)
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }
@@ -145,12 +147,13 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     fun testTopComments() {
         val site = authenticate()
 
-        val fetchedInsights = runBlocking { insightsStore.fetchComments(site) }
+        val pageSize = 5
+        val fetchedInsights = runBlocking { insightsStore.fetchComments(site, pageSize) }
 
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = insightsStore.getComments(site)
+        val insightsFromDb = insightsStore.getComments(site, pageSize)
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }
@@ -159,12 +162,13 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     fun testTagsAndCategoriesInsights() {
         val site = authenticate()
 
-        val fetchedInsights = runBlocking { insightsStore.fetchTags(site) }
+        val pageSize = 5
+        val fetchedInsights = runBlocking { insightsStore.fetchTags(site, pageSize) }
 
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = insightsStore.getTags(site)
+        val insightsFromDb = insightsStore.getTags(site, pageSize)
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -346,7 +346,7 @@ class InsightsRestClientTest {
     fun `returns tags and categories`() = test {
         initTagsResponse(TAGS_RESPONSE)
 
-        val responseModel = insightsRestClient.fetchTags(site, pageSize = pageSize,  forced = false)
+        val responseModel = insightsRestClient.fetchTags(site, pageSize = pageSize, forced = false)
 
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(TAGS_RESPONSE)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -39,8 +39,8 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.FOLLOWERS_RESPONSE
 import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.store.POST_STATS_RESPONSE
-import org.wordpress.android.fluxc.store.TOP_COMMENTS_RESPONSE
 import org.wordpress.android.fluxc.store.TAGS_RESPONSE
+import org.wordpress.android.fluxc.store.TOP_COMMENTS_RESPONSE
 import org.wordpress.android.fluxc.store.VISITS_RESPONSE
 import org.wordpress.android.fluxc.test
 import java.text.SimpleDateFormat
@@ -59,6 +59,7 @@ class InsightsRestClientTest {
     private lateinit var insightsRestClient: InsightsRestClient
     private val siteId: Long = 12
     private val postId: Long = 1
+    private val pageSize = 5
 
     @Before
     fun setUp() {
@@ -334,7 +335,7 @@ class InsightsRestClientTest {
                 )
         )
 
-        val responseModel = insightsRestClient.fetchTopComments(site, forced = false)
+        val responseModel = insightsRestClient.fetchTopComments(site, pageSize = pageSize, forced = false)
 
         assertThat(responseModel.error).isNotNull()
         assertThat(responseModel.error.type).isEqualTo(API_ERROR)
@@ -345,12 +346,12 @@ class InsightsRestClientTest {
     fun `returns tags and categories`() = test {
         initTagsResponse(TAGS_RESPONSE)
 
-        val responseModel = insightsRestClient.fetchTags(site, forced = false)
+        val responseModel = insightsRestClient.fetchTags(site, pageSize = pageSize,  forced = false)
 
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(TAGS_RESPONSE)
         assertThat(urlCaptor.lastValue).isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/tags/")
-        assertThat(paramsCaptor.lastValue).isEqualTo(mapOf("max" to "6"))
+        assertThat(paramsCaptor.lastValue).isEqualTo(mapOf("max" to "$pageSize"))
     }
 
     @Test
@@ -366,7 +367,7 @@ class InsightsRestClientTest {
                 )
         )
 
-        val responseModel = insightsRestClient.fetchTags(site, forced = false)
+        val responseModel = insightsRestClient.fetchTags(site, pageSize = pageSize, forced = false)
 
         assertThat(responseModel.error).isNotNull()
         assertThat(responseModel.error.type).isEqualTo(API_ERROR)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
@@ -43,6 +43,8 @@ import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
+private const val PAGE_SIZE = 8
+
 @RunWith(MockitoJUnitRunner::class)
 class InsightsStoreTest {
     @Mock lateinit var site: SiteModel
@@ -280,13 +282,13 @@ class InsightsStoreTest {
                 FOLLOWERS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, WP_COM, 6, forced)).thenReturn(
+        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, WP_COM)).thenReturn(model)
+        whenever(mapper.map(FOLLOWERS_RESPONSE, WP_COM, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchWpComFollowers(site, forced)
+        val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, WP_COM)
@@ -298,13 +300,13 @@ class InsightsStoreTest {
                 FOLLOWERS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, EMAIL, 6, forced)).thenReturn(
+        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, EMAIL)).thenReturn(model)
+        whenever(mapper.map(FOLLOWERS_RESPONSE, EMAIL, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchEmailFollowers(site, forced)
+        val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, EMAIL)
@@ -314,9 +316,9 @@ class InsightsStoreTest {
     fun `returns WPCOM followers from db`() {
         whenever(sqlUtils.selectFollowers(site, WP_COM)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, WP_COM)).thenReturn(model)
+        whenever(mapper.map(FOLLOWERS_RESPONSE, WP_COM, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getWpComFollowers(site)
+        val result = store.getWpComFollowers(site, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }
@@ -325,9 +327,9 @@ class InsightsStoreTest {
     fun `returns email followers from db`() {
         whenever(sqlUtils.selectFollowers(site, EMAIL)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, EMAIL)).thenReturn(model)
+        whenever(mapper.map(FOLLOWERS_RESPONSE, EMAIL, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getEmailFollowers(site)
+        val result = store.getEmailFollowers(site, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }
@@ -338,9 +340,9 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchInsightsPayload<FollowersResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, WP_COM, 6, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchWpComFollowers(site, forced)
+        val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -354,9 +356,9 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchInsightsPayload<FollowersResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, EMAIL, 6, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchEmailFollowers(site, forced)
+        val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -370,13 +372,13 @@ class InsightsStoreTest {
                 TOP_COMMENTS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchTopComments(site, 6, forced)).thenReturn(
+        whenever(insightsRestClient.fetchTopComments(site, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<CommentsModel>()
-        whenever(mapper.map(TOP_COMMENTS_RESPONSE)).thenReturn(model)
+        whenever(mapper.map(TOP_COMMENTS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchComments(site, forced)
+        val responseModel = store.fetchComments(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, TOP_COMMENTS_RESPONSE)
@@ -386,9 +388,9 @@ class InsightsStoreTest {
     fun `returns top comments from db`() {
         whenever(sqlUtils.selectCommentInsights(site)).thenReturn(TOP_COMMENTS_RESPONSE)
         val model = mock<CommentsModel>()
-        whenever(mapper.map(TOP_COMMENTS_RESPONSE)).thenReturn(model)
+        whenever(mapper.map(TOP_COMMENTS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getComments(site)
+        val result = store.getComments(site, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }
@@ -399,9 +401,9 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchInsightsPayload<CommentsResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchTopComments(site, 6, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchTopComments(site, PAGE_SIZE, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchComments(site, forced)
+        val responseModel = store.fetchComments(site, PAGE_SIZE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -415,13 +417,13 @@ class InsightsStoreTest {
                 TAGS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchTags(site, forced = forced)).thenReturn(
+        whenever(insightsRestClient.fetchTags(site, PAGE_SIZE + 1, forced = forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<TagsModel>()
-        whenever(mapper.map(TAGS_RESPONSE)).thenReturn(model)
+        whenever(mapper.map(TAGS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchTags(site, forced)
+        val responseModel = store.fetchTags(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, TAGS_RESPONSE)
@@ -431,9 +433,9 @@ class InsightsStoreTest {
     fun `returns tags and categories from db`() {
         whenever(sqlUtils.selectTags(site)).thenReturn(TAGS_RESPONSE)
         val model = mock<TagsModel>()
-        whenever(mapper.map(TAGS_RESPONSE)).thenReturn(model)
+        whenever(mapper.map(TAGS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getTags(site)
+        val result = store.getTags(site, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }
@@ -444,9 +446,9 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchInsightsPayload<TagsResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchTags(site, forced = forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchTags(site, PAGE_SIZE + 1, forced = forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchTags(site, forced)
+        val responseModel = store.fetchTags(site, PAGE_SIZE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!

--- a/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/InsightsStoreTest.kt
@@ -401,7 +401,7 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchInsightsPayload<CommentsResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchTopComments(site, PAGE_SIZE, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchTopComments(site, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
         val responseModel = store.fetchComments(site, PAGE_SIZE, forced)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/CommentsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/CommentsModel.kt
@@ -2,7 +2,9 @@ package org.wordpress.android.fluxc.model.stats
 
 data class CommentsModel(
     var posts: List<Post>,
-    var authors: List<Author>
+    var authors: List<Author>,
+    val hasMorePosts: Boolean,
+    val hasMoreAuthors: Boolean
 ) {
     data class Post(val id: Long, val name: String, val comments: Int, val link: String)
     data class Author(val name: String, val comments: Int, val link: String, val gravatar: String)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/FollowersModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/FollowersModel.kt
@@ -4,7 +4,8 @@ import java.util.Date
 
 data class FollowersModel(
     val totalCount: Int,
-    val followers: List<FollowerModel>
+    val followers: List<FollowerModel>,
+    val hasMore: Boolean
 ) {
     data class FollowerModel(
         val avatar: String,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -96,8 +96,8 @@ class InsightsMapper
         )
     }
 
-    fun map(response: FollowersResponse, followerType: FollowerType): FollowersModel {
-        val followers = response.subscribers.map {
+    fun map(response: FollowersResponse, followerType: FollowerType, pageSize: Int): FollowersModel {
+        val followers = response.subscribers.take(pageSize).map {
             FollowerModel(
                     it.avatar,
                     it.label,
@@ -109,11 +109,11 @@ class InsightsMapper
             WP_COM -> response.totalWpCom
             EMAIL -> response.totalEmail
         }
-        return FollowersModel(total, followers)
+        return FollowersModel(total, followers, response.subscribers.size > pageSize)
     }
 
-    fun map(response: CommentsResponse): CommentsModel {
-        val authors = response.authors?.mapNotNull {
+    fun map(response: CommentsResponse, pageSize: Int): CommentsModel {
+        val authors = response.authors?.take(pageSize)?.mapNotNull {
             if (it.name != null && it.comments != null && it.link != null && it.gravatar != null) {
                 CommentsModel.Author(it.name, it.comments, it.link, it.gravatar)
             } else {
@@ -121,7 +121,7 @@ class InsightsMapper
                 null
             }
         }
-        val posts = response.posts?.mapNotNull {
+        val posts = response.posts?.take(pageSize)?.mapNotNull {
             if (it.id != null && it.name != null && it.comments != null && it.link != null) {
                 CommentsModel.Post(it.id, it.name, it.comments, it.link)
             } else {
@@ -129,13 +129,15 @@ class InsightsMapper
                 null
             }
         }
-        return CommentsModel(posts ?: listOf(), authors ?: listOf())
+        val hasMoreAuthors = (response.authors != null && response.authors.size > pageSize)
+        val hasMorePosts = (response.posts != null && response.posts.size > pageSize)
+        return CommentsModel(posts ?: listOf(), authors ?: listOf(), hasMorePosts, hasMoreAuthors)
     }
 
-    fun map(response: TagsResponse): TagsModel {
-        return TagsModel(response.tags.map { tag ->
+    fun map(response: TagsResponse, pageSize: Int): TagsModel {
+        return TagsModel(response.tags.take(pageSize).map { tag ->
             TagModel(tag.tags.map { it.toItem() }, tag.views)
-        })
+        }, response.tags.size > pageSize)
     }
 
     private fun TagResponse.toItem(): TagModel.Item {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/TagsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/TagsModel.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.model.stats
 
-data class TagsModel(val tags: List<TagModel>) {
+data class TagsModel(val tags: List<TagModel>, val hasMore: Boolean) {
     class TagModel(val items: List<Item>, val views: Long) {
         data class Item(val name: String, val type: String, val link: String)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClient.kt
@@ -178,7 +178,7 @@ constructor(
     suspend fun fetchFollowers(
         site: SiteModel,
         type: FollowerType,
-        pageSize: Int = 6,
+        pageSize: Int,
         forced: Boolean
     ): FetchInsightsPayload<FollowersResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.followers.urlV1_1
@@ -207,7 +207,7 @@ constructor(
 
     suspend fun fetchTopComments(
         site: SiteModel,
-        pageSize: Int = 6,
+        pageSize: Int,
         forced: Boolean
     ): FetchInsightsPayload<CommentsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.comments.urlV1_1
@@ -235,7 +235,7 @@ constructor(
 
     suspend fun fetchTags(
         site: SiteModel,
-        pageSize: Int = 6,
+        pageSize: Int,
         forced: Boolean
     ): FetchInsightsPayload<TagsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.tags.urlV1_1


### PR DESCRIPTION
- This PR adds a page size parameter to comments, followers and tags and categories. We're loading pageSize + 1 items from the API to find out if we should show the `View more` button in the UI. We're returning only `pageSize` items to the UI.