### PR TITLE
Ignore timezone in stats params

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -223,7 +223,7 @@ class InsightsRestClientTest {
 
         val date = Date(10)
         val formattedDate = "2019-01-17"
-        whenever(statsUtils.getFormattedDate(site, date)).thenReturn(formattedDate)
+        whenever(statsUtils.getFormattedDate(date)).thenReturn(formattedDate)
         val responseModel = insightsRestClient.fetchTimePeriodStats(site, DAYS, date, false)
 
         assertThat(responseModel.response).isNotNull()

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
@@ -68,7 +68,7 @@ class AuthorsRestClientTest {
                 gson,
                 statsUtils
         )
-        whenever(statsUtils.getFormattedDate(eq(site), eq(requestedDate))).thenReturn(stringDate)
+        whenever(statsUtils.getFormattedDate(eq(requestedDate))).thenReturn(stringDate)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClientTest.kt
@@ -69,7 +69,7 @@ class ClicksRestClientTest {
                 gson,
                 statsUtils
         )
-        whenever(statsUtils.getFormattedDate(eq(site), eq(currentDate))).thenReturn(currentDateValue)
+        whenever(statsUtils.getFormattedDate(eq(currentDate))).thenReturn(currentDateValue)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
@@ -64,7 +64,7 @@ class CountryViewsRestClientTest {
                 userAgent,
                 statsUtils
         )
-        whenever(statsUtils.getFormattedDate(eq(site), eq(currentDate))).thenReturn(currentDateValue)
+        whenever(statsUtils.getFormattedDate(eq(currentDate))).thenReturn(currentDateValue)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClientTest.kt
@@ -64,7 +64,7 @@ class PostAndPageViewsRestClientTest {
                 userAgent,
                 statsUtils
         )
-        whenever(statsUtils.getFormattedDate(eq(site), eq(currentDate))).thenReturn(currentStringDate)
+        whenever(statsUtils.getFormattedDate(eq(currentDate))).thenReturn(currentStringDate)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
@@ -69,7 +69,7 @@ class ReferrersRestClientTest {
                 gson,
                 statsUtils
         )
-        whenever(statsUtils.getFormattedDate(eq(site), eq(currentDate))).thenReturn(currentStringDate)
+        whenever(statsUtils.getFormattedDate(eq(currentDate))).thenReturn(currentStringDate)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClientTest.kt
@@ -64,7 +64,7 @@ class SearchTermsRestClientTest {
                 userAgent,
                 statsUtils
         )
-        whenever(statsUtils.getFormattedDate(eq(site), eq(currentDate))).thenReturn(currentDateValue)
+        whenever(statsUtils.getFormattedDate(eq(currentDate))).thenReturn(currentDateValue)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/StatsUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/StatsUtilsTest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
 
-import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -10,8 +9,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.CurrentDateUtils
 import java.util.Calendar
-import java.util.Locale
-import java.util.TimeZone
 
 @RunWith(MockitoJUnitRunner::class)
 class StatsUtilsTest {
@@ -25,49 +22,21 @@ class StatsUtilsTest {
 
     @Test
     fun `moves date to future when timezone is adds time`() {
-        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US)
+        val cal = Calendar.getInstance()
         cal.set(2018, 10, 10, 23, 55)
-        whenever(currentDateUtils.getCurrentDate()).thenReturn(cal.time)
-        whenever(siteModel.timezone).thenReturn("+1.5")
 
-        val result = statsUtils.getFormattedDate(siteModel)
+        val result = statsUtils.getFormattedDate(cal.time)
 
-        assertThat(result).isEqualTo("2018-11-11")
+        assertThat(result).isEqualTo("2018-11-10")
     }
 
     @Test
     fun `keeps correct date when timezone is within bounds`() {
-        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US)
+        val cal = Calendar.getInstance()
         cal.set(2018, 10, 10, 0, 15)
-        whenever(currentDateUtils.getCurrentDate()).thenReturn(cal.time)
-        whenever(siteModel.timezone).thenReturn("+0.0")
 
-        val result = statsUtils.getFormattedDate(siteModel)
+        val result = statsUtils.getFormattedDate(cal.time)
 
         assertThat(result).isEqualTo("2018-11-10")
-    }
-
-    @Test
-    fun `keeps correct date when timezone is null`() {
-        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US)
-        cal.set(2018, 10, 10, 0, 15)
-        whenever(currentDateUtils.getCurrentDate()).thenReturn(cal.time)
-        whenever(siteModel.timezone).thenReturn(null)
-
-        val result = statsUtils.getFormattedDate(siteModel)
-
-        assertThat(result).isEqualTo("2018-11-10")
-    }
-
-    @Test
-    fun `moves date to past when timezone is removes time`() {
-        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US)
-        cal.set(2018, 10, 10, 0, 15)
-        whenever(currentDateUtils.getCurrentDate()).thenReturn(cal.time)
-        whenever(siteModel.timezone).thenReturn("-0.5")
-
-        val result = statsUtils.getFormattedDate(siteModel)
-
-        assertThat(result).isEqualTo("2018-11-09")
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClientTest.kt
@@ -68,7 +68,7 @@ class VideoPlaysRestClientTest {
                 gson,
                 statsUtils
         )
