### PR TITLE
Issue/1020 woo order search paging

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -114,7 +114,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     @Test
     fun testSearchOrdersSuccess() {
         interceptor.respondWith("wc-orders-response-success.json")
-        orderRestClient.searchOrders(siteModel, "")
+        orderRestClient.searchOrders(siteModel, "", 0)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -128,7 +128,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     @Test
     fun testSearchOrdersError() {
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
-        orderRestClient.searchOrders(SiteModel(), "")
+        orderRestClient.searchOrders(SiteModel(), "", 0)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -101,7 +101,15 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.SEARCHED_ORDERS
         mCountDownLatch = CountDownLatch(1)
 
-        mDispatcher.dispatch(WCOrderActionBuilder.newSearchOrdersAction(SearchOrdersPayload(sSite, orderSearchQuery)))
+        mDispatcher.dispatch(
+                WCOrderActionBuilder.newSearchOrdersAction(
+                        SearchOrdersPayload(
+                                sSite,
+                                orderSearchQuery,
+                                0
+                        )
+                )
+        )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -124,7 +124,7 @@ class WooCommerceFragment : Fragment() {
                     val searchQuery = editText.text.toString().trim().takeIf { it.isNotEmpty() }
                     searchQuery?.let {
                         prependToLog("Submitting request to search orders matching $it")
-                        val payload = SearchOrdersPayload(site, searchQuery)
+                        val payload = SearchOrdersPayload(site, searchQuery, 0)
                         dispatcher.dispatch(WCOrderActionBuilder.newSearchOrdersAction(payload))
                     } ?: prependToLog("No search query entered")
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -120,12 +120,13 @@ class OrderRestClient(
                     }.orEmpty()
 
                     val canLoadMore = orderModels.size == WCOrderStore.NUM_ORDERS_PER_FETCH
-                    val payload = SearchOrdersResponsePayload(site, searchQuery, offset, canLoadMore, orderModels)
+                    val nextOffset = offset + orderModels.size
+                    val payload = SearchOrdersResponsePayload(site, searchQuery, canLoadMore, nextOffset, orderModels)
                     mDispatcher.dispatch(WCOrderActionBuilder.newSearchedOrdersAction(payload))
                 },
                 WPComErrorListener { networkError ->
                     val orderError = networkErrorToOrderError(networkError)
-                    val payload = SearchOrdersResponsePayload(orderError, site, searchQuery, offset)
+                    val payload = SearchOrdersResponsePayload(orderError, site, searchQuery)
                     mDispatcher.dispatch(WCOrderActionBuilder.newSearchedOrdersAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -31,7 +31,6 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     : Store(dispatcher) {
     companion object {
         const val NUM_ORDERS_PER_FETCH = 25
-        const val NUM_ORDERS_PER_SEARCH = 50
         const val DEFAULT_ORDER_STATUS = "any"
     }
 
@@ -53,15 +52,20 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     class SearchOrdersPayload(
         var site: SiteModel,
-        var searchQuery: String
+        var searchQuery: String,
+        var offset: Int
     ) : Payload<BaseNetworkError>()
 
     class SearchOrdersResponsePayload(
         var site: SiteModel,
         var searchQuery: String,
+        var offset: Int = 0,
+        var canLoadMore: Boolean = false,
         var orders: List<WCOrderModel> = emptyList()
     ) : Payload<OrderError>() {
-        constructor(error: OrderError, site: SiteModel, query: String) : this(site, query) { this.error = error }
+        constructor(error: OrderError, site: SiteModel, query: String, offset: Int) : this(site, query, offset) {
+            this.error = error
+        }
     }
 
     class FetchOrdersCountPayload(
@@ -232,7 +236,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     private fun searchOrders(payload: SearchOrdersPayload) {
-        wcOrderRestClient.searchOrders(payload.site, payload.searchQuery)
+        wcOrderRestClient.searchOrders(payload.site, payload.searchQuery, payload.offset)
     }
 
     private fun fetchOrdersCount(payload: FetchOrdersCountPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -171,6 +171,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     class OnOrdersSearched(
         var searchQuery: String = "",
+        var canLoadMore: Boolean = false,
+        var offset: Int = 0,
         var searchResults: List<WCOrderModel> = emptyList()
     ) : OnChanged<OrderError>()
 
@@ -289,9 +291,9 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     private fun handleSearchOrdersCompleted(payload: SearchOrdersResponsePayload) {
         val onOrdersSearched = if (payload.isError) {
-            OnOrdersSearched(payload.searchQuery, emptyList()).also { it.error = payload.error }
+            OnOrdersSearched(payload.searchQuery)
         } else {
-            OnOrdersSearched(payload.searchQuery, payload.orders)
+            OnOrdersSearched(payload.searchQuery, payload.canLoadMore, payload.offset, payload.orders)
         }
         emitChange(onOrdersSearched)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -59,11 +59,11 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     class SearchOrdersResponsePayload(
         var site: SiteModel,
         var searchQuery: String,
-        var offset: Int = 0,
         var canLoadMore: Boolean = false,
+        var offset: Int = 0,
         var orders: List<WCOrderModel> = emptyList()
     ) : Payload<OrderError>() {
-        constructor(error: OrderError, site: SiteModel, query: String, offset: Int) : this(site, query, offset) {
+        constructor(error: OrderError, site: SiteModel, query: String) : this(site, query) {
             this.error = error
         }
     }
@@ -172,7 +172,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     class OnOrdersSearched(
         var searchQuery: String = "",
         var canLoadMore: Boolean = false,
-        var offset: Int = 0,
+        var nextOffset: Int = 0,
         var searchResults: List<WCOrderModel> = emptyList()
     ) : OnChanged<OrderError>()
 


### PR DESCRIPTION
Resolves #1020 - adds paging to the WooCommerce order search so clients can support infinite scroll.