### PR TITLE
Woo Notification: Fetch and save a single notification

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.model.notification.NoteIdSet
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
+import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload
@@ -136,6 +137,28 @@ class MockedStack_NotificationTest : MockedStack_Base() {
         assertNotNull(payload)
         with(payload.notifs) {
             assertEquals(5, size)
+        }
+    }
+
+    @Test
+    fun testFetchNotificationSuccess() {
+        val remoteNoteId = 3695324025L
+        val remoteSiteId = 153482281L
+
+        interceptor.respondWith("fetch-notification-response-success.json")
+        notificationRestClient.fetchNotification(remoteNoteId)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(NotificationAction.FETCHED_NOTIFICATION, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchNotificationResponsePayload
+
+        assertNotNull(payload)
+        assertNotNull(payload.notification)
+        with(payload) {
+            assertEquals(notification!!.remoteNoteId, remoteNoteId)
+            assertEquals(notification!!.getRemoteSiteId(), remoteSiteId)
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -12,15 +12,19 @@ import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.notification.NoteIdSet
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.NotificationAppKey
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
 import org.wordpress.android.fluxc.store.SiteStore
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 import kotlin.properties.Delegates
 
@@ -148,6 +152,30 @@ class MockedStack_NotificationTest : MockedStack_Base() {
 
         assertNotNull(payload)
         assertEquals(payload.lastSeenTime, 1543265347L)
+    }
+
+    @Test
+    fun testMarkNotificationReadSuccess() {
+        val testNoteIdSet = NoteIdSet(0, 22L, 2)
+
+        interceptor.respondWith("mark-notification-read-response-success.json")
+        notificationRestClient.markNotificationRead(
+                NotificationModel(
+                        remoteNoteId = testNoteIdSet.remoteNoteId,
+                        localSiteId = testNoteIdSet.localSiteId))
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        assertEquals(NotificationAction.MARKED_NOTIFICATION_READ, lastAction!!.type)
+        val payload = lastAction!!.payload as MarkNotificationReadResponsePayload
+
+        assertNotNull(payload)
+        assertEquals(payload.success, true)
+        assertNotNull(payload.notification)
+        with(payload.notification!!) {
+            assertEquals(remoteNoteId, testNoteIdSet.remoteNoteId)
+        }
     }
 
     @Suppress("unused")

--- a/example/src/androidTest/resources/fetch-notification-response-success.json
+++ b/example/src/androidTest/resources/fetch-notification-response-success.json
@@ -1,0 +1,151 @@
+{
+  "last_seen_time": "1544585135",
+  "number": 1,
+  "notes": [
+    {
+      "id": 3695324025,
+      "type": "comment",
+      "subtype": "store_review",
+      "read": 0,
+      "noticon": "\uf300",
+      "timestamp": "2018-12-15T03:00:19+00:00",
+      "icon": "https:\/\/2.gravatar.com\/avatar\/26efbe729a124202fa9106c52cc6db05?s=256&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D256&r=G",
+      "url": "https:\/\/testwooshop.mystagingwebsite.com\/product\/long-sleeve-tee\/#comment-2785",
+      "subject": [
+        {
+          "text": "Marlin Bryant left a review on Long Sleeve Tee",
+          "ranges": [
+            {
+              "type": "user",
+              "indices": [
+                0,
+                13
+              ],
+              "email": "loy.rodriguez@example.org"
+            },
+            {
+              "type": "post",
+              "indices": [
+                31,
+                46
+              ],
+              "url": "https:\/\/testwooshop.mystagingwebsite.com\/product\/long-sleeve-tee\/",
+              "site_id": 153482281,
+              "id": 22
+            }
+          ]
+        },
+        {
+          "text": "Lovely\n",
+          "ranges": [
+            {
+              "type": "comment",
+              "indices": [
+                0,
+                7
+              ],
+              "url": "https:\/\/testwooshop.mystagingwebsite.com\/product\/long-sleeve-tee\/#comment-2785",
+              "site_id": 153482281,
+              "post_id": 22,
+              "id": 2785
+            }
+          ]
+        }
+      ],
+      "body": [
+        {
+          "text": "Marlin Bryant",
+          "ranges": [
+            {
+              "email": "loy.rodriguez@example.org",
+              "type": "user",
+              "indices": [
+                0,
+                13
+              ]
+            }
+          ],
+          "media": [
+            {
+              "type": "image",
+              "indices": [
+                0,
+                0
+              ],
+              "height": "256",
+              "width": "256",
+              "url": "https:\/\/2.gravatar.com\/avatar\/26efbe729a124202fa9106c52cc6db05?s=256&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D256&r=G"
+            }
+          ],
+          "meta": {
+            "links": {
+              "email": "loy.rodriguez@example.org"
+            }
+          },
+          "type": "user"
+        },
+        {
+          "text": "Lovely",
+          "actions": {
+            "spam-comment": false,
+            "trash-comment": false,
+            "approve-comment": false,
+            "edit-comment": true,
+            "replyto-comment": true
+          },
+          "meta": {
+            "ids": {
+              "comment": 2785,
+              "post": 22,
+              "site": 153482281
+            },
+            "links": {
+              "comment": "https:\/\/public-api.wordpress.com\/rest\/v1\/comments\/2785",
+              "post": "https:\/\/public-api.wordpress.com\/rest\/v1\/posts\/22",
+              "site": "https:\/\/public-api.wordpress.com\/rest\/v1\/sites\/153482281"
+            }
+          },
+          "type": "comment",
+          "nest_level": 0,
+          "edit_comment_link": "https:\/\/testwooshop.mystagingwebsite.com\/wp-admin\/comment.php?action=editcomment&c=2785"
+        },
+        {
+          "text": "Review for Long Sleeve Tee\n\u2605 \u2605 \u2605 \u2605 \u2605 ",
+          "ranges": [
+            {
+              "url": "https:\/\/testwooshop.mystagingwebsite.com\/product\/long-sleeve-tee\/",
+              "indices": [
+                27,
+                37
+              ],
+              "type": "link"
+            },
+            {
+              "url": "https:\/\/testwooshop.mystagingwebsite.com\/product\/long-sleeve-tee\/",
+              "indices": [
+                11,
+                26
+              ],
+              "type": "link"
+            }
+          ]
+        }
+      ],
+      "meta": {
+        "ids": {
+          "user": 0,
+          "comment": 2785,
+          "post": 22,
+          "site": 153482281
+        },
+        "links": {
+          "user": "https:\/\/public-api.wordpress.com\/rest\/v1\/users\/0",
+          "comment": "https:\/\/public-api.wordpress.com\/rest\/v1\/comments\/2785",
+          "post": "https:\/\/public-api.wordpress.com\/rest\/v1\/posts\/22",
+          "site": "https:\/\/public-api.wordpress.com\/rest\/v1\/sites\/153482281"
+        }
+      },
+      "title": "Product Review"
+    }
+  ]
+}

--- a/example/src/androidTest/resources/mark-notification-read-response-success.json
+++ b/example/src/androidTest/resources/mark-notification-read-response-success.json
@@ -1,0 +1,1 @@
+{"updated":[],"success":true}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.model.notification.NotificationModel;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPayload;
@@ -43,7 +44,9 @@ public enum NotificationAction implements IAction {
     @Action(payloadType = MarkNotificationSeenResponsePayload.class)
     MARKED_NOTIFICATIONS_SEEN, // Response to marking a notification as seen
     @Action(payloadType = MarkNotificationReadResponsePayload.class)
-    MARKED_NOTIFICATION_READ // Response to marking a notification as read
+    MARKED_NOTIFICATION_READ, // Response to marking a notification as read
 
     // Local actions
+    @Action(payloadType = NotificationModel.class)
+    UPDATE_NOTIFICATION // Save updates to db
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -3,6 +3,8 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayload;
+import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadPayload;
@@ -22,6 +24,8 @@ public enum NotificationAction implements IAction {
     UNREGISTER_DEVICE, // Unregister device for push notifications with WordPress.com
     @Action(payloadType = FetchNotificationsPayload.class)
     FETCH_NOTIFICATIONS, // Fetch notifications
+    @Action(payloadType = FetchNotificationPayload.class)
+    FETCH_NOTIFICATION, // Fetch a single notification
     @Action(payloadType = MarkNotificationsSeenPayload.class)
     MARK_NOTIFICATIONS_SEEN, // Mark last notification time seen
     @Action(payloadType = MarkNotificationReadPayload.class)
@@ -34,6 +38,8 @@ public enum NotificationAction implements IAction {
     UNREGISTERED_DEVICE, // Response to device unregistration
     @Action(payloadType = FetchNotificationsResponsePayload.class)
     FETCHED_NOTIFICATIONS, // Response to fetching notifications
+    @Action(payloadType = FetchNotificationResponsePayload.class)
+    FETCHED_NOTIFICATION, // Response to fetching a single notification
     @Action(payloadType = MarkNotificationSeenResponsePayload.class)
     MARKED_NOTIFICATIONS_SEEN, // Response to marking a notification as seen
     @Action(payloadType = MarkNotificationReadResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -5,6 +5,8 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload;
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadPayload;
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsSeenPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDevicePayload;
@@ -22,6 +24,8 @@ public enum NotificationAction implements IAction {
     FETCH_NOTIFICATIONS, // Fetch notifications
     @Action(payloadType = MarkNotificationsSeenPayload.class)
     MARK_NOTIFICATIONS_SEEN, // Mark last notification time seen
+    @Action(payloadType = MarkNotificationReadPayload.class)
+    MARK_NOTIFICATION_READ, // Mark notification as read by user
 
     // Remote responses
     @Action(payloadType = RegisterDeviceResponsePayload.class)
@@ -31,7 +35,9 @@ public enum NotificationAction implements IAction {
     @Action(payloadType = FetchNotificationsResponsePayload.class)
     FETCHED_NOTIFICATIONS, // Response to fetching notifications
     @Action(payloadType = MarkNotificationSeenResponsePayload.class)
-    MARKED_NOTIFICATIONS_SEEN // Response to marking a notification as seen
+    MARKED_NOTIFICATIONS_SEEN, // Response to marking a notification as seen
+    @Action(payloadType = MarkNotificationReadResponsePayload.class)
+    MARKED_NOTIFICATION_READ // Response to marking a notification as read
 
     // Local actions
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 data class NotificationModel(
     val noteId: Int = 0,
     val remoteNoteId: Long = 0L,
-    val localSiteId: Int = 0,
+    var localSiteId: Int = 0,
     val noteHash: Long = 0L,
     val type: Kind = NotificationModel.Kind.STORE_ORDER,
     val subtype: Subkind? = null,
@@ -53,4 +53,6 @@ data class NotificationModel(
             fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: UNKNOWN
         }
     }
+
+    fun getRemoteSiteId(): Long? = meta?.ids?.site
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -5,21 +5,21 @@ import org.wordpress.android.fluxc.tools.FormattableMeta
 import java.util.Locale
 
 data class NotificationModel(
-    val noteId: Int,
-    val remoteNoteId: Long,
-    val localSiteId: Int,
-    val noteHash: Long,
-    val type: Kind,
-    val subtype: Subkind?,
-    val read: Boolean,
-    val icon: String?,
-    val noticon: String?,
-    val timestamp: String?,
-    val url: String?,
-    val title: String?,
-    val body: List<FormattableContent>?,
-    val subject: List<FormattableContent>?,
-    val meta: FormattableMeta?
+    val noteId: Int = 0,
+    val remoteNoteId: Long = 0L,
+    val localSiteId: Int = 0,
+    val noteHash: Long = 0L,
+    val type: Kind = NotificationModel.Kind.STORE_ORDER,
+    val subtype: Subkind? = null,
+    var read: Boolean = false,
+    val icon: String? = null,
+    val noticon: String? = null,
+    val timestamp: String? = null,
+    val url: String? = null,
+    val title: String? = null,
+    val body: List<FormattableContent>? = null,
+    val subject: List<FormattableContent>? = null,
+    val meta: FormattableMeta? = null
 ) {
     enum class Kind {
         AUTOMATTCHER,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationApiResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationApiResponse.kt
@@ -23,7 +23,7 @@ class NotificationApiResponse : Response {
     companion object {
         fun notificationResponseToNotificationModel(
             response: NotificationApiResponse,
-            siteId: Int
+            siteId: Int = 0
         ): NotificationModel {
             val noteType = response.type?.let {
                 NotificationModel.Kind.fromString(response.type)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationReadApiResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationReadApiResponse.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.notifications
+
+import org.wordpress.android.fluxc.network.Response
+
+class NotificationReadApiResponse(val success: Boolean) : Response

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -17,6 +18,7 @@ import org.wordpress.android.fluxc.store.NotificationStore.DeviceRegistrationErr
 import org.wordpress.android.fluxc.store.NotificationStore.DeviceUnregistrationError
 import org.wordpress.android.fluxc.store.NotificationStore.DeviceUnregistrationErrorType
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.NotificationAppKey
 import org.wordpress.android.fluxc.store.NotificationStore.NotificationError
@@ -156,6 +158,31 @@ class NotificationRestClient constructor(
                         )
                     }
                     dispatcher.dispatch(NotificationActionBuilder.newMarkedNotificationsSeenAction(payload))
+                })
+        add(request)
+    }
+
+    /**
+     * Mark a notification as read
+     * Decrement the unread count for a notification. Key=note_ID, Value=decrement amount.
+     *
+     * https://developer.wordpress.com/docs/api/1/post/notifications/read/
+     */
+    fun markNotificationRead(notification: NotificationModel) {
+        val url = WPCOMREST.notifications.read.urlV1_1
+        val params = mapOf("counts[${notification.remoteNoteId}]" to "9999") // Just like WPAndroid
+        val request = WPComGsonRequest.buildPostRequest(url, params, NotificationReadApiResponse::class.java,
+                { response ->
+                    val payload = MarkNotificationReadResponsePayload(notification, response.success)
+                    dispatcher.dispatch(NotificationActionBuilder.newMarkedNotificationReadAction(payload))
+                },
+                { networkError ->
+                    val payload = MarkNotificationReadResponsePayload().apply {
+                        error = NotificationError(
+                                NotificationErrorType.fromString(networkError.apiError),
+                                networkError.message)
+                    }
+                    dispatcher.dispatch(NotificationActionBuilder.newMarkedNotificationReadAction(payload))
                 })
         add(request)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATIONS
 import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_SEEN
+import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATION_READ
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -105,6 +106,17 @@ constructor(
         constructor(error: NotificationError) : this() { this.error = error }
     }
 
+    class MarkNotificationReadPayload(
+        val notification: NotificationModel
+    ) : Payload<BaseNetworkError>()
+
+    class MarkNotificationReadResponsePayload(
+        val notification: NotificationModel? = null,
+        val success: Boolean = false
+    ) : Payload<NotificationError>() {
+        constructor(error: NotificationError) : this() { this.error = error }
+    }
+
     class NotificationError(val type: NotificationErrorType, val message: String = "") : OnChangedError
 
     enum class NotificationErrorType {
@@ -140,6 +152,8 @@ constructor(
             NotificationAction.FETCH_NOTIFICATIONS -> fetchNotifications()
             NotificationAction.MARK_NOTIFICATIONS_SEEN ->
                 markNotificationSeen(action.payload as MarkNotificationsSeenPayload)
+            NotificationAction.MARK_NOTIFICATION_READ ->
+                markNotificationRead(action.payload as MarkNotificationReadPayload)
 
             // remote responses
             NotificationAction.REGISTERED_DEVICE ->
@@ -150,6 +164,8 @@ constructor(
                 handleFetchNotificationsCompleted(action.payload as FetchNotificationsResponsePayload)
             NotificationAction.MARKED_NOTIFICATIONS_SEEN ->
                 handleMarkedNotificationSeen(action.payload as MarkNotificationSeenResponsePayload)
+            NotificationAction.MARKED_NOTIFICATION_READ ->
+                handleMarkedNotificationRead(action.payload as MarkNotificationReadResponsePayload)
         }
     }
 
@@ -302,7 +318,33 @@ constructor(
         }.apply {
             causeOfChange = MARK_NOTIFICATIONS_SEEN
         }
+        emitChange(onNotificationChanged)
+    }
 
+    private fun markNotificationRead(payload: MarkNotificationReadPayload) {
+        notificationRestClient.markNotificationRead(payload.notification)
+    }
+
+    private fun handleMarkedNotificationRead(payload: MarkNotificationReadResponsePayload) {
+        // Update the notification in the database
+        payload.notification?.let {
+            it.read = true // Just in case it wasn't set by the calling client
+            if (payload.success) notificationSqlUtils.insertOrUpdateNotification(it)
+        }
+
+        // Create an dispatch result
+        val onNotificationChanged = if (payload.isError) {
+            OnNotificationChanged(0).apply {
+                error = payload.error
+                success = false
+            }
+        } else {
+            OnNotificationChanged(1).apply {
+                success = true
+            }
+        }.apply {
+            causeOfChange = MARK_NOTIFICATION_READ
+        }
         emitChange(onNotificationChanged)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATIONS
 import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_SEEN
 import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATION_READ
+import org.wordpress.android.fluxc.action.NotificationAction.UPDATE_NOTIFICATION
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -150,6 +151,7 @@ constructor(
         var causeOfChange: NotificationAction? = null
         var lastSeenTime: Long? = null
         var success: Boolean = true
+        val changedNotificationLocalIds = mutableListOf<Int>()
     }
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
@@ -179,6 +181,9 @@ constructor(
                 handleMarkedNotificationSeen(action.payload as MarkNotificationSeenResponsePayload)
             NotificationAction.MARKED_NOTIFICATION_READ ->
                 handleMarkedNotificationRead(action.payload as MarkNotificationReadResponsePayload)
+
+            // local actions
+            NotificationAction.UPDATE_NOTIFICATION -> updateNotification(action.payload as NotificationModel)
         }
     }
 
@@ -382,6 +387,16 @@ constructor(
             }
         }.apply {
             causeOfChange = MARK_NOTIFICATION_READ
+        }
+        emitChange(onNotificationChanged)
+    }
+
+    private fun updateNotification(payload: NotificationModel) {
+        // save notification to the db
+        val rowsAffected = notificationSqlUtils.insertOrUpdateNotification(payload)
+        val onNotificationChanged = OnNotificationChanged(rowsAffected).apply {
+            changedNotificationLocalIds.add(payload.noteId)
+            causeOfChange = UPDATE_NOTIFICATION
         }
         emitChange(onNotificationChanged)
     }

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -23,6 +23,7 @@
 /me/username/
 
 /notifications/
+/notifications/$note_id
 /notifications/seen/
 /notifications/read/
 

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -24,6 +24,7 @@
 
 /notifications/
 /notifications/seen/
+/notifications/read/
 
 /read/feed/
 /read/feed/$feed_url_or_id#long,String


### PR DESCRIPTION
Fixes #1039 

Covers the following:
- Adds the ability to fetch a single notification by the `remote_note_id`. A successful response will be parsed into a 'NotificationModel` and saved to the database. 
- Adds a local `NotificationAction.UPDATE_NOTIFICATION` for saving a single notification directly to the database. Will send an `OnNotificationChanged` event when complete. 

Also added a new test to `MockedStack_NotificationTest`

Note: #1038 must be merged before this one can be. 