### PR TITLE
Fix empty collection/list exception in TimeStatsMapper + tests

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.VisitResponse
 import org.wordpress.android.fluxc.store.stats.ALL_TIME_RESPONSE
 import org.wordpress.android.fluxc.store.stats.COMMENT_COUNT
 import org.wordpress.android.fluxc.store.stats.FIRST_DAY
@@ -87,5 +88,13 @@ class InsightsMapperTest {
         assertThat(model.reblogs).isEqualTo(REBLOG_COUNT)
         assertThat(model.views).isEqualTo(VIEWS)
         assertThat(model.visitors).isEqualTo(org.wordpress.android.fluxc.store.stats.VISITORS)
+    }
+
+    @Test
+    fun `maps visits response with empty data`() {
+        val model = mapper.map(VisitResponse(null, null, listOf("views", "comments"), listOf(listOf("10"))))
+
+        assertThat(model.views).isEqualTo(10)
+        assertThat(model.comments).isEqualTo(0)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.model.stats
 
 import com.google.gson.Gson
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -22,7 +21,6 @@ class TimeStatsMapperTest {
     @Mock lateinit var gson: Gson
     private lateinit var timeStatsMapper: TimeStatsMapper
 
-    @ExperimentalCoroutinesApi
     @Before
     fun setUp() {
         timeStatsMapper = TimeStatsMapper(gson)

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
@@ -1,0 +1,111 @@
+package org.wordpress.android.fluxc.model.stats
+
+import com.google.gson.Gson
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
+
+@RunWith(MockitoJUnitRunner::class)
+class TimeStatsMapperTest {
+    @Mock lateinit var gson: Gson
+    private lateinit var timeStatsMapper: TimeStatsMapper
+
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setUp() {
+        timeStatsMapper = TimeStatsMapper(gson)
+    }
+
+    @Test
+    fun `parses empty referrers`() {
+        val response = ReferrersResponse("DAYS", emptyMap())
+
+        val result = timeStatsMapper.map(response, 5)
+
+        assertThat(result.groups).isEmpty()
+        assertThat(result.hasMore).isFalse()
+        assertThat(result.otherViews).isZero()
+        assertThat(result.totalViews).isZero()
+    }
+
+    @Test
+    fun `parses empty posts and views`() {
+        val response = PostAndPageViewsResponse(null, emptyMap(), "DAYS")
+
+        val result = timeStatsMapper.map(response, 5)
+
+        assertThat(result.views).isEmpty()
+        assertThat(result.hasMore).isFalse()
+    }
+
+    @Test
+    fun `parses empty clicks`() {
+        val response = ClicksResponse(null, emptyMap())
+
+        val result = timeStatsMapper.map(response, 5)
+
+        assertThat(result.groups).isEmpty()
+        assertThat(result.hasMore).isFalse()
+        assertThat(result.otherClicks).isZero()
+        assertThat(result.totalClicks).isZero()
+    }
+
+    @Test
+    fun `parses empty country views`() {
+        val response = CountryViewsResponse(emptyMap(), emptyMap())
+
+        val result = timeStatsMapper.map(response, 5)
+
+        assertThat(result.countries).isEmpty()
+        assertThat(result.hasMore).isFalse()
+        assertThat(result.otherViews).isZero()
+        assertThat(result.totalViews).isZero()
+    }
+
+    @Test
+    fun `parses empty authors`() {
+        val response = AuthorsResponse(null, emptyMap())
+
+        val result = timeStatsMapper.map(response, 5)
+
+        assertThat(result.authors).isEmpty()
+        assertThat(result.hasMore).isFalse()
+        assertThat(result.otherViews).isZero()
+    }
+
+    @Test
+    fun `parses empty search terms`() {
+        val response = SearchTermsResponse(null, emptyMap())
+
+        val result = timeStatsMapper.map(response, 5)
+
+        assertThat(result.searchTerms).isEmpty()
+        assertThat(result.hasMore).isFalse()
+        assertThat(result.otherSearchTerms).isZero()
+        assertThat(result.totalSearchTerms).isZero()
+    }
+
+    @Test
+    fun `parses empty videos`() {
+        val response = VideoPlaysResponse(null, emptyMap())
+
+        val result = timeStatsMapper.map(response, 5)
+
+        assertThat(result.plays).isEmpty()
+        assertThat(result.hasMore).isFalse()
+        assertThat(result.otherPlays).isZero()
+        assertThat(result.totalPlays).isZero()
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
@@ -13,13 +13,11 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
-import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.persistence.TimeStatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
-import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -84,8 +84,12 @@ class InsightsMapper
     }
 
     fun map(response: VisitResponse): VisitsModel {
-        val result: Map<String, String> = response.fields.mapIndexed { index, value ->
-            value to response.data[0][index]
+        val result: Map<String, String> = response.fields.mapIndexedNotNull { index, value ->
+            if (response.data.isNotEmpty() && response.data[0].size > index) {
+                value to response.data[0][index]
+            } else {
+                null
+            }
         }.toMap()
         return VisitsModel(
                 result[PERIOD] ?: "",


### PR DESCRIPTION
Fixes #1069 #1072 

This adds extra checks in case there are unexpected empty parameters. The unit tests should be enough to test it. The interface hasn't changed. 

I'm also including a little fix in the InsightsMapper that's similar to the TimeStatsMapper fix

@jtreanor should I point this to release?