### PR TITLE
Jetpack Tunnel: Dispatch event on timeout

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -10,6 +10,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 
+import org.jetbrains.annotations.Nullable;
 import org.wordpress.android.fluxc.network.BaseRequest;
 
 import java.io.UnsupportedEncodingException;
@@ -73,6 +74,11 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
         }
 
         return mGson.toJson(mBody).getBytes(Charset.forName("UTF-8"));
+    }
+
+    @Nullable
+    protected Map<String, Object> getBodyAsMap() {
+        return mBody;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -11,6 +11,8 @@ import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.OnAuthFailedListener;
 import org.wordpress.android.fluxc.network.BaseRequest.OnParseErrorListener;
 import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError;
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTunnelTimeoutListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountSocialRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
@@ -27,6 +29,7 @@ public abstract class BaseWPComRestClient {
 
     private OnAuthFailedListener mOnAuthFailedListener;
     private OnParseErrorListener mOnParseErrorListener;
+    private OnJetpackTunnelTimeoutListener mOnJetpackTunnelTimeoutListener;
 
     public BaseWPComRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
                                AccessToken accessToken, UserAgent userAgent) {
@@ -45,6 +48,12 @@ public abstract class BaseWPComRestClient {
             @Override
             public void onParseError(OnUnexpectedError event) {
                 mDispatcher.emitChange(event);
+            }
+        };
+        mOnJetpackTunnelTimeoutListener = new OnJetpackTunnelTimeoutListener() {
+            @Override
+            public void onJetpackTunnelTimeout(OnJetpackTimeoutError onTimeoutError) {
+                mDispatcher.emitChange(onTimeoutError);
             }
         };
     }
@@ -95,6 +104,7 @@ public abstract class BaseWPComRestClient {
     private WPComGsonRequest setRequestAuthParams(WPComGsonRequest request, boolean shouldAuth) {
         request.setOnAuthFailedListener(mOnAuthFailedListener);
         request.setOnParseErrorListener(mOnParseErrorListener);
+        request.setOnJetpackTunnelTimeoutListener(mOnJetpackTunnelTimeoutListener);
         request.setUserAgent(mUserAgent.getUserAgent());
         request.setAccessToken(shouldAuth ? mAccessToken.get() : null);
         return request;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -186,9 +186,18 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
             }
 
             if (JetpackTimeoutRequestHandler.isJetpackTimeoutError(returnedError)) {
-                OnJetpackTimeoutError onJetpackTimeoutError =
-                        new OnJetpackTimeoutError(getParams().get("path"), mNumManualRetries);
-                mOnJetpackTunnelTimeoutListener.onJetpackTunnelTimeout(onJetpackTimeoutError);
+                OnJetpackTimeoutError onJetpackTimeoutError = null;
+                if (getMethod() == Method.GET && getParams() != null) {
+                    onJetpackTimeoutError = new OnJetpackTimeoutError(getParams().get("path"), mNumManualRetries);
+                } else if (getMethod() == Method.POST && getBodyAsMap() != null) {
+                    Object pathValue = getBodyAsMap().get("path");
+                    if (pathValue != null) {
+                        onJetpackTimeoutError = new OnJetpackTimeoutError(pathValue.toString(), mNumManualRetries);
+                    }
+                }
+                if (onJetpackTimeoutError != null) {
+                    mOnJetpackTunnelTimeoutListener.onJetpackTunnelTimeout(onJetpackTimeoutError);
+                }
             }
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -10,6 +10,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.fluxc.network.rest.GsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTimeoutRequestHandler;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError;
 
@@ -21,6 +22,22 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
     public interface WPComErrorListener {
         void onErrorResponse(@NonNull WPComGsonNetworkError error);
     }
+
+    public interface OnJetpackTunnelTimeoutListener {
+        void onJetpackTunnelTimeout(OnJetpackTimeoutError event);
+    }
+
+    public static class OnJetpackTimeoutError {
+        public String apiPath;
+        public int timesRetried;
+
+        public OnJetpackTimeoutError(String apiPath, int timesRetried) {
+            this.apiPath = apiPath;
+            this.timesRetried = timesRetried;
+        }
+    }
+
+    private OnJetpackTunnelTimeoutListener mOnJetpackTunnelTimeoutListener;
 
     private int mNumManualRetries = 0;
 
@@ -105,6 +122,10 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         return url;
     }
 
+    void setOnJetpackTunnelTimeoutListener(OnJetpackTunnelTimeoutListener onJetpackTunnelTimeoutListener) {
+        mOnJetpackTunnelTimeoutListener = onJetpackTunnelTimeoutListener;
+    }
+
     /**
      * Mark that this request has been retried manually (by duplicating and re-enqueuing it).
      */
@@ -162,6 +183,12 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
                         returnedError.message);
                 AuthenticateErrorPayload payload = new AuthenticateErrorPayload(authError);
                 mOnAuthFailedListener.onAuthFailed(payload);
