### PR TITLE
Add method to get notification by remote id from the local database

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -132,6 +132,15 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
                 .firstOrNull()?.build(formattableContentMapper)
     }
 
+    fun getNotificationByRemoteId(remoteNoteId: Long): NotificationModel? {
+        return WellSql.select(NotificationModelBuilder::class.java)
+                .where()
+                .equals(NotificationModelTable.REMOTE_NOTE_ID, remoteNoteId)
+                .endWhere()
+                .asModel
+                .firstOrNull()?.build(formattableContentMapper)
+    }
+
     fun deleteNotifications(): Int {
         return WellSql.delete(NotificationModelBuilder::class.java).execute()
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -198,6 +198,12 @@ constructor(
      */
     fun getNotificationByIdSet(idSet: NoteIdSet) = notificationSqlUtils.getNotificationByIdSet(idSet)
 
+    /**
+     * Fetch a notification from the database by the remote notification ID.
+     */
+    fun getNotificationByRemoteId(remoteNoteId: Long) =
+            notificationSqlUtils.getNotificationByRemoteId(remoteNoteId)
+
     private fun registerDevice(payload: RegisterDevicePayload) {
         val uuid = preferences.getString(WPCOM_PUSH_DEVICE_UUID, null) ?: generateAndStoreUUID()
 


### PR DESCRIPTION
Fixes #1028 

Adds a way to fetch a single notification from the local database by it's `remote_note_id` to the `NotificationStore`