### PR TITLE
Adds vertical, segment and tagLine info to site creation

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.site;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.RequestQueue;
@@ -190,7 +191,8 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void newSite(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
-                        @NonNull SiteVisibility visibility, final boolean dryRun) {
+                        @NonNull SiteVisibility visibility, @Nullable String verticalId, @Nullable Long segmentId,
+                        @Nullable String tagLine, final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1();
         Map<String, Object> body = new HashMap<>();
         body.put("blog_name", siteName);
@@ -200,6 +202,23 @@ public class SiteRestClient extends BaseWPComRestClient {
         body.put("validate", dryRun ? "1" : "0");
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());
+
+        // Add site options if available
+        Map<String, Object> options = new HashMap<>();
+        if (verticalId != null) {
+            options.put("site_vertical", verticalId);
+        }
+        if (segmentId != null) {
+            options.put("site_segment", segmentId);
+        }
+        if (tagLine != null) {
+            Map<String, Object> siteInformation = new HashMap<>();
+            siteInformation.put("site_tagline", tagLine);
+            options.put("site_information", siteInformation);
+        }
+        if (options.size() > 0) {
+            body.put("options", options);
+        }
 
         WPComGsonRequest<NewSiteResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 NewSiteResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -58,18 +58,32 @@ public class SiteStore extends Store {
         public String url;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class NewSitePayload extends Payload<BaseNetworkError> {
-        public String siteName;
-        public String siteTitle;
-        public String language;
-        public SiteVisibility visibility;
-        public boolean dryRun;
+        @NonNull public String siteName;
+        @NonNull public String siteTitle;
+        @NonNull public String language;
+        @NonNull public SiteVisibility visibility;
+        @Nullable public String verticalId;
+        @Nullable public Long segmentId;
+        @Nullable public String tagLine;
+        @NonNull public boolean dryRun;
+
         public NewSitePayload(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
-                              SiteVisibility visibility, boolean dryRun) {
+                              @NonNull SiteVisibility visibility, boolean dryRun) {
+            this(siteName, siteTitle, language, visibility, null, null, null, dryRun);
+        }
+
+        public NewSitePayload(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
+                              @NonNull SiteVisibility visibility, @Nullable String verticalId, @Nullable Long segmentId,
+                              @Nullable String tagLine, boolean dryRun) {
             this.siteName = siteName;
             this.siteTitle = siteTitle;
             this.language = language;
             this.visibility = visibility;
+            this.verticalId = verticalId;
+            this.segmentId = segmentId;
+            this.tagLine = tagLine;
             this.dryRun = dryRun;
         }
     }
@@ -1450,7 +1464,7 @@ public class SiteStore extends Store {
 
     private void createNewSite(NewSitePayload payload) {
         mSiteRestClient.newSite(payload.siteName, payload.siteTitle, payload.language, payload.visibility,
-                payload.dryRun);
+                payload.verticalId, payload.segmentId, payload.tagLine, payload.dryRun);
     }
 
     private void handleCreateNewSiteCompleted(NewSiteResponsePayload payload) {


### PR DESCRIPTION
Fixes #1079. This PR adds vertical, segment and tagLine information to the site creation request. The implementation has been done in a way to make sure not to affect the current site creation flow. All 3 parameters will only be added if they are available and the `options` parameter itself will be added only if at least one parameter is added. A new constructor is added to `NewSitePayload` and the older constructor should work as is. Finally, `@Nullable` and `@NonNull` annotations have been added to `NewSitePayload` to better convey its usage in `SiteRestClient.newSite` where these annotations were also being used.

**To test**

I have created a temporary branch in WPAndroid and pushed the FluxC hash change so Travis can do a fresh build and it worked as expected: https://github.com/wordpress-mobile/WordPress-Android/tree/issue/update-fluxc-hash-for-options-site-creation-parameter. I don't think there is anything to test here, but it's possible to check what information is being sent by network spoofing if one wants to be sure.