### PR TITLE
Woo: Differentiate system-generated order notes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -246,9 +246,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         assertEquals(WCOrderAction.FETCHED_ORDER_NOTES, lastAction!!.type)
         val payload = lastAction!!.payload as FetchOrderNotesResponsePayload
         assertNull(payload.error)
-        assertEquals(7, payload.notes.size)
+        assertEquals(8, payload.notes.size)
 
-        // Verify basic order fields and private note
+        // Verify basic order fields and private, system note
         with(payload.notes[0]) {
             assertEquals(1942, remoteNoteId)
             assertEquals("2018-04-27T20:48:10Z", dateCreated)
@@ -258,13 +258,22 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
                     "Email queued: Poster Purchase Follow-Up scheduled " +
                             "on Poster Purchase Follow-Up<br/>Trigger: Poster Purchase Follow-Up", note
             )
-            assertEquals(false, isCustomerNote)
+            assertFalse(isCustomerNote)
+            assertTrue(isSystemNote)
         }
 
-        // Verify customer note
+        // Verify private user-created note
         with(payload.notes[6]) {
-            assertEquals("Please gift wrap", note)
+            assertEquals("Interesting order!", note)
+            assertFalse(isCustomerNote)
+            assertFalse(isSystemNote)
+        }
+
+        // Verify customer-facing note
+        with(payload.notes[7]) {
+            assertEquals("Shipping soon!", note)
             assertTrue(isCustomerNote)
+            assertFalse(isSystemNote)
         }
     }
 
@@ -313,6 +322,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertNull(error)
             assertEquals(originalNote.note, note.note)
             assertEquals(originalNote.isCustomerNote, note.isCustomerNote)
+            assertFalse(note.isSystemNote) // Any note created from the app should be flagged as user-created
             assertEquals(originalNote.localOrderId, note.localOrderId)
             assertEquals(originalNote.localSiteId, note.localSiteId)
         }

