### PR TITLE
Use fixed date format in Stats Jsons

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -27,9 +27,9 @@ import org.wordpress.android.fluxc.store.stats.time.ClicksStore
 import org.wordpress.android.fluxc.store.stats.time.CountryViewsStore
 import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.fluxc.store.stats.time.ReferrersStore
-import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.fluxc.store.stats.time.SearchTermsStore
 import org.wordpress.android.fluxc.store.stats.time.VideoPlaysStore
+import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Date
@@ -161,13 +161,14 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                         true
                 )
             }
+            if (!fetchedInsights.isError) {
+                assertNotNull(fetchedInsights)
+                assertNotNull(fetchedInsights.model)
 
-            assertNotNull(fetchedInsights)
-            assertNotNull(fetchedInsights.model)
+                val insightsFromDb = visitsAndViewsStore.getVisits(site, SELECTED_DATE, granularity)
 
-            val insightsFromDb = visitsAndViewsStore.getVisits(site, SELECTED_DATE, granularity)
-
-            assertEquals(fetchedInsights.model, insightsFromDb)
+                assertEquals(fetchedInsights.model, insightsFromDb)
+            }
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -330,6 +330,7 @@ public class ReleaseNetworkModule {
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrFalse.class, new JsonObjectOrFalseDeserializer());
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrEmptyArray.class,
                 new JsonObjectOrEmptyArrayDeserializer());
+        gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
         return gsonBuilder.create();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -62,7 +62,6 @@ import okhttp3.OkHttpClient;
 public class ReleaseNetworkModule {
     private static final String DEFAULT_CACHE_DIR = "volley-fluxc";
     private static final int NETWORK_THREAD_POOL_SIZE = 10;
-    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
 
     private RequestQueue newRequestQueue(OkHttpClient.Builder okHttpClientBuilder, Context appContext) {
         File cacheDir = new File(appContext.getCacheDir(), DEFAULT_CACHE_DIR);
@@ -331,7 +330,6 @@ public class ReleaseNetworkModule {
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrFalse.class, new JsonObjectOrFalseDeserializer());
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrEmptyArray.class,
                 new JsonObjectOrEmptyArrayDeserializer());
-        gsonBuilder.setDateFormat(DATE_FORMAT);
         return gsonBuilder.create();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -62,6 +62,7 @@ import okhttp3.OkHttpClient;
 public class ReleaseNetworkModule {
     private static final String DEFAULT_CACHE_DIR = "volley-fluxc";
     private static final int NETWORK_THREAD_POOL_SIZE = 10;
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
 
     private RequestQueue newRequestQueue(OkHttpClient.Builder okHttpClientBuilder, Context appContext) {
         File cacheDir = new File(appContext.getCacheDir(), DEFAULT_CACHE_DIR);
@@ -330,7 +331,7 @@ public class ReleaseNetworkModule {
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrFalse.class, new JsonObjectOrFalseDeserializer());
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrEmptyArray.class,
                 new JsonObjectOrEmptyArrayDeserializer());
-        gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        gsonBuilder.setDateFormat(DATE_FORMAT);
         return gsonBuilder.create();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.persistence
 
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import com.wellsql.generated.StatsBlockTable
 import com.yarolegovich.wellsql.WellSql
 import com.yarolegovich.wellsql.core.Identifiable
@@ -11,9 +12,16 @@ import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ"
+
 @Singleton
 class StatsSqlUtils
-@Inject constructor(private val gson: Gson) {
+@Inject constructor() {
+    private val gson: Gson by lazy {
+        val builder = GsonBuilder()
+        builder.setDateFormat(DATE_FORMAT)
+        builder.create()
+    }
     fun <T> insert(site: SiteModel, blockType: BlockType, statsType: StatsType, item: T, date: String = "") {
         val json = gson.toJson(item)
         WellSql.delete(StatsBlockBuilder::class.java)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 47;
+        return 48;
     }
 
     @Override
@@ -387,6 +387,13 @@ public class WellSqlConfig extends DefaultWellConfig {
                            + "TITLE TEXT,FORMATTABLE_BODY TEXT,FORMATTABLE_SUBJECT TEXT,FORMATTABLE_META TEXT)");
                 oldVersion++;
             case 46:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS StatsBlock");
+                db.execSQL(
+                        "CREATE TABLE StatsBlock (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT NOT NULL,JSON TEXT NOT NULL)");
+                oldVersion++;
+            case 47:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("DROP TABLE IF EXISTS StatsBlock");
                 db.execSQL(


### PR DESCRIPTION
Should fix: #1073

I think this is caused by different Locales saving and restoring the date in a wrong way. The date is stored without `AM/PM` suffix and the retrieving doesn't work if it's not there. This PR sets a constant standard date format to the Gson builder and rebuilds the DB cache.

This should be tested with the WPAndroid PR.