### PR TITLE
Create video plays endpoint in Stats

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.stats.time.ClicksStore
 import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.fluxc.store.stats.time.ReferrersStore
+import org.wordpress.android.fluxc.store.stats.time.VideoPlaysStore
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Date
@@ -43,6 +44,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
     @Inject lateinit var postAndPageViewsStore: PostAndPageViewsStore
     @Inject lateinit var referrersStore: ReferrersStore
     @Inject lateinit var clicksStore: ClicksStore
+    @Inject lateinit var videoPlaysStore: VideoPlaysStore
     @Inject lateinit var accountStore: AccountStore
     @Inject internal lateinit var siteStore: SiteStore
 
@@ -132,6 +134,30 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights.model)
 
             val insightsFromDb = clicksStore.getClicks(site, granularity, PAGE_SIZE, SELECTED_DATE)
+
+            assertEquals(fetchedInsights.model, insightsFromDb)
+        }
+    }
+
+    @Test
+    fun testFetchVideoPlays() {
+        val site = authenticate()
+
+        for (granularity in StatsGranularity.values()) {
+            val fetchedInsights = runBlocking {
+                videoPlaysStore.fetchVideoPlays(
+                        site,
+                        PAGE_SIZE,
+                        granularity,
+                        SELECTED_DATE,
+                        true
+                )
+            }
+
+            assertNotNull(fetchedInsights)
+            assertNotNull(fetchedInsights.model)
+
+            val insightsFromDb = videoPlaysStore.getVideoPlays(site, granularity, PAGE_SIZE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClientTest.kt
@@ -1,0 +1,180 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class VideoPlaysRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var statsUtils: StatsUtils
+    private val gson: Gson = GsonBuilder().create()
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var restClient: VideoPlaysRestClient
+    private val siteId: Long = 12
+    private val pageSize = 5
+    private val currentDateValue = "2018-10-10"
+    private val currentDate = Date(0)
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        restClient = VideoPlaysRestClient(
+                dispatcher,
+                wpComGsonRequestBuilder,
+                null,
+                requestQueue,
+                accessToken,
+                userAgent,
+                gson,
+                statsUtils
+        )
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(currentDate))).thenReturn(currentDateValue)
+    }
+
+    @Test
+    fun `returns post & page day views success response`() = test {
+        testSuccessResponse(DAYS)
+    }
+
+    @Test
+    fun `returns post & page day views error response`() = test {
+        testErrorResponse(DAYS)
+    }
+
+    @Test
+    fun `returns post & page week views success response`() = test {
+        testSuccessResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns post & page week views error response`() = test {
+        testErrorResponse(WEEKS)
+    }
+
+    @Test
+    fun `returns post & page month views success response`() = test {
+        testSuccessResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns post & page month views error response`() = test {
+        testErrorResponse(MONTHS)
+    }
+
+    @Test
+    fun `returns post & page year views success response`() = test {
+        testSuccessResponse(YEARS)
+    }
+
+    @Test
+    fun `returns post & page year views error response`() = test {
+        testErrorResponse(YEARS)
+    }
+
+    private suspend fun testSuccessResponse(period: StatsGranularity) {
+        val response = mock<VideoPlaysResponse>()
+        initVideoPlaysResponse(response)
+
+        val responseModel = restClient.fetchVideoPlays(site, period, currentDate, pageSize, false)
+
+        assertThat(responseModel.response).isNotNull()
+        assertThat(responseModel.response).isEqualTo(response)
+        assertThat(urlCaptor.lastValue)
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/video-plays/")
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mapOf(
+                        "max" to pageSize.toString(),
+                        "period" to period.toString(),
+                        "date" to currentDateValue
+                )
+        )
+    }
+
+    private suspend fun testErrorResponse(period: StatsGranularity) {
+        val errorMessage = "message"
+        initVideoPlaysResponse(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR,
+                                errorMessage,
+                                VolleyError(errorMessage)
+                        )
+                )
+        )
+
+        val responseModel = restClient.fetchVideoPlays(site, period, currentDate, pageSize, false)
+
+        assertThat(responseModel.error).isNotNull()
+        assertThat(responseModel.error.type).isEqualTo(API_ERROR)
+        assertThat(responseModel.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initVideoPlaysResponse(
+        data: VideoPlaysResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<VideoPlaysResponse> {
+        return initResponse(VideoPlaysResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun <T> initResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null,
+        cachingEnabled: Boolean = false
+    ): Response<T> {
+        val response = if (error != null) Response.Error<T>(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncGetRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        eq(kclass),
+                        eq(cachingEnabled),
+                        any(),
+                        eq(false)
+                )
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VideoPlaysSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VideoPlaysSqlUtilsTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.fluxc.persistance.stats.time
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.VIDEO_PLAYS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.DAY
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.MONTH
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.WEEK
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.YEAR
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.stats.time.VIDEO_PLAYS_RESPONSE
+import java.util.Date
+import kotlin.test.assertEquals
+
+private val DATE = Date(0)
+private const val DATE_VALUE = "2018-10-10"
+
+@RunWith(MockitoJUnitRunner::class)
+class VideoPlaysSqlUtilsTest {
+    @Mock lateinit var statsSqlUtils: StatsSqlUtils
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var statsUtils: StatsUtils
+    private lateinit var timeStatsSqlUtils: TimeStatsSqlUtils
+    private val mappedTypes = mapOf(DAY to DAYS, WEEK to WEEKS, MONTH to MONTHS, YEAR to YEARS)
+
+    @Before
+    fun setUp() {
+        timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
+        whenever(statsUtils.getFormattedDate(eq(site), any(), eq(DATE))).thenReturn(DATE_VALUE)
+    }
+
+    @Test
+    fun `returns video plays from stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+
+            whenever(statsSqlUtils.select(site, VIDEO_PLAYS, statsType, VideoPlaysResponse::class.java, DATE_VALUE))
+                    .thenReturn(
+                            VIDEO_PLAYS_RESPONSE
+                    )
+
+            val result = timeStatsSqlUtils.selectVideoPlays(site, dbGranularity, DATE)
+
+            assertEquals(result, VIDEO_PLAYS_RESPONSE)
+        }
+    }
+
+    @Test
+    fun `inserts video plays to stats utils`() {
+        mappedTypes.forEach { statsType, dbGranularity ->
+            timeStatsSqlUtils.insert(site, VIDEO_PLAYS_RESPONSE, dbGranularity, DATE)
+
+            verify(statsSqlUtils).insert(site, VIDEO_PLAYS, statsType, VIDEO_PLAYS_RESPONSE, DATE_VALUE)
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -17,11 +17,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestCl
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Group
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Groups
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Referrer
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse.SearchTerm
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse.Play
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.store.stats.DATE
 import org.wordpress.android.fluxc.store.stats.POST_COUNT
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -10,6 +10,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestCl
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Group
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Groups
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Referrer
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse.Play
 import org.wordpress.android.fluxc.store.stats.DATE
 import org.wordpress.android.fluxc.store.stats.POST_COUNT
 
@@ -115,3 +117,8 @@ val GROUP = Group(GROUP_ID, "Group 1", "icon.jpg", "url.com", 50, null, referrer
 val REFERRERS_RESPONSE = ReferrersResponse(null, mapOf("2018-10-10" to Groups(10, 20, listOf(GROUP))))
 val CLICK_GROUP = ClickGroup(GROUP_ID, "Click name", "click.jpg", "click.com", 20, null)
 val CLICKS_RESPONSE = ClicksResponse(null, mapOf("2018-10-10" to ClicksResponse.Groups(10, 15, listOf(CLICK_GROUP))))
+val PLAY = Play("post1", "Post 1", "post1.com", 50)
+val VIDEO_PLAYS_RESPONSE = VideoPlaysResponse(
+        "day",
+        mapOf("2018-10-10" to VideoPlaysResponse.Days(10, 15, listOf(PLAY)))
+)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VideoPlaysStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VideoPlaysStoreTest.kt
@@ -1,0 +1,92 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.Dispatchers.Unconfined
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.model.stats.time.VideoPlaysModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+import java.util.Date
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+private const val PAGE_SIZE = 8
+private val DATE = Date(0)
+
+@RunWith(MockitoJUnitRunner::class)
+class VideoPlaysStoreTest {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var restClient: VideoPlaysRestClient
+    @Mock lateinit var sqlUtils: TimeStatsSqlUtils
+    @Mock lateinit var mapper: TimeStatsMapper
+    private lateinit var store: VideoPlaysStore
+    @Before
+    fun setUp() {
+        store = VideoPlaysStore(
+                restClient,
+                sqlUtils,
+                mapper,
+                Unconfined
+        )
+    }
+
+    @Test
+    fun `returns video plays per site`() = test {
+        val fetchInsightsPayload = FetchStatsPayload(
+                VIDEO_PLAYS_RESPONSE
+        )
+        val forced = true
+        whenever(restClient.fetchVideoPlays(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
+                fetchInsightsPayload
+        )
+        val model = mock<VideoPlaysModel>()
+        whenever(mapper.map(VIDEO_PLAYS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val responseModel = store.fetchVideoPlays(site, PAGE_SIZE, DAYS, DATE, forced)
+
+        assertThat(responseModel.model).isEqualTo(model)
+        verify(sqlUtils).insert(site, VIDEO_PLAYS_RESPONSE, DAYS, DATE)
+    }
+
+    @Test
+    fun `returns error when video plays call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchStatsPayload<VideoPlaysResponse>(StatsError(type, message))
+        val forced = true
+        whenever(restClient.fetchVideoPlays(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+
+        val responseModel = store.fetchVideoPlays(site, PAGE_SIZE, DAYS, DATE, forced)
+
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns video plays from db`() {
+        whenever(sqlUtils.selectVideoPlays(site, DAYS, DATE)).thenReturn(VIDEO_PLAYS_RESPONSE)
+        val model = mock<VideoPlaysModel>()
+        whenever(mapper.map(VIDEO_PLAYS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+
+        val result = store.getVideoPlays(site, DAYS, PAGE_SIZE, DATE)
+
+        assertThat(result).isEqualTo(model)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.stats.time.ReferrersModel.Referrer
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.STATS
 import javax.inject.Inject
@@ -71,6 +72,24 @@ class TimeStatsMapper
                 first.totalClicks ?: 0,
                 groups,
                 first.clicks.size > groups.size
+        )
+    }
+
+    fun map(response: VideoPlaysResponse, pageSize: Int): VideoPlaysModel {
+        val first = response.days.values.first()
+        val groups = first.plays.take(pageSize).mapNotNull { result ->
+                if (result.postId != null && result.title != null) {
+                    VideoPlaysModel.VideoPlays(result.postId, result.title, result.url, result.plays ?: 0)
+                } else {
+                    AppLog.e(STATS, "VideoPlaysResponse: Missing fields on a Video plays object")
+                    null
+                }
+        }
+        return VideoPlaysModel(
+                first.otherPlays ?: 0,
+                first.totalPlays ?: 0,
+                groups,
+                first.plays.size > groups.size
         )
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/VideoPlaysModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/VideoPlaysModel.kt
@@ -1,6 +1,11 @@
 package org.wordpress.android.fluxc.model.stats.time
 
-data class VideoPlaysModel(val otherPlays: Int, val totalPlays: Int, val plays: List<VideoPlays>, val hasMore: Boolean) {
+data class VideoPlaysModel(
+    val otherPlays: Int,
+    val totalPlays: Int,
+    val plays: List<VideoPlays>,
+    val hasMore: Boolean
+) {
     data class VideoPlays(
         val postId: String,
         val title: String,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/VideoPlaysModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/VideoPlaysModel.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.model.stats.time
+
+data class VideoPlaysModel(val otherPlays: Int, val totalPlays: Int, val plays: List<VideoPlays>, val hasMore: Boolean) {
+    data class VideoPlays(
+        val postId: String,
+        val title: String,
+        val url: String?,
+        val plays: Int
+    )
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
@@ -66,7 +66,7 @@ class VideoPlaysRestClient
 
     data class VideoPlaysResponse(
         @SerializedName("period") val granularity: String?,
-        @SerializedName("days") val groups: Map<String, Days>
+        @SerializedName("days") val days: Map<String, Days>
     ) {
         data class Days(
             @SerializedName("other_plays") val otherPlays: Int?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
@@ -33,7 +33,7 @@ class VideoPlaysRestClient
     val gson: Gson,
     private val statsUtils: StatsUtils
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    suspend fun fetchVideos(
+    suspend fun fetchVideoPlays(
         site: SiteModel,
         granularity: StatsGranularity,
         date: Date,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
@@ -1,0 +1,84 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.toStatsError
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class VideoPlaysRestClient
+@Inject constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    @param:Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    val gson: Gson,
+    private val statsUtils: StatsUtils
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchVideos(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        date: Date,
+        pageSize: Int,
+        forced: Boolean
+    ): FetchStatsPayload<VideoPlaysResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).stats.video_plays.urlV1_1
+        val params = mapOf(
+                "period" to granularity.toString(),
+                "max" to pageSize.toString(),
+                "date" to statsUtils.getFormattedDate(site, granularity, date)
+        )
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                params,
+                VideoPlaysResponse::class.java,
+                enableCaching = false,
+                forced = forced
+        )
+        return when (response) {
+            is Success -> {
+                FetchStatsPayload(response.data)
+            }
+            is Error -> {
+                FetchStatsPayload(response.error.toStatsError())
+            }
+        }
+    }
+
+    data class VideoPlaysResponse(
+        @SerializedName("period") val granularity: String?,
+        @SerializedName("days") val groups: Map<String, Days>
+    ) {
+        data class Days(
+            @SerializedName("other_plays") val otherPlays: Int?,
+            @SerializedName("total_plays") val totalPlays: Int?,
+            @SerializedName("plays") val plays: List<Play>
+        )
+
+        data class Play(
+            @SerializedName("post_id") val postId: String?,
+            @SerializedName("title") val title: String?,
+            @SerializedName("url") val url: String?,
+            @SerializedName("plays") val plays: Int?
+        )
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -94,6 +94,7 @@ class StatsSqlUtils
         POSTS_AND_PAGES_VIEWS,
         REFERRERS,
         CLICKS,
+        VIDEO_PLAYS,
         PUBLICIZE_INSIGHTS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClien
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
@@ -13,6 +14,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.REFERRERS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.VIDEO_PLAYS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
 import java.util.Date
 import javax.inject.Inject
@@ -51,6 +53,16 @@ class TimeStatsSqlUtils
         )
     }
 
+    fun insert(site: SiteModel, data: VideoPlaysResponse, granularity: StatsGranularity, date: Date) {
+        statsSqlUtils.insert(
+                site,
+                VIDEO_PLAYS,
+                granularity.toStatsType(),
+                data,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
     fun selectPostAndPageViews(site: SiteModel, granularity: StatsGranularity, date: Date): PostAndPageViewsResponse? {
         return statsSqlUtils.select(
                 site,
@@ -77,6 +89,16 @@ class TimeStatsSqlUtils
                 CLICKS,
                 granularity.toStatsType(),
                 ClicksResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
+    fun selectVideoPlays(site: SiteModel, granularity: StatsGranularity, date: Date): VideoPlaysResponse? {
+        return statsSqlUtils.select(
+                site,
+                VIDEO_PLAYS,
+                granularity.toStatsType(),
+                VideoPlaysResponse::class.java,
                 statsUtils.getFormattedDate(site, granularity, date)
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -8,8 +8,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageView
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
@@ -20,9 +20,9 @@ import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.CLICKS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.COUNTRY_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTS_AND_PAGES_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.REFERRERS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.VISITS_AND_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.SEARCH_TERMS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.VIDEO_PLAYS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.VISITS_AND_VIEWS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
 import java.util.Date
 import javax.inject.Inject
@@ -147,6 +147,46 @@ class TimeStatsSqlUtils
                 VISITS_AND_VIEWS,
                 granularity.toStatsType(),
                 VisitsAndViewsResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
+    fun selectCountryViews(site: SiteModel, granularity: StatsGranularity, date: Date): CountryViewsResponse? {
+        return statsSqlUtils.select(
+                site,
+                COUNTRY_VIEWS,
+                granularity.toStatsType(),
+                CountryViewsResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
+    fun selectAuthors(site: SiteModel, granularity: StatsGranularity, date: Date): AuthorsResponse? {
+        return statsSqlUtils.select(
+                site,
+                AUTHORS,
+                granularity.toStatsType(),
+                AuthorsResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
+    fun selectSearchTerms(site: SiteModel, granularity: StatsGranularity, date: Date): SearchTermsResponse? {
+        return statsSqlUtils.select(
+                site,
+                SEARCH_TERMS,
+                granularity.toStatsType(),
+                SearchTermsResponse::class.java,
+                statsUtils.getFormattedDate(site, granularity, date)
+        )
+    }
+
+    fun selectVideoPlays(site: SiteModel, granularity: StatsGranularity, date: Date): VideoPlaysResponse? {
+        return statsSqlUtils.select(
+                site,
+                VIDEO_PLAYS,
+                granularity.toStatsType(),
+                VideoPlaysResponse::class.java,
                 statsUtils.getFormattedDate(site, granularity, date)
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VideoPlaysStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VideoPlaysStore.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.store.stats.time
+
+import kotlinx.coroutines.experimental.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.model.stats.time.VideoPlaysModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.experimental.CoroutineContext
+
+@Singleton
+class VideoPlaysStore
+@Inject constructor(
+    private val restClient: VideoPlaysRestClient,
+    private val sqlUtils: TimeStatsSqlUtils,
+    private val timeStatsMapper: TimeStatsMapper,
+    private val coroutineContext: CoroutineContext
+) {
+    suspend fun fetchVideoPlays(
+        site: SiteModel,
+        pageSize: Int,
+        granularity: StatsGranularity,
+        date: Date,
+        forced: Boolean = false
+    ) = withContext(coroutineContext) {
+        val payload = restClient.fetchVideoPlays(site, granularity, date, pageSize + 1, forced)
+        return@withContext when {
+            payload.isError -> OnStatsFetched(payload.error)
+            payload.response != null -> {
+                sqlUtils.insert(site, payload.response, granularity, date)
+                OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
+            }
+            else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
+        }
+    }
+
+    fun getVideoPlays(site: SiteModel, period: StatsGranularity, pageSize: Int, date: Date): VideoPlaysModel? {
+        return sqlUtils.selectVideoPlays(site, period, date)?.let { timeStatsMapper.map(it, pageSize) }
+    }
+}


### PR DESCRIPTION
Fixes #1003 
This PR adds a video plays endpoint for the refreshed stats. It should be reviewed with the corresponding WPAndroid PR.