### PR TITLE
Properly translate remoteSiteId to localSiteId before storing notific…

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsRes
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.NotificationAppKey
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
+import org.wordpress.android.fluxc.store.SiteStore
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -30,6 +31,7 @@ import kotlin.properties.Delegates
 class MockedStack_NotificationTest : MockedStack_Base() {
     @Inject internal lateinit var notificationRestClient: NotificationRestClient
     @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var siteStore: SiteStore
 
     @Inject internal lateinit var interceptor: ResponseMockingInterceptor
 
@@ -119,7 +121,7 @@ class MockedStack_NotificationTest : MockedStack_Base() {
     @Test
     fun testFetchNotificationsSuccess() {
         interceptor.respondWith("fetch-notifications-response-success.json")
-        notificationRestClient.fetchNotifications()
+        notificationRestClient.fetchNotifications(siteStore)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -38,7 +38,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it)
+            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
         } ?: emptyList()
 
         // Test inserting notifications
@@ -54,7 +54,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it)
+            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(5, inserted)
@@ -73,7 +73,8 @@ class NotificationSqlUtilsTest {
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it)
+            val siteId = NotificationApiResponse.getRemoteSiteId(it)
+            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(5, inserted)
@@ -91,7 +92,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/store-order-notification.json")
         val apiResponse = NotificationTestUtils.parseNotificationApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 141286411 }
-        val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse))
+        val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse, site.id))
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(1, inserted)
 
@@ -171,7 +172,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/store-review-notification.json")
         val apiResponse = NotificationTestUtils.parseNotificationApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
-        val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse))
+        val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse, site.id))
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(1, inserted)
 
@@ -208,7 +209,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it)
+            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(5, inserted)
@@ -239,7 +240,8 @@ class NotificationSqlUtilsTest {
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it)
+            val siteId = NotificationApiResponse.getRemoteSiteId(it)
+            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(5, inserted)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/NotificationModel.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 data class NotificationModel(
     val noteId: Int,
     val remoteNoteId: Long,
-    val localSiteId: Long?,
+    val localSiteId: Int,
     val noteHash: Long,
     val type: Kind,
     val subtype: Subkind?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationApiResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationApiResponse.kt
@@ -22,7 +22,8 @@ class NotificationApiResponse : Response {
 
     companion object {
         fun notificationResponseToNotificationModel(
-            response: NotificationApiResponse
+            response: NotificationApiResponse,
+            siteId: Int
         ): NotificationModel {
             val noteType = response.type?.let {
                 NotificationModel.Kind.fromString(response.type)
@@ -35,7 +36,7 @@ class NotificationApiResponse : Response {
             return NotificationModel(
                     noteId = 0,
                     remoteNoteId = response.id ?: 0,
-                    localSiteId = response.meta?.ids?.site,
+                    localSiteId = siteId,
                     noteHash = response.note_hash ?: 0L,
                     type = noteType,
                     subtype = noteSubType,
@@ -49,5 +50,7 @@ class NotificationApiResponse : Response {
                     subject = response.subject,
                     meta = response.meta)
         }
+
+        fun getRemoteSiteId(response: NotificationApiResponse): Long? = response.meta?.ids?.site
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -143,7 +143,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
     data class NotificationModelBuilder(
         @PrimaryKey @Column private var mId: Int = -1,
         @Column var remoteNoteId: Long,
-        @Column var localSiteId: Long?,
+        @Column var localSiteId: Int,
         @Column var noteHash: Long,
         @Column var type: String,
         @Column var subtype: String? = null,
@@ -157,7 +157,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
         @Column var formattableSubject: String? = null,
         @Column var formattableMeta: String? = null
     ) : Identifiable {
-        constructor() : this(-1, 0L, 0, 0L, NotificationModel.Kind.STORE_ORDER.toString())
+        constructor() : this(-1, 0L, -1, 0, NotificationModel.Kind.STORE_ORDER.toString())
         override fun setId(id: Int) {
             this.mId = id
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -31,7 +31,8 @@ constructor(
     dispatcher: Dispatcher,
     private val context: Context,
     private val notificationRestClient: NotificationRestClient,
-    private val notificationSqlUtils: NotificationSqlUtils
+    private val notificationSqlUtils: NotificationSqlUtils,
+    private val siteStore: SiteStore
 ) : Store(dispatcher) {
     companion object {
         const val WPCOM_PUSH_DEVICE_UUID = "NOTIFICATIONS_UUID_PREF_KEY"
@@ -251,7 +252,8 @@ constructor(
     }
 
     private fun fetchNotifications() {
-        notificationRestClient.fetchNotifications()
+        // get a map of all the cached sites
+        notificationRestClient.fetchNotifications(siteStore)
     }
 
     private fun handleFetchNotificationsCompleted(payload: FetchNotificationsResponsePayload) {


### PR DESCRIPTION
Fixes #1016 

Uses the `SiteStore` to query for the matching `local_site_id` using the remote site id. This value is then stored in the NotificationModelTable and allows for querying the database for notifications matching the current site on Woo.