### PR TITLE
Feature/997 woo order search

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -80,7 +80,16 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
         val statusFilter = "completed"
 
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, statusFilter, false)))
+        mDispatcher.dispatch(
+                WCOrderActionBuilder.newFetchOrdersAction(
+                        FetchOrdersPayload(
+                                sSite,
+                                statusFilter,
+                                keywordFilter = null,
+                                loadMore = false
+                        )
+                )
+        )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         val firstFetchOrders = orderStore.getOrdersForSite(sSite)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -173,14 +173,14 @@ class WooCommerceFragment : Fragment() {
                 showSingleLineDialog(activity, "Enter a keyword to filter by:") { editText ->
                     pendingFetchOrdersKeyword = editText.text.toString()
                     prependToLog("Submitting request to fetch orders matching keyword $pendingFetchOrdersKeyword")
+                    val payload = FetchOrdersPayload(
+                            site,
+                            statusFilter = null,
+                            keywordFilter = pendingFetchOrdersKeyword,
+                            loadMore = false
+                    )
+                    dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
                 }
-                val payload = FetchOrdersPayload(
-                        site,
-                        statusFilter = null,
-                        keywordFilter = pendingFetchOrdersKeyword,
-                        loadMore = false
-                )
-                dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
             }
         }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -61,7 +61,6 @@ class WooCommerceFragment : Fragment() {
     private var pendingFetchOrdersFilter: List<String>? = null
     private var pendingFetchCompletedOrders: Boolean = false
     private var pendingFetchSingleOrderRemoteId: Long? = null
-    private var pendingFetchOrdersKeyword: String ? = null
 
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
@@ -171,12 +170,12 @@ class WooCommerceFragment : Fragment() {
         fetch_orders_by_keyword.setOnClickListener {
             getFirstWCSite()?.let { site ->
                 showSingleLineDialog(activity, "Enter a keyword to filter by:") { editText ->
-                    pendingFetchOrdersKeyword = editText.text.toString()
-                    prependToLog("Submitting request to fetch orders matching keyword $pendingFetchOrdersKeyword")
+                    val keyword = editText.text.toString()
+                    prependToLog("Submitting request to fetch orders matching keyword $keyword")
                     val payload = FetchOrdersPayload(
                             site,
                             statusFilter = null,
-                            keywordFilter = pendingFetchOrdersKeyword,
+                            keywordFilter = keyword,
                             loadMore = false
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
@@ -309,10 +308,9 @@ class WooCommerceFragment : Fragment() {
                 when (event.causeOfChange) {
                     FETCH_ORDERS -> {
                         when {
-                            pendingFetchOrdersKeyword != null -> {
+                            !event.keywordFilter.isNullOrBlank() -> {
                                 prependToLog("Fetched ${event.rowsAffected} orders from: ${site.name} " +
-                                        "matching keyword $pendingFetchOrdersKeyword")
-                                pendingFetchOrdersKeyword = null
+                                        "matching keyword ${event.keywordFilter}")
                             }
                             pendingFetchOrdersFilter != null -> {
                                 // get orders and group by order.status

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -316,8 +316,10 @@ class WooCommerceFragment : Fragment() {
                             }
                             pendingFetchOrdersFilter != null -> {
                                 // get orders and group by order.status
-                                val orders = wcOrderStore.getOrdersForSite(site, *pendingFetchOrdersFilter!!.toTypedArray())
-                                        .groupBy { order -> order.status }
+                                val orders = wcOrderStore.getOrdersForSite(
+                                        site,
+                                        *pendingFetchOrdersFilter!!.toTypedArray()
+                                ).groupBy { order -> order.status }
                                 // print count of orders fetched by filtered status
                                 pendingFetchOrdersFilter!!.forEach { status ->
                                     prependToLog("Fetched ${orders[status]?.count() ?: 0} orders for status [$status]")

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -59,6 +59,12 @@
             android:text="Fetch Completed Orders (API)"/>
 
         <Button
+            android:id="@+id/fetch_orders_by_keyword"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fetch Orders Filtered by Keyword"/>
+
+        <Button
             android:id="@+id/fetch_order_notes"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -56,18 +56,17 @@ class OrderRestClient(
         filterByKeyword: String? = null,
         countOnly: Boolean = false
     ) {
-        // If null, set the filter to the api default value of "any", which will not apply any order status filters.
-        val statusFilter = if (filterByStatus.isNullOrBlank()) { "any" } else { filterByStatus!! }
+        // If null, set the status filter to the api default value of "any", which will not apply any order status filters.
+        val statusFilter = if (filterByStatus.isNullOrBlank()) "any" else filterByStatus!!
+        val keywordFilter = if (filterByKeyword.isNullOrBlank()) "" else filterByKeyword!!
 
         val url = WOOCOMMERCE.orders.pathV3
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
         val params = mapOf(
                 "per_page" to WCOrderStore.NUM_ORDERS_PER_FETCH.toString(),
                 "offset" to offset.toString(),
-                "status" to statusFilter)
-        filterByKeyword?.let {
-            params.entries.plus("search" to it)
-        }
+                "status" to statusFilter,
+                "search" to keywordFilter)
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderApiResponse>? ->
                     val orderModels = response?.map {


### PR DESCRIPTION
Resolves #997 - adds the ability to search orders. Rather than create a ton of new code I chose to piggyback on the existing `fetchOrders()` routine, as we did when we added filtering by status.