-        whenever(statsUtils.getFormattedDate(eq(site), eq(currentDate))).thenReturn(currentDateValue)
+        whenever(statsUtils.getFormattedDate(eq(currentDate))).thenReturn(currentDateValue)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClientTest.kt
@@ -64,7 +64,7 @@ class VisitAndViewsRestClientTest {
                 userAgent,
                 statsUtils
         )
-        whenever(statsUtils.getFormattedDate(eq(site), eq(currentDate))).thenReturn(currentDateValue)
+        whenever(statsUtils.getFormattedDate(eq(currentDate))).thenReturn(currentDateValue)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/AuthorsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/AuthorsSqlUtilsTest.kt
@@ -40,7 +40,7 @@ class AuthorsSqlUtilsTest {
     @Before
     fun setUp() {
         timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
-        whenever(statsUtils.getFormattedDate(eq(site), eq(DATE))).thenReturn(STRING_DATE)
+        whenever(statsUtils.getFormattedDate(eq(DATE))).thenReturn(STRING_DATE)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ClicksSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ClicksSqlUtilsTest.kt
@@ -40,7 +40,7 @@ class ClicksSqlUtilsTest {
     @Before
     fun setUp() {
         timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
-        whenever(statsUtils.getFormattedDate(eq(site), eq(DATE))).thenReturn(DATE_VALUE)
+        whenever(statsUtils.getFormattedDate(eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/CountryViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/CountryViewsSqlUtilsTest.kt
@@ -40,7 +40,7 @@ class CountryViewsSqlUtilsTest {
     @Before
     fun setUp() {
         timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
-        whenever(statsUtils.getFormattedDate(eq(site), eq(DATE))).thenReturn(DATE_VALUE)
+        whenever(statsUtils.getFormattedDate(eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/PostAndPageViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/PostAndPageViewsSqlUtilsTest.kt
@@ -42,7 +42,7 @@ class PostAndPageViewsSqlUtilsTest {
     @Before
     fun setUp() {
         timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
-        whenever(statsUtils.getFormattedDate(eq(site), eq(DATE))).thenReturn(DATE_VALUE)
+        whenever(statsUtils.getFormattedDate(eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ReferrersSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ReferrersSqlUtilsTest.kt
@@ -40,7 +40,7 @@ class ReferrersSqlUtilsTest {
     @Before
     fun setUp() {
         timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
-        whenever(statsUtils.getFormattedDate(eq(site), eq(DATE))).thenReturn(DATE_VALUE)
+        whenever(statsUtils.getFormattedDate(eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/SearchTermsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/SearchTermsSqlUtilsTest.kt
@@ -40,7 +40,7 @@ class SearchTermsSqlUtilsTest {
     @Before
     fun setUp() {
         timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
-        whenever(statsUtils.getFormattedDate(eq(site), eq(DATE))).thenReturn(DATE_VALUE)
+        whenever(statsUtils.getFormattedDate(eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VideoPlaysSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VideoPlaysSqlUtilsTest.kt
@@ -40,7 +40,7 @@ class VideoPlaysSqlUtilsTest {
     @Before
     fun setUp() {
         timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
-        whenever(statsUtils.getFormattedDate(eq(site), eq(DATE))).thenReturn(DATE_VALUE)
+        whenever(statsUtils.getFormattedDate(eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VisitAndViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VisitAndViewsSqlUtilsTest.kt
@@ -40,7 +40,7 @@ class VisitAndViewsSqlUtilsTest {
     @Before
     fun setUp() {
         timeStatsSqlUtils = TimeStatsSqlUtils(statsSqlUtils, statsUtils)
-        whenever(statsUtils.getFormattedDate(eq(site), eq(DATE))).thenReturn(DATE_VALUE)
+        whenever(statsUtils.getFormattedDate(eq(DATE))).thenReturn(DATE_VALUE)
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClient.kt
@@ -136,7 +136,7 @@ constructor(
         val params = mapOf(
                 "unit" to period.toString(),
                 "quantity" to "1",
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
@@ -48,7 +48,7 @@ class AuthorsRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClient.kt
@@ -46,7 +46,7 @@ class ClicksRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
@@ -42,7 +42,7 @@ class CountryViewsRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClient.kt
@@ -42,7 +42,7 @@ class PostAndPageViewsRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClient.kt
@@ -48,7 +48,7 @@ class ReferrersRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClient.kt
@@ -42,7 +42,7 @@ class SearchTermsRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/StatsUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/StatsUtils.kt
@@ -1,16 +1,17 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.stats.time
 
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.CurrentDateUtils
-import org.wordpress.android.fluxc.utils.SiteUtils
+import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 const val DATE_FORMAT_DAY = "yyyy-MM-dd"
 
 class StatsUtils
 @Inject constructor(private val currentDateUtils: CurrentDateUtils) {
-    fun getFormattedDate(site: SiteModel, date: Date? = null): String {
-        return SiteUtils.getDateTimeForSite(site, DATE_FORMAT_DAY, date ?: currentDateUtils.getCurrentDate())
+    fun getFormattedDate(date: Date? = null): String {
+        val dateFormat = SimpleDateFormat(DATE_FORMAT_DAY, Locale.ROOT)
+        return dateFormat.format(date ?: currentDateUtils.getCurrentDate())
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
@@ -44,7 +44,7 @@ class VideoPlaysRestClient
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to pageSize.toString(),
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
@@ -42,7 +42,7 @@ class VisitAndViewsRestClient
         val params = mapOf(
                 "unit" to granularity.toString(),
                 "quantity" to pageSize.toString(),
-                "date" to statsUtils.getFormattedDate(site, date)
+                "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -37,7 +37,7 @@ class TimeStatsSqlUtils
                 POSTS_AND_PAGES_VIEWS,
                 granularity.toStatsType(),
                 data,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -47,7 +47,7 @@ class TimeStatsSqlUtils
                 REFERRERS,
                 granularity.toStatsType(),
                 data,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -57,7 +57,7 @@ class TimeStatsSqlUtils
                 CLICKS,
                 granularity.toStatsType(),
                 data,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -67,7 +67,7 @@ class TimeStatsSqlUtils
                 VISITS_AND_VIEWS,
                 granularity.toStatsType(),
                 data,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -77,7 +77,7 @@ class TimeStatsSqlUtils
                 COUNTRY_VIEWS,
                 granularity.toStatsType(),
                 data,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -87,7 +87,7 @@ class TimeStatsSqlUtils
                 AUTHORS,
                 granularity.toStatsType(),
                 data,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -97,7 +97,7 @@ class TimeStatsSqlUtils
                 SEARCH_TERMS,
                 granularity.toStatsType(),
                 data,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -107,7 +107,7 @@ class TimeStatsSqlUtils
                 VIDEO_PLAYS,
                 granularity.toStatsType(),
                 data,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -117,7 +117,7 @@ class TimeStatsSqlUtils
                 POSTS_AND_PAGES_VIEWS,
                 granularity.toStatsType(),
                 PostAndPageViewsResponse::class.java,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -127,7 +127,7 @@ class TimeStatsSqlUtils
                 REFERRERS,
                 granularity.toStatsType(),
                 ReferrersResponse::class.java,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -137,7 +137,7 @@ class TimeStatsSqlUtils
                 CLICKS,
                 granularity.toStatsType(),
                 ClicksResponse::class.java,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -147,7 +147,7 @@ class TimeStatsSqlUtils
                 VISITS_AND_VIEWS,
                 granularity.toStatsType(),
                 VisitsAndViewsResponse::class.java,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -157,7 +157,7 @@ class TimeStatsSqlUtils
                 COUNTRY_VIEWS,
                 granularity.toStatsType(),
                 CountryViewsResponse::class.java,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -167,7 +167,7 @@ class TimeStatsSqlUtils
                 AUTHORS,
                 granularity.toStatsType(),
                 AuthorsResponse::class.java,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -177,7 +177,7 @@ class TimeStatsSqlUtils
                 SEARCH_TERMS,
                 granularity.toStatsType(),
                 SearchTermsResponse::class.java,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 
@@ -187,7 +187,7 @@ class TimeStatsSqlUtils
                 VIDEO_PLAYS,
                 granularity.toStatsType(),
                 VideoPlaysResponse::class.java,
-                statsUtils.getFormattedDate(site, date)
+                statsUtils.getFormattedDate(date)
         )
     }
 


### PR DESCRIPTION
This fixed an issue that happens when the Site has a timezone that doesn't match the current device timezone, it is possible that the date gets shifted and the app shows data for a wrong day.