### PR TITLE
Amanda/note actions

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -244,9 +244,12 @@ class NotificationSqlUtilsTest {
             NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(5, inserted)
+        assertEquals(6, inserted)
 
-        // Get notifications of type "store_order"
+        // Get notifications of type "store_order".
+        //
+        // Note: TWO store_order notifications were inserted into the db, but they belong to two
+        // different sites so only 1 should be returned.
         val newOrderNotifications = notificationSqlUtils.getNotificationsForSite(
                 site,
                 filterByType = listOf(NotificationModel.Kind.STORE_ORDER.toString()))
@@ -256,13 +259,13 @@ class NotificationSqlUtilsTest {
         val storeReviewNotifications = notificationSqlUtils.getNotificationsForSite(
                 site,
                 filterBySubtype = listOf(NotificationModel.Subkind.STORE_REVIEW.toString()))
-        assertEquals(1, storeReviewNotifications.size)
+        assertEquals(2, storeReviewNotifications.size)
 
         // Get notifications of type "store_order" or subtype "store_review"
         val combinedNotifications = notificationSqlUtils.getNotificationsForSite(
                 site,
                 filterByType = listOf(NotificationModel.Kind.STORE_ORDER.toString()),
                 filterBySubtype = listOf(NotificationModel.Subkind.STORE_REVIEW.toString()))
-        assertEquals(2, combinedNotifications.size)
+        assertEquals(3, combinedNotifications.size)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -11,7 +11,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.UnitTestUtils
-import org.wordpress.android.fluxc.model.NotificationModel
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationApiResponse
 import org.wordpress.android.fluxc.persistence.NotificationSqlUtils

--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -44,7 +44,16 @@ class NotificationSqlUtilsTest {
 
         // Test inserting notifications
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(5, inserted)
+        assertEquals(6, inserted)
+
+        // Test updating notifications
+        val newNote = notesList[0].copy(noteId = -1, remoteNoteId = 333)
+        val dbList = notificationSqlUtils.getNotifications().toMutableList()
+        dbList.add(newNote)
+        val updated = dbList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
+        assertEquals(7, updated)
+        val updatedList = notificationSqlUtils.getNotifications()
+        assertEquals(7, updatedList.size)
     }
 
     @Test
@@ -58,11 +67,11 @@ class NotificationSqlUtilsTest {
             NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(5, inserted)
+        assertEquals(6, inserted)
 
         // Get notifications
         val notifications = notificationSqlUtils.getNotifications(SelectQuery.ORDER_DESCENDING)
-        assertEquals(5, notifications.size)
+        assertEquals(6, notifications.size)
     }
 
     @Test
@@ -78,11 +87,11 @@ class NotificationSqlUtilsTest {
             NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(5, inserted)
+        assertEquals(6, inserted)
 
         // Get notifications
         val notifications = notificationSqlUtils.getNotificationsForSite(site, SelectQuery.ORDER_DESCENDING)
-        assertEquals(2, notifications.size)
+        assertEquals(3, notifications.size)
     }
 
     @Test
@@ -213,7 +222,7 @@ class NotificationSqlUtilsTest {
             NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(5, inserted)
+        assertEquals(6, inserted)
 
         // Get notifications of type "store_order"
         val newOrderNotifications = notificationSqlUtils.getNotifications(
@@ -223,13 +232,13 @@ class NotificationSqlUtilsTest {
         // Get notifications of subtype "store_review"
         val storeReviewNotifications = notificationSqlUtils.getNotifications(
                 filterBySubtype = listOf(NotificationModel.Subkind.STORE_REVIEW.toString()))
-        assertEquals(1, storeReviewNotifications.size)
+        assertEquals(2, storeReviewNotifications.size)
 
         // Get notifications of type "store_order" or subtype "store_review"
         val combinedNotifications = notificationSqlUtils.getNotifications(
                 filterByType = listOf(NotificationModel.Kind.STORE_ORDER.toString()),
                 filterBySubtype = listOf(NotificationModel.Subkind.STORE_REVIEW.toString()))
-        assertEquals(3, combinedNotifications.size)
+        assertEquals(4, combinedNotifications.size)
     }
 
     @Test

--- a/example/src/test/resources/notifications/notifications-api-response.json
+++ b/example/src/test/resources/notifications/notifications-api-response.json
@@ -244,6 +244,152 @@
       "note_hash": 854333643
     },
     {
+      "id": 3675336239,
+      "type": "comment",
+      "subtype": "store_review",
+      "read": 0,
+      "noticon": "",
+      "timestamp": "2018-12-04T01:29:03+00:00",
+      "icon": "https://1.gravatar.com/avatar/4aa04cfcaaaa1045cfc6656c8449429c?s=256&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D256&r=G",
+      "url": "https://testwooshop.mystagingwebsite.com/product/beanie-with-logo/#comment-2733",
+      "subject": [
+        {
+          "text": "Amanda Droid left a review on Beanie with Logo",
+          "ranges": [
+            {
+              "type": "user",
+              "indices": [
+                0,
+                12
+              ],
+              "email": "amanda.droid2014@gmail.com"
+            },
+            {
+              "type": "post",
+              "indices": [
+                30,
+                46
+              ],
+              "url": "https://testwooshop.mystagingwebsite.com/product/beanie-with-logo/",
+              "site_id": 153482281,
+              "id": 33
+            }
+          ]
+        },
+        {
+          "text": "Nice and warm\n",
+          "ranges": [
+            {
+              "type": "comment",
+              "indices": [
+                0,
+                14
+              ],
+              "url": "https://testwooshop.mystagingwebsite.com/product/beanie-with-logo/#comment-2733",
+              "site_id": 153482281,
+              "post_id": 33,
+              "id": 2733
+            }
+          ]
+        }
+      ],
+      "body": [
+        {
+          "text": "Amanda Droid",
+          "ranges": [
+            {
+              "email": "amanda.droid2014@gmail.com",
+              "type": "user",
+              "indices": [
+                0,
+                12
+              ]
+            }
+          ],
+          "media": [
+            {
+              "type": "image",
+              "indices": [
+                0,
+                0
+              ],
+              "height": "256",
+              "width": "256",
+              "url": "https://1.gravatar.com/avatar/4aa04cfcaaaa1045cfc6656c8449429c?s=256&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D256&r=G"
+            }
+          ],
+          "meta": {
+            "links": {
+              "email": "amanda.droid2014@gmail.com"
+            }
+          },
+          "type": "user"
+        },
+        {
+          "text": "Nice and warm",
+          "actions": {
+            "spam-comment": false,
+            "trash-comment": false,
+            "approve-comment": true,
+            "edit-comment": true,
+            "replyto-comment": true
+          },
+          "meta": {
+            "ids": {
+              "comment": 2733,
+              "post": 33,
+              "site": 153482281
+            },
+            "links": {
+              "comment": "https://public-api.wordpress.com/rest/v1/comments/2733",
+              "post": "https://public-api.wordpress.com/rest/v1/posts/33",
+              "site": "https://public-api.wordpress.com/rest/v1/sites/153482281"
+            }
+          },
+          "type": "comment",
+          "nest_level": 0,
+          "edit_comment_link": "https://testwooshop.mystagingwebsite.com/wp-admin/comment.php?action=editcomment&c=2733"
+        },
+        {
+          "text": "Review for Beanie with Logo\n★ ★ ★ ★ ☆ ",
+          "ranges": [
+            {
+              "url": "https://testwooshop.mystagingwebsite.com/product/beanie-with-logo/",
+              "indices": [
+                28,
+                38
+              ],
+              "type": "link"
+            },
+            {
+              "url": "https://testwooshop.mystagingwebsite.com/product/beanie-with-logo/",
+              "indices": [
+                11,
+                27
+              ],
+              "type": "link"
+            }
+          ]
+        }
+      ],
+      "meta": {
+        "ids": {
+          "user": 0,
+          "comment": 2733,
+          "post": 33,
+          "site": 153482281
+        },
+        "links": {
+          "user": "https://public-api.wordpress.com/rest/v1/users/0",
+          "comment": "https://public-api.wordpress.com/rest/v1/comments/2733",
+          "post": "https://public-api.wordpress.com/rest/v1/posts/33",
+          "site": "https://public-api.wordpress.com/rest/v1/sites/153482281"
+        }
+      },
+      "title": "Product Review",
+      "note_hash": 2624601148
+    },
+    {
       "id": 3617558725,
       "type": "comment",
       "subtype": "store_review",

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NoteIdSet.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NoteIdSet.kt
@@ -1,0 +1,3 @@
+package org.wordpress.android.fluxc.model.notification
+
+data class NoteIdSet(val id: Int, val remoteNoteId: Long, val localSiteId: Int)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.model
+package org.wordpress.android.fluxc.model.notification
 
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableMeta
@@ -36,7 +36,8 @@ data class NotificationModel(
         UNKNOWN;
 
         companion object {
-            private val reverseMap = Kind.values().associateBy(Kind::name)
+            private val reverseMap = Kind.values().associateBy(
+                    Kind::name)
             fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: UNKNOWN
         }
     }
@@ -47,7 +48,8 @@ data class NotificationModel(
         UNKNOWN;
 
         companion object {
-            private val reverseMap = Subkind.values().associateBy(Subkind::name)
+            private val reverseMap = Subkind.values().associateBy(
+                    Subkind::name)
             fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: UNKNOWN
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationApiResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationApiResponse.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.notifications
 
-import org.wordpress.android.fluxc.model.NotificationModel
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.network.Response
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableMeta
@@ -48,7 +48,8 @@ class NotificationApiResponse : Response {
                     title = response.title,
                     body = response.body,
                     subject = response.subject,
-                    meta = response.meta)
+                    meta = response.meta
+            )
         }
 
         fun getRemoteSiteId(response: NotificationApiResponse): Long? = response.meta?.ids?.site

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -9,8 +9,10 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
-import org.wordpress.android.fluxc.model.NotificationModel
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.notification.NoteIdSet
+import org.wordpress.android.fluxc.model.notification.NotificationModel.Kind
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableContentMapper
 import org.wordpress.android.fluxc.tools.FormattableMeta
@@ -115,6 +117,21 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
         return emptyList()
     }
 
+    fun getNotificationByIdSet(idSet: NoteIdSet): NotificationModel? {
+        val (id, remoteNoteId, localSiteId) = idSet
+        return WellSql.select(NotificationModelBuilder::class.java)
+                .where().beginGroup()
+                .equals(NotificationModelTable.ID, id)
+                .or()
+                .beginGroup()
+                .equals(NotificationModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(NotificationModelTable.REMOTE_NOTE_ID, remoteNoteId)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel
+                .firstOrNull()?.build(formattableContentMapper)
+    }
+
     fun deleteNotifications(): Int {
         return WellSql.delete(NotificationModelBuilder::class.java).execute()
     }
@@ -181,7 +198,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
                     remoteNoteId,
                     localSiteId,
                     noteHash,
-                    NotificationModel.Kind.fromString(type),
+                    Kind.fromString(type),
                     subkind,
                     read,
                     icon,
@@ -191,7 +208,8 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
                     title,
                     body,
                     subject,
-                    meta)
+                    meta
+            )
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -11,8 +11,9 @@ import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATIONS
 import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_SEEN
 import org.wordpress.android.fluxc.annotations.action.Action
-import org.wordpress.android.fluxc.model.NotificationModel
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.notification.NoteIdSet
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
 import org.wordpress.android.fluxc.persistence.NotificationSqlUtils
@@ -189,6 +190,13 @@ constructor(
         filterBySubtype: List<String>? = null
     ): List<NotificationModel> =
             notificationSqlUtils.getNotificationsForSite(site, ORDER_DESCENDING, filterByType, filterBySubtype)
+
+    /**
+     * Fetch the first notification matching the parameters specified in [NoteIdSet].
+     *
+     * @param idSet A [NoteIdSet] containing the localSiteId, remoteNoteId, and localNoteId
+     */
+    fun getNotificationByIdSet(idSet: NoteIdSet) = notificationSqlUtils.getNotificationByIdSet(idSet)
 
     private fun registerDevice(payload: RegisterDevicePayload) {
         val uuid = preferences.getString(WPCOM_PUSH_DEVICE_UUID, null) ?: generateAndStoreUUID()


### PR DESCRIPTION
Fixes #1024 

Adds the ability to request a single notification from the database using only the `local_site_id` and `remote_note_id`.

Also added some additional data and tests for testing the sql side.