### PR TITLE
Empty domain suggestions should be handled as successful response

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -66,6 +66,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteError;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError;
+import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesError;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesErrorType;
@@ -400,9 +401,16 @@ public class SiteRestClient extends BaseWPComRestClient {
                             public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                                 SuggestDomainError suggestDomainError =
                                         new SuggestDomainError(error.apiError, error.message);
-                                SuggestDomainsResponsePayload payload =
-                                        new SuggestDomainsResponsePayload(query, suggestDomainError);
-                                mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
+                                if (suggestDomainError.type == SuggestDomainErrorType.EMPTY_RESULTS) {
+                                    // Empty results is not an actual error, the API should return 200 for it
+                                    SuggestDomainsResponsePayload payload = new SuggestDomainsResponsePayload(query,
+                                            Collections.<DomainSuggestionResponse>emptyList());
+                                    mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
+                                } else {
+                                    SuggestDomainsResponsePayload payload =
+                                            new SuggestDomainsResponsePayload(query, suggestDomainError);
+                                    mDispatcher.dispatch(SiteActionBuilder.newSuggestedDomainsAction(payload));
+                                }
                             }
                         }
                 );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -134,7 +134,7 @@ public class SiteStore extends Store {
             this.suggestions = new ArrayList<>();
         }
 
-        public SuggestDomainsResponsePayload(@NonNull String query, ArrayList<DomainSuggestionResponse> suggestions) {
+        public SuggestDomainsResponsePayload(@NonNull String query, List<DomainSuggestionResponse> suggestions) {
             this.query = query;
             this.suggestions = suggestions;
         }
@@ -679,6 +679,7 @@ public class SiteStore extends Store {
     }
 
     public enum SuggestDomainErrorType {
+        EMPTY_RESULTS,
         EMPTY_QUERY,
         INVALID_MINIMUM_QUANTITY,
         INVALID_MAXIMUM_QUANTITY,


### PR DESCRIPTION
When we make a request to `/domains/suggestions` if there are no suggestions found, it returns a 400 error. An empty suggestion list is a completely valid state and I don't think it should be returning an error for it. When we handle error states in the clients, it's not a state where we need to show a big error for it. It should be handled as an empty list just like any other.

This PR adds an error type `EMPTY_RESULTS` for it and handles this case as if we got a successful response from the server. It also adds a test for it as well as improving the existing domain suggestion tests just a little bit.

I don't think this change will have a negative effect on the existing implementation, but it'd be good to double check just in case @malinajirka. Also cc @hypest since you have worked on this feature before if I am not mistaken. (just to check I am not missing something)

P.S: I considered changing the domain queries to be constants, but decided not to do that to keep the test class consistent.