### PR TITLE
Bugfix: Change Order LineItem quantity from Int to Float

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -154,7 +154,7 @@ class NotificationRestClient constructor(
                 "num_note_items" to NOTIFICATION_DEFAULT_NUM_NOTE_ITEMS.toString(),
                 "fields" to NOTIFICATION_DEFAULT_FIELDS)
 
-        remoteNoteIds?.let { if (remoteNoteIds.isNotEmpty()) params["ids"] = remoteNoteIds.joinToString() }
+        remoteNoteIds?.let { if (it.isNotEmpty()) params["ids"] = it.joinToString() }
 
         val request = WPComGsonRequest.buildGetRequest(url, params, NotificationsApiResponse::class.java,
                 { response: NotificationsApiResponse? ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -70,7 +70,7 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         val productId: Long? = null
         @SerializedName("variation_id")
         val variationId: Long? = null
-        val quantity: Int? = null
+        val quantity: Float? = null
         val subtotal: String? = null
         val total: String? = null // Price x quantity
         @SerializedName("total_tax")


### PR DESCRIPTION
Fixes #972 by updating the `LineItem.quantity` property from an Int to a Float just in case we get another fractional value back from the api. 