### PR TITLE
Create authors endpoint for Stats

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
+import org.wordpress.android.fluxc.store.stats.time.AuthorsStore
 import org.wordpress.android.fluxc.store.stats.time.ClicksStore
 import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.fluxc.store.stats.time.ReferrersStore
@@ -41,6 +42,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
     @Inject lateinit var postAndPageViewsStore: PostAndPageViewsStore
     @Inject lateinit var referrersStore: ReferrersStore
     @Inject lateinit var clicksStore: ClicksStore
+    @Inject lateinit var authorsStore: AuthorsStore
     @Inject lateinit var accountStore: AccountStore
     @Inject internal lateinit var siteStore: SiteStore
 
@@ -114,6 +116,22 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights.model)
 
             val insightsFromDb = clicksStore.getClicks(site, period, PAGE_SIZE)
+
+            assertEquals(fetchedInsights.model, insightsFromDb)
+        }
+    }
+
+    @Test
+    fun testFetchAuthors() {
+        val site = authenticate()
+
+        for (period in StatsGranularity.values()) {
+            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, PAGE_SIZE, period, true) }
+
+            assertNotNull(fetchedInsights)
+            assertNotNull(fetchedInsights.model)
+
+            val insightsFromDb = authorsStore.getAuthors(site, period, PAGE_SIZE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -144,12 +144,12 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         for (period in StatsGranularity.values()) {
-            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, PAGE_SIZE, period, true) }
+            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, PAGE_SIZE, period, SELECTED_DATE) }
 
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = authorsStore.getAuthors(site, period, PAGE_SIZE)
+            val insightsFromDb = authorsStore.getAuthors(site, period, PAGE_SIZE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
@@ -118,7 +118,7 @@ class AuthorsRestClientTest {
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(response)
         assertThat(urlCaptor.lastValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/clicks/")
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/top-authors/")
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
                         "max" to pageSize.toString(),

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
@@ -1,0 +1,178 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+
+@RunWith(MockitoJUnitRunner::class)
+class AuthorsRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var statsUtils: StatsUtils
+    private val gson: Gson = GsonBuilder().create()
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var restClient: AuthorsRestClient
+    private val siteId: Long = 12
+    private val pageSize = 5
+    private val currentDate = "2018-10-10"
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        restClient = AuthorsRestClient(
+                dispatcher,
+                wpComGsonRequestBuilder,
+                null,
+                requestQueue,
+                accessToken,
+                userAgent,
+                gson,
+                statsUtils
+        )
+        whenever(statsUtils.getCurrentDateTZ(site)).thenReturn(currentDate)
+    }
+
+    @Test
+    fun `returns authors by day success response`() = test {
+        testSuccessResponse(DAYS)
+    }
+
+    @Test
+    fun `returns authors by day error response`() = test {
+        testErrorResponse(DAYS)
+    }
+
+    @Test
+    fun `returns authors by week success response`() = test {
+        testSuccessResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns authors by week error response`() = test {
+        testErrorResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns authors by month success response`() = test {
+        testSuccessResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns authors by month error response`() = test {
+        testErrorResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns authors by year success response`() = test {
+        testSuccessResponse(YEARS)
+    }
+
+    @Test
+    fun `returns authors by year error response`() = test {
+        testErrorResponse(YEARS)
+    }
+
+    private suspend fun testSuccessResponse(period: StatsGranularity) {
+        val response = mock<AuthorsResponse>()
+        initAuthorsResponse(response)
+
+        val responseModel = restClient.fetchAuthors(site, period, pageSize, false)
+
+        assertThat(responseModel.response).isNotNull()
+        assertThat(responseModel.response).isEqualTo(response)
+        assertThat(urlCaptor.lastValue)
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/clicks/")
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mapOf(
+                        "max" to pageSize.toString(),
+                        "period" to period.toString(),
+                        "date" to currentDate
+                )
+        )
+    }
+
+    private suspend fun testErrorResponse(period: StatsGranularity) {
+        val errorMessage = "message"
+        initAuthorsResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val responseModel = restClient.fetchAuthors(site, period, pageSize, false)
+
+        assertThat(responseModel.error).isNotNull()
+        assertThat(responseModel.error.type).isEqualTo(API_ERROR)
+        assertThat(responseModel.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initAuthorsResponse(
+        data: AuthorsResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<AuthorsResponse> {
+        return initResponse(AuthorsResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun <T> initResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null,
+        cachingEnabled: Boolean = false
+    ): Response<T> {
+        val response = if (error != null) Response.Error<T>(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncGetRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        eq(kclass),
+                        eq(cachingEnabled),
+                        any(),
+                        eq(false)
+                )
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class AuthorsRestClientTest {
@@ -50,7 +51,8 @@ class AuthorsRestClientTest {
     private lateinit var restClient: AuthorsRestClient
     private val siteId: Long = 12
     private val pageSize = 5
-    private val currentDate = "2018-10-10"
+    private val stringDate = "2018-10-10"
+    private val requestedDate = Date(0)
 
     @Before
     fun setUp() {
@@ -66,7 +68,7 @@ class AuthorsRestClientTest {
                 gson,
                 statsUtils
         )
-        whenever(statsUtils.getCurrentDateTZ(site)).thenReturn(currentDate)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(requestedDate))).thenReturn(stringDate)
     }
 
     @Test
@@ -113,7 +115,7 @@ class AuthorsRestClientTest {
         val response = mock<AuthorsResponse>()
         initAuthorsResponse(response)
 
-        val responseModel = restClient.fetchAuthors(site, period, pageSize, false)
+        val responseModel = restClient.fetchAuthors(site, period, requestedDate, pageSize, false)
 
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(response)
@@ -123,7 +125,7 @@ class AuthorsRestClientTest {
                 mapOf(
                         "max" to pageSize.toString(),
                         "period" to period.toString(),
-                        "date" to currentDate
+                        "date" to stringDate
                 )
         )
     }
@@ -140,7 +142,7 @@ class AuthorsRestClientTest {
                 )
         )
 
-        val responseModel = restClient.fetchAuthors(site, period, pageSize, false)
+        val responseModel = restClient.fetchAuthors(site, period, requestedDate, pageSize, false)
 
         assertThat(responseModel.error).isNotNull()
         assertThat(responseModel.error.type).isEqualTo(API_ERROR)

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/AuthorsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/AuthorsSqlUtilsTest.kt
@@ -1,0 +1,61 @@
+package org.wordpress.android.fluxc.persistance.stats.time
+
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.AUTHORS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.DAY
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.MONTH
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.stats.time.AUTHORS_RESPONSE
+import kotlin.test.assertEquals
+
+@RunWith(MockitoJUnitRunner::class)
+class AuthorsSqlUtilsTest {
+    @Mock lateinit var statsSqlUtils: StatsSqlUtils
+    @Mock lateinit var site: SiteModel
+    private lateinit var timeStatsSqlUtils: TimeStatsSqlUtils
+    private val mappedTypes = mapOf(DAY to DAYS, WEEK to WEEKS, MONTH to MONTHS, YEAR to YEARS)
+
+    @Before
+    fun setUp() {
+        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils)
+    }
+
+    @Test
+    fun `returns data from stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+
+            whenever(statsSqlUtils.select(site, AUTHORS, statsType, AuthorsResponse::class.java))
+                    .thenReturn(
+                            AUTHORS_RESPONSE
+                    )
+
+            val result = timeStatsSqlUtils.selectAuthors(site, dbGranularity)
+
+            assertEquals(result, AUTHORS_RESPONSE)
+        }
+    }
+
+    @Test
+    fun `inserts data to stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+            timeStatsSqlUtils.insert(site, AUTHORS_RESPONSE, dbGranularity)
+
+            verify(statsSqlUtils).insert(site, AUTHORS, statsType, AUTHORS_RESPONSE)
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStoreTest.kt
@@ -1,0 +1,90 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.Dispatchers.Unconfined
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.AuthorsModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+private const val PAGE_SIZE = 8
+
+@RunWith(MockitoJUnitRunner::class)
+class AuthorsStoreTest {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var restClient: AuthorsRestClient
+    @Mock lateinit var sqlUtils: TimeStatsSqlUtils
+    @Mock lateinit var mapper: TimeStatsMapper
+    private lateinit var store: AuthorsStore
+    @Before
+    fun setUp() {
+        store = AuthorsStore(
+                restClient,
+                sqlUtils,
+                mapper,
+                Unconfined
+        )
+    }
+
+    @Test
+    fun `returns data per site`() = test {
+        val fetchInsightsPayload = FetchStatsPayload(
+                AUTHORS_RESPONSE
+        )
+        val forced = true
+        whenever(restClient.fetchAuthors(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(
+                fetchInsightsPayload
+        )
+        val model = mock<AuthorsModel>()
+        whenever(mapper.map(AUTHORS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val responseModel = store.fetchAuthors(site, PAGE_SIZE, DAYS, forced)
+
+        assertThat(responseModel.model).isEqualTo(model)
+        verify(sqlUtils).insert(site, AUTHORS_RESPONSE, DAYS)
+    }
+
+    @Test
+    fun `returns error when data call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchStatsPayload<AuthorsResponse>(StatsError(type, message))
+        val forced = true
+        whenever(restClient.fetchAuthors(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+
+        val responseModel = store.fetchAuthors(site, PAGE_SIZE, DAYS, forced)
+
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns data from db`() {
+        whenever(sqlUtils.selectAuthors(site, DAYS)).thenReturn(AUTHORS_RESPONSE)
+        val model = mock<AuthorsModel>()
+        whenever(mapper.map(AUTHORS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val result = store.getAuthors(site, DAYS, PAGE_SIZE)
+
+        assertThat(result).isEqualTo(model)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStoreTest.kt
@@ -21,10 +21,12 @@ import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
+import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 private const val PAGE_SIZE = 8
+private val DATE = Date(0)
 
 @RunWith(MockitoJUnitRunner::class)
 class AuthorsStoreTest {
@@ -49,16 +51,16 @@ class AuthorsStoreTest {
                 AUTHORS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchAuthors(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchAuthors(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<AuthorsModel>()
         whenever(mapper.map(AUTHORS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val responseModel = store.fetchAuthors(site, PAGE_SIZE, DAYS, forced)
+        val responseModel = store.fetchAuthors(site, PAGE_SIZE, DAYS, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, AUTHORS_RESPONSE, DAYS)
+        verify(sqlUtils).insert(site, AUTHORS_RESPONSE, DAYS, DATE)
     }
 
     @Test
@@ -67,9 +69,9 @@ class AuthorsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<AuthorsResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchAuthors(site, DAYS, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchAuthors(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchAuthors(site, PAGE_SIZE, DAYS, forced)
+        val responseModel = store.fetchAuthors(site, PAGE_SIZE, DAYS, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -79,11 +81,11 @@ class AuthorsStoreTest {
 
     @Test
     fun `returns data from db`() {
-        whenever(sqlUtils.selectAuthors(site, DAYS)).thenReturn(AUTHORS_RESPONSE)
+        whenever(sqlUtils.selectAuthors(site, DAYS, DATE)).thenReturn(AUTHORS_RESPONSE)
         val model = mock<AuthorsModel>()
         whenever(mapper.map(AUTHORS_RESPONSE, PAGE_SIZE)).thenReturn(model)
 
-        val result = store.getAuthors(site, DAYS, PAGE_SIZE)
+        val result = store.getAuthors(site, DAYS, PAGE_SIZE, DATE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.store.stats.time
 
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse.Author
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse.Post
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse.ClickGroup
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
@@ -115,3 +118,10 @@ val GROUP = Group(GROUP_ID, "Group 1", "icon.jpg", "url.com", 50, null, referrer
 val REFERRERS_RESPONSE = ReferrersResponse(null, mapOf("2018-10-10" to Groups(10, 20, listOf(GROUP))))
 val CLICK_GROUP = ClickGroup(GROUP_ID, "Click name", "click.jpg", "click.com", 20, null)
 val CLICKS_RESPONSE = ClicksResponse(null, mapOf("2018-10-10" to ClicksResponse.Groups(10, 15, listOf(CLICK_GROUP))))
+val AUTHOR = Author(
+        "John", 5, "avatar.jpg", null, listOf(
+        Post("15", "Post 1", 100, "post.com")
+)
+)
+val AUTHORS_GROUP = AuthorsResponse.Groups(10, listOf(AUTHOR))
+val AUTHORS_RESPONSE = AuthorsResponse("day", mapOf("2018-10-10" to AUTHORS_GROUP))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/AuthorsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/AuthorsModel.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.model.stats.time
+
+data class AuthorsModel(val otherViews: Int, val authors: List<Author>, val hasMore: Boolean) {
+    data class Author(
+        val name: String,
+        val views: Int,
+        val avatar: String?,
+        val posts: List<Post>
+    )
+    data class Post(val id: String, val title: String, val views: Int, val url: String?)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/AuthorsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/AuthorsModel.kt
@@ -4,7 +4,7 @@ data class AuthorsModel(val otherViews: Int, val authors: List<Author>, val hasM
     data class Author(
         val name: String,
         val views: Int,
-        val avatar: String?,
+        val avatarUrl: String?,
         val posts: List<Post>
     )
     data class Post(val id: String, val title: String, val views: Int, val url: String?)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -2,10 +2,12 @@ package org.wordpress.android.fluxc.model.stats.time
 
 import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.stats.time.ClicksModel.Click
+import org.wordpress.android.fluxc.model.stats.time.AuthorsModel.Post
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsModel
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType
 import org.wordpress.android.fluxc.model.stats.time.ReferrersModel.Referrer
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.util.AppLog
@@ -44,7 +46,7 @@ class TimeStatsMapper
                     val firstChildUrl = result.children?.firstOrNull()?.url
                     Referrer(result.name, result.views, result.icon, firstChildUrl ?: result.url)
                 } else {
-                    AppLog.e(STATS, "ReferrersResponse.type: Missing fields on a referrer")
+                    AppLog.e(STATS, "ReferrersResponse: Missing fields on a referrer")
                     null
                 }
             }
@@ -72,5 +74,24 @@ class TimeStatsMapper
                 groups,
                 first.clicks.size > groups.size
         )
+    }
+
+    fun map(response: AuthorsResponse, pageSize: Int): AuthorsModel {
+        val first = response.groups.values.first()
+        val authors = first.authors.take(pageSize).map { author ->
+            val posts = author.mappedPosts?.mapNotNull { result ->
+                if (result.postId != null && result.title != null) {
+                    Post(result.postId, result.title, result.views ?: 0, result.url)
+                } else {
+                    AppLog.e(STATS, "AuthorsResponse: Missing fields on a post")
+                    null
+                }
+            }
+            if (author.name == null || author.views == null || author.avatar == null) {
+                AppLog.e(STATS, "AuthorsResponse: Missing fields on an author")
+            }
+            AuthorsModel.Author(author.name ?: "", author.views ?: 0, author.avatar, posts ?: listOf())
+        }
+        return AuthorsModel(first.otherViews ?: 0, authors, first.authors.size > authors.size)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -1,14 +1,14 @@
 package org.wordpress.android.fluxc.model.stats.time
 
 import com.google.gson.Gson
-import org.wordpress.android.fluxc.model.stats.time.ClicksModel.Click
 import org.wordpress.android.fluxc.model.stats.time.AuthorsModel.Post
+import org.wordpress.android.fluxc.model.stats.time.ClicksModel.Click
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsModel
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType
 import org.wordpress.android.fluxc.model.stats.time.ReferrersModel.Referrer
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
@@ -128,10 +128,10 @@ class TimeStatsMapper
                     null
                 }
             }
-            if (author.name == null || author.views == null || author.avatar == null) {
+            if (author.name == null || author.views == null || author.avatarUrl == null) {
                 AppLog.e(STATS, "AuthorsResponse: Missing fields on an author")
             }
-            AuthorsModel.Author(author.name ?: "", author.views ?: 0, author.avatar, posts ?: listOf())
+            AuthorsModel.Author(author.name ?: "", author.views ?: 0, author.avatarUrl, posts ?: listOf())
         }
         return AuthorsModel(first.otherViews ?: 0, authors, first.authors.size > authors.size)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
@@ -81,7 +81,7 @@ class AuthorsRestClient
         data class Author(
             @SerializedName("name") val name: String?,
             @SerializedName("views") var views: Int?,
-            @SerializedName("avatar") val avatar: String?,
+            @SerializedName("avatar") val avatarUrl: String?,
             @SerializedName("posts") val posts: JsonElement?,
             @SerializedName("mappedPosts") var mappedPosts: List<Post>? = null
         ) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.getInt
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -38,15 +39,16 @@ class AuthorsRestClient
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchAuthors(
         site: SiteModel,
-        period: StatsGranularity,
+        granularity: StatsGranularity,
+        date: Date,
         pageSize: Int,
         forced: Boolean
     ): FetchStatsPayload<AuthorsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.top_authors.urlV1_1
         val params = mapOf(
-                "period" to period.toString(),
+                "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getCurrentDateTZ(site)
+                "date" to statsUtils.getFormattedDate(site, granularity, date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
@@ -42,7 +42,7 @@ class AuthorsRestClient
         pageSize: Int,
         forced: Boolean
     ): FetchStatsPayload<AuthorsResponse> {
-        val url = WPCOMREST.sites.site(site.siteId).stats.referrers.urlV1_1
+        val url = WPCOMREST.sites.site(site.siteId).stats.top_authors.urlV1_1
         val params = mapOf(
                 "period" to period.toString(),
                 "max" to pageSize.toString(),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
@@ -1,0 +1,106 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.getInt
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.toStatsError
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class AuthorsRestClient
+@Inject constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    @param:Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    val gson: Gson,
+    private val statsUtils: StatsUtils
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchAuthors(
+        site: SiteModel,
+        period: StatsGranularity,
+        pageSize: Int,
+        forced: Boolean
+    ): FetchStatsPayload<AuthorsResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).stats.referrers.urlV1_1
+        val params = mapOf(
+                "period" to period.toString(),
+                "max" to pageSize.toString(),
+                "date" to statsUtils.getCurrentDateTZ(site)
+        )
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                params,
+                AuthorsResponse::class.java,
+                enableCaching = false,
+                forced = forced
+        )
+        return when (response) {
+            is Success -> {
+                response.data.groups.values.forEach { it.authors.forEach { group -> group.build(gson) } }
+                FetchStatsPayload(response.data)
+            }
+            is Error -> {
+                FetchStatsPayload(response.error.toStatsError())
+            }
+        }
+    }
+
+    data class AuthorsResponse(
+        @SerializedName("period") val statsGranularity: String?,
+        @SerializedName("days") val groups: Map<String, Groups>
+    ) {
+        data class Groups(
+            @SerializedName("other_views") val otherViews: Int?,
+            @SerializedName("authors") val authors: List<Author>
+        )
+
+        data class Author(
+            @SerializedName("name") val name: String?,
+            @SerializedName("views") var views: Int?,
+            @SerializedName("avatar") val avatar: String?,
+            @SerializedName("posts") val posts: JsonElement?,
+            @SerializedName("mappedPosts") var mappedPosts: List<Post>? = null
+        ) {
+            fun build(gson: Gson) {
+                when (this.posts) {
+                    is JsonArray -> this.mappedPosts = this.posts.map {
+                        gson.fromJson<Post>(
+                                it,
+                                Post::class.java
+                        )
+                    }
+                    is JsonObject -> this.views = this.posts.getInt("views")
+                }
+            }
+        }
+
+        data class Post(
+            @SerializedName("id") val postId: String?,
+            @SerializedName("title") val title: String?,
+            @SerializedName("views") val views: Int?,
+            @SerializedName("url") val url: String?
+        )
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -84,6 +84,7 @@ class StatsSqlUtils
         POSTS_AND_PAGES_VIEWS,
         REFERRERS,
         CLICKS,
+        AUTHORS,
         PUBLICIZE_INSIGHTS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.persistence
 
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
@@ -11,8 +11,8 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.AUTHORS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.REFERRERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
@@ -97,7 +97,7 @@ class TimeStatsSqlUtils
         return statsSqlUtils.select(
                 site,
                 AUTHORS,
-                period.toStatsType(),
+                granularity.toStatsType(),
                 AuthorsResponse::class.java,
                 statsUtils.getFormattedDate(site, granularity, date)
         )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.persistence
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
@@ -10,6 +11,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.AUTHORS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.REFERRERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
@@ -29,6 +31,10 @@ class TimeStatsSqlUtils
 
     fun insert(site: SiteModel, data: ClicksResponse, granularity: StatsGranularity) {
         statsSqlUtils.insert(site, CLICKS, granularity.toStatsType(), data)
+    }
+
+    fun insert(site: SiteModel, data: AuthorsResponse, granularity: StatsGranularity) {
+        statsSqlUtils.insert(site, AUTHORS, granularity.toStatsType(), data)
     }
 
     fun selectPostAndPageViews(site: SiteModel, granularity: StatsGranularity): PostAndPageViewsResponse? {
@@ -55,6 +61,15 @@ class TimeStatsSqlUtils
                 CLICKS,
                 granularity.toStatsType(),
                 ClicksResponse::class.java
+        )
+    }
+
+    fun selectAuthors(site: SiteModel, period: StatsGranularity): AuthorsResponse? {
+        return statsSqlUtils.select(
+                site,
+                AUTHORS,
+                period.toStatsType(),
+                AuthorsResponse::class.java
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStore.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.CoroutineContext
@@ -26,20 +27,21 @@ class AuthorsStore
         site: SiteModel,
         pageSize: Int,
         period: StatsGranularity,
+        date: Date,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
-        val payload = restClient.fetchAuthors(site, period, pageSize + 1, forced)
+        val payload = restClient.fetchAuthors(site, period, date, pageSize + 1, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
-                sqlUtils.insert(site, payload.response, period)
+                sqlUtils.insert(site, payload.response, period, date)
                 OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
     }
 
-    fun getAuthors(site: SiteModel, period: StatsGranularity, pageSize: Int): AuthorsModel? {
-        return sqlUtils.selectAuthors(site, period)?.let { timeStatsMapper.map(it, pageSize) }
+    fun getAuthors(site: SiteModel, period: StatsGranularity, pageSize: Int, date: Date): AuthorsModel? {
+        return sqlUtils.selectAuthors(site, period, date)?.let { timeStatsMapper.map(it, pageSize) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStore.kt
@@ -1,0 +1,45 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import kotlinx.coroutines.experimental.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.AuthorsModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
+
+@Singleton
+class AuthorsStore
+@Inject constructor(
+    private val restClient: AuthorsRestClient,
+    private val sqlUtils: TimeStatsSqlUtils,
+    private val timeStatsMapper: TimeStatsMapper,
+    private val coroutineContext: CoroutineContext
+) {
+    suspend fun fetchAuthors(
+        site: SiteModel,
+        pageSize: Int,
+        period: StatsGranularity,
+        forced: Boolean = false
+    ) = withContext(coroutineContext) {
+        val payload = restClient.fetchAuthors(site, period, pageSize + 1, forced)
+        return@withContext when {
+            payload.isError -> OnStatsFetched(payload.error)
+            payload.response != null -> {
+                sqlUtils.insert(site, payload.response, period)
+                OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
+            }
+            else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
+        }
+    }
+
+    fun getAuthors(site: SiteModel, period: StatsGranularity, pageSize: Int): AuthorsModel? {
+        return sqlUtils.selectAuthors(site, period)?.let { timeStatsMapper.map(it, pageSize) }
+    }
+}


### PR DESCRIPTION
Fixes #1000 
In this PR I'm adding an endpoint that returns a list of Authors with their top posts for Stats.
This should be tested with the WPAndroid PR