### PR TITLE
Fix a crash caused by empty lists

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListItemSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListItemSqlUtilsTest.kt
@@ -138,6 +138,32 @@ class ListItemSqlUtilsTest {
     }
 
     @Test
+    fun testDeleteFromListsDoesNotCrashForEmptyRemoteItemIds() {
+        /**
+         * 1. Create a test list
+         * 2. Attempt to delete an empty list of remote item ids from the list
+         * 3. Verify that this case is handled correctly in `deleteItemsFromLists` and it does not crash.
+         *
+         * This test is added due to a bug in WellSql where it doesn't handle empty lists properly while building
+         * `isIn` queries.
+         */
+        val testList = insertTestList(PostListDescriptorForXmlRpcSite(testSite()))
+        listItemSqlUtils.deleteItemsFromLists(listOf(testList.id), emptyList())
+    }
+
+    @Test
+    fun testDeleteFromListsDoesNotCrashForEmptyListOfLists() {
+        /**
+         * 1. Attempt to delete a list of remote item ids from an empty list of lists
+         * 2. Verify that this case is handled correctly in `deleteItemsFromLists` and it does not crash.
+         *
+         * This test is added due to a bug in WellSql where it doesn't handle empty lists properly while building
+         * `isIn` queries.
+         */
+        listItemSqlUtils.deleteItemsFromLists(emptyList(), listOf(1L, 2L))
+    }
+
+    @Test
     fun insertDuplicateListItemModel() {
         val testRemoteItemId = 1245L // value doesn't matter
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
@@ -60,16 +60,7 @@ class ListItemSqlUtils @Inject constructor() {
      */
     fun deleteItemsFromLists(listIds: List<Int>, remoteItemIds: List<Long>) {
 
-        /// This check fixes a bug caused by WellSQL. In `ConditionClauseBuilder` (the location where `isIn()` is
-        /// declared), the code iterates through the items in the provided list argument, appending "?," to each.
-        /// It then removes the very last character from the created query. The issue is, if there are no items
-        /// to iterate through, removing the last character removes the opening "(" in the query. This results in a
-        //  query that looks like:
-        //
-        //  DELETE FROM ListItemModel WHERE LIST_ID IN ) AND REMOTE_ITEM_ID IN (?)
-        //
-        //  When SQLite tries to run this query, it crashes attempting to compile it with an SQLiteException.
-        
+        // Prevent a crash caused by either of these lists being empty
         if(listIds.isEmpty() || remoteItemIds.isEmpty()) {
             return
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
@@ -59,9 +59,8 @@ class ListItemSqlUtils @Inject constructor() {
      * This function deletes [ListItemModel]s for [remoteItemIds] in every lists with [listIds]
      */
     fun deleteItemsFromLists(listIds: List<Int>, remoteItemIds: List<Long>) {
-
         // Prevent a crash caused by either of these lists being empty
-        if(listIds.isEmpty() || remoteItemIds.isEmpty()) {
+        if (listIds.isEmpty() || remoteItemIds.isEmpty()) {
             return
         }
 


### PR DESCRIPTION
This change resolves a crash caused by insufficient bounds checking in WellSQL. In `ConditionClauseBuilder` (the location where `isIn()` is declared), the code iterates through the items in the provided list argument, appending "?," to each.

It then removes the last character from the created query. The issue is, if there are no items to iterate through, removing the last character removes the opening "(" in the query. This results in a query that looks like:

```sql
DELETE FROM ListItemModel WHERE LIST_ID IN ) AND REMOTE_ITEM_ID IN (?)
```
When SQLite tries to run this query, it crashes attempting to compile it with an SQLiteException.

~I attempted to create a failing test case for this, but wasn't able to easily build up an SQLite stack to test against.~

~A quick read through the relevant code should validate the approach, but~
Let me know if there's anything else you'd like me to add! 

Source: 5908a31cbe077a4dcc335dab-fabric