### PR TITLE
Adds isMobileSegment property to VerticalSegmentModel

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_VerticalTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_VerticalTest.kt
@@ -113,8 +113,7 @@ class ReleaseStack_VerticalTest : ReleaseStack_Base() {
             throw AssertionError("Unexpected error occurred with type: " + event.error.type)
         }
         assertEquals(TestEvents.VERTICALS_FETCHED, nextEvent)
-        // TODO: Re-enable this check once the API is fixed
-//        assertTrue(event.verticalList.size == FETCH_VERTICALS_LIMIT)
+        assertTrue(event.verticalList.size == FETCH_VERTICALS_LIMIT)
         mCountDownLatch.countDown()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/vertical/VerticalSegmentModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/vertical/VerticalSegmentModel.kt
@@ -7,5 +7,6 @@ data class VerticalSegmentModel(
     @SerializedName("segment_type_subtitle") val subtitle: String,
     @SerializedName("icon_URL") val iconUrl: String,
     @SerializedName("icon_color") val iconColor: String,
-    @SerializedName("id") val segmentId: Long
+    @SerializedName("id") val segmentId: Long,
+    @SerializedName("mobile") val isMobileSegment: Boolean
 )


### PR DESCRIPTION
This PR implements the FluxC side of https://github.com/wordpress-mobile/WordPress-Android/issues/8999 by adding `isMobileSegment` property to `VerticalSegmentModel`. The endpoint returns this property as `mobile`, but I think this name makes it clear. I am open to suggestions for an even better name.

I've also re-enabled the limit check for the verticals connected test. This basically tests that the `limit` parameter for the `/verticals` endpoint is respected which has been recently fixed on the server-side.

**To test:**
1. Run all the connected tests in `ReleaseStack_VerticalTest`
2. Debug the `ReleaseStack_VerticalTest.testFetchSegments` by putting a breakpoint in `ReleaseStack_VerticalTest.onSegmentsFetched` and observe that every segment except for `Online Store` has its `isMobileSegment` set to `true`.