### PR TITLE
Woo: Remove label property from CoreOrderStatus

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/CoreOrderStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/CoreOrderStatus.kt
@@ -3,23 +3,17 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 /**
  * Standard Core WooCommerce order statuses
  */
-enum class CoreOrderStatus(val label: String, val value: String) {
-    PENDING("Pending Payment", "pending"),
-    PROCESSING("Processing", "processing"),
-    ON_HOLD("On-Hold", "on-hold"),
-    COMPLETED("Completed", "completed"),
-    CANCELLED("Cancelled", "cancelled"),
-    REFUNDED("Refunded", "refunded"),
-    FAILED("Failed", "failed");
+enum class CoreOrderStatus(val value: String) {
+    PENDING("pending"),
+    PROCESSING("processing"),
+    ON_HOLD("on-hold"),
+    COMPLETED("completed"),
+    CANCELLED("cancelled"),
+    REFUNDED("refunded"),
+    FAILED("failed");
 
     companion object {
-        private val labelMap = CoreOrderStatus.values().associateBy(CoreOrderStatus::label)
         private val valueMap = CoreOrderStatus.values().associateBy(CoreOrderStatus::value)
-
-        /**
-         * Convert the label value back into the associated CoreOrderStatus object
-         */
-        fun fromLabel(label: String) = labelMap[label]
 
         /**
          * Convert the base value into the associated CoreOrderStatus object


### PR DESCRIPTION
Drops the now-unused `label` property from `CoreOrderStatus` (it was replaced with app-side labels for internationalization purposes).

### To test
Build the WooCommerce app with this FluxC hash and ensure everything builds okay - the latest `develop` should already have all `CoreOrderStatus.label` usages removed.