### PR TITLE
Replace first() with firstOrNull() to account for empty lists

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -191,7 +191,7 @@ class NotificationRestClient constructor(
                 "fields" to NOTIFICATION_DEFAULT_FIELDS)
         val request = WPComGsonRequest.buildGetRequest(url, params, NotificationsApiResponse::class.java,
                 { response ->
-                    val notification = response?.notes?.first()?.let {
+                    val notification = response?.notes?.firstOrNull()?.let {
                         NotificationApiResponse.notificationResponseToNotificationModel(it)
                     }
                     val payload = FetchNotificationResponsePayload(notification)


### PR DESCRIPTION
Fixes #1057 by using `firstOrNull()` instead of `first()` to prevent a `NoSuchElementException` when dealing with empty results