### PR TITLE
Create visits and views endpoint

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.stats.time.ClicksStore
 import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.fluxc.store.stats.time.ReferrersStore
+import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Date
@@ -43,6 +44,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
     @Inject lateinit var postAndPageViewsStore: PostAndPageViewsStore
     @Inject lateinit var referrersStore: ReferrersStore
     @Inject lateinit var clicksStore: ClicksStore
+    @Inject lateinit var visitsAndViewsStore: VisitsAndViewsStore
     @Inject lateinit var accountStore: AccountStore
     @Inject internal lateinit var siteStore: SiteStore
 
@@ -132,6 +134,30 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights.model)
 
             val insightsFromDb = clicksStore.getClicks(site, granularity, PAGE_SIZE, SELECTED_DATE)
+
+            assertEquals(fetchedInsights.model, insightsFromDb)
+        }
+    }
+
+    @Test
+    fun testFetchVisitsAndViews() {
+        val site = authenticate()
+
+        for (granularity in StatsGranularity.values()) {
+            val fetchedInsights = runBlocking {
+                visitsAndViewsStore.fetchVisits(
+                        site,
+                        PAGE_SIZE,
+                        SELECTED_DATE,
+                        granularity,
+                        true
+                )
+            }
+
+            assertNotNull(fetchedInsights)
+            assertNotNull(fetchedInsights.model)
+
+            val insightsFromDb = visitsAndViewsStore.getVisits(site, SELECTED_DATE, granularity)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClientTest.kt
@@ -1,0 +1,176 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class VisitAndViewsRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var statsUtils: StatsUtils
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var restClient: VisitAndViewsRestClient
+    private val siteId: Long = 12
+    private val pageSize = 5
+    private val currentDateValue = "2018-10-10"
+    private val currentDate = Date(0)
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        restClient = VisitAndViewsRestClient(
+                dispatcher,
+                wpComGsonRequestBuilder,
+                null,
+                requestQueue,
+                accessToken,
+                userAgent,
+                statsUtils
+        )
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(currentDate))).thenReturn(currentDateValue)
+    }
+
+    @Test
+    fun `returns visits and views per day success response`() = test {
+        testSuccessResponse(DAYS)
+    }
+
+    @Test
+    fun `returns visits and views per day error response`() = test {
+        testErrorResponse(DAYS)
+    }
+
+    @Test
+    fun `returns visits and views per week success response`() = test {
+        testSuccessResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns visits and views per week error response`() = test {
+        testErrorResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns visits and views per month success response`() = test {
+        testSuccessResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns visits and views per month error response`() = test {
+        testErrorResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns visits and views per year success response`() = test {
+        testSuccessResponse(YEARS)
+    }
+
+    @Test
+    fun `returns visits and views per year error response`() = test {
+        testErrorResponse(YEARS)
+    }
+
+    private suspend fun testSuccessResponse(period: StatsGranularity) {
+        val response = mock<VisitsAndViewsResponse>()
+        initVisitsAndViewsResponse(response)
+
+        val responseModel = restClient.fetchVisits(site, currentDate, period, pageSize, false)
+
+        assertThat(responseModel.response).isNotNull()
+        assertThat(responseModel.response).isEqualTo(response)
+        assertThat(urlCaptor.lastValue)
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/visits/")
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mapOf(
+                        "quantity" to pageSize.toString(),
+                        "unit" to period.toString(),
+                        "date" to currentDateValue
+                )
+        )
+    }
+
+    private suspend fun testErrorResponse(period: StatsGranularity) {
+        val errorMessage = "message"
+        initVisitsAndViewsResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val responseModel = restClient.fetchVisits(site, currentDate, period, pageSize, false)
+
+        assertThat(responseModel.error).isNotNull()
+        assertThat(responseModel.error.type).isEqualTo(API_ERROR)
+        assertThat(responseModel.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initVisitsAndViewsResponse(
+        data: VisitsAndViewsResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<VisitsAndViewsResponse> {
+        return initResponse(VisitsAndViewsResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun <T> initResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null,
+        cachingEnabled: Boolean = false
+    ): Response<T> {
+        val response = if (error != null) Response.Error<T>(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncGetRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        eq(kclass),
+                        eq(cachingEnabled),
+                        any(),
+                        eq(false)
+                )
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ClicksSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ClicksSqlUtilsTest.kt
@@ -45,7 +45,7 @@ class ClicksSqlUtilsTest {
     }
 
     @Test
-    fun `returns referrers from stats utils`() {
+    fun `returns data from stats utils`() {
         mappedTypes.forEach { statsType, dbGranularity ->
 
             whenever(statsSqlUtils.select(site, CLICKS, statsType, ClicksResponse::class.java, DATE_VALUE))
@@ -60,7 +60,7 @@ class ClicksSqlUtilsTest {
     }
 
     @Test
-    fun `inserts referrers to stats utils`() {
+    fun `inserts data to stats utils`() {
         mappedTypes.forEach { statsType, dbGranularity ->
             timeStatsSqlUtils.insert(site, CLICKS_RESPONSE, dbGranularity, DATE)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VisitAndViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VisitAndViewsSqlUtilsTest.kt
@@ -10,20 +10,20 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.VISITS_AND_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.DAY
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.MONTH
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
 import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
-import org.wordpress.android.fluxc.store.stats.time.CLICKS_RESPONSE
+import org.wordpress.android.fluxc.store.stats.time.VISITS_AND_VIEWS_RESPONSE
 import java.util.Date
 import kotlin.test.assertEquals
 
@@ -31,7 +31,7 @@ private val DATE = Date(0)
 private const val DATE_VALUE = "2018-10-10"
 
 @RunWith(MockitoJUnitRunner::class)
-class ClicksSqlUtilsTest {
+class VisitAndViewsSqlUtilsTest {
     @Mock lateinit var statsSqlUtils: StatsSqlUtils
     @Mock lateinit var site: SiteModel
     @Mock lateinit var statsUtils: StatsUtils
@@ -45,26 +45,34 @@ class ClicksSqlUtilsTest {
     }
 
     @Test
-    fun `returns referrers from stats utils`() {
+    fun `returns data from stats utils`() {
         mappedTypes.forEach { statsType, dbGranularity ->
 
-            whenever(statsSqlUtils.select(site, CLICKS, statsType, ClicksResponse::class.java, DATE_VALUE))
+            whenever(
+                    statsSqlUtils.select(
+                            site,
+                            VISITS_AND_VIEWS,
+                            statsType,
+                            VisitsAndViewsResponse::class.java,
+                            DATE_VALUE
+                    )
+            )
                     .thenReturn(
-                            CLICKS_RESPONSE
+                            VISITS_AND_VIEWS_RESPONSE
                     )
 
-            val result = timeStatsSqlUtils.selectClicks(site, dbGranularity, DATE)
+            val result = timeStatsSqlUtils.selectVisitsAndViews(site, dbGranularity, DATE)
 
-            assertEquals(result, CLICKS_RESPONSE)
+            assertEquals(result, VISITS_AND_VIEWS_RESPONSE)
         }
     }
 
     @Test
-    fun `inserts referrers to stats utils`() {
+    fun `inserts data to stats utils`() {
         mappedTypes.forEach { statsType, dbGranularity ->
-            timeStatsSqlUtils.insert(site, CLICKS_RESPONSE, dbGranularity, DATE)
+            timeStatsSqlUtils.insert(site, VISITS_AND_VIEWS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, CLICKS, statsType, CLICKS_RESPONSE, DATE_VALUE)
+            verify(statsSqlUtils).insert(site, VISITS_AND_VIEWS, statsType, VISITS_AND_VIEWS_RESPONSE, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VisitAndViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VisitAndViewsSqlUtilsTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.fluxc.persistance.stats.time
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.DAY
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.MONTH
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.stats.time.CLICKS_RESPONSE
+import java.util.Date
+import kotlin.test.assertEquals
+
+private val DATE = Date(0)
+private const val DATE_VALUE = "2018-10-10"
+
+@RunWith(MockitoJUnitRunner::class)
+class ClicksSqlUtilsTest {
+    @Mock lateinit var statsSqlUtils: StatsSqlUtils
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var statsUtils: StatsUtils
+    private lateinit var timeStatsSqlUtils: TimeStatsSqlUtils
+    private val mappedTypes = mapOf(DAY to DAYS, WEEK to WEEKS, MONTH to MONTHS, YEAR to YEARS)
+
+    @Before
+    fun setUp() {
+        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(DATE))).thenReturn(DATE_VALUE)
+    }
+
+    @Test
+    fun `returns referrers from stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+
+            whenever(statsSqlUtils.select(site, CLICKS, statsType, ClicksResponse::class.java, DATE_VALUE))
+                    .thenReturn(
+                            CLICKS_RESPONSE
+                    )
+
+            val result = timeStatsSqlUtils.selectClicks(site, dbGranularity, DATE)
+
+            assertEquals(result, CLICKS_RESPONSE)
+        }
+    }
+
+    @Test
+    fun `inserts referrers to stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+            timeStatsSqlUtils.insert(site, CLICKS_RESPONSE, dbGranularity, DATE)
+
+            verify(statsSqlUtils).insert(site, CLICKS, statsType, CLICKS_RESPONSE, DATE_VALUE)
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestCl
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Group
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Groups
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Referrer
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.store.stats.DATE
 import org.wordpress.android.fluxc.store.stats.POST_COUNT
 
@@ -115,3 +116,9 @@ val GROUP = Group(GROUP_ID, "Group 1", "icon.jpg", "url.com", 50, null, referrer
 val REFERRERS_RESPONSE = ReferrersResponse(null, mapOf("2018-10-10" to Groups(10, 20, listOf(GROUP))))
 val CLICK_GROUP = ClickGroup(GROUP_ID, "Click name", "click.jpg", "click.com", 20, null)
 val CLICKS_RESPONSE = ClicksResponse(null, mapOf("2018-10-10" to ClicksResponse.Groups(10, 15, listOf(CLICK_GROUP))))
+val VISITS_AND_VIEWS_RESPONSE = VisitsAndViewsResponse(
+        "2018-10-10",
+        listOf("period", "views", "likes", "comments", "visitors"),
+        listOf(listOf("2018-10-09", "10", "15", "20", "25")),
+        "day"
+)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
@@ -51,7 +51,7 @@ class VisitsAndViewsStoreTest {
                 VISITS_AND_VIEWS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchVisits(site, DATE, DAYS, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchVisits(site, DATE, DAYS, PAGE_SIZE, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<VisitsAndViewsModel>()
@@ -69,7 +69,7 @@ class VisitsAndViewsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<VisitsAndViewsResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchVisits(site, DATE, DAYS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchVisits(site, DATE, DAYS, PAGE_SIZE, forced)).thenReturn(errorPayload)
 
         val responseModel = store.fetchVisits(site, PAGE_SIZE, DATE, DAYS, forced)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
@@ -1,0 +1,92 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.Dispatchers.Unconfined
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.ClicksModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import java.util.Date
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+private const val PAGE_SIZE = 8
+private val DATE = Date(0)
+
+@RunWith(MockitoJUnitRunner::class)
+class VisitsAndViewsStoreTest {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var restClient: VisitAndViewsRestClient
+    @Mock lateinit var sqlUtils: TimeStatsSqlUtils
+    @Mock lateinit var mapper: TimeStatsMapper
+    private lateinit var store: VisitsAndViewsStore
+    @Before
+    fun setUp() {
+        store = VisitsAndViewsStore(
+                restClient,
+                sqlUtils,
+                mapper,
+                Unconfined
+        )
+    }
+
+    @Test
+    fun `returns data per site`() = test {
+        val fetchInsightsPayload = FetchStatsPayload(
+                VISITS_AND_VIEWS_RESPONSE
+        )
+        val forced = true
+        whenever(restClient.fetchVisits(site, DATE, DAYS, PAGE_SIZE + 1, forced)).thenReturn(
+                fetchInsightsPayload
+        )
+        val model = mock<ClicksModel>()
+        whenever(mapper.map(CLICKS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val responseModel = store.fetchVisits(site, PAGE_SIZE, DATE, DAYS, forced)
+
+        assertThat(responseModel.model).isEqualTo(model)
+        verify(sqlUtils).insert(site, CLICKS_RESPONSE, DAYS, DATE)
+    }
+
+    @Test
+    fun `returns error when data call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchStatsPayload<VisitsAndViewsResponse>(StatsError(type, message))
+        val forced = true
+        whenever(restClient.fetchVisits(site, DATE, DAYS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+
+        val responseModel = store.fetchVisits(site, PAGE_SIZE, DATE, DAYS, forced)
+
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns data from db`() {
+        whenever(sqlUtils.selectClicks(site, DAYS, DATE)).thenReturn(CLICKS_RESPONSE)
+        val model = mock<ClicksModel>()
+        whenever(mapper.map(CLICKS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val result = store.getVisits(site, DATE, DAYS)
+
+        assertThat(result).isEqualTo(model)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
@@ -11,8 +11,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.stats.time.ClicksModel
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
@@ -54,13 +54,13 @@ class VisitsAndViewsStoreTest {
         whenever(restClient.fetchVisits(site, DATE, DAYS, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
-        val model = mock<ClicksModel>()
-        whenever(mapper.map(CLICKS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        val model = mock<VisitsAndViewsModel>()
+        whenever(mapper.map(VISITS_AND_VIEWS_RESPONSE)).thenReturn(model)
 
         val responseModel = store.fetchVisits(site, PAGE_SIZE, DATE, DAYS, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, CLICKS_RESPONSE, DAYS, DATE)
+        verify(sqlUtils).insert(site, VISITS_AND_VIEWS_RESPONSE, DAYS, DATE)
     }
 
     @Test
@@ -81,9 +81,9 @@ class VisitsAndViewsStoreTest {
 
     @Test
     fun `returns data from db`() {
-        whenever(sqlUtils.selectClicks(site, DAYS, DATE)).thenReturn(CLICKS_RESPONSE)
-        val model = mock<ClicksModel>()
-        whenever(mapper.map(CLICKS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(sqlUtils.selectVisitsAndViews(site, DAYS, DATE)).thenReturn(VISITS_AND_VIEWS_RESPONSE)
+        val model = mock<VisitsAndViewsModel>()
+        whenever(mapper.map(VISITS_AND_VIEWS_RESPONSE)).thenReturn(model)
 
         val result = store.getVisits(site, DATE, DAYS)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -5,9 +5,11 @@ import org.wordpress.android.fluxc.model.stats.time.ClicksModel.Click
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsModel
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType
 import org.wordpress.android.fluxc.model.stats.time.ReferrersModel.Referrer
+import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.STATS
 import javax.inject.Inject
@@ -72,5 +74,44 @@ class TimeStatsMapper
                 groups,
                 first.clicks.size > groups.size
         )
+    }
+
+    fun map(response: VisitsAndViewsResponse): VisitsAndViewsModel {
+        val periodIndex = response.fields?.indexOf("period")
+        val viewsIndex = response.fields?.indexOf("views")
+        val visitorsIndex = response.fields?.indexOf("visitors")
+        val likesIndex = response.fields?.indexOf("likes")
+        val reblogsIndex = response.fields?.indexOf("reblogs")
+        val commentsIndex = response.fields?.indexOf("comments")
+        val postsIndex = response.fields?.indexOf("posts")
+        val dataPerPeriod = response.data?.mapNotNull { periodData ->
+            periodData?.let {
+                val period = periodIndex?.let { periodData[it] }
+                if (period != null) {
+                    PeriodData(
+                            period,
+                            periodData.getLongOrZero(viewsIndex),
+                            periodData.getLongOrZero(visitorsIndex),
+                            periodData.getLongOrZero(likesIndex),
+                            periodData.getLongOrZero(reblogsIndex),
+                            periodData.getLongOrZero(commentsIndex),
+                            periodData.getLongOrZero(postsIndex)
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+        if (response.data == null) {
+            AppLog.e(STATS, "VisitsAndViewsResponse: Date field should never be null")
+        }
+        return VisitsAndViewsModel(response.date ?: "", dataPerPeriod ?: listOf())
+    }
+
+    private fun List<String?>.getLongOrZero(itemIndex: Int?): Long {
+        return itemIndex?.let {
+            val stringValue = this[it]
+            stringValue?.toLong()
+        } ?: 0
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/VisitsAndViewsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/VisitsAndViewsModel.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.model.stats.time
 
-import org.wordpress.android.fluxc.network.utils.StatsGranularity
-
 data class VisitsAndViewsModel(val period: String, val dates: List<PeriodData>) {
     data class PeriodData(
         val period: String,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/VisitsAndViewsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/VisitsAndViewsModel.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.fluxc.model.stats.time
+
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+
+data class VisitsAndViewsModel(val period: String, val dates: List<PeriodData>) {
+    data class PeriodData(
+        val period: String,
+        val views: Long,
+        val visitors: Long,
+        val likes: Long,
+        val reblogs: Long,
+        val comments: Long,
+        val posts: Long
+    )
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.toStatsError
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class VisitAndViewsRestClient
+@Inject constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    @param:Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    val gson: Gson,
+    private val statsUtils: StatsUtils
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchVisits(
+        site: SiteModel,
+        date: Date,
+        granularity: StatsGranularity,
+        pageSize: Int,
+        forced: Boolean
+    ): FetchStatsPayload<VisitsAndViewsResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).stats.visits.urlV1_1
+        val params = mapOf(
+                "unit" to granularity.toString(),
+                "quantity" to pageSize.toString(),
+                "date" to statsUtils.getFormattedDate(site, granularity, date)
+        )
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                params,
+                VisitsAndViewsResponse::class.java,
+                enableCaching = false,
+                forced = forced
+        )
+        return when (response) {
+            is Success -> {
+                FetchStatsPayload(response.data)
+            }
+            is Error -> {
+                FetchStatsPayload(response.error.toStatsError())
+            }
+        }
+    }
+
+    data class VisitsAndViewsResponse(
+        @SerializedName("date") val date: String?,
+        @SerializedName("fields") val fields: List<String>?,
+        @SerializedName("data") val data: List<List<String>?>?,
+        @SerializedName("unit") val unit: String?
+    )
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
 
 import android.content.Context
 import com.android.volley.RequestQueue
-import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
@@ -30,7 +29,6 @@ class VisitAndViewsRestClient
     @param:Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
-    val gson: Gson,
     private val statsUtils: StatsUtils
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchVisits(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -94,6 +94,7 @@ class StatsSqlUtils
         POSTS_AND_PAGES_VIEWS,
         REFERRERS,
         CLICKS,
+        VISITS_AND_VIEWS,
         PUBLICIZE_INSIGHTS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClien
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
@@ -13,6 +14,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.REFERRERS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.VISITS_AND_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
 import java.util.Date
 import javax.inject.Inject
@@ -51,6 +53,16 @@ class TimeStatsSqlUtils
         )
     }
 
+    fun insert(site: SiteModel, data: VisitsAndViewsResponse, granularity: StatsGranularity, date: Date) {
+        statsSqlUtils.insert(
+                site,
+                VISITS_AND_VIEWS,
+                granularity.toStatsType(),
+                data,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
     fun selectPostAndPageViews(site: SiteModel, granularity: StatsGranularity, date: Date): PostAndPageViewsResponse? {
         return statsSqlUtils.select(
                 site,
@@ -77,6 +89,16 @@ class TimeStatsSqlUtils
                 CLICKS,
                 granularity.toStatsType(),
                 ClicksResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
+    fun selectVisitsAndViews(site: SiteModel, granularity: StatsGranularity, date: Date): VisitsAndViewsResponse? {
+        return statsSqlUtils.select(
+                site,
+                VISITS_AND_VIEWS,
+                granularity.toStatsType(),
+                VisitsAndViewsResponse::class.java,
                 statsUtils.getFormattedDate(site, granularity, date)
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import kotlinx.coroutines.experimental.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
+
+@Singleton
+class VisitsAndViewsStore
+@Inject constructor(
+    private val restClient: VisitAndViewsRestClient,
+    private val sqlUtils: TimeStatsSqlUtils,
+    private val timeStatsMapper: TimeStatsMapper,
+    private val coroutineContext: CoroutineContext
+) {
+    suspend fun fetchVisits(
+        site: SiteModel,
+        pageSize: Int,
+        date: Date,
+        granularity: StatsGranularity,
+        forced: Boolean = false
+    ) = withContext(coroutineContext) {
+        val payload = restClient.fetchVisits(site, date, granularity, pageSize, forced)
+        return@withContext when {
+            payload.isError -> OnStatsFetched(payload.error)
+            payload.response != null -> {
+                sqlUtils.insert(site, payload.response, granularity, date)
+                OnStatsFetched(timeStatsMapper.map(payload.response))
+            }
+            else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
+        }
+    }
+
+    fun getVisits(site: SiteModel, date: Date, granularity: StatsGranularity): VisitsAndViewsModel? {
+        return sqlUtils.selectVisitsAndViews(site, granularity, date)?.let { timeStatsMapper.map(it) }
+    }
+}


### PR DESCRIPTION
fixes #1026 

This PR creates a Rest client, SQL utils and Store to retrieve Likes, Comments, Visitors and Views to show in the Overview block in stats.

This should be tested with the WPAndroid PR for the Overview block - https://github.com/wordpress-mobile/WordPress-Android/pull/8775