### PR TITLE
VerticalStore: Minor fixes and Additions

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/VerticalAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/VerticalAction.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.action
 import org.wordpress.android.fluxc.annotations.Action
 import org.wordpress.android.fluxc.annotations.ActionEnum
 import org.wordpress.android.fluxc.annotations.action.IAction
+import org.wordpress.android.fluxc.store.VerticalStore.FetchSegmentPromptPayload
 import org.wordpress.android.fluxc.store.VerticalStore.FetchVerticalsPayload
 
 @ActionEnum
@@ -10,5 +11,7 @@ enum class VerticalAction : IAction {
     @Action
     FETCH_SEGMENTS,
     @Action(payloadType = FetchVerticalsPayload::class)
-    FETCH_VERTICALS
+    FETCH_VERTICALS,
+    @Action(payloadType = FetchSegmentPromptPayload::class)
+    FETCH_SEGMENT_PROMPT
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/vertical/SegmentPromptModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/vertical/SegmentPromptModel.kt
@@ -1,0 +1,3 @@
+package org.wordpress.android.fluxc.model.vertical
+
+data class SegmentPromptModel(val title: String, val subtitle: String, val hint: String)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/vertical/VerticalModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/vertical/VerticalModel.kt
@@ -1,3 +1,3 @@
 package org.wordpress.android.fluxc.model.vertical
 
-data class VerticalModel(val name: String, val verticalId: String)
+data class VerticalModel(val name: String, val verticalId: String, val isNewUserVertical: Boolean)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/vertical/VerticalSegmentModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/vertical/VerticalSegmentModel.kt
@@ -1,3 +1,9 @@
 package org.wordpress.android.fluxc.model.vertical
 
-data class VerticalSegmentModel(val title: String, val subtitle: String, val iconUrl: String, val segmentId: Long)
+data class VerticalSegmentModel(
+    val title: String,
+    val subtitle: String,
+    val iconUrl: String,
+    val iconColor: String,
+    val segmentId: Long
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedSegmentPromptPayload
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedSegmentsPayload
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedVerticalsPayload
-import java.util.Random
 import javax.inject.Singleton
 
 @Singleton
@@ -53,14 +52,14 @@ constructor(
         return FetchedSegmentPromptPayload(prompt)
     }
 
-    suspend fun fetchVerticals(searchQuery: String): FetchedVerticalsPayload {
+    suspend fun fetchVerticals(searchQuery: String, limit: Int): FetchedVerticalsPayload {
         // TODO: Implement the actual call
         delay(1000)
-        val verticalList = (1..100).map {
+        val verticalList = (1..limit).map {
             VerticalModel(
                     name = "name-$it",
                     verticalId = "vertical-id-$it",
-                    isNewUserVertical = it == 1
+                    isNewUserVertical = it == limit
             )
         }
         return FetchedVerticalsPayload(verticalList)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedSegmentPromptPayload
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedSegmentsPayload
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedVerticalsPayload
+import java.util.Random
 import javax.inject.Singleton
 
 @Singleton
@@ -55,7 +56,13 @@ constructor(
     suspend fun fetchVerticals(searchQuery: String): FetchedVerticalsPayload {
         // TODO: Implement the actual call
         delay(1000)
-        val verticalList = (1..100).map { VerticalModel(name = "name-$it", verticalId = "vertical-id-$it") }
+        val verticalList = (1..100).map {
+            VerticalModel(
+                    name = "name-$it",
+                    verticalId = "vertical-id-$it",
+                    isNewUserVertical = it == 1
+            )
+        }
         return FetchedVerticalsPayload(verticalList)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
@@ -32,6 +32,7 @@ constructor(
                     title = "title-$it",
                     subtitle = "subtitle-$it",
                     iconUrl = "https://picsum.photos/50",
+                    iconColor = "#0000FF",
                     segmentId = it
             )
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import com.android.volley.RequestQueue
 import kotlinx.coroutines.experimental.delay
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.vertical.SegmentPromptModel
 import org.wordpress.android.fluxc.model.vertical.VerticalModel
 import org.wordpress.android.fluxc.model.vertical.VerticalSegmentModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.VerticalStore.FetchedSegmentPromptPayload
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedSegmentsPayload
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedVerticalsPayload
 import javax.inject.Singleton
@@ -37,6 +39,17 @@ constructor(
             )
         }
         return FetchedSegmentsPayload(segmentList)
+    }
+
+    suspend fun fetchSegmentPrompt(segmentId: Long): FetchedSegmentPromptPayload {
+        // TODO: Implement the actual call
+        delay(1000)
+        val prompt = SegmentPromptModel(
+                title = "Title-$segmentId",
+                subtitle = "Subtitle-$segmentId",
+                hint = "Hint-$segmentId"
+        )
+        return FetchedSegmentPromptPayload(prompt)
     }
 
     suspend fun fetchVerticals(searchQuery: String): FetchedVerticalsPayload {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/VerticalStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/VerticalStore.kt
@@ -66,7 +66,7 @@ class VerticalStore @Inject constructor(
     class OnVerticalsFetched(
         val searchQuery: String,
         val verticalList: List<VerticalModel>,
-        error: FetchVerticalsError
+        error: FetchVerticalsError?
     ) : Store.OnChanged<FetchVerticalsError>() {
         init {
             this.error = error

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/VerticalStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/VerticalStore.kt
@@ -19,6 +19,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.CoroutineContext
 
+private const val DEFAULT_FETCH_VERTICAL_LIMIT = 5
+
 @Singleton
 class VerticalStore @Inject constructor(
     private val verticalRestClient: VerticalRestClient,
@@ -58,7 +60,7 @@ class VerticalStore @Inject constructor(
     }
 
     private suspend fun fetchVerticals(payload: FetchVerticalsPayload): OnVerticalsFetched {
-        val fetchedVerticalsPayload = verticalRestClient.fetchVerticals(payload.searchQuery)
+        val fetchedVerticalsPayload = verticalRestClient.fetchVerticals(payload.searchQuery, payload.limit)
         return OnVerticalsFetched(
                 searchQuery = payload.searchQuery,
                 verticalList = fetchedVerticalsPayload.verticalList,
@@ -95,7 +97,7 @@ class VerticalStore @Inject constructor(
         }
     }
 
-    class FetchVerticalsPayload(val searchQuery: String)
+    class FetchVerticalsPayload(val searchQuery: String, val limit: Int = DEFAULT_FETCH_VERTICAL_LIMIT)
     class FetchSegmentPromptPayload(val segmentId: Long)
 
     class FetchedSegmentsPayload(val segmentList: List<VerticalSegmentModel>) : Payload<FetchSegmentsError>()


### PR DESCRIPTION
Fixes #983 & #1011. This PR is a combination of the following minor changes and additions:

1. Makes `OnVerticalsFetched`s error `nullable`
2. Adds `iconColor` to `VerticalSegmentModel`
3. Adds an action to fetch the prompt for the given segment
4. Adds `isNewUserVertical` to `VerticalModel`
5. Adds a limit to the fetch verticals `FetchVerticalsPayload` with a default value of `5`.

Similar to the previous PR, we are waiting for the things to finalize before we add tests for the changes.

