### PR TITLE
Adds INVALID_QUERY SuggestDomainErrorType and its test

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -683,6 +683,7 @@ public class SiteStore extends Store {
         EMPTY_QUERY,
         INVALID_MINIMUM_QUANTITY,
         INVALID_MAXIMUM_QUANTITY,
+        INVALID_QUERY,
         GENERIC_ERROR;
 
         public static SuggestDomainErrorType fromString(final String string) {


### PR DESCRIPTION
This is a very simple PR that adds the `INVALID_QUERY` error type to `/domains/suggestions` network call. I came across this error accidentally when I searched for `.` while testing the new site creation flow. This change will give us a chance to handle this error type differently, probably similar to `EMPTY_RESULTS`, if we wanted to.

It also adds a connected test for this case mostly so that the reviewer can test it easily :)

**To test:**

* Run the connected tests for domain suggestions (all of which has a minor refactor change)

_One reviewer should be enough for this PR._