### PR TITLE
Add missing migration of refreshed stats

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -12,7 +12,7 @@ class TimeStatsMapper
     fun map(response: PostAndPageViewsResponse, pageSize: Int): PostAndPageViewsModel {
         val postViews = response.days.entries.first().value.postViews
         val stats = postViews.take(pageSize).mapNotNull { item ->
-            val type = when(item.type) {
+            val type = when (item.type) {
                 "post" -> ViewsType.POST
                 "page" -> ViewsType.PAGE
                 else -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -3,14 +3,24 @@ package org.wordpress.android.fluxc.model.stats.time
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsModel
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.STATS
 import javax.inject.Inject
 
 class TimeStatsMapper
 @Inject constructor() {
     fun map(response: PostAndPageViewsResponse, pageSize: Int): PostAndPageViewsModel {
         val postViews = response.days.entries.first().value.postViews
-        val stats = postViews.take(pageSize).map {
-            ViewsModel(it.title, it.views, ViewsType.valueOf(it.type))
+        val stats = postViews.take(pageSize).mapNotNull { item ->
+            val type = when(item.type) {
+                "post" -> ViewsType.POST
+                "page" -> ViewsType.PAGE
+                else -> {
+                    AppLog.e(STATS, "PostAndPageViewsResponse.type: Unexpected view type: ${item.type}")
+                    null
+                }
+            }
+            type?.let { ViewsModel(item.title, item.views, type) }
         }
         return PostAndPageViewsModel(stats, postViews.size > pageSize)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 44;
+        return 45;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -371,6 +371,13 @@ public class WellSqlConfig extends DefaultWellConfig {
                            + "UNIQUE(LIST_ID, REMOTE_ITEM_ID) ON CONFLICT IGNORE)");
                 db.execSQL("ALTER TABLE PostModel ADD LAST_MODIFIED TEXT");
                 oldVersion++;
+            case 44:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS StatsBlock");
+                db.execSQL(
+                        "CREATE TABLE StatsBlock (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,JSON TEXT NOT NULL)");
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();


### PR DESCRIPTION
- the migration step was missing after adding new fields to the Stats cache table
- As part of this PR I've also fixed the incorrect Enum mapping 