### PR TITLE
Woo: Add action for fetching the max supported WooCommerce version

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -27,6 +27,7 @@ public interface MockedNetworkAppComponent {
     void inject(MockedStack_SiteTest object);
     void inject(MockedStack_UploadStoreTest object);
     void inject(MockedStack_UploadTest object);
+    void inject(MockedStack_WCBaseStoreTest object);
     void inject(MockedStack_WCOrdersTest object);
     void inject(MockedStack_WCStatsTest object);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.fluxc.mocked
+
+import org.greenrobot.eventbus.Subscribe
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.action.WCCoreAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.store.WooCommerceStore.FetchApiVersionResponsePayload
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlin.properties.Delegates.notNull
+
+/**
+ * Tests using a Mocked Network app component. Test the network client itself and not the underlying
+ * network component(s).
+ */
+class MockedStack_WCBaseStoreTest : MockedStack_Base() {
+    @Inject internal lateinit var wcRestClient: WooCommerceRestClient
+    @Inject internal lateinit var dispatcher: Dispatcher
+
+    @Inject internal lateinit var interceptor: ResponseMockingInterceptor
+
+    private var lastAction: Action<*>? = null
+    private var countDownLatch: CountDownLatch by notNull()
+
+    private val siteModel = SiteModel().apply {
+        id = 5
+        siteId = 567
+    }
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mMockedNetworkAppComponent.inject(this)
+        dispatcher.register(this)
+        lastAction = null
+    }
+
+    @Test
+    fun testApiVersionFetch() {
+        interceptor.respondWith("jetpack-tunnel-root-response-success.json")
+        wcRestClient.getSupportedWooApiVersion(siteModel)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCCoreAction.FETCHED_SITE_API_VERSION, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchApiVersionResponsePayload
+        assertNull(payload.error)
+        assertEquals(WooCommerceStore.WOO_API_NAMESPACE_V3, payload.version)
+    }
+
+    @Suppress("unused")
+    @Subscribe
+    fun onAction(action: Action<*>) {
+        lastAction = action
+        countDownLatch.countDown()
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
@@ -7,12 +7,23 @@ import dagger.Provides
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import javax.inject.Singleton
 
 @Module
 class MockedWCNetworkModule {
+    @Singleton
+    @Provides
+    fun provideWooCommerceRestClient(
+        appContext: Context,
+        dispatcher: Dispatcher,
+        requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = WooCommerceRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+
     @Singleton
     @Provides
     fun provideOrderRestClient(

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -17,6 +17,12 @@
             android:text="Log Sites"/>
 
         <Button
+            android:id="@+id/log_woo_api_versions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Log Woo API versions"/>
+
+        <Button
             android:id="@+id/fetch_orders"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.wc
 
+import com.nhaarman.mockito_kotlin.mock
 import com.yarolegovich.wellsql.WellSql
 import org.junit.Before
 import org.junit.Test
@@ -17,7 +18,7 @@ import kotlin.test.assertEquals
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
 class WooCommerceStoreTest {
-    private val wooCommerceStore = WooCommerceStore(Dispatcher())
+    private val wooCommerceStore = WooCommerceStore(Dispatcher(), mock())
 
     @Before
     fun setUp() {

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCCoreAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCCoreAction.java
@@ -1,0 +1,18 @@
+package org.wordpress.android.fluxc.action;
+
+import org.wordpress.android.fluxc.annotations.Action;
+import org.wordpress.android.fluxc.annotations.ActionEnum;
+import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.WooCommerceStore.FetchApiVersionResponsePayload;
+
+@ActionEnum
+public enum WCCoreAction implements IAction {
+    // Remote actions
+    @Action(payloadType = SiteModel.class)
+    FETCH_SITE_API_VERSION,
+
+    // Remote responses
+    @Action(payloadType = FetchApiVersionResponsePayload.class)
+    FETCHED_SITE_API_VERSION
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import javax.inject.Named
@@ -14,6 +15,16 @@ import javax.inject.Singleton
 
 @Module
 class ReleaseWCNetworkModule {
+    @Singleton
+    @Provides
+    fun provideWooCommerceRestClient(
+        appContext: Context,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = WooCommerceRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+
     @Singleton
     @Provides
     fun provideOrderRestClient(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -1,0 +1,72 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCCoreAction
+import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.store.WooCommerceStore.ApiVersionError
+import org.wordpress.android.fluxc.store.WooCommerceStore.ApiVersionErrorType
+import org.wordpress.android.fluxc.store.WooCommerceStore.FetchApiVersionResponsePayload
+import javax.inject.Singleton
+
+@Singleton
+class WooCommerceRestClient(
+    appContext: Context,
+    private val dispatcher: Dispatcher,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    /**
+     * Makes a GET call to the root wp-json endpoint (`/`) via the Jetpack tunnel (see [JetpackTunnelGsonRequest])
+     * for the given [SiteModel], and parses through the `namespaces` field in the result for supported versions
+     * of the Woo API.
+     *
+     * Dispatches a [WCCoreAction.FETCHED_SITE_API_VERSION] action with the highest version of the Woo API supported
+     * by the site (but no newer than the latest supported by FluxC).
+     */
+    fun getSupportedWooApiVersion(site: SiteModel) {
+        val url = "/"
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, emptyMap(),
+                RootWPAPIRestResponse::class.java,
+                { response: RootWPAPIRestResponse? ->
+                    val namespaces = response?.namespaces
+
+                    val maxWooApiVersion = namespaces?.run {
+                        find { it == WooCommerceStore.WOO_API_NAMESPACE_V3 }
+                                ?: find { it == WooCommerceStore.WOO_API_NAMESPACE_V2 }
+                                ?: find { it == WooCommerceStore.WOO_API_NAMESPACE_V1 }
+                    }
+
+                    maxWooApiVersion?.let { maxApiVersion ->
+                        val payload = FetchApiVersionResponsePayload(site, maxApiVersion)
+                        dispatcher.dispatch(WCCoreActionBuilder.newFetchedSiteApiVersionAction(payload))
+                    } ?: run {
+                        val apiVersionError = ApiVersionError(ApiVersionErrorType.NO_WOO_API)
+                        val payload = FetchApiVersionResponsePayload(apiVersionError, site)
+                        dispatcher.dispatch(WCCoreActionBuilder.newFetchedSiteApiVersionAction(payload))
+                    }
+                },
+                WPComGsonRequest.WPComErrorListener { networkError ->
+                    val payload = FetchApiVersionResponsePayload(networkErrorToApiVersionError(networkError), site)
+                    dispatcher.dispatch(WCCoreActionBuilder.newFetchedSiteApiVersionAction(payload))
+                },
+                { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
+    private fun networkErrorToApiVersionError(wpComError: WPComGsonNetworkError): ApiVersionError {
+        val apiVersionErrorType = ApiVersionErrorType.fromString(wpComError.apiError)
+        return ApiVersionError(apiVersionErrorType, wpComError.message)
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -4,21 +4,78 @@ import com.wellsql.generated.SiteModelTable
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.action.WCCoreAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.store.WooCommerceStore.ApiVersionErrorType.GENERIC_ERROR
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WooCommerceStore @Inject constructor(dispatcher: Dispatcher) : Store(dispatcher) {
+class WooCommerceStore @Inject constructor(dispatcher: Dispatcher, private val wcCoreRestClient: WooCommerceRestClient)
+    : Store(dispatcher) {
+    companion object {
+        const val WOO_API_NAMESPACE_V1 = "wc/v1"
+        const val WOO_API_NAMESPACE_V2 = "wc/v2"
+        const val WOO_API_NAMESPACE_V3 = "wc/v3"
+    }
+
+    class FetchApiVersionResponsePayload(
+        var site: SiteModel,
+        var version: String
+    ) : Payload<ApiVersionError>() {
+        constructor(error: ApiVersionError, site: SiteModel) : this(site, "") { this.error = error }
+    }
+
+    class ApiVersionError(val type: ApiVersionErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
+
+    enum class ApiVersionErrorType {
+        GENERIC_ERROR,
+        NO_WOO_API;
+
+        companion object {
+            private val reverseMap = ApiVersionErrorType.values().associateBy(ApiVersionErrorType::name)
+            fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: ApiVersionErrorType.GENERIC_ERROR
+        }
+    }
+
+    // OnChanged events
+    class OnApiVersionFetched(val site: SiteModel, val apiVersion: String) : OnChanged<ApiVersionError>()
+
     override fun onRegister() = AppLog.d(T.API, "WooCommerceStore onRegister")
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
-    override fun onAction(action: Action<*>) {}
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? WCCoreAction ?: return
+        when (actionType) {
+            // Remote actions
+            WCCoreAction.FETCH_SITE_API_VERSION -> getApiVersion(action.payload as SiteModel)
+            // Remote responses
+            WCCoreAction.FETCHED_SITE_API_VERSION ->
+                handleGetApiVersionCompleted(action.payload as FetchApiVersionResponsePayload)
+        }
+    }
 
     fun getWooCommerceSites(): MutableList<SiteModel> =
             SiteSqlUtils.getSitesWith(SiteModelTable.HAS_WOO_COMMERCE, true).asModel
+
+    private fun getApiVersion(site: SiteModel) = wcCoreRestClient.getSupportedWooApiVersion(site)
+
+    private fun handleGetApiVersionCompleted(payload: FetchApiVersionResponsePayload) {
+        val onApiVersionFetched: OnApiVersionFetched
+
+        if (payload.isError) {
+            onApiVersionFetched = OnApiVersionFetched(payload.site, "").also { it.error = payload.error }
+        } else {
+            onApiVersionFetched = OnApiVersionFetched(payload.site, payload.version)
+        }
+
+        emitChange(onApiVersionFetched)
+    }
 }


### PR DESCRIPTION
Adds a `WooCommerceStore` action for obtaining the maximum supported version of the WooCommerce API for any Jetpack-connected, logged in site.

This happens by doing a call to the site's root `wp-json` API through the WP.com Jetpack tunnel (the site's `wp-json` root corresponds to `/` in the Jetpack tunnel). Among other things, this returns a list of namespaces supported by the site, which looks like this:

```js
{
    ...
    "namespaces": [
      "oembed/1.0",
      "akismet/v1",
      "jetpack/v4",
      "wc/v1",
      "wc/v2",
      "wc/v3",
      "wp/v2"
    ],
    ...
}
```

The callback will contain the latest API version the site supports that FluxC knows about (currently up to V3).

Intended use is to identify sites that aren't updated to WooCommerce 3.5 (and so are lacking the V3 API endpoints), and warn those users to update to continue using the WooCommerce app.

### To test
The WooCommerce fragment in the example app has a new "Log Woo API versions" button, which will log the max supported Woo API version for every WooCommerce site attached to the logged-into account.