### PR TITLE
Issue/update checklist notification

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.IsWPCo
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferStatusResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartPayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesResponsePayload;
@@ -70,7 +71,7 @@ public enum SiteAction implements IAction {
     FETCH_DOMAIN_SUPPORTED_STATES,
     @Action
     FETCH_DOMAIN_SUPPORTED_COUNTRIES,
-    @Action(payloadType = SiteModel.class)
+    @Action(payloadType = CompleteQuickStartPayload.class)
     COMPLETE_QUICK_START,
 
     // Remote responses

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -723,11 +723,12 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void completeQuickStart(@NonNull final SiteModel site) {
+    public void completeQuickStart(@NonNull final SiteModel site, String variant) {
         String url = WPCOMREST.sites.site(site.getSiteId()).mobile_quick_start.getUrlV1_1();
-
+        Map<String, Object> params = new HashMap<>();
+        params.put("variant", variant);
         final WPComGsonRequest<QuickStartCompletedResponse> request = WPComGsonRequest
-                .buildPostRequest(url, null, QuickStartCompletedResponse.class,
+                .buildPostRequest(url, params, QuickStartCompletedResponse.class,
                         new Listener<QuickStartCompletedResponse>() {
                             @Override
                             public void onResponse(QuickStartCompletedResponse response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1288,7 +1288,7 @@ public class SiteStore extends Store {
                 handleCheckedAutomatedTransferStatus((AutomatedTransferStatusResponsePayload) action.getPayload());
                 break;
             case COMPLETE_QUICK_START:
-                completeQuickStart((SiteModel) action.getPayload());
+                completeQuickStart((CompleteQuickStartPayload) action.getPayload());
                 break;
             case COMPLETED_QUICK_START:
                 handleQuickStartCompleted((QuickStartCompletedResponsePayload) action.getPayload());
@@ -1639,8 +1639,8 @@ public class SiteStore extends Store {
         emitChange(event);
     }
 
-    private void completeQuickStart(@NonNull SiteModel site) {
-        mSiteRestClient.completeQuickStart(site);
+    private void completeQuickStart(@NonNull CompleteQuickStartPayload payload) {
+        mSiteRestClient.completeQuickStart(payload.site, payload.variant);
     }
 
     private void handleQuickStartCompleted(QuickStartCompletedResponsePayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -850,6 +850,21 @@ public class SiteStore extends Store {
         }
     }
 
+    public enum CompleteQuickStartVariant {
+        NEXT_STEPS("next-steps");
+
+        private final String mString;
+
+        CompleteQuickStartVariant(final String s) {
+            mString = s;
+        }
+
+        @Override
+        public String toString() {
+            return mString;
+        }
+    }
+
     private SiteRestClient mSiteRestClient;
     private SiteXMLRPCClient mSiteXMLRPCClient;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -51,6 +51,12 @@ import javax.inject.Singleton;
 @Singleton
 public class SiteStore extends Store {
     // Payloads
+    public static class CompleteQuickStartPayload extends Payload<BaseNetworkError> {
+        public CompleteQuickStartPayload() {}
+        public SiteModel site;
+        public String variant;
+    }
+
     public static class RefreshSitesXMLRPCPayload extends Payload<BaseNetworkError> {
         public RefreshSitesXMLRPCPayload() {}
         public String username;


### PR DESCRIPTION
### Fix
Update the Quick Start checklist notification endpoint with an optional `variant` parameter for https://github.com/wordpress-mobile/WordPress-Android/issues/8648.  If the parameter is missing or the value isn't exactly `next-steps`, the old notification will be used.