### PR TITLE
Add date to stats endpoints

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -117,13 +117,21 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
     fun testFetchClicks() {
         val site = authenticate()
 
-        for (period in StatsGranularity.values()) {
-            val fetchedInsights = runBlocking { clicksStore.fetchClicks(site, PAGE_SIZE, period, true) }
+        for (granularity in StatsGranularity.values()) {
+            val fetchedInsights = runBlocking {
+                clicksStore.fetchClicks(
+                        site,
+                        PAGE_SIZE,
+                        granularity,
+                        SELECTED_DATE,
+                        true
+                )
+            }
 
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = clicksStore.getClicks(site, period, PAGE_SIZE)
+            val insightsFromDb = clicksStore.getClicks(site, granularity, PAGE_SIZE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -26,11 +26,13 @@ import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.fluxc.store.stats.time.ReferrersStore
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 private const val PAGE_SIZE = 8
+private val SELECTED_DATE = Date(10)
 
 /**
  * Tests with real credentials on real servers using the full release stack (no mock)
@@ -71,7 +73,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                 postAndPageViewsStore.fetchPostAndPageViews(
                         site,
                         PAGE_SIZE,
-                        granularity,
+                        granularity, SELECTED_DATE,
                         true
                 )
             }
@@ -79,7 +81,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = postAndPageViewsStore.getPostAndPageViews(site, granularity, PAGE_SIZE)
+            val insightsFromDb = postAndPageViewsStore.getPostAndPageViews(site, granularity, SELECTED_DATE, PAGE_SIZE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -90,12 +92,20 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         for (granularity in StatsGranularity.values()) {
-            val fetchedInsights = runBlocking { referrersStore.fetchReferrers(site, PAGE_SIZE, granularity, true) }
+            val fetchedInsights = runBlocking {
+                referrersStore.fetchReferrers(
+                        site,
+                        PAGE_SIZE,
+                        granularity,
+                        SELECTED_DATE,
+                        true
+                )
+            }
 
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = referrersStore.getReferrers(site, granularity, PAGE_SIZE)
+            val insightsFromDb = referrersStore.getReferrers(site, granularity, SELECTED_DATE, PAGE_SIZE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClientTest.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class ClicksRestClientTest {
@@ -51,7 +52,8 @@ class ClicksRestClientTest {
     private lateinit var restClient: ClicksRestClient
     private val siteId: Long = 12
     private val pageSize = 5
-    private val currentDate = "2018-10-10"
+    private val currentDateValue = "2018-10-10"
+    private val currentDate = Date(0)
 
     @Before
     fun setUp() {
@@ -67,7 +69,7 @@ class ClicksRestClientTest {
                 gson,
                 statsUtils
         )
-        whenever(statsUtils.getCurrentDateTZ(site)).thenReturn(currentDate)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(currentDate))).thenReturn(currentDateValue)
     }
 
     @Test
@@ -159,7 +161,7 @@ class ClicksRestClientTest {
         val response = mock<ClicksResponse>()
         initClicksResponse(response)
 
-        val responseModel = restClient.fetchClicks(site, period, pageSize, false)
+        val responseModel = restClient.fetchClicks(site, period, currentDate, pageSize, false)
 
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(response)
@@ -169,7 +171,7 @@ class ClicksRestClientTest {
                 mapOf(
                         "max" to pageSize.toString(),
                         "period" to period.toString(),
-                        "date" to currentDate
+                        "date" to currentDateValue
                 )
         )
     }
@@ -186,7 +188,7 @@ class ClicksRestClientTest {
                 )
         )
 
-        val responseModel = restClient.fetchClicks(site, period, pageSize, false)
+        val responseModel = restClient.fetchClicks(site, period, currentDate, pageSize, false)
 
         assertThat(responseModel.error).isNotNull()
         assertThat(responseModel.error.type).isEqualTo(API_ERROR)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClientTest.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class PostAndPageViewsRestClientTest {
@@ -47,7 +48,8 @@ class PostAndPageViewsRestClientTest {
     private lateinit var restClient: PostAndPageViewsRestClient
     private val siteId: Long = 12
     private val pageSize = 5
-    private val currentDate = "2018-10-10"
+    private val currentStringDate = "2018-10-10"
+    private val currentDate = Date(0)
 
     @Before
     fun setUp() {
@@ -62,7 +64,7 @@ class PostAndPageViewsRestClientTest {
                 userAgent,
                 statsUtils
         )
-        whenever(statsUtils.getCurrentDateTZ(site)).thenReturn(currentDate)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(currentDate))).thenReturn(currentStringDate)
     }
 
     @Test
@@ -109,7 +111,7 @@ class PostAndPageViewsRestClientTest {
         val response = mock<PostAndPageViewsResponse>()
         initAllTimeResponse(response)
 
-        val responseModel = restClient.fetchPostAndPageViews(site, granularity, pageSize, false)
+        val responseModel = restClient.fetchPostAndPageViews(site, granularity, currentDate, pageSize, false)
 
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(response)
@@ -119,7 +121,7 @@ class PostAndPageViewsRestClientTest {
                 mapOf(
                         "max" to pageSize.toString(),
                         "period" to granularity.toString(),
-                        "date" to currentDate
+                        "date" to currentStringDate
                 )
         )
     }
@@ -136,7 +138,7 @@ class PostAndPageViewsRestClientTest {
                 )
         )
 
-        val responseModel = restClient.fetchPostAndPageViews(site, granularity, pageSize, false)
+        val responseModel = restClient.fetchPostAndPageViews(site, granularity, currentDate, pageSize, false)
 
         assertThat(responseModel.error).isNotNull()
         assertThat(responseModel.error.type).isEqualTo(API_ERROR)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class ReferrersRestClientTest {
@@ -51,7 +52,8 @@ class ReferrersRestClientTest {
     private lateinit var restClient: ReferrersRestClient
     private val siteId: Long = 12
     private val pageSize = 5
-    private val currentDate = "2018-10-10"
+    private val currentStringDate = "2018-10-10"
+    private val currentDate = Date(0)
 
     @Before
     fun setUp() {
@@ -67,7 +69,7 @@ class ReferrersRestClientTest {
                 gson,
                 statsUtils
         )
-        whenever(statsUtils.getCurrentDateTZ(site)).thenReturn(currentDate)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(currentDate))).thenReturn(currentStringDate)
     }
 
     @Test
@@ -171,7 +173,7 @@ class ReferrersRestClientTest {
         val response = mock<ReferrersResponse>()
         initReferrersResponse(response)
 
-        val responseModel = restClient.fetchReferrers(site, granularity, pageSize, false)
+        val responseModel = restClient.fetchReferrers(site, granularity, currentDate, pageSize, false)
 
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(response)
@@ -181,7 +183,7 @@ class ReferrersRestClientTest {
                 mapOf(
                         "max" to pageSize.toString(),
                         "period" to granularity.toString(),
-                        "date" to currentDate
+                        "date" to currentStringDate
                 )
         )
     }
@@ -198,7 +200,7 @@ class ReferrersRestClientTest {
                 )
         )
 
-        val responseModel = restClient.fetchReferrers(site, granularity, pageSize, false)
+        val responseModel = restClient.fetchReferrers(site, granularity, currentDate, pageSize, false)
 
         assertThat(responseModel.error).isNotNull()
         assertThat(responseModel.error.type).isEqualTo(API_ERROR)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/StatsUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/StatsUtilsTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.CurrentDateUtils
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
@@ -20,7 +21,7 @@ class StatsUtilsTest {
     private lateinit var statsUtils: StatsUtils
     @Before
     fun setUp() {
-        statsUtils = StatsUtils(Locale.US, currentDateUtils)
+        statsUtils = StatsUtils(currentDateUtils)
     }
 
     @Test
@@ -30,7 +31,7 @@ class StatsUtilsTest {
         whenever(currentDateUtils.getCurrentDate()).thenReturn(cal.time)
         whenever(siteModel.timezone).thenReturn("+1.5")
 
-        val result = statsUtils.getCurrentDateTZ(siteModel)
+        val result = statsUtils.getFormattedDate(siteModel, DAYS)
 
         assertThat(result).isEqualTo("2018-11-11")
     }
@@ -42,7 +43,7 @@ class StatsUtilsTest {
         whenever(currentDateUtils.getCurrentDate()).thenReturn(cal.time)
         whenever(siteModel.timezone).thenReturn("+0.0")
 
-        val result = statsUtils.getCurrentDateTZ(siteModel)
+        val result = statsUtils.getFormattedDate(siteModel, DAYS)
 
         assertThat(result).isEqualTo("2018-11-10")
     }
@@ -54,7 +55,7 @@ class StatsUtilsTest {
         whenever(currentDateUtils.getCurrentDate()).thenReturn(cal.time)
         whenever(siteModel.timezone).thenReturn(null)
 
-        val result = statsUtils.getCurrentDateTZ(siteModel)
+        val result = statsUtils.getFormattedDate(siteModel, DAYS)
 
         assertThat(result).isEqualTo("2018-11-10")
     }
@@ -66,7 +67,7 @@ class StatsUtilsTest {
         whenever(currentDateUtils.getCurrentDate()).thenReturn(cal.time)
         whenever(siteModel.timezone).thenReturn("-0.5")
 
-        val result = statsUtils.getCurrentDateTZ(siteModel)
+        val result = statsUtils.getFormattedDate(siteModel, DAYS)
 
         assertThat(result).isEqualTo("2018-11-09")
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ClicksSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ClicksSqlUtilsTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.persistance.stats.time
 
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
@@ -9,6 +11,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
@@ -21,30 +24,36 @@ import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
 import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.store.stats.time.CLICKS_RESPONSE
+import java.util.Date
 import kotlin.test.assertEquals
+
+private val DATE = Date(0)
+private const val DATE_VALUE = "2018-10-10"
 
 @RunWith(MockitoJUnitRunner::class)
 class ClicksSqlUtilsTest {
     @Mock lateinit var statsSqlUtils: StatsSqlUtils
     @Mock lateinit var site: SiteModel
+    @Mock lateinit var statsUtils: StatsUtils
     private lateinit var timeStatsSqlUtils: TimeStatsSqlUtils
     private val mappedTypes = mapOf(DAY to DAYS, WEEK to WEEKS, MONTH to MONTHS, YEAR to YEARS)
 
     @Before
     fun setUp() {
-        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils)
+        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test
     fun `returns referrers from stats utils`() {
         mappedTypes.forEach { statsType, dbGranularity ->
 
-            whenever(statsSqlUtils.select(site, CLICKS, statsType, ClicksResponse::class.java))
+            whenever(statsSqlUtils.select(site, CLICKS, statsType, ClicksResponse::class.java, DATE_VALUE))
                     .thenReturn(
                             CLICKS_RESPONSE
                     )
 
-            val result = timeStatsSqlUtils.selectClicks(site, dbGranularity)
+            val result = timeStatsSqlUtils.selectClicks(site, dbGranularity, DATE)
 
             assertEquals(result, CLICKS_RESPONSE)
         }
@@ -53,9 +62,9 @@ class ClicksSqlUtilsTest {
     @Test
     fun `inserts referrers to stats utils`() {
         mappedTypes.forEach { statsType, dbGranularity ->
-            timeStatsSqlUtils.insert(site, CLICKS_RESPONSE, dbGranularity)
+            timeStatsSqlUtils.insert(site, CLICKS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, CLICKS, statsType, CLICKS_RESPONSE)
+            verify(statsSqlUtils).insert(site, CLICKS, statsType, CLICKS_RESPONSE, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/PostAndPageViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/PostAndPageViewsSqlUtilsTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.persistance.stats.time
 
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
@@ -9,119 +11,158 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
-import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.DAY
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.MONTH
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.store.stats.time.DAY_POST_AND_PAGE_VIEWS_RESPONSE
 import org.wordpress.android.fluxc.store.stats.time.MONTH_POST_AND_PAGE_VIEWS_RESPONSE
 import org.wordpress.android.fluxc.store.stats.time.WEEK_POST_AND_PAGE_VIEWS_RESPONSE
 import org.wordpress.android.fluxc.store.stats.time.YEAR_POST_AND_PAGE_VIEWS_RESPONSE
+import java.util.Date
 import kotlin.test.assertEquals
+
+private val DATE = Date(0)
+private const val DATE_VALUE = "2018-10-10"
 
 @RunWith(MockitoJUnitRunner::class)
 class PostAndPageViewsSqlUtilsTest {
     @Mock lateinit var statsSqlUtils: StatsSqlUtils
+    @Mock lateinit var statsUtils: StatsUtils
     @Mock lateinit var site: SiteModel
     private lateinit var timeStatsSqlUtils: TimeStatsSqlUtils
 
     @Before
     fun setUp() {
-        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils)
+        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test
     fun `returns post and page day views from stats utils`() {
-        whenever(statsSqlUtils.select(site, POSTS_AND_PAGES_VIEWS, DAY, PostAndPageViewsResponse::class.java))
+        whenever(
+                statsSqlUtils.select(
+                        site,
+                        POSTS_AND_PAGES_VIEWS,
+                        DAY,
+                        PostAndPageViewsResponse::class.java,
+                        DATE_VALUE
+                )
+        )
                 .thenReturn(
                         DAY_POST_AND_PAGE_VIEWS_RESPONSE
                 )
 
-        val result = timeStatsSqlUtils.selectPostAndPageViews(site, DAYS)
+        val result = timeStatsSqlUtils.selectPostAndPageViews(site, DAYS, DATE)
 
         assertEquals(result, DAY_POST_AND_PAGE_VIEWS_RESPONSE)
     }
 
     @Test
     fun `inserts post and page day views to stats utils`() {
-        timeStatsSqlUtils.insert(site,
-                DAY_POST_AND_PAGE_VIEWS_RESPONSE, DAYS)
-
-        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, DAY,
-                DAY_POST_AND_PAGE_VIEWS_RESPONSE
+        timeStatsSqlUtils.insert(
+                site,
+                DAY_POST_AND_PAGE_VIEWS_RESPONSE, DAYS, DATE
         )
+
+        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, DAY, DAY_POST_AND_PAGE_VIEWS_RESPONSE, DATE_VALUE)
     }
 
     @Test
     fun `returns post and page week views from stats utils`() {
-        whenever(statsSqlUtils.select(site, POSTS_AND_PAGES_VIEWS, WEEK, PostAndPageViewsResponse::class.java))
+        whenever(
+                statsSqlUtils.select(
+                        site,
+                        POSTS_AND_PAGES_VIEWS,
+                        WEEK,
+                        PostAndPageViewsResponse::class.java,
+                        DATE_VALUE
+                )
+        )
                 .thenReturn(
                         WEEK_POST_AND_PAGE_VIEWS_RESPONSE
                 )
 
-        val result = timeStatsSqlUtils.selectPostAndPageViews(site, WEEKS)
+        val result = timeStatsSqlUtils.selectPostAndPageViews(site, WEEKS, DATE)
 
         assertEquals(result, WEEK_POST_AND_PAGE_VIEWS_RESPONSE)
     }
 
     @Test
     fun `inserts post and page week views to stats utils`() {
-        timeStatsSqlUtils.insert(site,
-                WEEK_POST_AND_PAGE_VIEWS_RESPONSE, WEEKS)
-
-        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, WEEK,
-                WEEK_POST_AND_PAGE_VIEWS_RESPONSE
+        timeStatsSqlUtils.insert(
+                site,
+                WEEK_POST_AND_PAGE_VIEWS_RESPONSE, WEEKS, DATE
         )
+
+        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, WEEK, WEEK_POST_AND_PAGE_VIEWS_RESPONSE, DATE_VALUE)
     }
 
     @Test
     fun `returns post and page month views from stats utils`() {
-        whenever(statsSqlUtils.select(site, POSTS_AND_PAGES_VIEWS, MONTH, PostAndPageViewsResponse::class.java))
+        whenever(
+                statsSqlUtils.select(
+                        site,
+                        POSTS_AND_PAGES_VIEWS,
+                        MONTH,
+                        PostAndPageViewsResponse::class.java,
+                        DATE_VALUE
+                )
+        )
                 .thenReturn(
                         MONTH_POST_AND_PAGE_VIEWS_RESPONSE
                 )
 
-        val result = timeStatsSqlUtils.selectPostAndPageViews(site, MONTHS)
+        val result = timeStatsSqlUtils.selectPostAndPageViews(site, MONTHS, DATE)
 
         assertEquals(result, MONTH_POST_AND_PAGE_VIEWS_RESPONSE)
     }
 
     @Test
     fun `inserts post and page month views to stats utils`() {
-        timeStatsSqlUtils.insert(site,
-                MONTH_POST_AND_PAGE_VIEWS_RESPONSE, MONTHS)
-
-        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, MONTH,
-                MONTH_POST_AND_PAGE_VIEWS_RESPONSE
+        timeStatsSqlUtils.insert(
+                site,
+                MONTH_POST_AND_PAGE_VIEWS_RESPONSE, MONTHS, DATE
         )
+
+        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, MONTH, MONTH_POST_AND_PAGE_VIEWS_RESPONSE, DATE_VALUE)
     }
 
     @Test
     fun `returns post and page year views from stats utils`() {
-        whenever(statsSqlUtils.select(site, POSTS_AND_PAGES_VIEWS, YEAR, PostAndPageViewsResponse::class.java))
+        whenever(
+                statsSqlUtils.select(
+                        site,
+                        POSTS_AND_PAGES_VIEWS,
+                        YEAR,
+                        PostAndPageViewsResponse::class.java,
+                        DATE_VALUE
+                )
+        )
                 .thenReturn(
                         YEAR_POST_AND_PAGE_VIEWS_RESPONSE
                 )
 
-        val result = timeStatsSqlUtils.selectPostAndPageViews(site, YEARS)
+        val result = timeStatsSqlUtils.selectPostAndPageViews(site, YEARS, DATE)
 
         assertEquals(result, YEAR_POST_AND_PAGE_VIEWS_RESPONSE)
     }
 
     @Test
     fun `inserts post and page year views to stats utils`() {
-        timeStatsSqlUtils.insert(site,
-                YEAR_POST_AND_PAGE_VIEWS_RESPONSE, YEARS)
-
-        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, YEAR,
-                YEAR_POST_AND_PAGE_VIEWS_RESPONSE
+        timeStatsSqlUtils.insert(
+                site,
+                YEAR_POST_AND_PAGE_VIEWS_RESPONSE, YEARS, DATE
         )
+
+        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, YEAR, YEAR_POST_AND_PAGE_VIEWS_RESPONSE, DATE_VALUE)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ReferrersSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ReferrersSqlUtilsTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.persistance.stats.time
 
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
@@ -9,6 +11,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
@@ -21,30 +24,36 @@ import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
 import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.store.stats.time.REFERRERS_RESPONSE
+import java.util.Date
 import kotlin.test.assertEquals
+
+private val DATE = Date(0)
+private const val DATE_VALUE = "2018-10-10"
 
 @RunWith(MockitoJUnitRunner::class)
 class ReferrersSqlUtilsTest {
     @Mock lateinit var statsSqlUtils: StatsSqlUtils
+    @Mock lateinit var statsUtils: StatsUtils
     @Mock lateinit var site: SiteModel
     private lateinit var timeStatsSqlUtils: TimeStatsSqlUtils
     private val mappedTypes = mapOf(DAY to DAYS, WEEK to WEEKS, MONTH to MONTHS, YEAR to YEARS)
 
     @Before
     fun setUp() {
-        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils)
+        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test
     fun `returns referrers from stats utils`() {
         mappedTypes.forEach { statsType, dbGranularity ->
 
-            whenever(statsSqlUtils.select(site, REFERRERS, statsType, ReferrersResponse::class.java))
+            whenever(statsSqlUtils.select(site, REFERRERS, statsType, ReferrersResponse::class.java, DATE_VALUE))
                     .thenReturn(
                             REFERRERS_RESPONSE
                     )
 
-            val result = timeStatsSqlUtils.selectReferrers(site, dbGranularity)
+            val result = timeStatsSqlUtils.selectReferrers(site, dbGranularity, DATE)
 
             assertEquals(result, REFERRERS_RESPONSE)
         }
@@ -53,9 +62,9 @@ class ReferrersSqlUtilsTest {
     @Test
     fun `inserts referrers to stats utils`() {
         mappedTypes.forEach { statsType, dbGranularity ->
-            timeStatsSqlUtils.insert(site, REFERRERS_RESPONSE, dbGranularity)
+            timeStatsSqlUtils.insert(site, REFERRERS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, REFERRERS, statsType, REFERRERS_RESPONSE)
+            verify(statsSqlUtils).insert(site, REFERRERS, statsType, REFERRERS_RESPONSE, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ClicksStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ClicksStoreTest.kt
@@ -21,10 +21,12 @@ import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 private const val PAGE_SIZE = 8
+private val DATE = Date(0)
 
 @RunWith(MockitoJUnitRunner::class)
 class ClicksStoreTest {
@@ -49,16 +51,16 @@ class ClicksStoreTest {
                 CLICKS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchClicks(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchClicks(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<ClicksModel>()
         whenever(mapper.map(CLICKS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchClicks(site, PAGE_SIZE, DAYS, forced)
+        val responseModel = store.fetchClicks(site, PAGE_SIZE, DAYS, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, CLICKS_RESPONSE, DAYS)
+        verify(sqlUtils).insert(site, CLICKS_RESPONSE, DAYS, DATE)
     }
 
     @Test
@@ -67,9 +69,9 @@ class ClicksStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<ClicksResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchClicks(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchClicks(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchClicks(site, PAGE_SIZE, DAYS, forced)
+        val responseModel = store.fetchClicks(site, PAGE_SIZE, DAYS, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -79,11 +81,11 @@ class ClicksStoreTest {
 
     @Test
     fun `returns clicks from db`() {
-        whenever(sqlUtils.selectClicks(site, DAYS)).thenReturn(CLICKS_RESPONSE)
+        whenever(sqlUtils.selectClicks(site, DAYS, DATE)).thenReturn(CLICKS_RESPONSE)
         val model = mock<ClicksModel>()
         whenever(mapper.map(CLICKS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getClicks(site, DAYS, PAGE_SIZE)
+        val result = store.getClicks(site, DAYS, PAGE_SIZE, DATE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/PostAndPageViewsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/PostAndPageViewsStoreTest.kt
@@ -24,10 +24,12 @@ import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 private const val PAGE_SIZE = 8
+private val DATE = Date(0)
 
 @RunWith(MockitoJUnitRunner::class)
 class PostAndPageViewsStoreTest {
@@ -52,16 +54,16 @@ class PostAndPageViewsStoreTest {
                 DAY_POST_AND_PAGE_VIEWS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchPostAndPageViews(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchPostAndPageViews(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<PostAndPageViewsModel>()
         whenever(mapper.map(DAY_POST_AND_PAGE_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, DAYS, forced)
+        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, DAYS, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, DAY_POST_AND_PAGE_VIEWS_RESPONSE, DAYS)
+        verify(sqlUtils).insert(site, DAY_POST_AND_PAGE_VIEWS_RESPONSE, DAYS, DATE)
     }
 
     @Test
@@ -70,9 +72,9 @@ class PostAndPageViewsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<PostAndPageViewsResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchPostAndPageViews(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchPostAndPageViews(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, DAYS, forced)
+        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, DAYS, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -82,11 +84,11 @@ class PostAndPageViewsStoreTest {
 
     @Test
     fun `returns post and page day views from db`() {
-        whenever(sqlUtils.selectPostAndPageViews(site, DAYS)).thenReturn(DAY_POST_AND_PAGE_VIEWS_RESPONSE)
+        whenever(sqlUtils.selectPostAndPageViews(site, DAYS, DATE)).thenReturn(DAY_POST_AND_PAGE_VIEWS_RESPONSE)
         val model = mock<PostAndPageViewsModel>()
         whenever(mapper.map(DAY_POST_AND_PAGE_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getPostAndPageViews(site, DAYS, PAGE_SIZE)
+        val result = store.getPostAndPageViews(site, DAYS, DATE, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }
@@ -97,16 +99,16 @@ class PostAndPageViewsStoreTest {
                 WEEK_POST_AND_PAGE_VIEWS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchPostAndPageViews(site, WEEKS, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchPostAndPageViews(site, WEEKS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<PostAndPageViewsModel>()
         whenever(mapper.map(WEEK_POST_AND_PAGE_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, WEEKS, forced)
+        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, WEEKS, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, WEEK_POST_AND_PAGE_VIEWS_RESPONSE, WEEKS)
+        verify(sqlUtils).insert(site, WEEK_POST_AND_PAGE_VIEWS_RESPONSE, WEEKS, DATE)
     }
 
     @Test
@@ -115,9 +117,9 @@ class PostAndPageViewsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<PostAndPageViewsResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchPostAndPageViews(site, WEEKS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchPostAndPageViews(site, WEEKS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, WEEKS, forced)
+        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, WEEKS, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -127,11 +129,11 @@ class PostAndPageViewsStoreTest {
 
     @Test
     fun `returns post and page week views from db`() {
-        whenever(sqlUtils.selectPostAndPageViews(site, WEEKS)).thenReturn(WEEK_POST_AND_PAGE_VIEWS_RESPONSE)
+        whenever(sqlUtils.selectPostAndPageViews(site, WEEKS, DATE)).thenReturn(WEEK_POST_AND_PAGE_VIEWS_RESPONSE)
         val model = mock<PostAndPageViewsModel>()
         whenever(mapper.map(WEEK_POST_AND_PAGE_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getPostAndPageViews(site, WEEKS, PAGE_SIZE)
+        val result = store.getPostAndPageViews(site, WEEKS, DATE, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }
@@ -142,16 +144,16 @@ class PostAndPageViewsStoreTest {
                 MONTH_POST_AND_PAGE_VIEWS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchPostAndPageViews(site, MONTHS, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchPostAndPageViews(site, MONTHS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<PostAndPageViewsModel>()
         whenever(mapper.map(MONTH_POST_AND_PAGE_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, MONTHS, forced)
+        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, MONTHS, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, MONTH_POST_AND_PAGE_VIEWS_RESPONSE, MONTHS)
+        verify(sqlUtils).insert(site, MONTH_POST_AND_PAGE_VIEWS_RESPONSE, MONTHS, DATE)
     }
 
     @Test
@@ -160,9 +162,9 @@ class PostAndPageViewsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<PostAndPageViewsResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchPostAndPageViews(site, MONTHS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchPostAndPageViews(site, MONTHS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, MONTHS, forced)
+        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, MONTHS, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -172,11 +174,11 @@ class PostAndPageViewsStoreTest {
 
     @Test
     fun `returns post and page month views from db`() {
-        whenever(sqlUtils.selectPostAndPageViews(site, MONTHS)).thenReturn(MONTH_POST_AND_PAGE_VIEWS_RESPONSE)
+        whenever(sqlUtils.selectPostAndPageViews(site, MONTHS, DATE)).thenReturn(MONTH_POST_AND_PAGE_VIEWS_RESPONSE)
         val model = mock<PostAndPageViewsModel>()
         whenever(mapper.map(MONTH_POST_AND_PAGE_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getPostAndPageViews(site, MONTHS, PAGE_SIZE)
+        val result = store.getPostAndPageViews(site, MONTHS, DATE, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }
@@ -187,16 +189,16 @@ class PostAndPageViewsStoreTest {
                 YEAR_POST_AND_PAGE_VIEWS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchPostAndPageViews(site, YEARS, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchPostAndPageViews(site, YEARS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<PostAndPageViewsModel>()
         whenever(mapper.map(YEAR_POST_AND_PAGE_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, YEARS, forced)
+        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, YEARS, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, YEAR_POST_AND_PAGE_VIEWS_RESPONSE, YEARS)
+        verify(sqlUtils).insert(site, YEAR_POST_AND_PAGE_VIEWS_RESPONSE, YEARS, DATE)
     }
 
     @Test
@@ -205,9 +207,9 @@ class PostAndPageViewsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<PostAndPageViewsResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchPostAndPageViews(site, YEARS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchPostAndPageViews(site, YEARS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, YEARS, forced)
+        val responseModel = store.fetchPostAndPageViews(site, PAGE_SIZE, YEARS, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -217,11 +219,11 @@ class PostAndPageViewsStoreTest {
 
     @Test
     fun `returns post and page year views from db`() {
-        whenever(sqlUtils.selectPostAndPageViews(site, YEARS)).thenReturn(YEAR_POST_AND_PAGE_VIEWS_RESPONSE)
+        whenever(sqlUtils.selectPostAndPageViews(site, YEARS, DATE)).thenReturn(YEAR_POST_AND_PAGE_VIEWS_RESPONSE)
         val model = mock<PostAndPageViewsModel>()
         whenever(mapper.map(YEAR_POST_AND_PAGE_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getPostAndPageViews(site, YEARS, PAGE_SIZE)
+        val result = store.getPostAndPageViews(site, YEARS, DATE, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
@@ -21,10 +21,12 @@ import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 private const val PAGE_SIZE = 8
+private val DATE = Date(0)
 
 @RunWith(MockitoJUnitRunner::class)
 class ReferrersStoreTest {
@@ -49,16 +51,16 @@ class ReferrersStoreTest {
                 REFERRERS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchReferrers(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchReferrers(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<ReferrersModel>()
         whenever(mapper.map(REFERRERS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchReferrers(site, PAGE_SIZE, DAYS, forced)
+        val responseModel = store.fetchReferrers(site, PAGE_SIZE, DAYS, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, REFERRERS_RESPONSE, DAYS)
+        verify(sqlUtils).insert(site, REFERRERS_RESPONSE, DAYS, DATE)
     }
 
     @Test
@@ -67,9 +69,9 @@ class ReferrersStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<ReferrersResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchReferrers(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchReferrers(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchReferrers(site, PAGE_SIZE, DAYS, forced)
+        val responseModel = store.fetchReferrers(site, PAGE_SIZE, DAYS, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -79,11 +81,11 @@ class ReferrersStoreTest {
 
     @Test
     fun `returns referrers from db`() {
-        whenever(sqlUtils.selectReferrers(site, DAYS)).thenReturn(REFERRERS_RESPONSE)
+        whenever(sqlUtils.selectReferrers(site, DAYS, DATE)).thenReturn(REFERRERS_RESPONSE)
         val model = mock<ReferrersModel>()
         whenever(mapper.map(REFERRERS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getReferrers(site, DAYS, PAGE_SIZE)
+        val result = store.getReferrers(site, DAYS, DATE, PAGE_SIZE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClient.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -37,6 +38,7 @@ class ClicksRestClient
     suspend fun fetchClicks(
         site: SiteModel,
         granularity: StatsGranularity,
+        date: Date,
         pageSize: Int,
         forced: Boolean
     ): FetchStatsPayload<ClicksResponse> {
@@ -44,7 +46,7 @@ class ClicksRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getCurrentDateTZ(site)
+                "date" to statsUtils.getFormattedDate(site, granularity, date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClient.kt
@@ -34,6 +34,7 @@ class PostAndPageViewsRestClient
     suspend fun fetchPostAndPageViews(
         site: SiteModel,
         granularity: StatsGranularity,
+        date: Date,
         pageSize: Int,
         forced: Boolean
     ): FetchStatsPayload<PostAndPageViewsResponse> {
@@ -41,7 +42,7 @@ class PostAndPageViewsRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getCurrentDateTZ(site)
+                "date" to statsUtils.getFormattedDate(site, granularity, date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClient.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.getInt
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -39,6 +40,7 @@ class ReferrersRestClient
     suspend fun fetchReferrers(
         site: SiteModel,
         granularity: StatsGranularity,
+        date: Date,
         pageSize: Int,
         forced: Boolean
     ): FetchStatsPayload<ReferrersResponse> {
@@ -46,7 +48,7 @@ class ReferrersRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getCurrentDateTZ(site)
+                "date" to statsUtils.getFormattedDate(site, granularity, date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/StatsUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/StatsUtils.kt
@@ -1,57 +1,15 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
 
-import android.text.TextUtils
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.CurrentDateUtils
-import java.text.SimpleDateFormat
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.getFormattedDate
 import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
 import javax.inject.Inject
 
 class StatsUtils
-@Inject constructor(val locale: Locale, private val currentDateUtils: CurrentDateUtils) {
-    fun getCurrentDateTZ(site: SiteModel): String {
-        val statsDatePattern = "yyyy-MM-dd"
-        return getCurrentDateTimeTZ(site.timezone, statsDatePattern, currentDateUtils.getCurrentDate())
-    }
-
-    private fun getCurrentDateTimeTZ(blogTimeZoneOption: String?, pattern: String, date: Date): String {
-        val gmtDf = SimpleDateFormat(pattern, locale)
-
-        if (blogTimeZoneOption == null) {
-            return gmtDf.format(date)
-        }
-
-        /*
-        Convert the timezone to a form that is compatible with Java TimeZone class
-        WordPress returns something like the following:
-        UTC+0:30 ----> 0.5
-        UTC+1 ----> 1.0
-        UTC-0:30 ----> -1.0
-        */
-
-        var timezoneNormalized: String
-        if (TextUtils.isEmpty(blogTimeZoneOption) || blogTimeZoneOption == "0" || blogTimeZoneOption == "0.0") {
-            timezoneNormalized = "GMT"
-        } else {
-            val timezoneSplitted = org.apache.commons.lang3.StringUtils.split(blogTimeZoneOption, ".")
-            timezoneNormalized = timezoneSplitted[0]
-            if (timezoneSplitted.size > 1 && timezoneSplitted[1] == "5") {
-                timezoneNormalized += ":30"
-            }
-            timezoneNormalized = if (timezoneNormalized.startsWith("-")) {
-                "GMT$timezoneNormalized"
-            } else {
-                if (timezoneNormalized.startsWith("+")) {
-                    "GMT$timezoneNormalized"
-                } else {
-                    "GMT+$timezoneNormalized"
-                }
-            }
-        }
-
-        gmtDf.timeZone = TimeZone.getTimeZone(timezoneNormalized)
-        return gmtDf.format(date)
+@Inject constructor(private val currentDateUtils: CurrentDateUtils) {
+    fun getFormattedDate(site: SiteModel, granularity: StatsGranularity, date: Date? = null): String {
+        return getFormattedDate(site, date ?: currentDateUtils.getCurrentDate(), granularity)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -14,31 +14,40 @@ import javax.inject.Singleton
 @Singleton
 class StatsSqlUtils
 @Inject constructor(private val gson: Gson) {
-    fun <T> insert(site: SiteModel, blockType: BlockType, statsType: StatsType, item: T) {
+    fun <T> insert(site: SiteModel, blockType: BlockType, statsType: StatsType, item: T, date: String = "") {
         val json = gson.toJson(item)
         WellSql.delete(StatsBlockBuilder::class.java)
                 .where()
                 .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
                 .equals(StatsBlockTable.STATS_TYPE, statsType.name)
+                .equals(StatsBlockTable.DATE, date)
                 .endWhere()
                 .execute()
         WellSql.insert(
-                    StatsBlockBuilder(
-                            localSiteId = site.id,
-                            blockType = blockType.name,
-                            statsType = statsType.name,
-                            json = json
-                    )
+                StatsBlockBuilder(
+                        localSiteId = site.id,
+                        blockType = blockType.name,
+                        statsType = statsType.name,
+                        date = date,
+                        json = json
                 )
+        )
                 .execute()
     }
 
-    fun <T> select(site: SiteModel, blockType: BlockType, statsType: StatsType, classOfT: Class<T>): T? {
+    fun <T> select(
+        site: SiteModel,
+        blockType: BlockType,
+        statsType: StatsType,
+        classOfT: Class<T>,
+        date: String = ""
+    ): T? {
         val model = WellSql.select(StatsBlockBuilder::class.java)
                 .where()
                 .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
                 .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
                 .equals(StatsBlockTable.STATS_TYPE, statsType.name)
+                .equals(StatsBlockTable.DATE, date)
                 .endWhere().asModel.firstOrNull()
         if (model != null) {
             return gson.fromJson(model.json, classOfT)
@@ -52,9 +61,10 @@ class StatsSqlUtils
         @Column var localSiteId: Int,
         @Column var blockType: String,
         @Column var statsType: String,
+        @Column var date: String,
         @Column var json: String
     ) : Identifiable {
-        constructor() : this(-1, -1, "", "", "")
+        constructor() : this(-1, -1, "", "", "", "")
 
         override fun setId(id: Int) {
             this.mId = id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
@@ -11,35 +12,50 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.REFERRERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class TimeStatsSqlUtils
-@Inject constructor(private val statsSqlUtils: StatsSqlUtils) {
-    fun insert(site: SiteModel, data: PostAndPageViewsResponse, granularity: StatsGranularity) {
-        statsSqlUtils.insert(site, POSTS_AND_PAGES_VIEWS, granularity.toStatsType(), data)
+@Inject constructor(private val statsSqlUtils: StatsSqlUtils, private val statsUtils: StatsUtils) {
+    fun insert(site: SiteModel, data: PostAndPageViewsResponse, granularity: StatsGranularity, date: Date) {
+        statsSqlUtils.insert(
+                site,
+                POSTS_AND_PAGES_VIEWS,
+                granularity.toStatsType(),
+                data,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
     }
 
-    fun insert(site: SiteModel, data: ReferrersResponse, granularity: StatsGranularity) {
-        statsSqlUtils.insert(site, REFERRERS, granularity.toStatsType(), data)
+    fun insert(site: SiteModel, data: ReferrersResponse, granularity: StatsGranularity, date: Date) {
+        statsSqlUtils.insert(
+                site,
+                REFERRERS,
+                granularity.toStatsType(),
+                data,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
     }
 
-    fun selectPostAndPageViews(site: SiteModel, granularity: StatsGranularity): PostAndPageViewsResponse? {
+    fun selectPostAndPageViews(site: SiteModel, granularity: StatsGranularity, date: Date): PostAndPageViewsResponse? {
         return statsSqlUtils.select(
                 site,
                 POSTS_AND_PAGES_VIEWS,
                 granularity.toStatsType(),
-                PostAndPageViewsResponse::class.java
+                PostAndPageViewsResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
         )
     }
 
-    fun selectReferrers(site: SiteModel, granularity: StatsGranularity): ReferrersResponse? {
+    fun selectReferrers(site: SiteModel, granularity: StatsGranularity, date: Date): ReferrersResponse? {
         return statsSqlUtils.select(
                 site,
                 REFERRERS,
                 granularity.toStatsType(),
-                ReferrersResponse::class.java
+                ReferrersResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 46;
+        return 47;
     }
 
     @Override
@@ -385,6 +385,13 @@ public class WellSqlConfig extends DefaultWellConfig {
                            + "REMOTE_NOTE_ID INTEGER,LOCAL_SITE_ID INTEGER,NOTE_HASH INTEGER,TYPE TEXT,"
                            + "SUBTYPE TEXT,READ INTEGER,ICON TEXT,NOTICON TEXT,TIMESTAMP TEXT,URL TEXT,"
                            + "TITLE TEXT,FORMATTABLE_BODY TEXT,FORMATTABLE_SUBJECT TEXT,FORMATTABLE_META TEXT)");
+                oldVersion++;
+            case 46:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS StatsBlock");
+                db.execSQL(
+                        "CREATE TABLE StatsBlock (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT NOT NULL,JSON TEXT NOT NULL)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ClicksStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ClicksStore.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.CoroutineContext
@@ -26,20 +27,21 @@ class ClicksStore
         site: SiteModel,
         pageSize: Int,
         granularity: StatsGranularity,
+        date: Date,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
-        val payload = restClient.fetchClicks(site, granularity, pageSize + 1, forced)
+        val payload = restClient.fetchClicks(site, granularity, date, pageSize + 1, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
-                sqlUtils.insert(site, payload.response, granularity)
+                sqlUtils.insert(site, payload.response, granularity, date)
                 OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
     }
 
-    fun getClicks(site: SiteModel, period: StatsGranularity, pageSize: Int): ClicksModel? {
-        return sqlUtils.selectClicks(site, period)?.let { timeStatsMapper.map(it, pageSize) }
+    fun getClicks(site: SiteModel, period: StatsGranularity, pageSize: Int, date: Date): ClicksModel? {
+        return sqlUtils.selectClicks(site, period, date)?.let { timeStatsMapper.map(it, pageSize) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/PostAndPageViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/PostAndPageViewsStore.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.CoroutineContext
@@ -26,20 +27,26 @@ class PostAndPageViewsStore
         site: SiteModel,
         pageSize: Int,
         granularity: StatsGranularity,
+        date: Date,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
-        val payload = restClient.fetchPostAndPageViews(site, granularity, pageSize + 1, forced)
+        val payload = restClient.fetchPostAndPageViews(site, granularity, date, pageSize + 1, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
-                sqlUtils.insert(site, payload.response, granularity)
+                sqlUtils.insert(site, payload.response, granularity, date)
                 OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
     }
 
-    fun getPostAndPageViews(site: SiteModel, granularity: StatsGranularity, pageSize: Int): PostAndPageViewsModel? {
-        return sqlUtils.selectPostAndPageViews(site, granularity)?.let { timeStatsMapper.map(it, pageSize) }
+    fun getPostAndPageViews(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        date: Date,
+        pageSize: Int
+    ): PostAndPageViewsModel? {
+        return sqlUtils.selectPostAndPageViews(site, granularity, date)?.let { timeStatsMapper.map(it, pageSize) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.CoroutineContext
@@ -26,20 +27,21 @@ class ReferrersStore
         site: SiteModel,
         pageSize: Int,
         granularity: StatsGranularity,
+        date: Date,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
-        val payload = restClient.fetchReferrers(site, granularity, pageSize + 1, forced)
+        val payload = restClient.fetchReferrers(site, granularity, date, pageSize + 1, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
-                sqlUtils.insert(site, payload.response, granularity)
+                sqlUtils.insert(site, payload.response, granularity, date)
                 OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
     }
 
-    fun getReferrers(site: SiteModel, granularity: StatsGranularity, pageSize: Int): ReferrersModel? {
-        return sqlUtils.selectReferrers(site, granularity)?.let { timeStatsMapper.map(it, pageSize) }
+    fun getReferrers(site: SiteModel, granularity: StatsGranularity, date: Date, pageSize: Int): ReferrersModel? {
+        return sqlUtils.selectReferrers(site, granularity, date)?.let { timeStatsMapper.map(it, pageSize) }
     }
 }


### PR DESCRIPTION
- we need to send a date as part of requests for Granular stats endpoints in order to show different data when the user selects different date
- this PR is adding date to `PostsAndPages` endpoint and to `Referrers` endpoint. The Date is now cached in DB (so we can cache multiple days per Tab)