### PR TITLE
Woo: Migrate to V3 API

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/endpoints/WCWPAPIEndpointTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/endpoints/WCWPAPIEndpointTest.kt
@@ -17,7 +17,6 @@ class WCWPAPIEndpointTest {
     @Test
     fun testAllUrls() {
         // Orders
-        assertEquals("/wc/v2/orders/", WOOCOMMERCE.orders.pathV2)
         assertEquals("/wc/v3/orders/", WOOCOMMERCE.orders.pathV3)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/endpoints/WCWPAPIEndpointTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/endpoints/WCWPAPIEndpointTest.kt
@@ -18,5 +18,6 @@ class WCWPAPIEndpointTest {
     fun testAllUrls() {
         // Orders
         assertEquals("/wc/v2/orders/", WOOCOMMERCE.orders.pathV2)
+        assertEquals("/wc/v3/orders/", WOOCOMMERCE.orders.pathV3)
     }
 }

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.annotations.endpoint;
 
 public class WCWPAPIEndpoint {
-    private static final String WC_PREFIX_V2 = "wc/v2";
     private static final String WC_PREFIX_V3 = "wc/v3";
 
     private final String mEndpoint;
@@ -20,10 +19,6 @@ public class WCWPAPIEndpoint {
 
     public String getEndpoint() {
         return mEndpoint;
-    }
-
-    public String getPathV2() {
-        return "/" + WC_PREFIX_V2 + mEndpoint;
     }
 
     public String getPathV3() {

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.annotations.endpoint;
 
 public class WCWPAPIEndpoint {
     private static final String WC_PREFIX_V2 = "wc/v2";
+    private static final String WC_PREFIX_V3 = "wc/v3";
 
     private final String mEndpoint;
 
@@ -23,5 +24,9 @@ public class WCWPAPIEndpoint {
 
     public String getPathV2() {
         return "/" + WC_PREFIX_V2 + mEndpoint;
+    }
+
+    public String getPathV3() {
+        return "/" + WC_PREFIX_V3 + mEndpoint;
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -37,7 +37,7 @@ class OrderRestClient(
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     /**
-     * Makes a GET call to `/wc/v2/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
+     * Makes a GET call to `/wc/v3/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * retrieving a list of orders for the given WooCommerce [SiteModel].
      *
      * The number of orders fetched is defined in [WCOrderStore.NUM_ORDERS_PER_FETCH], and retrieving older
@@ -52,7 +52,7 @@ class OrderRestClient(
         // If null, set the filter to the api default value of "any", which will not apply any order status filters.
         val statusFilter = if (filterByStatus.isNullOrBlank()) { "any" } else { filterByStatus!! }
 
-        val url = WOOCOMMERCE.orders.pathV2
+        val url = WOOCOMMERCE.orders.pathV3
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
         val params = mapOf(
                 "per_page" to WCOrderStore.NUM_ORDERS_PER_FETCH.toString(),
@@ -91,14 +91,14 @@ class OrderRestClient(
     }
 
     /**
-     * Makes a GET request to `/wc/v2/orders/{remoteOrderId}` to fetch a single order by the remoteOrderId
+     * Makes a GET request to `/wc/v3/orders/{remoteOrderId}` to fetch a single order by the remoteOrderId
      *
      * Dispatches a [WCOrderAction.FETCHED_SINGLE_ORDER] action with the result
      *
      * @param [remoteOrderId] Unique server id of the order to fetch
      */
     fun fetchSingleOrder(site: SiteModel, remoteOrderId: Long) {
-        val url = WOOCOMMERCE.orders.id(remoteOrderId).pathV2
+        val url = WOOCOMMERCE.orders.id(remoteOrderId).pathV3
         val responseType = object : TypeToken<OrderApiResponse>() {}.type
         val params = emptyMap<String, String>()
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
@@ -125,7 +125,7 @@ class OrderRestClient(
     }
 
     /**
-     * Makes a GET request to `/wc/v2/orders` for a single order of a specific type (or any type) in order to
+     * Makes a GET request to `/wc/v3/orders` for a single order of a specific type (or any type) in order to
      * determine if there are any orders in the store.
      *
      * Dispatches a [WCOrderAction.FETCHED_HAS_ORDERS] action with the result
@@ -135,7 +135,7 @@ class OrderRestClient(
     fun fetchHasOrders(site: SiteModel, filterByStatus: String? = null) {
         val statusFilter = if (filterByStatus.isNullOrBlank()) { "any" } else { filterByStatus!! }
 
-        val url = WOOCOMMERCE.orders.pathV2
+        val url = WOOCOMMERCE.orders.pathV3
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
         val params = mapOf(
                 "per_page" to "1",
@@ -161,7 +161,7 @@ class OrderRestClient(
     }
 
     /**
-     * Makes a PUT call to `/wc/v2/orders/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
+     * Makes a PUT call to `/wc/v3/orders/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * updating the status for the given [order] to [status].
      *
      * Dispatches a [WCOrderAction.UPDATED_ORDER_STATUS] with the updated [WCOrderModel].
@@ -171,7 +171,7 @@ class OrderRestClient(
      * [OrderErrorType.INVALID_ID] if an order by this id was not found on the server
      */
     fun updateOrderStatus(order: WCOrderModel, site: SiteModel, status: String) {
-        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).pathV2
+        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).pathV3
         val params = mapOf("status" to status)
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, params, OrderApiResponse::class.java,
                 { response: OrderApiResponse? ->
@@ -193,13 +193,13 @@ class OrderRestClient(
     }
 
     /**
-     * Makes a GET call to `/wc/v2/orders/<id>/notes` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
+     * Makes a GET call to `/wc/v3/orders/<id>/notes` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * retrieving a list of notes for the given WooCommerce [SiteModel] and [WCOrderModel].
      *
      * Dispatches a [WCOrderAction.FETCHED_ORDER_NOTES] action with the resulting list of order notes.
      */
     fun fetchOrderNotes(order: WCOrderModel, site: SiteModel) {
-        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).notes.pathV2
+        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).notes.pathV3
         val responseType = object : TypeToken<List<OrderNoteApiResponse>>() {}.type
         val params = emptyMap<String, String>()
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
@@ -223,13 +223,13 @@ class OrderRestClient(
     }
 
     /**
-     * Makes a POST call to `/wc/v2/orders/<id>/notes` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
+     * Makes a POST call to `/wc/v3/orders/<id>/notes` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * saving the provide4d note for the given WooCommerce [SiteModel] and [WCOrderModel].
      *
      * Dispatches a [WCOrderAction.POSTED_ORDER_NOTE] action with the resulting saved version of the order note.
      */
     fun postOrderNote(order: WCOrderModel, site: SiteModel, note: WCOrderNoteModel) {
-        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).notes.pathV2
+        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).notes.pathV3
 
         val params = mutableMapOf("note" to note.note, "customer_note" to note.isCustomerNote)
         val request = JetpackTunnelGsonRequest.buildPostRequest(


### PR DESCRIPTION
Replaces all uses of the `wc/v2` API with `wc/v3`. This is a non-breaking change, though this is a good time to take advantage of some improvements the V3 API offers - will be adding those in follow-up PRs.

This is targeting a feature branch, which we should hold off merging until after the next WooCommerce app release.

### To test
Run through the example app, make sure order-related calls are working as expected. Order note creation should work, but all created notes will be flagged as `system` - I'll be addressing that in a followup PR.