### PR TITLE
Create search terms endpoint in Stats

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.stats.time.ClicksStore
 import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.fluxc.store.stats.time.ReferrersStore
+import org.wordpress.android.fluxc.store.stats.time.SearchTermsStore
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Date
@@ -43,6 +44,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
     @Inject lateinit var postAndPageViewsStore: PostAndPageViewsStore
     @Inject lateinit var referrersStore: ReferrersStore
     @Inject lateinit var clicksStore: ClicksStore
+    @Inject lateinit var searchTermsStore: SearchTermsStore
     @Inject lateinit var accountStore: AccountStore
     @Inject internal lateinit var siteStore: SiteStore
 
@@ -132,6 +134,30 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights.model)
 
             val insightsFromDb = clicksStore.getClicks(site, granularity, PAGE_SIZE, SELECTED_DATE)
+
+            assertEquals(fetchedInsights.model, insightsFromDb)
+        }
+    }
+
+    @Test
+    fun testFetchSearchTerms() {
+        val site = authenticate()
+
+        for (granularity in StatsGranularity.values()) {
+            val fetchedInsights = runBlocking {
+                searchTermsStore.fetchSearchTerms(
+                        site,
+                        PAGE_SIZE,
+                        granularity,
+                        SELECTED_DATE,
+                        true
+                )
+            }
+
+            assertNotNull(fetchedInsights)
+            assertNotNull(fetchedInsights.model)
+
+            val insightsFromDb = searchTermsStore.getSearchTerms(site, granularity, PAGE_SIZE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClientTest.kt
@@ -1,0 +1,176 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class SearchTermsRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var statsUtils: StatsUtils
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var restClient: SearchTermsRestClient
+    private val siteId: Long = 12
+    private val pageSize = 5
+    private val currentDateValue = "2018-10-10"
+    private val currentDate = Date(0)
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        restClient = SearchTermsRestClient(
+                dispatcher,
+                wpComGsonRequestBuilder,
+                null,
+                requestQueue,
+                accessToken,
+                userAgent,
+                statsUtils
+        )
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(currentDate))).thenReturn(currentDateValue)
+    }
+
+    @Test
+    fun `returns search terms per day success response`() = test {
+        testSuccessResponse(DAYS)
+    }
+
+    @Test
+    fun `returns search terms per day error response`() = test {
+        testErrorResponse(DAYS)
+    }
+
+    @Test
+    fun `returns search terms per week success response`() = test {
+        testSuccessResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns search terms per week error response`() = test {
+        testErrorResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns search terms per month success response`() = test {
+        testSuccessResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns search terms per month error response`() = test {
+        testErrorResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns search terms per year success response`() = test {
+        testSuccessResponse(YEARS)
+    }
+
+    @Test
+    fun `returns search terms per year error response`() = test {
+        testErrorResponse(YEARS)
+    }
+
+    private suspend fun testSuccessResponse(period: StatsGranularity) {
+        val response = mock<SearchTermsResponse>()
+        initSearchTermsResponse(response)
+
+        val responseModel = restClient.fetchSearchTerms(site, period, currentDate, pageSize, false)
+
+        assertThat(responseModel.response).isNotNull()
+        assertThat(responseModel.response).isEqualTo(response)
+        assertThat(urlCaptor.lastValue)
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/search-terms/")
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mapOf(
+                        "max" to pageSize.toString(),
+                        "period" to period.toString(),
+                        "date" to currentDateValue
+                )
+        )
+    }
+
+    private suspend fun testErrorResponse(period: StatsGranularity) {
+        val errorMessage = "message"
+        initSearchTermsResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val responseModel = restClient.fetchSearchTerms(site, period, currentDate, pageSize, false)
+
+        assertThat(responseModel.error).isNotNull()
+        assertThat(responseModel.error.type).isEqualTo(API_ERROR)
+        assertThat(responseModel.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initSearchTermsResponse(
+        data: SearchTermsResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<SearchTermsResponse> {
+        return initResponse(SearchTermsResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun <T> initResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null,
+        cachingEnabled: Boolean = false
+    ): Response<T> {
+        val response = if (error != null) Response.Error<T>(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncGetRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        eq(kclass),
+                        eq(cachingEnabled),
+                        any(),
+                        eq(false)
+                )
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/SearchTermsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/SearchTermsSqlUtilsTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.fluxc.persistance.stats.time
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.SEARCH_TERMS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.DAY
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.MONTH
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.stats.time.SEARCH_TERMS_RESPONSE
+import java.util.Date
+import kotlin.test.assertEquals
+
+private val DATE = Date(0)
+private const val DATE_VALUE = "2018-10-10"
+
+@RunWith(MockitoJUnitRunner::class)
+class SearchTermsSqlUtilsTest {
+    @Mock lateinit var statsSqlUtils: StatsSqlUtils
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var statsUtils: StatsUtils
+    private lateinit var timeStatsSqlUtils: TimeStatsSqlUtils
+    private val mappedTypes = mapOf(DAY to DAYS, WEEK to WEEKS, MONTH to MONTHS, YEAR to YEARS)
+
+    @Before
+    fun setUp() {
+        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(DATE))).thenReturn(DATE_VALUE)
+    }
+
+    @Test
+    fun `returns search terms from stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+
+            whenever(statsSqlUtils.select(site, SEARCH_TERMS, statsType, SearchTermsResponse::class.java, DATE_VALUE))
+                    .thenReturn(
+                            SEARCH_TERMS_RESPONSE
+                    )
+
+            val result = timeStatsSqlUtils.selectSearchTerms(site, dbGranularity, DATE)
+
+            assertEquals(result, SEARCH_TERMS_RESPONSE)
+        }
+    }
+
+    @Test
+    fun `inserts search terms to stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+            timeStatsSqlUtils.insert(site, SEARCH_TERMS_RESPONSE, dbGranularity, DATE)
+
+            verify(statsSqlUtils).insert(site, SEARCH_TERMS, statsType, SEARCH_TERMS_RESPONSE, DATE_VALUE)
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/SearchTermsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/SearchTermsStoreTest.kt
@@ -1,0 +1,92 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.Dispatchers.Unconfined
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.SearchTermsModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import java.util.Date
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+private const val PAGE_SIZE = 8
+private val DATE = Date(0)
+
+@RunWith(MockitoJUnitRunner::class)
+class SearchTermsStoreTest {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var restClient: SearchTermsRestClient
+    @Mock lateinit var sqlUtils: TimeStatsSqlUtils
+    @Mock lateinit var mapper: TimeStatsMapper
+    private lateinit var store: SearchTermsStore
+    @Before
+    fun setUp() {
+        store = SearchTermsStore(
+                restClient,
+                sqlUtils,
+                mapper,
+                Unconfined
+        )
+    }
+
+    @Test
+    fun `returns search terms per site`() = test {
+        val fetchInsightsPayload = FetchStatsPayload(
+                SEARCH_TERMS_RESPONSE
+        )
+        val forced = true
+        whenever(restClient.fetchSearchTerms(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
+                fetchInsightsPayload
+        )
+        val model = mock<SearchTermsModel>()
+        whenever(mapper.map(SEARCH_TERMS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val responseModel = store.fetchSearchTerms(site, PAGE_SIZE, DAYS, DATE, forced)
+
+        assertThat(responseModel.model).isEqualTo(model)
+        verify(sqlUtils).insert(site, SEARCH_TERMS_RESPONSE, DAYS, DATE)
+    }
+
+    @Test
+    fun `returns error when search terms call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchStatsPayload<SearchTermsResponse>(StatsError(type, message))
+        val forced = true
+        whenever(restClient.fetchSearchTerms(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+
+        val responseModel = store.fetchSearchTerms(site, PAGE_SIZE, DAYS, DATE, forced)
+
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns search terms from db`() {
+        whenever(sqlUtils.selectSearchTerms(site, DAYS, DATE)).thenReturn(SEARCH_TERMS_RESPONSE)
+        val model = mock<SearchTermsModel>()
+        whenever(mapper.map(SEARCH_TERMS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val result = store.getSearchTerms(site, DAYS, PAGE_SIZE, DATE)
+
+        assertThat(result).isEqualTo(model)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -10,6 +10,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestCl
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Group
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Groups
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Referrer
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse.SearchTerm
 import org.wordpress.android.fluxc.store.stats.DATE
 import org.wordpress.android.fluxc.store.stats.POST_COUNT
 
@@ -115,3 +117,6 @@ val GROUP = Group(GROUP_ID, "Group 1", "icon.jpg", "url.com", 50, null, referrer
 val REFERRERS_RESPONSE = ReferrersResponse(null, mapOf("2018-10-10" to Groups(10, 20, listOf(GROUP))))
 val CLICK_GROUP = ClickGroup(GROUP_ID, "Click name", "click.jpg", "click.com", 20, null)
 val CLICKS_RESPONSE = ClicksResponse(null, mapOf("2018-10-10" to ClicksResponse.Groups(10, 15, listOf(CLICK_GROUP))))
+val SEARCH_TERMS_RESPONSE = SearchTermsResponse("day", mapOf("2018-10-10" to SearchTermsResponse.Day(10, 15, 20, listOf(
+        SearchTerm("search term", 20)
+))))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/SearchTermsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/SearchTermsModel.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.model.stats.time
 data class SearchTermsModel(
     val otherSearchTerms: Int,
     val totalSearchTerms: Int,
+    val unknownSearchCount: Int,
     val searchTerms: List<SearchTerm>,
     val hasMore: Boolean
 ) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/SearchTermsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/SearchTermsModel.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.model.stats.time
+
+data class SearchTermsModel(
+    val otherSearchTerms: Int,
+    val totalSearchTerms: Int,
+    val list: List<SearchTerm>,
+    val hasMore: Boolean
+) {
+    data class SearchTerm(val text: String, val views: Int)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/SearchTermsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/SearchTermsModel.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.model.stats.time
 data class SearchTermsModel(
     val otherSearchTerms: Int,
     val totalSearchTerms: Int,
-    val list: List<SearchTerm>,
+    val searchTerms: List<SearchTerm>,
     val hasMore: Boolean
 ) {
     data class SearchTerm(val text: String, val views: Int)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.stats.time.ReferrersModel.Referrer
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.STATS
 import javax.inject.Inject
@@ -71,6 +72,24 @@ class TimeStatsMapper
                 first.totalClicks ?: 0,
                 groups,
                 first.clicks.size > groups.size
+        )
+    }
+
+    fun map(response: SearchTermsResponse, pageSize: Int): SearchTermsModel {
+        val first = response.days.values.first()
+        val groups = first.searchTerms.mapNotNull { searchTerm ->
+            if (searchTerm.term != null) {
+                SearchTermsModel.SearchTerm(searchTerm.term, searchTerm.views ?: 0)
+            } else {
+                AppLog.e(STATS, "ClicksResponse.type: Missing fields on a Click object")
+                null
+            }
+        }.take(pageSize)
+        return SearchTermsModel(
+                first.otherSearchTerms ?: 0,
+                first.totalSearchTimes ?: 0,
+                groups,
+                first.searchTerms.size > groups.size
         )
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -81,13 +81,14 @@ class TimeStatsMapper
             if (searchTerm.term != null) {
                 SearchTermsModel.SearchTerm(searchTerm.term, searchTerm.views ?: 0)
             } else {
-                AppLog.e(STATS, "ClicksResponse.type: Missing fields on a Click object")
+                AppLog.e(STATS, "SearchTermsResponse: Missing term field on a Search terms object")
                 null
             }
         }.take(pageSize)
         return SearchTermsModel(
                 first.otherSearchTerms ?: 0,
                 first.totalSearchTimes ?: 0,
+                first.encryptedSearchTerms ?: 0,
                 groups,
                 first.searchTerms.size > groups.size
         )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClient.kt
@@ -1,0 +1,81 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.toStatsError
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class SearchTermsRestClient
+@Inject constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    @param:Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    private val statsUtils: StatsUtils
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchSearchTerms(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        date: Date,
+        pageSize: Int,
+        forced: Boolean
+    ): FetchStatsPayload<SearchTermsResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).stats.search_terms.urlV1_1
+        val params = mapOf(
+                "period" to granularity.toString(),
+                "max" to pageSize.toString(),
+                "date" to statsUtils.getFormattedDate(site, granularity, date)
+        )
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                params,
+                SearchTermsResponse::class.java,
+                enableCaching = false,
+                forced = forced
+        )
+        return when (response) {
+            is Success -> {
+                FetchStatsPayload(response.data)
+            }
+            is Error -> {
+                FetchStatsPayload(response.error.toStatsError())
+            }
+        }
+    }
+
+    data class SearchTermsResponse(
+        @SerializedName("period") val granularity: String?,
+        @SerializedName("days") val days: Map<String, Day>
+    ) {
+        data class Day(
+            @SerializedName("encrypted_search_terms") val encryptedSearchTerms: Int?,
+            @SerializedName("other_search_terms") val otherSearchTerms: Int?,
+            @SerializedName("total_search_terms") val totalSearchTimes: Int?,
+            @SerializedName("search_terms") val searchTerms: List<SearchTerm>
+        )
+
+        data class SearchTerm(
+            @SerializedName("term") val term: String?,
+            @SerializedName("views") val views: Int?
+        )
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -94,6 +94,7 @@ class StatsSqlUtils
         POSTS_AND_PAGES_VIEWS,
         REFERRERS,
         CLICKS,
+        SEARCH_TERMS,
         PUBLICIZE_INSIGHTS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
@@ -13,6 +14,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.REFERRERS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.SEARCH_TERMS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
 import java.util.Date
 import javax.inject.Inject
@@ -51,6 +53,16 @@ class TimeStatsSqlUtils
         )
     }
 
+    fun insert(site: SiteModel, data: SearchTermsResponse, granularity: StatsGranularity, date: Date) {
+        statsSqlUtils.insert(
+                site,
+                SEARCH_TERMS,
+                granularity.toStatsType(),
+                data,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
     fun selectPostAndPageViews(site: SiteModel, granularity: StatsGranularity, date: Date): PostAndPageViewsResponse? {
         return statsSqlUtils.select(
                 site,
@@ -77,6 +89,16 @@ class TimeStatsSqlUtils
                 CLICKS,
                 granularity.toStatsType(),
                 ClicksResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
+    fun selectSearchTerms(site: SiteModel, granularity: StatsGranularity, date: Date): SearchTermsResponse? {
+        return statsSqlUtils.select(
+                site,
+                SEARCH_TERMS,
+                granularity.toStatsType(),
+                SearchTermsResponse::class.java,
                 statsUtils.getFormattedDate(site, granularity, date)
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/SearchTermsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/SearchTermsStore.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import kotlinx.coroutines.experimental.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.SearchTermsModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
+
+@Singleton
+class SearchTermsStore
+@Inject constructor(
+    private val restClient: SearchTermsRestClient,
+    private val sqlUtils: TimeStatsSqlUtils,
+    private val timeStatsMapper: TimeStatsMapper,
+    private val coroutineContext: CoroutineContext
+) {
+    suspend fun fetchSearchTerms(
+        site: SiteModel,
+        pageSize: Int,
+        granularity: StatsGranularity,
+        date: Date,
+        forced: Boolean = false
+    ) = withContext(coroutineContext) {
+        val payload = restClient.fetchSearchTerms(site, granularity, date, pageSize + 1, forced)
+        return@withContext when {
+            payload.isError -> OnStatsFetched(payload.error)
+            payload.response != null -> {
+                sqlUtils.insert(site, payload.response, granularity, date)
+                OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
+            }
+            else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
+        }
+    }
+
+    fun getSearchTerms(site: SiteModel, period: StatsGranularity, pageSize: Int, date: Date): SearchTermsModel? {
+        return sqlUtils.selectSearchTerms(site, period, date)?.let { timeStatsMapper.map(it, pageSize) }
+    }
+}


### PR DESCRIPTION
Fixes #1002 
This PR adds the Search terms endpoint for Stats. It should be tested with the WPAndroid PR with the Search terms block. Most of the code is the same as in the other blocks.