### PR TITLE
Woo: create OrderIdentifier from remoteOrderId and localSiteId

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderIdentifier.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderIdentifier.kt
@@ -11,6 +11,11 @@ fun OrderIdentifier(orderModel: WCOrderModel): OrderIdentifier {
     return with(orderModel) { "$id-$remoteOrderId-$localSiteId" }
 }
 
+@Suppress("FunctionName")
+fun OrderIdentifier(localSiteId: Int, remoteOrderId: Long): OrderIdentifier {
+    return "0-$remoteOrderId-$localSiteId"
+}
+
 fun OrderIdentifier.toIdSet(): OrderIdSet {
     val (id, remoteOrderId, localSiteId) = split("-")
     return OrderIdSet(id.toInt(), remoteOrderId.toLong(), localSiteId.toInt())


### PR DESCRIPTION
Fixes #1030 

There are two ways to fetch an order from the database: using the local order `id`, or using the `localSiteId` with the `remoteOrderId`. Before this PR you could only get an instance of `OrderIdentifier` if you had a `WCOrderModel` fetched from FluxC first. If you only knew the `remoteNoteId` and `localSiteId` (like when dealing with Notifications), then a hack of creating a temp `WCOrderModel` was the only way to get that `OrderIdentifier` object, even though the local order `id` is not required.

This PR adds a way method for creating an `OrderIdentifier` object using only the `localSiteId` and `remoteNoteId`. 