### PR TITLE
Add support for marking a notification as read

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:support-v4:$supportLibraryVersion"
     implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
     // WordPress libs
     implementation ('org.wordpress:utils:1.20.0') {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -12,10 +12,13 @@ import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.notification.NoteIdSet
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.NotificationAppKey
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
@@ -171,6 +174,30 @@ class MockedStack_NotificationTest : MockedStack_Base() {
 
         assertNotNull(payload)
         assertEquals(payload.lastSeenTime, 1543265347L)
+    }
+
+    @Test
+    fun testMarkNotificationReadSuccess() {
+        val testNoteIdSet = NoteIdSet(0, 22L, 2)
+
+        interceptor.respondWith("mark-notification-read-response-success.json")
+        notificationRestClient.markNotificationRead(
+                NotificationModel(
+                        remoteNoteId = testNoteIdSet.remoteNoteId,
+                        localSiteId = testNoteIdSet.localSiteId))
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(NotificationAction.MARKED_NOTIFICATION_READ, lastAction!!.type)
+        val payload = lastAction!!.payload as MarkNotificationReadResponsePayload
+
+        assertNotNull(payload)
+        assertEquals(payload.success, true)
+        assertNotNull(payload.notification)
+        with(payload.notification!!) {
+            assertEquals(remoteNoteId, testNoteIdSet.remoteNoteId)
+        }
     }
 
     @Suppress("unused")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -110,7 +110,7 @@ class MainFragment : Fragment() {
     private fun showSSLWarningDialog(certifString: String) {
         val ft = fragmentManager?.beginTransaction()
         val newFragment = SSLWarningDialog.newInstance(
-                { dialog, which ->
+                { _, _ ->
                     // Add the certificate to our list
                     memorizingTrustManager.storeLastFailure()
                     // Retry login action

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -89,6 +89,7 @@ class MainFragment : Fragment() {
         uploads.setOnClickListener(getOnClickListener(UploadsFragment()))
         themes.setOnClickListener(getOnClickListener(ThemeFragment()))
         woo.setOnClickListener(getOnClickListener(WooCommerceFragment()))
+        notifs.setOnClickListener(getOnClickListener(NotificationsFragment()))
     }
 
     // Private methods

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationTypeSubtypeDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationTypeSubtypeDialog.kt
@@ -26,7 +26,7 @@ class NotificationTypeSubtypeDialog : DialogFragment() {
     override fun onResume() {
         super.onResume()
 
-        dialog.window.setLayout(WindowManager.LayoutParams.MATCH_PARENT,WindowManager.LayoutParams.WRAP_CONTENT);
+        dialog.window.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.WRAP_CONTENT)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationTypeSubtypeDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationTypeSubtypeDialog.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.fluxc.example
+
+import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.widget.ArrayAdapter
+import kotlinx.android.synthetic.main.dialog_notification_type_subtype.*
+import org.wordpress.android.fluxc.model.notification.NotificationModel.Kind
+import org.wordpress.android.fluxc.model.notification.NotificationModel.Subkind
+
+class NotificationTypeSubtypeDialog : DialogFragment() {
+    companion object {
+        @JvmStatic
+        fun newInstance(listener: Listener) = NotificationTypeSubtypeDialog().apply { this.listener = listener }
+    }
+
+    interface Listener {
+        fun onSubmitted(type: String, subtype: String)
+    }
+
+    var listener: Listener? = null
+
+    override fun onResume() {
+        super.onResume()
+
+        dialog.window.setLayout(WindowManager.LayoutParams.MATCH_PARENT,WindowManager.LayoutParams.WRAP_CONTENT);
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
+            inflater.inflate(R.layout.dialog_notification_type_subtype, container)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        notif_type.adapter =
+                ArrayAdapter<Kind>(activity, android.R.layout.simple_dropdown_item_1line, Kind.values())
+        notif_subtype.adapter =
+                ArrayAdapter<Subkind>(activity, android.R.layout.simple_dropdown_item_1line, Subkind.values())
+
+        notif_dialog_ok.setOnClickListener {
+            listener?.let {
+                val type = notif_type.selectedItem.toString()
+                val subtype = notif_subtype.selectedItem.toString()
+                it.onSubmitted(type, subtype)
+            }
+            dismiss()
+        }
+
+        notif_dialog_cancel.setOnClickListener {
+            dismiss()
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -1,0 +1,167 @@
+package org.wordpress.android.fluxc.example
+
+import android.content.Context
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_notifications.*
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATION
+import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATIONS
+import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_SEEN
+import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATION_READ
+import org.wordpress.android.fluxc.action.NotificationAction.UPDATE_NOTIFICATION
+import org.wordpress.android.fluxc.example.NotificationTypeSubtypeDialog.Listener
+import org.wordpress.android.fluxc.generated.NotificationActionBuilder
+import org.wordpress.android.fluxc.model.notification.NotificationModel.Subkind
+import org.wordpress.android.fluxc.store.NotificationStore
+import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayload
+import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPayload
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadPayload
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsSeenPayload
+import org.wordpress.android.fluxc.store.NotificationStore.OnNotificationChanged
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+import javax.inject.Inject
+
+class NotificationsFragment : Fragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var notificationStore: NotificationStore
+    @Inject internal lateinit var siteStore: SiteStore
+
+    private var typeSelectionDialog: NotificationTypeSubtypeDialog? = null
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_notifications, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        notifs_fetch_all.setOnClickListener {
+            prependToLog("Fetching all notifications from the api...")
+            dispatcher.dispatch(NotificationActionBuilder.newFetchNotificationsAction(FetchNotificationsPayload()))
+        }
+
+        notifs_fetch_for_site.setOnClickListener {
+            prependToLog("Getting all notifications for the first site...")
+            val site = siteStore.sites.first()
+            val notifs = notificationStore.getNotificationsForSite(site)
+
+            // todo amanda - fix display name
+            prependToLog("SUCCESS! ${notifs.size} pulled from the database for ${site.name}")
+        }
+
+        notifs_by_type_subtype.setOnClickListener {
+            showNotificationTypeSubtypeDialog(object : Listener {
+                override fun onSubmitted(type: String, subtype: String) {
+                    prependToLog("Fetching notifications matching $type or $subtype...")
+                    val notifs = notificationStore.getNotifications(listOf(type), listOf(subtype))
+                    val groups = notifs.groupingBy {
+                        it.subtype?.name?.takeIf { it != Subkind.UNKNOWN.name } ?: it.type.name
+                    }.fold(0) { acc, _ -> acc + 1 }
+                    prependToLog("SUCCESS! Total records matching filtered selections:" +
+                            "\n- $type: ${groups[type] ?: 0}\n- $subtype: ${groups[subtype] ?: 0}")
+                }
+            })
+        }
+
+        notifs_mark_seen.setOnClickListener {
+            prependToLog("Setting notifications last seen time to now")
+            dispatcher.dispatch(NotificationActionBuilder
+                    .newMarkNotificationsSeenAction(MarkNotificationsSeenPayload(Date().time)))
+        }
+
+        notifs_fetch_first.setOnClickListener {
+            val note = notificationStore.getNotifications().first()
+            prependToLog("Fetching a single notification with remoteNoteId = ${note.remoteNoteId}")
+            dispatcher.dispatch(NotificationActionBuilder
+                    .newFetchNotificationAction(FetchNotificationPayload(note.remoteNoteId)))
+        }
+
+        notifs_mark_read.setOnClickListener {
+            val note = notificationStore.getNotifications().first()
+            prependToLog("Setting notification with remoteNoteId of ${note.remoteNoteId} as read")
+            dispatcher.dispatch(NotificationActionBuilder
+                    .newMarkNotificationReadAction(MarkNotificationReadPayload(note)))
+        }
+
+        notifs_update_first.setOnClickListener {
+            val note = notificationStore.getNotifications().first()
+            note.read = !note.read
+            prependToLog("Updating notification with remoteNoteId of ${note.remoteNoteId}")
+            dispatcher.dispatch(NotificationActionBuilder.newUpdateNotificationAction(note))
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dispatcher.register(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        dispatcher.unregister(this)
+        typeSelectionDialog?.dismiss()
+        typeSelectionDialog = null
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = MAIN)
+    fun onNotificationChanged(event: OnNotificationChanged) {
+        if (event.isError) {
+            prependToLog("Error from ${event.causeOfChange} - error: ${event.error.type}")
+            return
+        }
+
+        when (event.causeOfChange) {
+            FETCH_NOTIFICATIONS -> {
+                val notifs = notificationStore.getNotifications()
+                prependToLog("SUCCESS! - Fetched ${notifs.size} notifications from the API")
+            }
+            FETCH_NOTIFICATION -> {
+                val localNoteId = event.changedNotificationLocalIds[0]
+                notificationStore.getNotificationByLocalId(localNoteId)?.let {
+                    prependToLog("SUCCESS! ${it.toLogString()}")
+                } ?: prependToLog("Error! Notification not found in db!")
+            }
+            UPDATE_NOTIFICATION -> {
+                val localNoteId = event.changedNotificationLocalIds[0]
+                notificationStore.getNotificationByLocalId(localNoteId)?.let {
+                    prependToLog("SUCCESS! ${it.toLogString()}")
+                }
+            }
+            MARK_NOTIFICATION_READ -> {
+                val localNoteId = event.changedNotificationLocalIds[0]
+                notificationStore.getNotificationByLocalId(localNoteId)?.let {
+                    prependToLog("SUCCESS! ${it.toLogString()}")
+                }
+            }
+            MARK_NOTIFICATIONS_SEEN -> {
+                val lastSeenDate = event.lastSeenTime?.let {
+                    DateTimeUtils.iso8601FromTimestamp(it)
+                } ?: ""
+                prependToLog("SUCCESS! Last seen set to $lastSeenDate")
+            }
+        }
+    }
+
+    private fun prependToLog(s: String) = (activity as MainExampleActivity).prependToLog(s)
+
+    private fun showNotificationTypeSubtypeDialog(listener: NotificationTypeSubtypeDialog.Listener){
+        fragmentManager?.let { fm ->
+            val dialog = NotificationTypeSubtypeDialog.newInstance(listener)
+            dialog.show(fm, "NotificationFragment")
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -153,12 +153,13 @@ class NotificationsFragment : Fragment() {
                 } ?: ""
                 prependToLog("SUCCESS! Last seen set to $lastSeenDate")
             }
+            else -> {}
         }
     }
 
     private fun prependToLog(s: String) = (activity as MainExampleActivity).prependToLog(s)
 
-    private fun showNotificationTypeSubtypeDialog(listener: NotificationTypeSubtypeDialog.Listener){
+    private fun showNotificationTypeSubtypeDialog(listener: NotificationTypeSubtypeDialog.Listener) {
         fragmentManager?.let { fm ->
             val dialog = NotificationTypeSubtypeDialog.newInstance(listener)
             dialog.show(fm, "NotificationFragment")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.example.AccountFragment
 import org.wordpress.android.fluxc.example.CommentsFragment
 import org.wordpress.android.fluxc.example.MainFragment
 import org.wordpress.android.fluxc.example.MediaFragment
+import org.wordpress.android.fluxc.example.NotificationsFragment
 import org.wordpress.android.fluxc.example.PostsFragment
 import org.wordpress.android.fluxc.example.SignedOutActionsFragment
 import org.wordpress.android.fluxc.example.SitesFragment
@@ -48,4 +49,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooCommerceFragmentInjector(): WooCommerceFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideNotificationsFragmentInjector(): NotificationsFragment
 }

--- a/example/src/main/res/layout/dialog_notification_type_subtype.xml
+++ b/example/src/main/res/layout/dialog_notification_type_subtype.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:padding="16dp"
+    android:id="@+id/linearLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/notif_dialog_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Title"
+        android:text="Filter Notifications:"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/notif_label_type"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Type:"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notif_dialog_title"/>
+
+    <Spinner
+        android:id="@+id/notif_type"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notif_label_type"/>
+
+    <TextView
+        android:id="@+id/notif_label_subtype"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Subtype:"
+        app:layout_constraintStart_toStartOf="@+id/notif_type"
+        app:layout_constraintTop_toBottomOf="@+id/notif_type"/>
+
+    <Spinner
+        android:id="@+id/notif_subtype"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        app:layout_constraintEnd_toEndOf="@+id/notif_type"
+        app:layout_constraintStart_toStartOf="@+id/notif_type"
+        app:layout_constraintTop_toBottomOf="@+id/notif_label_subtype"/>
+
+    <Button
+        android:id="@+id/notif_dialog_ok"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginTop="8dp"
+        android:text="OK"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/notif_dialog_cancel"
+        app:layout_constraintTop_toBottomOf="@+id/notif_subtype"/>
+
+    <Button
+        android:id="@+id/notif_dialog_cancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        android:text="Cancel"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notif_subtype"/>
+</android.support.constraint.ConstraintLayout>

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -117,6 +117,12 @@
                 android:layout_gravity="right"
                 android:text="Woo" />
 
+            <Button
+                android:id="@+id/notifs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="right"
+                android:text="Notifications"/>
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_notifications.xml
+++ b/example/src/main/res/layout/fragment_notifications.xml
@@ -14,6 +14,12 @@
         android:layout_height="wrap_content"
         android:text="Fetch All Notifications from API"/>
 
+    <Button
+        android:id="@+id/notifs_mark_seen"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Mark Notifications Seen"/>
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -32,12 +38,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Get Notifications by type or subtype (db)"/>
-
-    <Button
-        android:id="@+id/notifs_mark_seen"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Mark Notifications Seen"/>
 
     <TextView
         android:layout_width="wrap_content"
@@ -62,5 +62,5 @@
         android:id="@+id/notifs_update_first"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Update Notification"/>
+        android:text="Update Notification (DB)"/>
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_notifications.xml
+++ b/example/src/main/res/layout/fragment_notifications.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".NotificationsFragment"
+    android:layout_margin="8dp"
+    android:orientation="vertical">
+
+    <Button
+        android:id="@+id/notifs_fetch_all"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch All Notifications from API"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        android:text="Perform actions on the first site:"/>
+
+    <Button
+        android:id="@+id/notifs_fetch_for_site"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Get Notifications For First Site (db)"/>
+
+    <Button
+        android:id="@+id/notifs_by_type_subtype"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Get Notifications by type or subtype (db)"/>
+
+    <Button
+        android:id="@+id/notifs_mark_seen"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Mark Notifications Seen"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        android:text="Perform actions on the first notification in list:"/>
+
+    <Button
+        android:id="@+id/notifs_fetch_first"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch Notification From API"/>
+
+    <Button
+        android:id="@+id/notifs_mark_read"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Mark Read"/>
+
+    <Button
+        android:id="@+id/notifs_update_first"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Update Notification"/>
+</LinearLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -8,6 +8,8 @@ import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayl
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload;
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadPayload;
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsSeenPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDevicePayload;
@@ -27,6 +29,8 @@ public enum NotificationAction implements IAction {
     FETCH_NOTIFICATION, // Fetch a single notification
     @Action(payloadType = MarkNotificationsSeenPayload.class)
     MARK_NOTIFICATIONS_SEEN, // Mark last notification time seen
+    @Action(payloadType = MarkNotificationReadPayload.class)
+    MARK_NOTIFICATION_READ, // Mark notification as read by user
 
     // Remote responses
     @Action(payloadType = RegisterDeviceResponsePayload.class)
@@ -39,6 +43,8 @@ public enum NotificationAction implements IAction {
     FETCHED_NOTIFICATION, // Response to fetching a single notification
     @Action(payloadType = MarkNotificationSeenResponsePayload.class)
     MARKED_NOTIFICATIONS_SEEN, // Response to marking a notification as seen
+    @Action(payloadType = MarkNotificationReadResponsePayload.class)
+    MARKED_NOTIFICATION_READ, // Response to marking a notification as read
 
     // Local actions
     @Action(payloadType = NotificationModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -28,7 +28,7 @@ public enum NotificationAction implements IAction {
     @Action(payloadType = FetchNotificationPayload.class)
     FETCH_NOTIFICATION, // Fetch a single notification
     @Action(payloadType = MarkNotificationsSeenPayload.class)
-    MARK_NOTIFICATIONS_SEEN, // Mark last notification time seen
+    MARK_NOTIFICATIONS_SEEN, // Submit the time notifications were last seen
     @Action(payloadType = MarkNotificationReadPayload.class)
     MARK_NOTIFICATION_READ, // Mark notification as read by user
 
@@ -42,7 +42,7 @@ public enum NotificationAction implements IAction {
     @Action(payloadType = FetchNotificationResponsePayload.class)
     FETCHED_NOTIFICATION, // Response to fetching a single notification
     @Action(payloadType = MarkNotificationSeenResponsePayload.class)
-    MARKED_NOTIFICATIONS_SEEN, // Response to marking a notification as seen
+    MARKED_NOTIFICATIONS_SEEN, // Response to submitting the time notifications were last seen
     @Action(payloadType = MarkNotificationReadResponsePayload.class)
     MARKED_NOTIFICATION_READ, // Response to marking a notification as read
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -10,7 +10,7 @@ data class NotificationModel(
     var localSiteId: Int = 0,
     val noteHash: Long = 0L,
     val type: Kind = NotificationModel.Kind.UNKNOWN,
-    val subtype: Subkind? = null,
+    val subtype: Subkind? = NotificationModel.Subkind.NONE,
     var read: Boolean = false,
     val icon: String? = null,
     val noticon: String? = null,
@@ -45,12 +45,19 @@ data class NotificationModel(
     enum class Subkind {
         STORE_REVIEW,
         REWIND_BACKUP_INITIAL,
-        UNKNOWN;
+        UNKNOWN,
+        NONE;
 
         companion object {
             private val reverseMap = Subkind.values().associateBy(
                     Subkind::name)
-            fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: UNKNOWN
+            fun fromString(type: String): Subkind {
+                return if (type.isEmpty()){
+                    NONE
+                } else {
+                    reverseMap[type.toUpperCase(Locale.US)] ?: UNKNOWN
+                }
+            }
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -55,4 +55,9 @@ data class NotificationModel(
     }
 
     fun getRemoteSiteId(): Long? = meta?.ids?.site
+
+    fun toLogString(): String {
+        return "[id=$noteId, remoteNoteId=$remoteNoteId, read=$read, " +
+                "localSiteId=$localSiteId, type=${type.name}, subtype=${subtype?.name}, title=$title]"
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -52,7 +52,7 @@ data class NotificationModel(
             private val reverseMap = Subkind.values().associateBy(
                     Subkind::name)
             fun fromString(type: String): Subkind {
-                return if (type.isEmpty()){
+                return if (type.isEmpty()) {
                     NONE
                 } else {
                     reverseMap[type.toUpperCase(Locale.US)] ?: UNKNOWN

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -32,8 +32,10 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
     protected GsonRequest(int method, Map<String, String> params, Map<String, Object> body, String url, Class<T> clazz,
                        Type type, Listener<T> listener, BaseErrorListener errorListener) {
         super(method, url, errorListener);
-        // HTTP RFC requires a body (even empty) for all POST requests.
-        if (method == Method.POST && body == null) {
+        // HTTP RFC requires a body (even empty) for all POST requests. Volley will default to using the params
+        // for the body so only do this if params is null since this behavior is desirable for form-encoded
+        // POST requests.
+        if (method == Method.POST && body == null && (params == null || params.size() == 0)) {
             body = new HashMap<>();
         }
 
@@ -52,7 +54,11 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
 
     @Override
     public String getBodyContentType() {
-        return PROTOCOL_CONTENT_TYPE;
+        if (mBody == null) {
+            return super.getBodyContentType();
+        } else {
+            return PROTOCOL_CONTENT_TYPE;
+        }
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -82,10 +82,9 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
                 wrapInBaseListener(errorListener));
     }
 
-    public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, String> params,
-                                                           Map<String, Object> body, Type type,
+    public static <T> WPComGsonRequest<T> buildFormPostRequest(String url, Map<String, String> params, Type type,
                                                            Listener<T> listener, WPComErrorListener errorListener) {
-        return new WPComGsonRequest<>(Method.POST, url, params, body, null, type, listener,
+        return new WPComGsonRequest<>(Method.POST, url, params, null, null, type, listener,
                 wrapInBaseListener(errorListener));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -82,6 +82,13 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
                 wrapInBaseListener(errorListener));
     }
 
+    public static <T> WPComGsonRequest<T> buildPostRequest(String url, Map<String, String> params,
+                                                           Map<String, Object> body, Type type,
+                                                           Listener<T> listener, WPComErrorListener errorListener) {
+        return new WPComGsonRequest<>(Method.POST, url, params, body, null, type, listener,
+                wrapInBaseListener(errorListener));
+    }
+
     private static BaseErrorListener wrapInBaseListener(final WPComErrorListener wpComErrorListener) {
         return new BaseErrorListener() {
             @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -199,9 +199,9 @@ class NotificationRestClient constructor(
      */
     fun markNotificationRead(notification: NotificationModel) {
         val url = WPCOMREST.notifications.read.urlV1_1
-        val params = mapOf("counts[${notification.remoteNoteId}]" to 9999) // Just like WPAndroid
-        val request = WPComGsonRequest.buildPostRequest(url, params, NotificationReadApiResponse::class.java,
-                { response ->
+        val params = mapOf("counts[${notification.remoteNoteId}]" to "9999") // Just like WPAndroid
+        val request = WPComGsonRequest.buildPostRequest(url, params, null, NotificationReadApiResponse::class.java,
+                { response: NotificationReadApiResponse ->
                     val payload = MarkNotificationReadResponsePayload(notification, response.success)
                     dispatcher.dispatch(NotificationActionBuilder.newMarkedNotificationReadAction(payload))
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -199,7 +199,9 @@ class NotificationRestClient constructor(
      */
     fun markNotificationRead(notification: NotificationModel) {
         val url = WPCOMREST.notifications.read.urlV1_1
-        val params = mapOf("counts[${notification.remoteNoteId}]" to "9999") // Just like WPAndroid
+        // "9999" Ensures the "read" count of the notification is decremented enough so the notification
+        // is marked read across all devices (just like WPAndroid)
+        val params = mapOf("counts[${notification.remoteNoteId}]" to "9999")
         val request = WPComGsonRequest.buildFormPostRequest(url, params, NotificationReadApiResponse::class.java,
                 { response: NotificationReadApiResponse ->
                     val payload = MarkNotificationReadResponsePayload(notification, response.success)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -199,7 +199,7 @@ class NotificationRestClient constructor(
      */
     fun markNotificationRead(notification: NotificationModel) {
         val url = WPCOMREST.notifications.read.urlV1_1
-        val params = mapOf("counts[${notification.remoteNoteId}]" to "9999") // Just like WPAndroid
+        val params = mapOf("counts[${notification.remoteNoteId}]" to 9999) // Just like WPAndroid
         val request = WPComGsonRequest.buildPostRequest(url, params, NotificationReadApiResponse::class.java,
                 { response ->
                     val payload = MarkNotificationReadResponsePayload(notification, response.success)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -200,7 +200,7 @@ class NotificationRestClient constructor(
     fun markNotificationRead(notification: NotificationModel) {
         val url = WPCOMREST.notifications.read.urlV1_1
         val params = mapOf("counts[${notification.remoteNoteId}]" to "9999") // Just like WPAndroid
-        val request = WPComGsonRequest.buildPostRequest(url, params, null, NotificationReadApiResponse::class.java,
+        val request = WPComGsonRequest.buildFormPostRequest(url, params, NotificationReadApiResponse::class.java,
                 { response: NotificationReadApiResponse ->
                     val payload = MarkNotificationReadResponsePayload(notification, response.success)
                     dispatcher.dispatch(NotificationActionBuilder.newMarkedNotificationReadAction(payload))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -78,7 +78,6 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
                 .orderBy(NotificationModelTable.TIMESTAMP, order)
                 .asModel
                 .map { it.build(formattableContentMapper) }
-        return emptyList()
     }
 
     @SuppressLint("WrongConstant")
@@ -114,7 +113,6 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
                 .orderBy(NotificationModelTable.TIMESTAMP, order)
                 .asModel
                 .map { it.build(formattableContentMapper) }
-        return emptyList()
     }
 
     fun getNotificationByIdSet(idSet: NoteIdSet): NotificationModel? {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -162,6 +162,7 @@ constructor(
             NotificationAction.REGISTER_DEVICE -> registerDevice(action.payload as RegisterDevicePayload)
             NotificationAction.UNREGISTER_DEVICE -> unregisterDevice()
             NotificationAction.FETCH_NOTIFICATIONS -> fetchNotifications()
+            NotificationAction.FETCH_NOTIFICATION -> fetchNotification(action.payload as FetchNotificationPayload)
             NotificationAction.MARK_NOTIFICATIONS_SEEN ->
                 markNotificationSeen(action.payload as MarkNotificationsSeenPayload)
             NotificationAction.MARK_NOTIFICATION_READ ->

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -376,21 +376,22 @@ constructor(
 
     private fun handleMarkedNotificationRead(payload: MarkNotificationReadResponsePayload) {
         // Update the notification in the database
+        var rowsAffected = 0
         if (payload.success) {
             payload.notification?.let {
                 it.read = true // Just in case it wasn't set by the calling client
-                notificationSqlUtils.insertOrUpdateNotification(it)
+                rowsAffected = notificationSqlUtils.insertOrUpdateNotification(it)
             }
         }
 
         // Create and dispatch result
         val onNotificationChanged = if (payload.isError) {
-            OnNotificationChanged(0).apply {
+            OnNotificationChanged(rowsAffected).apply {
                 error = payload.error
                 success = false
             }
         } else {
-            OnNotificationChanged(1).apply {
+            OnNotificationChanged(rowsAffected).apply {
                 success = true
             }
         }.apply {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -333,9 +333,11 @@ constructor(
 
     private fun handleMarkedNotificationRead(payload: MarkNotificationReadResponsePayload) {
         // Update the notification in the database
-        payload.notification?.let {
-            it.read = true // Just in case it wasn't set by the calling client
-            if (payload.success) notificationSqlUtils.insertOrUpdateNotification(it)
+        if (payload.success) {
+            payload.notification?.let {
+                it.read = true // Just in case it wasn't set by the calling client
+                notificationSqlUtils.insertOrUpdateNotification(it)
+            }
         }
 
         // Create an dispatch result

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -383,7 +383,7 @@ constructor(
             }
         }
 
-        // Create an dispatch result
+        // Create and dispatch result
         val onNotificationChanged = if (payload.isError) {
             OnNotificationChanged(0).apply {
                 error = payload.error

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -388,6 +388,9 @@ constructor(
                 success = true
             }
         }.apply {
+            payload.notification?.let {
+                changedNotificationLocalIds.add(it.noteId)
+            }
             causeOfChange = MARK_NOTIFICATION_READ
         }
         emitChange(onNotificationChanged)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -238,6 +238,12 @@ constructor(
     fun getNotificationByRemoteId(remoteNoteId: Long) =
             notificationSqlUtils.getNotificationByRemoteId(remoteNoteId)
 
+    /**
+     * Fetch a notification from the database by it's local notification id.
+     */
+    fun getNotificationByLocalId(noteId: Int) =
+            notificationSqlUtils.getNotificationByIdSet(NoteIdSet(noteId, 0, 0))
+
     private fun registerDevice(payload: RegisterDevicePayload) {
         val uuid = preferences.getString(WPCOM_PUSH_DEVICE_UUID, null) ?: generateAndStoreUUID()
 


### PR DESCRIPTION
This PR fixes #1037 and adds support for the following:

- The `/notifications/read/` rest api endpoint
- Notification actions for marking a notification as read
- Logic for posting the request to the api
- Saving the notification to the database on success
- Success and error response handling
- Mocked automated tests
- **New notifications test page in the example app**

### Comments
Turns out the endpoint for marking a notification as read is different from all the other endpoints in that it requires the parameters to be included in the body not as json but form-encoded. The previous implementation of `GsonRequest` specifically checked if the type of request was `POST` and if the `body` was null it would create an empty object for the body. This overrode the logic used in WPAndroid where the arguments for this endpoint are sent over as parameters in a post request. After some digging I found that in the case of a POST request, Volley will use the `params` property to populate the body if the `body` property is null. Adding a little check to make sure the `params` argument was not null or empty before creating that empty body object allowed for this built in functionality to work.

## Notifications Test fragment
I added a new notifications fragment to test all the functionality present in notifications so far as well. This became necessary since notifications are really difficult to test for release automated testing. This exercise uncovered an issue with the recently added `FETCH_NOTIFICATION` action (single notification) that has been fixed in #1046.  

### Main Fragment notifications button and Test page
![screenshot-1544658220736](https://user-images.githubusercontent.com/5810477/50254307-94b26e00-03bb-11e9-961c-b132338e0f90.png)


- **Fetch all notifications from API**: Fetches all available notifications from the api for the current user. These are populated in the database and seed the tests marked with `DB`
- **Get notifications for first site (DB)**: Pulls a list of notifications for the first site returned by the `SiteStore` for the current user.
- **Get notifications by type or subtype (DB)**: Opens a custom dialog for selecting a single type and subtype for pulling a filtered list from the database. 

<img src="https://user-images.githubusercontent.com/5810477/50253989-54062500-03ba-11e9-8ebd-a9a23e54221d.png" width="300">

- **Mark notifications seen**: Tells the api all notifications before this moment have been seen by the user.
- **Fetch notification from the API**: Grabs the `remoteNoteId` first notification in the database and fires off a request to fetch it from the api. ~~This will not completely work until #1046 is merged.~~ The request is still fired and response appropriately processed, but the missing `causeOfChange` makes it impossible for the example app to print the message that it was successful.
- **Mark read**: Grabs the first notification in the database and fires off a request to mark that notification as read.
- **Update Notification**: Grabs the first notification from the database, changes the `read` property to `false` and fires the request to update the notification.

