### PR TITLE
WC Notifications: Add mark all read

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NotificationTest.kt
@@ -4,6 +4,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
@@ -12,18 +13,22 @@ import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPayload
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadPayload
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsSeenPayload
 import org.wordpress.android.fluxc.store.NotificationStore.OnNotificationChanged
-import java.lang.AssertionError
 import java.lang.Exception
+import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
+import kotlin.AssertionError
 
 class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
     internal enum class TestEvent {
         NONE,
-        FETCHED_NOTES,
-        MARKED_NOTES_SEEN
+        FETCHED_NOTIFS,
+        MARKED_NOTIFS_SEEN,
+        MARKED_NOTIFS_READ
     }
 
     @Inject internal lateinit var notificationStore: NotificationStore
@@ -45,7 +50,7 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
     @Throws(InterruptedException::class)
     @Test
     fun testFetchNotifications() {
-        nextEvent = TestEvent.FETCHED_NOTES
+        nextEvent = TestEvent.FETCHED_NOTIFS
         mCountDownLatch = CountDownLatch(1)
 
         mDispatcher.dispatch(NotificationActionBuilder
@@ -55,6 +60,58 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
 
         val fetchedNotifs = notificationStore.getNotifications().size
         assertTrue(fetchedNotifs > 0 && fetchedNotifs <= NotificationRestClient.NOTIFICATION_DEFAULT_NUMBER)
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testMarkNotificationsSeen() {
+        nextEvent = TestEvent.MARKED_NOTIFS_SEEN
+        mCountDownLatch = CountDownLatch(1)
+
+        val lastSeenTime = Date().time
+        mDispatcher.dispatch(NotificationActionBuilder
+                .newMarkNotificationsSeenAction(MarkNotificationsSeenPayload(lastSeenTime)))
+
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertNotNull(lastEvent?.lastSeenTime)
+    }
+
+    @Throws(InterruptedException::class)
+    @Test
+    fun testMarkNotificationsRead() {
+        // First, fetch notifications and store in database.
+        nextEvent = TestEvent.FETCHED_NOTIFS
+        mCountDownLatch = CountDownLatch(1)
+
+        mDispatcher.dispatch(NotificationActionBuilder
+                .newFetchNotificationsAction(FetchNotificationsPayload()))
+
+        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        val fetchedNotifs = notificationStore.getNotifications()
+
+        // Second, request up to 3 notifications from the db to set to read
+        if (fetchedNotifs.isNotEmpty()) {
+            val requestList = fetchedNotifs.take(3)
+            val requestListSize = requestList.size
+
+            nextEvent = TestEvent.MARKED_NOTIFS_READ
+            mCountDownLatch = CountDownLatch(1)
+
+            mDispatcher.dispatch(NotificationActionBuilder
+                    .newMarkNotificationsReadAction(MarkNotificationsReadPayload(requestList)))
+            Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+            // Verify
+            Assert.assertNotNull(lastEvent)
+            Assert.assertTrue(lastEvent!!.success)
+            Assert.assertEquals(lastEvent!!.changedNotificationLocalIds.size, requestListSize)
+            with(lastEvent!!.changedNotificationLocalIds) {
+                requestList.forEach { Assert.assertTrue(contains(it.noteId)) }
+            }
+        } else {
+            throw AssertionError("No notifications fetched to run test with!")
+        }
     }
 
     @Suppress("unused")
@@ -67,11 +124,15 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         lastEvent = event
         when (event.causeOfChange) {
             NotificationAction.FETCH_NOTIFICATIONS -> {
-                assertEquals(TestEvent.FETCHED_NOTES, nextEvent)
+                assertEquals(TestEvent.FETCHED_NOTIFS, nextEvent)
                 mCountDownLatch.countDown()
             }
             NotificationAction.MARK_NOTIFICATIONS_SEEN -> {
-                assertEquals(TestEvent.MARKED_NOTES_SEEN, nextEvent)
+                assertEquals(TestEvent.MARKED_NOTIFS_SEEN, nextEvent)
+                mCountDownLatch.countDown()
+            }
+            NotificationAction.MARK_NOTIFICATIONS_READ -> {
+                assertEquals(TestEvent.MARKED_NOTIFS_READ, nextEvent)
                 mCountDownLatch.countDown()
             }
             else -> throw AssertionError("Unexpected cause of change: ${event.causeOfChange}")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/FragmentExt.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/FragmentExt.kt
@@ -1,0 +1,11 @@
+@file:JvmName("FragmentExtensions")
+package org.wordpress.android.fluxc.example
+
+import android.support.v4.app.Fragment
+
+/**
+ * Shortcut for appending messages to the log in MainActivity
+ */
+fun Fragment.prependToLog(s: String) {
+    (activity as? MainExampleActivity)?.prependToLog(s)
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -58,10 +58,9 @@ class NotificationsFragment : Fragment() {
 
         notifs_fetch_for_site.setOnClickListener {
             prependToLog("Getting all notifications for the first site...\n")
-            selectedSite?.let {
-                val notifs = notificationStore.getNotificationsForSite(it)
-                // todo amanda - fix display name
-                prependToLog("SUCCESS! ${notifs.size} pulled from the database for ${it.name}")
+            selectedSite?.let { site ->
+                val notifs = notificationStore.getNotificationsForSite(site)
+                prependToLog("SUCCESS! ${notifs.size} pulled from the database for ${site.name}")
             } ?: prependToLog("No site selected!")
         }
 
@@ -70,8 +69,8 @@ class NotificationsFragment : Fragment() {
                 override fun onSubmitted(type: String, subtype: String) {
                     prependToLog("Fetching notifications matching $type or $subtype...\n")
                     val notifs = notificationStore.getNotifications(listOf(type), listOf(subtype))
-                    val groups = notifs.groupingBy {
-                        it.subtype?.name?.takeIf { it != Subkind.UNKNOWN.name } ?: it.type.name
+                    val groups = notifs.groupingBy { notif ->
+                        notif.subtype?.name?.takeIf { subtype -> subtype != Subkind.UNKNOWN.name } ?: notif.type.name
                     }.fold(0) { acc, _ -> acc + 1 }
                     prependToLog("SUCCESS! Total records matching filtered selections:" +
                             "\n- $type: ${groups[type] ?: 0}\n- $subtype: ${groups[subtype] ?: 0}")
@@ -105,8 +104,8 @@ class NotificationsFragment : Fragment() {
 
         notifs_mark_all_read.setOnClickListener {
             // Fetch only unread notifications from the database for the first site
-            selectedSite?.let {
-                notificationStore.getNotificationsForSite(it).filter { note -> !note.read }
+            selectedSite?.let { site ->
+                notificationStore.getNotificationsForSite(site).filter { note -> !note.read }
                         .takeIf { list -> list.isNotEmpty() }?.let { notes ->
                             prependToLog("Marking [${notes.size}] unread notifications as read...\n")
                             dispatcher.dispatch(NotificationActionBuilder
@@ -176,8 +175,8 @@ class NotificationsFragment : Fragment() {
             }
             MARK_NOTIFICATIONS_READ -> {
                 event.changedNotificationLocalIds.forEach {
-                    notificationStore.getNotificationByLocalId(it)?.let {
-                        prependToLog("SUCCESS! ${it.toLogString()}")
+                    notificationStore.getNotificationByLocalId(it)?.let { notif ->
+                        prependToLog("SUCCESS! ${notif.toLogString()}")
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -85,20 +85,22 @@ class NotificationsFragment : Fragment() {
         }
 
         notifs_fetch_first.setOnClickListener {
-            selectedSite?.let {
-                val note = notificationStore.getNotificationsForSite(it).first()
-                prependToLog("Fetching a single notification with remoteNoteId = ${note.remoteNoteId}\n")
-                dispatcher.dispatch(NotificationActionBuilder
-                        .newFetchNotificationAction(FetchNotificationPayload(note.remoteNoteId)))
+            selectedSite?.let { site ->
+                notificationStore.getNotificationsForSite(site).firstOrNull()?.let { note ->
+                    prependToLog("Fetching a single notification with remoteNoteId = ${note.remoteNoteId}\n")
+                    dispatcher.dispatch(NotificationActionBuilder
+                            .newFetchNotificationAction(FetchNotificationPayload(note.remoteNoteId)))
+                } ?: prependToLog("No notifications found for selected site!")
             } ?: prependToLog("No site selected!")
         }
 
         notifs_mark_read.setOnClickListener {
-            selectedSite?.let {
-                val note = notificationStore.getNotificationsForSite(it).first()
-                prependToLog("Setting notification with remoteNoteId of ${note.remoteNoteId} as read\n")
-                dispatcher.dispatch(NotificationActionBuilder
-                        .newMarkNotificationsReadAction(MarkNotificationsReadPayload(listOf(note))))
+            selectedSite?.let { site ->
+                notificationStore.getNotificationsForSite(site).firstOrNull()?.let { note ->
+                    prependToLog("Setting notification with remoteNoteId of ${note.remoteNoteId} as read\n")
+                    dispatcher.dispatch(NotificationActionBuilder
+                            .newMarkNotificationsReadAction(MarkNotificationsReadPayload(listOf(note))))
+                } ?: prependToLog("No notifications found for selected site!")
             } ?: prependToLog("No site selected!")
         }
 
@@ -115,12 +117,13 @@ class NotificationsFragment : Fragment() {
         }
 
         notifs_update_first.setOnClickListener {
-            selectedSite?.let {
-                val note = notificationStore.getNotificationsForSite(it).first()
-                note.read = !note.read
-                prependToLog("Updating notification with remoteNoteId " +
-                        "of ${note.remoteNoteId} to [read = ${note.read}]\n")
-                dispatcher.dispatch(NotificationActionBuilder.newUpdateNotificationAction(note))
+            selectedSite?.let { site ->
+                notificationStore.getNotificationsForSite(site).firstOrNull()?.let { note ->
+                    note.read = !note.read
+                    prependToLog("Updating notification with remoteNoteId " +
+                            "of ${note.remoteNoteId} to [read = ${note.read}]\n")
+                    dispatcher.dispatch(NotificationActionBuilder.newUpdateNotificationAction(note))
+                } ?: prependToLog("No notifications found for selected site!")
             } ?: prependToLog("No site selected!")
         }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -49,12 +49,12 @@ class NotificationsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         notifs_fetch_all.setOnClickListener {
-            prependToLog("Fetching all notifications from the api...")
+            prependToLog("Fetching all notifications from the api...\n")
             dispatcher.dispatch(NotificationActionBuilder.newFetchNotificationsAction(FetchNotificationsPayload()))
         }
 
         notifs_fetch_for_site.setOnClickListener {
-            prependToLog("Getting all notifications for the first site...")
+            prependToLog("Getting all notifications for the first site...\n")
             val site = siteStore.sites.first()
             val notifs = notificationStore.getNotificationsForSite(site)
 
@@ -65,7 +65,7 @@ class NotificationsFragment : Fragment() {
         notifs_by_type_subtype.setOnClickListener {
             showNotificationTypeSubtypeDialog(object : Listener {
                 override fun onSubmitted(type: String, subtype: String) {
-                    prependToLog("Fetching notifications matching $type or $subtype...")
+                    prependToLog("Fetching notifications matching $type or $subtype...\n")
                     val notifs = notificationStore.getNotifications(listOf(type), listOf(subtype))
                     val groups = notifs.groupingBy {
                         it.subtype?.name?.takeIf { it != Subkind.UNKNOWN.name } ?: it.type.name
@@ -77,29 +77,32 @@ class NotificationsFragment : Fragment() {
         }
 
         notifs_mark_seen.setOnClickListener {
-            prependToLog("Setting notifications last seen time to now")
+            prependToLog("Setting notifications last seen time to now\n")
             dispatcher.dispatch(NotificationActionBuilder
                     .newMarkNotificationsSeenAction(MarkNotificationsSeenPayload(Date().time)))
         }
 
         notifs_fetch_first.setOnClickListener {
-            val note = notificationStore.getNotifications().first()
-            prependToLog("Fetching a single notification with remoteNoteId = ${note.remoteNoteId}")
+            val site = siteStore.sites.first()
+            val note = notificationStore.getNotificationsForSite(site).first()
+            prependToLog("Fetching a single notification with remoteNoteId = ${note.remoteNoteId}\n")
             dispatcher.dispatch(NotificationActionBuilder
                     .newFetchNotificationAction(FetchNotificationPayload(note.remoteNoteId)))
         }
 
         notifs_mark_read.setOnClickListener {
-            val note = notificationStore.getNotifications().first()
-            prependToLog("Setting notification with remoteNoteId of ${note.remoteNoteId} as read")
+            val site = siteStore.sites.first()
+            val note = notificationStore.getNotificationsForSite(site).first()
+            prependToLog("Setting notification with remoteNoteId of ${note.remoteNoteId} as read\n")
             dispatcher.dispatch(NotificationActionBuilder
-                    .newMarkNotificationReadAction(MarkNotificationReadPayload(note)))
+                    .newMarkNotificationsReadAction(MarkNotificationsReadPayload(listOf(note))))
         }
 
         notifs_update_first.setOnClickListener {
-            val note = notificationStore.getNotifications().first()
+            val site = siteStore.sites.first()
+            val note = notificationStore.getNotificationsForSite(site).first()
             note.read = !note.read
-            prependToLog("Updating notification with remoteNoteId of ${note.remoteNoteId}")
+            prependToLog("Updating notification with remoteNoteId of ${note.remoteNoteId} to [read = ${note.read}]\n")
             dispatcher.dispatch(NotificationActionBuilder.newUpdateNotificationAction(note))
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SiteSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SiteSelectorDialog.kt
@@ -1,0 +1,122 @@
+package org.wordpress.android.fluxc.example
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import dagger.android.support.AndroidSupportInjection
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import javax.inject.Inject
+
+class SiteSelectorDialog : DialogFragment() {
+    companion object {
+        @JvmStatic
+        fun newInstance(listener: Listener, selectedPos: Int) = SiteSelectorDialog().apply {
+            this.listener = listener
+            this.selectedPos = selectedPos
+        }
+    }
+
+    interface Listener {
+        fun onSiteSelected(site: SiteModel, pos: Int)
+    }
+
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var siteStore: SiteStore
+
+    var listener: Listener? = null
+    var selectedPos: Int = -1
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dispatcher.register(this)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // get sites from api
+        if (siteStore.sites.isEmpty()) {
+            dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        dispatcher.unregister(this)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return activity?.let {
+            val adapter = SiteAdapter(it, siteStore.sites)
+
+            // Use the Builder class for convenient dialog construction
+            val builder = AlertDialog.Builder(it)
+            builder.setTitle("Select a site")
+                    .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
+                        val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
+                        val site = adapter.getItem(which)
+                        listener?.onSiteSelected(site, which)
+                        dialog.dismiss()
+                    }
+            // Create the AlertDialog object and return it
+            builder.create()
+        } ?: throw IllegalStateException("Activity cannot be null")
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onSiteChanged(event: OnSiteChanged) {
+        if (event.isError) {
+            AppLog.e(T.TESTS, "SiteChanged error: " + event.error.type)
+            prependToLog("SiteChanged error: " + event.error.type)
+        } else {
+            prependToLog("SiteChanged: rowsAffected = " + event.rowsAffected)
+            siteStore.sites?.let {
+                val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
+                adapter.refreshSites(it)
+            }
+        }
+    }
+
+    class SiteAdapter(
+        ctx: Context,
+        items: MutableList<SiteModel>
+    ) : ArrayAdapter<SiteModel>(ctx, android.R.layout.simple_list_item_1, items) {
+        fun refreshSites(newItems: List<SiteModel>) {
+            setNotifyOnChange(true)
+            addAll(newItems)
+        }
+
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+            val cv = convertView
+                    ?: LayoutInflater.from(context)
+                            .inflate(android.R.layout.simple_list_item_single_choice, parent, false)
+            val site = getItem(position)
+            (cv as TextView).text = site.displayName ?: site.name
+            return cv
+        }
+
+        override fun getItemId(position: Int) = getItem(position).id.toLong()
+
+        override fun hasStableIds() = true
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.example.MediaFragment
 import org.wordpress.android.fluxc.example.NotificationsFragment
 import org.wordpress.android.fluxc.example.PostsFragment
 import org.wordpress.android.fluxc.example.SignedOutActionsFragment
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
 import org.wordpress.android.fluxc.example.SitesFragment
 import org.wordpress.android.fluxc.example.TaxonomiesFragment
 import org.wordpress.android.fluxc.example.ThemeFragment
@@ -52,4 +53,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideNotificationsFragmentInjector(): NotificationsFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideSiteSelectorDialogInjector(): SiteSelectorDialog
 }

--- a/example/src/main/res/layout/fragment_notifications.xml
+++ b/example/src/main/res/layout/fragment_notifications.xml
@@ -8,6 +8,13 @@
     android:layout_margin="8dp"
     android:orientation="vertical">
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        android:text="Perform actions for user:"/>
+
     <Button
         android:id="@+id/notifs_fetch_all"
         android:layout_width="wrap_content"
@@ -20,53 +27,80 @@
         android:layout_height="wrap_content"
         android:text="Mark Notifications Seen"/>
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp"
-        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-        android:text="Perform actions on the first site:"/>
-
-    <Button
-        android:id="@+id/notifs_fetch_for_site"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Get Notifications For First Site (db)"/>
-
     <Button
         android:id="@+id/notifs_by_type_subtype"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Get Notifications by type or subtype (db)"/>
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        android:text="Perform actions on a selected site:"/>
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/notifs_select_site"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Select Site"/>
+
+        <TextView
+            android:id="@+id/notif_selected_site"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+            android:textColor="@android:color/holo_blue_bright"
+            android:layout_width="wrap_content"
+            android:paddingStart="10dp"
+            android:paddingLeft="10dp"
+            android:layout_height="wrap_content"/>
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/notifs_fetch_for_site"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Get Notifications (db)"
+        android:enabled="false"/>
+
     <Button
         android:id="@+id/notifs_mark_all_read"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Mark all unread notifications as read"/>
+        android:text="Mark all unread notifications as read"
+        android:enabled="false"/>
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"
         android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-        android:text="Actions on the first notification for first site:"/>
+        android:text="Actions on the first notification for the selected site:"/>
 
     <Button
         android:id="@+id/notifs_fetch_first"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Fetch Notification From API"/>
+        android:text="Fetch Notification From API"
+        android:enabled="false"/>
 
     <Button
         android:id="@+id/notifs_mark_read"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Mark Read"/>
+        android:text="Mark Read"
+        android:enabled="false"/>
 
     <Button
         android:id="@+id/notifs_update_first"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Update Notification (DB)"/>
+        android:text="Update Notification (DB)"
+        android:enabled="false"/>
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_notifications.xml
+++ b/example/src/main/res/layout/fragment_notifications.xml
@@ -39,12 +39,18 @@
         android:layout_height="wrap_content"
         android:text="Get Notifications by type or subtype (db)"/>
 
+    <Button
+        android:id="@+id/notifs_mark_all_read"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Mark all unread notifications as read"/>
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"
         android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-        android:text="Perform actions on the first notification in list:"/>
+        android:text="Actions on the first notification for first site:"/>
 
     <Button
         android:id="@+id/notifs_fetch_first"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -30,7 +30,7 @@ public enum NotificationAction implements IAction {
     @Action(payloadType = MarkNotificationsSeenPayload.class)
     MARK_NOTIFICATIONS_SEEN, // Submit the time notifications were last seen
     @Action(payloadType = MarkNotificationsReadPayload.class)
-    MARK_NOTIFICATIONS_READ, // Mark notification as read by user
+    MARK_NOTIFICATIONS_READ, // Mark one or more notifications as read by user
 
     // Remote responses
     @Action(payloadType = RegisterDeviceResponsePayload.class)
@@ -44,7 +44,7 @@ public enum NotificationAction implements IAction {
     @Action(payloadType = MarkNotificationSeenResponsePayload.class)
     MARKED_NOTIFICATIONS_SEEN, // Response to submitting the time notifications were last seen
     @Action(payloadType = MarkNotificationsReadResponsePayload.class)
-    MARKED_NOTIFICATIONS_READ, // Response to marking a notification as read
+    MARKED_NOTIFICATIONS_READ, // Response to marking one or more notifications as read
 
     // Local actions
     @Action(payloadType = NotificationModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -8,8 +8,8 @@ import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayl
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload;
-import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadPayload;
-import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationReadResponsePayload;
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadPayload;
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsSeenPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDevicePayload;
@@ -29,8 +29,8 @@ public enum NotificationAction implements IAction {
     FETCH_NOTIFICATION, // Fetch a single notification
     @Action(payloadType = MarkNotificationsSeenPayload.class)
     MARK_NOTIFICATIONS_SEEN, // Submit the time notifications were last seen
-    @Action(payloadType = MarkNotificationReadPayload.class)
-    MARK_NOTIFICATION_READ, // Mark notification as read by user
+    @Action(payloadType = MarkNotificationsReadPayload.class)
+    MARK_NOTIFICATIONS_READ, // Mark notification as read by user
 
     // Remote responses
     @Action(payloadType = RegisterDeviceResponsePayload.class)
@@ -43,8 +43,8 @@ public enum NotificationAction implements IAction {
     FETCHED_NOTIFICATION, // Response to fetching a single notification
     @Action(payloadType = MarkNotificationSeenResponsePayload.class)
     MARKED_NOTIFICATIONS_SEEN, // Response to submitting the time notifications were last seen
-    @Action(payloadType = MarkNotificationReadResponsePayload.class)
-    MARKED_NOTIFICATION_READ, // Response to marking a notification as read
+    @Action(payloadType = MarkNotificationsReadResponsePayload.class)
+    MARKED_NOTIFICATIONS_READ, // Response to marking a notification as read
 
     // Local actions
     @Action(payloadType = NotificationModel.class)


### PR DESCRIPTION
Fixes #1050 

Adds the ability to mark multiple notifications as read. Instead of adding additional actions and payloads, I opted to modify the existing `Mark as read` functionality to accommodate a list of `NotificationModel` objects instead of a single object. 

**This currently only effects Woocommerce-Android since WPAndroid still has all this code handled in the main WPAndroid repo. This is a breaking change for WCAndroid and will require updates to the codebase there as well**

<img src="https://user-images.githubusercontent.com/5810477/50463056-39522400-0957-11e9-8174-7c1e7ac48f00.gif" width="300"/>

### Changes
- `MARK_NOTIFICATIONS_READ` action now accepts a list of `NotificationModel` objects 
- I figured I could be relatively safe adding "mark as seen" and "mark as read" release tests since most test accounts will have at least 1 notification. Those have been added.
- Updated the example app and added some new functionality such as the ability to select a site manually to prevent making updates to unintended sites, as well as the ability to mark multiple notifications as read.
- Added new mocked tests and fixed any existing ones.
- Cleaned up the messaging in the log of the example app to make it easier to follow for notification-related tests