+            }
+
+            if (JetpackTimeoutRequestHandler.isJetpackTimeoutError(returnedError)) {
+                OnJetpackTimeoutError onJetpackTimeoutError =
+                        new OnJetpackTimeoutError(getParams().get("path"), mNumManualRetries);
+                mOnJetpackTunnelTimeoutListener.onJetpackTunnelTimeout(onJetpackTimeoutError);
             }
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -22,6 +22,8 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         void onErrorResponse(@NonNull WPComGsonNetworkError error);
     }
 
+    private int mNumManualRetries = 0;
+
     public static final String REST_AUTHORIZATION_HEADER = "Authorization";
     public static final String REST_AUTHORIZATION_FORMAT = "Bearer %s";
 
@@ -103,6 +105,13 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         return url;
     }
 
+    /**
+     * Mark that this request has been retried manually (by duplicating and re-enqueuing it).
+     */
+    public void increaseManualRetryCount() {
+        mNumManualRetries++;
+    }
+
     public void setAccessToken(String token) {
         if (token == null) {
             mHeaders.remove(REST_AUTHORIZATION_HEADER);
@@ -110,6 +119,7 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
             mHeaders.put(REST_AUTHORIZATION_HEADER, String.format(REST_AUTHORIZATION_FORMAT, token));
         }
     }
+
     @Override
     public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
         WPComGsonNetworkError returnedError = new WPComGsonNetworkError(error);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
@@ -56,10 +56,11 @@ class JetpackTimeoutRequestHandler<T>(
                     if (numRetries > 0) {
                         // Delay retries after the first by a bit
                         with(Handler()) {
-                            postDelayed({ jpTimeoutListener(gsonRequest) }, ADDITIONAL_RETRY_DELAY_MS)
+                            postDelayed({ jpTimeoutListener(gsonRequest.apply { increaseManualRetryCount() }) },
+                                    ADDITIONAL_RETRY_DELAY_MS)
                         }
                     } else {
-                        jpTimeoutListener(gsonRequest)
+                        jpTimeoutListener(gsonRequest.apply { increaseManualRetryCount() })
                     }
                     numRetries++
                 } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
@@ -34,6 +34,11 @@ class JetpackTimeoutRequestHandler<T>(
     companion object {
         const val DEFAULT_MAX_RETRIES = 2
         const val ADDITIONAL_RETRY_DELAY_MS = 5000L
+
+        @JvmStatic
+        fun WPComGsonNetworkError.isJetpackTimeoutError(): Boolean {
+            return apiError == "http_request_failed" && message.startsWith("cURL error 28")
+        }
     }
 
     fun getRequest(): WPComGsonRequest<T> {
@@ -74,9 +79,5 @@ class JetpackTimeoutRequestHandler<T>(
                 wpComErrorListener.onErrorResponse(error)
             }
         }
-    }
-
-    private fun WPComGsonNetworkError.isJetpackTimeoutError(): Boolean {
-        return apiError == "http_request_failed" && message.startsWith("cURL error 28")
     }
 }


### PR DESCRIPTION
Network requests to a site's WP-API made through the WordPress.com Jetpack tunnel sometimes timeout (if the call to the site takes longer than 5 seconds). While we currently silently retry GET requests that experience this timeout, having some understanding of how often this happens, which endpoints are most likely to have a timeout, and how effective retrying is would be useful.

This PR adds a `OnJetpackTimeoutError` event, which is dispatched every time a Jetpack tunnel timeout error occurs, which describes the request path and which retry attempt for that network call this error corresponds to (if any).

This PR will be followed up by a Woo app PR receiving the event and dispatching a corresponding analytics event.

### To test

There are a few ways to induce the timeout error. One is to rig up a network interceptor like Charles Proxy to either break for Jetpack tunnel requests, or even better set up a Rewrite rule. Either way, calls made to:

https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/$siteId/rest-api/

should have their successful response replaced with a Jetpack timeout error:

```js
{"error":"http_request_failed","message":"cURL error 28: Operation timed out after 5001 milliseconds with 11111 bytes received"}
```

It's also possible to instead modify a real site, adding perhaps a `sleep(5000);` somewhere in the call stack for JSON API requests.

Once setup, a breakpoint [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/feature/jetpack-tunnel-timeout-track?expand=1#diff-a4a33e1f9969682c12ea4b061aba105fR56) allows inspection of the dispatched event when triggering events e.g. through the example app.

POST requests should only ever get a single event dispatched, while repeated failures for GET requests should end up with 3 events (the first attempt, and two unsuccessful retries).