### PR TITLE
Feature/997 woo order search take2

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -108,6 +109,33 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals("60.00", discountTotal)
             assertEquals("20\$off, 40\$off", discountCodes)
         }
+    }
+
+    @Test
+    fun testSearchOrdersSuccess() {
+        interceptor.respondWith("wc-orders-response-success.json")
+        orderRestClient.searchOrders(siteModel, "")
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.SEARCHED_ORDERS, lastAction!!.type)
+        val payload = lastAction!!.payload as SearchOrdersResponsePayload
+        assertNull(payload.error)
+        assertEquals(4, payload.orders.size)
+    }
+
+    @Test
+    fun testSearchOrdersError() {
+        interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
+        orderRestClient.searchOrders(SiteModel(), "")
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.SEARCHED_ORDERS, lastAction!!.type)
+        val payload = lastAction!!.payload as SearchOrdersResponsePayload
+        assertNotNull(payload.error)
     }
 
     @Test

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_SINGLE_ORDER
 import org.wordpress.android.fluxc.action.WCOrderAction.POST_ORDER_NOTE
-import org.wordpress.android.fluxc.action.WCOrderAction.SEARCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.action.WCStatsAction
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
@@ -36,6 +35,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrdersSearched
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
@@ -332,9 +332,6 @@ class WooCommerceFragment : Fragment() {
                             orders.take(5).forEach { prependToLog("- remoteOrderId [${it.remoteOrderId}]") }
                         }
                     }
-                    SEARCH_ORDERS -> {
-                        prependToLog("Found ${event.rowsAffected} orders matching ${event.searchQuery}")
-                    }
                     FETCH_ORDERS_COUNT -> {
                         val append = if (event.canLoadMore) "+" else ""
                         event.statusFilter?.let {
@@ -375,6 +372,16 @@ class WooCommerceFragment : Fragment() {
                     else -> prependToLog("Order store was updated from a " + event.causeOfChange)
                 }
             }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onOrdersSearched(event: OnOrdersSearched) {
+        if (event.isError) {
+            prependToLog("Error searching orders - error: " + event.error.type)
+        } else {
+            prependToLog("Found ${event.searchResults.size} orders matching ${event.searchQuery}")
         }
     }
 

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -59,6 +59,12 @@
             android:text="Fetch Completed Orders (API)"/>
 
         <Button
+            android:id="@+id/search_orders"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Search Orders"/>
+
+        <Button
             android:id="@+id/fetch_order_notes"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -15,6 +15,8 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload;
 
 @ActionEnum
@@ -34,6 +36,8 @@ public enum WCOrderAction implements IAction {
     POST_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersPayload.class)
     FETCH_HAS_ORDERS,
+    @Action(payloadType = SearchOrdersPayload.class)
+    SEARCH_ORDERS,
 
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
@@ -49,5 +53,7 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = RemoteOrderNotePayload.class)
     POSTED_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersResponsePayload.class)
