### PR TITLE
Create countries endpoint in Stats

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.stats.time.ClicksStore
+import org.wordpress.android.fluxc.store.stats.time.CountryViewsStore
 import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.fluxc.store.stats.time.ReferrersStore
 import org.wordpress.android.util.AppLog
@@ -43,6 +44,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
     @Inject lateinit var postAndPageViewsStore: PostAndPageViewsStore
     @Inject lateinit var referrersStore: ReferrersStore
     @Inject lateinit var clicksStore: ClicksStore
+    @Inject lateinit var countryViewsStore: CountryViewsStore
     @Inject lateinit var accountStore: AccountStore
     @Inject internal lateinit var siteStore: SiteStore
 
@@ -132,6 +134,30 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights.model)
 
             val insightsFromDb = clicksStore.getClicks(site, granularity, PAGE_SIZE, SELECTED_DATE)
+
+            assertEquals(fetchedInsights.model, insightsFromDb)
+        }
+    }
+
+    @Test
+    fun testFetchCountryViews() {
+        val site = authenticate()
+
+        for (granularity in StatsGranularity.values()) {
+            val fetchedInsights = runBlocking {
+                countryViewsStore.fetchCountryViews(
+                        site,
+                        PAGE_SIZE,
+                        granularity,
+                        SELECTED_DATE,
+                        true
+                )
+            }
+
+            assertNotNull(fetchedInsights)
+            assertNotNull(fetchedInsights.model)
+
+            val insightsFromDb = countryViewsStore.getCountryViews(site, granularity, PAGE_SIZE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
@@ -1,0 +1,176 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class CountryViewsRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var statsUtils: StatsUtils
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var restClient: CountryViewsRestClient
+    private val siteId: Long = 12
+    private val pageSize = 5
+    private val currentDateValue = "2018-10-10"
+    private val currentDate = Date(0)
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        restClient = CountryViewsRestClient(
+                dispatcher,
+                wpComGsonRequestBuilder,
+                null,
+                requestQueue,
+                accessToken,
+                userAgent,
+                statsUtils
+        )
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(currentDate))).thenReturn(currentDateValue)
+    }
+
+    @Test
+    fun `returns country views by day success response`() = test {
+        testSuccessResponse(DAYS)
+    }
+
+    @Test
+    fun `returns country views by day error response`() = test {
+        testErrorResponse(DAYS)
+    }
+
+    @Test
+    fun `returns country views by week success response`() = test {
+        testSuccessResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns country views by week error response`() = test {
+        testErrorResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns country views by month success response`() = test {
+        testSuccessResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns country views by month error response`() = test {
+        testErrorResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns country views by year success response`() = test {
+        testSuccessResponse(YEARS)
+    }
+
+    @Test
+    fun `returns country views by year error response`() = test {
+        testErrorResponse(YEARS)
+    }
+
+    private suspend fun testSuccessResponse(period: StatsGranularity) {
+        val response = mock<CountryViewsResponse>()
+        initCountryViewsResponse(response)
+
+        val responseModel = restClient.fetchCountryViews(site, period, currentDate, pageSize, false)
+
+        assertThat(responseModel.response).isNotNull()
+        assertThat(responseModel.response).isEqualTo(response)
+        assertThat(urlCaptor.lastValue)
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/country-views/")
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mapOf(
+                        "max" to pageSize.toString(),
+                        "period" to period.toString(),
+                        "date" to currentDateValue
+                )
+        )
+    }
+
+    private suspend fun testErrorResponse(period: StatsGranularity) {
+        val errorMessage = "message"
+        initCountryViewsResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val responseModel = restClient.fetchCountryViews(site, period, currentDate, pageSize, false)
+
+        assertThat(responseModel.error).isNotNull()
+        assertThat(responseModel.error.type).isEqualTo(API_ERROR)
+        assertThat(responseModel.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initCountryViewsResponse(
+        data: CountryViewsResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CountryViewsResponse> {
+        return initResponse(CountryViewsResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun <T> initResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null,
+        cachingEnabled: Boolean = false
+    ): Response<T> {
+        val response = if (error != null) Response.Error<T>(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncGetRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        eq(kclass),
+                        eq(cachingEnabled),
+                        any(),
+                        eq(false)
+                )
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/CountryViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/CountryViewsSqlUtilsTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.fluxc.persistance.stats.time
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.COUNTRY_VIEWS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.DAY
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.MONTH
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.stats.time.COUNTRY_VIEWS_RESPONSE
+import java.util.Date
+import kotlin.test.assertEquals
+
+private val DATE = Date(0)
+private const val DATE_VALUE = "2018-10-10"
+
+@RunWith(MockitoJUnitRunner::class)
+class CountryViewsSqlUtilsTest {
+    @Mock lateinit var statsSqlUtils: StatsSqlUtils
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var statsUtils: StatsUtils
+    private lateinit var timeStatsSqlUtils: TimeStatsSqlUtils
+    private val mappedTypes = mapOf(DAY to DAYS, WEEK to WEEKS, MONTH to MONTHS, YEAR to YEARS)
+
+    @Before
+    fun setUp() {
+        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(DATE))).thenReturn(DATE_VALUE)
+    }
+
+    @Test
+    fun `returns data from stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+
+            whenever(statsSqlUtils.select(site, COUNTRY_VIEWS, statsType, CountryViewsResponse::class.java, DATE_VALUE))
+                    .thenReturn(
+                            COUNTRY_VIEWS_RESPONSE
+                    )
+
+            val result = timeStatsSqlUtils.selectCountryViews(site, dbGranularity, DATE)
+
+            assertEquals(result, COUNTRY_VIEWS_RESPONSE)
+        }
+    }
+
+    @Test
+    fun `inserts data to stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+            timeStatsSqlUtils.insert(site, COUNTRY_VIEWS_RESPONSE, dbGranularity, DATE)
+
+            verify(statsSqlUtils).insert(site, COUNTRY_VIEWS, statsType, COUNTRY_VIEWS_RESPONSE, DATE_VALUE)
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/CountryViewsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/CountryViewsStoreTest.kt
@@ -1,0 +1,92 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.Dispatchers.Unconfined
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.CountryViewsModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import java.util.Date
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+private const val PAGE_SIZE = 8
+private val DATE = Date(0)
+
+@RunWith(MockitoJUnitRunner::class)
+class CountryViewsStoreTest {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var restClient: CountryViewsRestClient
+    @Mock lateinit var sqlUtils: TimeStatsSqlUtils
+    @Mock lateinit var mapper: TimeStatsMapper
+    private lateinit var store: CountryViewsStore
+    @Before
+    fun setUp() {
+        store = CountryViewsStore(
+                restClient,
+                sqlUtils,
+                mapper,
+                Unconfined
+        )
+    }
+
+    @Test
+    fun `returns country views per site`() = test {
+        val fetchInsightsPayload = FetchStatsPayload(
+                COUNTRY_VIEWS_RESPONSE
+        )
+        val forced = true
+        whenever(restClient.fetchCountryViews(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
+                fetchInsightsPayload
+        )
+        val model = mock<CountryViewsModel>()
+        whenever(mapper.map(COUNTRY_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val responseModel = store.fetchCountryViews(site, PAGE_SIZE, DAYS, DATE, forced)
+
+        assertThat(responseModel.model).isEqualTo(model)
+        verify(sqlUtils).insert(site, COUNTRY_VIEWS_RESPONSE, DAYS, DATE)
+    }
+
+    @Test
+    fun `returns error when country views call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchStatsPayload<CountryViewsResponse>(StatsError(type, message))
+        val forced = true
+        whenever(restClient.fetchCountryViews(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+
+        val responseModel = store.fetchCountryViews(site, PAGE_SIZE, DAYS, DATE, forced)
+
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns country views from db`() {
+        whenever(sqlUtils.selectCountryViews(site, DAYS, DATE)).thenReturn(COUNTRY_VIEWS_RESPONSE)
+        val model = mock<CountryViewsModel>()
+        whenever(mapper.map(COUNTRY_VIEWS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val result = store.getCountryViews(site, DAYS, PAGE_SIZE, DATE)
+
+        assertThat(result).isEqualTo(model)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -2,6 +2,10 @@ package org.wordpress.android.fluxc.store.stats.time
 
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse.ClickGroup
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse.CountryInfo
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse.CountryView
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse.Day
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse.ViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse.ViewsResponse.PostViewsResponse
@@ -115,3 +119,13 @@ val GROUP = Group(GROUP_ID, "Group 1", "icon.jpg", "url.com", 50, null, referrer
 val REFERRERS_RESPONSE = ReferrersResponse(null, mapOf("2018-10-10" to Groups(10, 20, listOf(GROUP))))
 val CLICK_GROUP = ClickGroup(GROUP_ID, "Click name", "click.jpg", "click.com", 20, null)
 val CLICKS_RESPONSE = ClicksResponse(null, mapOf("2018-10-10" to ClicksResponse.Groups(10, 15, listOf(CLICK_GROUP))))
+const val COUNTRY_CODE = "CZ"
+val COUNTRY_VIEWS_RESPONSE = CountryViewsResponse(
+        mapOf(COUNTRY_CODE to CountryInfo("flag.jpg", "flatFlag.jpg", "123", "Czech Republic")), days = mapOf(
+        "2018-10-10" to Day(
+                10, 20, listOf(
+                CountryView(COUNTRY_CODE, 150)
+        )
+        )
+)
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/CountryViewsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/CountryViewsModel.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.model.stats.time
+
+data class CountryViewsModel(
+    val otherViews: Int,
+    val totalViews: Int,
+    val countries: List<Country>,
+    val hasMore: Boolean
+) {
+    data class Country(
+        val countryCode: String,
+        val fullName: String,
+        val views: Int,
+        val flagIconUrl: String?,
+        val flatFlagIconUrl: String?
+    )
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -77,8 +77,9 @@ class TimeStatsMapper
 
     fun map(response: CountryViewsResponse, pageSize: Int): CountryViewsModel {
         val first = response.days.values.first()
+        val countriesInfo = response.countryInfo
         val groups = first.views.take(pageSize).mapNotNull { countryViews ->
-            val countryInfo = first.countryInfo[countryViews.countryCode]
+            val countryInfo = countriesInfo[countryViews.countryCode]
             if (countryViews.countryCode != null && countryInfo != null && countryInfo.countryFull != null) {
                 CountryViewsModel.Country(
                         countryViews.countryCode,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsM
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType
 import org.wordpress.android.fluxc.model.stats.time.ReferrersModel.Referrer
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.util.AppLog
@@ -71,6 +72,31 @@ class TimeStatsMapper
                 first.totalClicks ?: 0,
                 groups,
                 first.clicks.size > groups.size
+        )
+    }
+
+    fun map(response: CountryViewsResponse, pageSize: Int): CountryViewsModel {
+        val first = response.days.values.first()
+        val groups = first.views.take(pageSize).mapNotNull { countryViews ->
+            val countryInfo = first.countryInfo[countryViews.countryCode]
+            if (countryViews.countryCode != null && countryInfo != null && countryInfo.countryFull != null) {
+                CountryViewsModel.Country(
+                        countryViews.countryCode,
+                        countryInfo.countryFull,
+                        countryViews.views ?: 0,
+                        countryInfo.flagIcon,
+                        countryInfo.flatFlagIcon
+                )
+            } else {
+                AppLog.e(STATS, "CountryViewsResponse: Missing fields on a CountryViews object")
+                null
+            }
+        }
+        return CountryViewsModel(
+                first.otherViews ?: 0,
+                first.totalViews ?: 0,
+                groups,
+                first.views.size > groups.size
         )
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
@@ -65,12 +65,12 @@ class CountryViewsRestClient
     }
 
     data class CountryViewsResponse(
+        @SerializedName("country-info") val countryInfo: Map<String, CountryInfo>,
         @SerializedName("days") val days: Map<String, Day>
     ) {
         data class Day(
             @SerializedName("other_views") val otherViews: Int?,
             @SerializedName("total_views") val totalViews: Int?,
-            @SerializedName("country-info") val countryInfo: Map<String, CountryInfo>,
             @SerializedName("views") val views: List<CountryView>
         )
 
@@ -82,6 +82,7 @@ class CountryViewsRestClient
         data class CountryInfo(
             @SerializedName("flag_icon") val flagIcon: String?,
             @SerializedName("flat_flag_icon") val flatFlagIcon: String?,
+            @SerializedName("map_region") val mapRegion: String?,
             @SerializedName("country_full") val countryFull: String?
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
@@ -65,9 +65,9 @@ class CountryViewsRestClient
     }
 
     data class CountryViewsResponse(
-        @SerializedName("days") val groups: Map<String, Groups>
+        @SerializedName("days") val days: Map<String, Day>
     ) {
-        data class Groups(
+        data class Day(
             @SerializedName("other_views") val otherViews: Int?,
             @SerializedName("total_views") val totalViews: Int?,
             @SerializedName("country-info") val countryInfo: Map<String, CountryInfo>,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
@@ -1,0 +1,88 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.toStatsError
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class CountryViewsRestClient
+@Inject constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    @param:Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    val gson: Gson,
+    private val statsUtils: StatsUtils
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchCountryViews(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        date: Date,
+        pageSize: Int,
+        forced: Boolean
+    ): FetchStatsPayload<CountryViewsResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).stats.country_views.urlV1_1
+        val params = mapOf(
+                "period" to granularity.toString(),
+                "max" to pageSize.toString(),
+                "date" to statsUtils.getFormattedDate(site, granularity, date)
+        )
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                params,
+                CountryViewsResponse::class.java,
+                enableCaching = false,
+                forced = forced
+        )
+        return when (response) {
+            is Success -> {
+                FetchStatsPayload(response.data)
+            }
+            is Error -> {
+                FetchStatsPayload(response.error.toStatsError())
+            }
+        }
+    }
+
+    data class CountryViewsResponse(
+        @SerializedName("days") val groups: Map<String, Groups>
+    ) {
+        data class Groups(
+            @SerializedName("other_views") val otherViews: Int?,
+            @SerializedName("total_views") val totalViews: Int?,
+            @SerializedName("country-info") val countryInfo: Map<String, CountryInfo>,
+            @SerializedName("views") val views: List<CountryView>
+        )
+
+        data class CountryView(
+            @SerializedName("country_code") val countryCode: String?,
+            @SerializedName("views") val views: Int?
+        )
+
+        data class CountryInfo(
+            @SerializedName("flag_icon") val flagIcon: String?,
+            @SerializedName("flat_flag_icon") val flatFlagIcon: String?,
+            @SerializedName("country_full") val countryFull: String?
+        )
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
 
 import android.content.Context
 import com.android.volley.RequestQueue
-import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
@@ -30,7 +29,6 @@ class CountryViewsRestClient
     @param:Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
-    val gson: Gson,
     private val statsUtils: StatsUtils
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchCountryViews(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -94,6 +94,7 @@ class StatsSqlUtils
         POSTS_AND_PAGES_VIEWS,
         REFERRERS,
         CLICKS,
+        COUNTRY_VIEWS,
         PUBLICIZE_INSIGHTS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.persistence
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
@@ -11,6 +12,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.COUNTRY_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.REFERRERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
@@ -51,6 +53,16 @@ class TimeStatsSqlUtils
         )
     }
 
+    fun insert(site: SiteModel, data: CountryViewsResponse, granularity: StatsGranularity, date: Date) {
+        statsSqlUtils.insert(
+                site,
+                COUNTRY_VIEWS,
+                granularity.toStatsType(),
+                data,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
     fun selectPostAndPageViews(site: SiteModel, granularity: StatsGranularity, date: Date): PostAndPageViewsResponse? {
         return statsSqlUtils.select(
                 site,
@@ -77,6 +89,16 @@ class TimeStatsSqlUtils
                 CLICKS,
                 granularity.toStatsType(),
                 ClicksResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
+    fun selectCountryViews(site: SiteModel, granularity: StatsGranularity, date: Date): CountryViewsResponse? {
+        return statsSqlUtils.select(
+                site,
+                COUNTRY_VIEWS,
+                granularity.toStatsType(),
+                CountryViewsResponse::class.java,
                 statsUtils.getFormattedDate(site, granularity, date)
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/CountryViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/CountryViewsStore.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import kotlinx.coroutines.experimental.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.CountryViewsModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
+
+@Singleton
+class CountryViewsStore
+@Inject constructor(
+    private val restClient: CountryViewsRestClient,
+    private val sqlUtils: TimeStatsSqlUtils,
+    private val timeStatsMapper: TimeStatsMapper,
+    private val coroutineContext: CoroutineContext
+) {
+    suspend fun fetchCountryViews(
+        site: SiteModel,
+        pageSize: Int,
+        granularity: StatsGranularity,
+        date: Date,
+        forced: Boolean = false
+    ) = withContext(coroutineContext) {
+        val payload = restClient.fetchCountryViews(site, granularity, date, pageSize + 1, forced)
+        return@withContext when {
+            payload.isError -> OnStatsFetched(payload.error)
+            payload.response != null -> {
+                sqlUtils.insert(site, payload.response, granularity, date)
+                OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
+            }
+            else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
+        }
+    }
+
+    fun getCountryViews(site: SiteModel, period: StatsGranularity, pageSize: Int, date: Date): CountryViewsModel? {
+        return sqlUtils.selectCountryViews(site, period, date)?.let { timeStatsMapper.map(it, pageSize) }
+    }
+}


### PR DESCRIPTION
Fixes #1001 

This PR adds an endpoint for the Countries block in Stats. It should be tested with the WPAndroid PR.
Most of the code is copy&paste.