--- a/example/src/androidTest/resources/wc-order-notes-response-success.json
+++ b/example/src/androidTest/resources/wc-order-notes-response-success.json
@@ -2,6 +2,7 @@
   "data": [
     {
       "id": 1942,
+      "author": "system",
       "date_created": "2018-04-27T16:48:10",
       "date_created_gmt": "2018-04-27T20:48:10",
       "note": "Email queued: Poster Purchase Follow-Up scheduled on Poster Purchase Follow-Up<br\/>Trigger: Poster Purchase Follow-Up",
@@ -26,6 +27,7 @@
     },
     {
       "id": 1943,
+      "author": "system",
       "date_created": "2018-04-27T16:48:10",
       "date_created_gmt": "2018-04-27T20:48:10",
       "note": "Order status changed from Pending payment to Completed.",
@@ -50,6 +52,7 @@
     },
     {
       "id": 1944,
+      "author": "system",
       "date_created": "2018-04-27T16:48:10",
       "date_created_gmt": "2018-04-27T20:48:10",
       "note": "Stripe charge complete (Charge ID: ch_1CLdUCJK48mSkzFLtLjQTpKt)",
@@ -74,6 +77,7 @@
     },
     {
       "id": 1940,
+      "author": "system",
       "date_created": "2018-04-27T16:48:09",
       "date_created_gmt": "2018-04-27T20:48:09",
       "note": "Booking #1053 status changed from \"Unpaid\" to \"Paid\"",
@@ -98,6 +102,7 @@
     },
     {
       "id": 1941,
+      "author": "system",
       "date_created": "2018-04-27T16:48:09",
       "date_created_gmt": "2018-04-27T20:48:09",
       "note": "Email queued: 48 Hour Email scheduled on April 28, 2018 10:00 am<br\/>Trigger: 48 hours Before Booked Date",
@@ -122,6 +127,7 @@
     },
     {
       "id": 1939,
+      "author": "system",
       "date_created": "2018-04-27T16:48:07",
       "date_created_gmt": "2018-04-27T20:48:07",
       "note": "Booking #1053 status changed from \"In Cart\" to \"Unpaid\"",
@@ -145,10 +151,36 @@
       }
     },
     {
+      "id": 1945,
+      "author": "Johnny Admin",
+      "date_created": "2018-11-26T09:31:23",
+      "date_created_gmt": "2018-11-26T14:31:23",
+      "note": "Interesting order!",
+      "customer_note": false,
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jamosova3.mystagingwebsite.com\/wp-json\/wc\/v3\/orders\/1660\/notes\/3036"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/jamosova3.mystagingwebsite.com\/wp-json\/wc\/v3\/orders\/1660\/notes"
+          }
+        ],
+        "up": [
+          {
+            "href": "https:\/\/jamosova3.mystagingwebsite.com\/wp-json\/wc\/v3\/orders\/1660"
+          }
+        ]
+      }
+    },
+    {
       "id": 1938,
+      "author": "Johnny Admin",
       "date_created": "2018-04-27T16:48:07",
       "date_created_gmt": "2018-04-27T20:48:07",
-      "note": "Please gift wrap",
+      "note": "Shipping soon!",
       "customer_note": true,
       "_links": {
         "self": [

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 44;
+        return 45;
     }
 
     @Override
@@ -371,6 +371,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                            + "UNIQUE(LIST_ID, REMOTE_ITEM_ID) ON CONFLICT IGNORE)");
                 db.execSQL("ALTER TABLE PostModel ADD LAST_MODIFIED TEXT");
                 oldVersion++;
+            case 44:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -434,6 +438,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                     AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
                     db.execSQL("CREATE TABLE WCOrderStatsModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                                + "LOCAL_SITE_ID INTEGER,UNIT TEXT NOT NULL,FIELDS TEXT NOT NULL,DATA TEXT NOT NULL)");
+                    break;
+                case 44:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("ALTER TABLE WCOrderNoteModel ADD IS_SYSTEM_NOTE INTEGER");
                     break;
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderNoteModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderNoteModel.kt
@@ -13,6 +13,9 @@ data class WCOrderNoteModel(@PrimaryKey @Column private var id: Int = 0) : Ident
     @Column var remoteNoteId = 0L // The unique identifier for this note on the server
     @Column var dateCreated = "" // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @Column var note = ""
+    @Column var isSystemNote = false // True if the note is 'system-created', else created by a site user
+        @JvmName("setIsSystemNote")
+        set
     @Column var isCustomerNote = false // False if private, else customer-facing. Default is false
         @JvmName("setIsCustomerNote")
         set

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
@@ -2,10 +2,12 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import org.wordpress.android.fluxc.network.Response
 
+@Suppress("PropertyName")
 class OrderNoteApiResponse : Response {
     val id: Long? = null
     val date_created_gmt: String? = null
     val note: String? = null
+    val author: String? = null
     // If true, the note will be shown to customers and they will be notified. If false, the note will be for admin
     // reference only. Default is false.
     val customer_note: Boolean = false

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -231,7 +231,11 @@ class OrderRestClient(
     fun postOrderNote(order: WCOrderModel, site: SiteModel, note: WCOrderNoteModel) {
         val url = WOOCOMMERCE.orders.id(order.remoteOrderId).notes.pathV3
 
-        val params = mutableMapOf("note" to note.note, "customer_note" to note.isCustomerNote)
+        val params = mutableMapOf(
+                "note" to note.note,
+                "customer_note" to note.isCustomerNote,
+                "added_by_user" to true
+        )
         val request = JetpackTunnelGsonRequest.buildPostRequest(
                 url, site.siteId, params, OrderNoteApiResponse::class.java,
                 { response: OrderNoteApiResponse? ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -312,6 +312,7 @@ class OrderRestClient(
             remoteNoteId = response.id ?: 0
             dateCreated = response.date_created_gmt?.let { "${it}Z" } ?: ""
             note = response.note ?: ""
+            isSystemNote = response.author == "system"
             isCustomerNote = response.customer_note
         }
     }


### PR DESCRIPTION
Updates our use of the order notes API to take advantage of some V3 API additions:

1. Fetched order notes now have an `author` field, which will either be `system` or the name of a user. Using this field we can classify private notes as being system or non-system in the UI.
2. Uploaded order notes are marked `author = system` by default, but by passing `added_by_user = true` we can flag them as user-created (all app-created notes are now flagged this way by default)

Should be merged after #993.

### To test
Run the tests, and inspect the network requests made from the example app for note fetching and uploading. Fetched notes should have `isSystemNote` reflect the status of the note in `wp-admin`, and uploaded notes should always be marked as user-generated in `wp-admin`.