-    FETCHED_HAS_ORDERS
+    FETCHED_HAS_ORDERS,
+    @Action(payloadType = SearchOrdersResponsePayload.class)
+    SEARCHED_ORDERS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.store.WCOrderStore
-import org.wordpress.android.fluxc.store.WCOrderStore.Companion.DEFAULT_ORDER_STATUS
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
@@ -52,7 +51,11 @@ class OrderRestClient(
      */
     fun fetchOrders(site: SiteModel, offset: Int, filterByStatus: String? = null, countOnly: Boolean = false) {
         // If null, set the filter to the api default value of "any", which will not apply any order status filters.
-        val statusFilter = if (filterByStatus.isNullOrBlank()) { "any" } else { filterByStatus!! }
+        val statusFilter = if (filterByStatus.isNullOrBlank()) {
+            WCOrderStore.DEFAULT_ORDER_STATUS
+        } else {
+            filterByStatus!!
+        }
 
         val url = WOOCOMMERCE.orders.pathV3
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
@@ -107,7 +110,7 @@ class OrderRestClient(
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
         val params = mapOf(
                 "per_page" to WCOrderStore.NUM_ORDERS_PER_SEARCH.toString(),
-                "status" to DEFAULT_ORDER_STATUS,
+                "status" to WCOrderStore.DEFAULT_ORDER_STATUS,
                 "search" to searchQuery)
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderApiResponse>? ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -98,15 +98,14 @@ class OrderRestClient(
         val params = mapOf(
                 "per_page" to WCOrderStore.NUM_ORDERS_PER_SEARCH.toString(),
                 "status" to DEFAULT_ORDER_STATUS,
-                "searcg" to searchQuery)
+                "search" to searchQuery)
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderApiResponse>? ->
                     val orderModels = response?.map {
                         orderResponseToOrderModel(it).apply { localSiteId = site.id }
                     }.orEmpty()
 
-                    val payload = SearchOrdersResponsePayload(
-                            site, orderModels, searchQuery)
+                    val payload = SearchOrdersResponsePayload(site, searchQuery, orderModels)
                     mDispatcher.dispatch(WCOrderActionBuilder.newSearchedOrdersAction(payload))
                 },
                 WPComErrorListener { networkError ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -123,7 +123,7 @@ class OrderRestClient(
                 },
                 WPComErrorListener { networkError ->
                     val orderError = networkErrorToOrderError(networkError)
-                    val payload = SearchOrdersResponsePayload(orderError, site)
+                    val payload = SearchOrdersResponsePayload(orderError, site, searchQuery)
                     mDispatcher.dispatch(WCOrderActionBuilder.newSearchedOrdersAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -92,6 +92,16 @@ class OrderRestClient(
         add(request)
     }
 
+    /**
+     * Makes a GET call to `/wc/v3/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
+     * retrieving a list of orders for the given WooCommerce [SiteModel] matching [searchQuery]
+     *
+     * The number of orders fetched is defined in [WCOrderStore.NUM_ORDERS_PER_SEARCH]
+     *
+     * Dispatches a [WCOrderAction.SEARCHED_ORDERS] action with the resulting list of orders.
+     *
+     * @param [searchQuery] the keyword or phrase to match orders with
+     */
     fun searchOrders(site: SiteModel, searchQuery: String) {
         val url = WOOCOMMERCE.orders.pathV3
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -161,14 +161,14 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         var rowsAffected: Int,
         var statusFilter: String? = null,
         var canLoadMore: Boolean = false
-    ): OnChanged<OrderError>() {
+    ) : OnChanged<OrderError>() {
         var causeOfChange: WCOrderAction? = null
     }
 
     class OnOrdersSearched(
         var searchQuery: String = "",
         var searchResults: List<WCOrderModel> = emptyList()
-    ): OnChanged<OrderError>()
+    ) : OnChanged<OrderError>()
 
     override fun onRegister() = AppLog.d(T.API, "WCOrderStore onRegister")
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -5,9 +5,9 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.WCOrderAction
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
-import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.POST_ORDER_NOTE
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
@@ -16,8 +16,8 @@ import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import org.wordpress.android.util.AppLog
@@ -31,6 +31,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     : Store(dispatcher) {
     companion object {
         const val NUM_ORDERS_PER_FETCH = 25
+        const val NUM_ORDERS_PER_SEARCH = 100
+        const val DEFAULT_ORDER_STATUS = "any"
     }
 
     class FetchOrdersPayload(
@@ -47,6 +49,19 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         var canLoadMore: Boolean = false
     ) : Payload<OrderError>() {
         constructor(error: OrderError, site: SiteModel) : this(site) { this.error = error }
+    }
+
+    class SearchOrdersPayload(
+        var site: SiteModel,
+        var searchQuery: String
+    ) : Payload<BaseNetworkError>()
+
+    class SearchOrdersResponsePayload(
+        var site: SiteModel,
+        var searchQuery: String,
+        var orders: List<WCOrderModel> = emptyList()
+    ) : Payload<OrderError>() {
+        constructor(error: OrderError, site: SiteModel) : this(site, "") { this.error = error }
     }
 
     class FetchOrdersCountPayload(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -285,7 +285,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     private fun handleSearchOrdersCompleted(payload: SearchOrdersResponsePayload) {
         val onOrdersSearched = if (payload.isError) {
-            OnOrdersSearched("", emptyList()).also { it.error = payload.error }
+            OnOrdersSearched(payload.searchQuery, emptyList()).also { it.error = payload.error }
         } else {
             OnOrdersSearched(payload.searchQuery, payload.orders)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -31,7 +31,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     : Store(dispatcher) {
     companion object {
         const val NUM_ORDERS_PER_FETCH = 25
-        const val NUM_ORDERS_PER_SEARCH = 100
+        const val NUM_ORDERS_PER_SEARCH = 50
         const val DEFAULT_ORDER_STATUS = "any"
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -61,7 +61,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         var searchQuery: String,
         var orders: List<WCOrderModel> = emptyList()
     ) : Payload<OrderError>() {
-        constructor(error: OrderError, site: SiteModel) : this(site, "") { this.error = error }
+        constructor(error: OrderError, site: SiteModel, query: String) : this(site, query) { this.error = error }
     }
 
     class FetchOrdersCountPayload(


### PR DESCRIPTION
Resolves #997 - adds WooCommerce order search. Note that for now paging isn't supported, but this will come later. I want to tackle some of the related UI work before addressing paging.