### PR TITLE
Issue/1090 unread notifs check

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -80,6 +80,24 @@ class NotificationsFragment : Fragment() {
             })
         }
 
+        notifs_has_unread.setOnClickListener {
+            if (selectedSite == null) {
+                prependToLog("No site selected")
+            } else {
+                showNotificationTypeSubtypeDialog(object : Listener {
+                    override fun onSubmitted(type: String, subtype: String) {
+                        prependToLog("Checking unread notifications matching $type or $subtype...\n")
+                        val hasUnread = notificationStore.hasUnreadNotificationsForSite(
+                                selectedSite!!,
+                                listOf(type),
+                                listOf(subtype)
+                        )
+                        prependToLog("Has unread notifications is $hasUnread")
+                    }
+                })
+            }
+        }
+
         notifs_mark_seen.setOnClickListener {
             prependToLog("Setting notifications last seen time to now\n")
             dispatcher.dispatch(NotificationActionBuilder

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -246,5 +246,6 @@ class NotificationsFragment : Fragment() {
         notifs_fetch_first.isEnabled = enabled
         notifs_mark_read.isEnabled = enabled
         notifs_update_first.isEnabled = enabled
+        notifs_has_unread.isEnabled = enabled
     }
 }

--- a/example/src/main/res/layout/fragment_notifications.xml
+++ b/example/src/main/res/layout/fragment_notifications.xml
@@ -88,6 +88,13 @@
         android:enabled="false"
         android:text="Mark all unread notifications as read"/>
 
+    <Button
+        android:id="@+id/notifs_has_unread"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="Check unread Notifications (db)"/>
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -115,12 +122,4 @@
         android:layout_height="wrap_content"
         android:enabled="false"
         android:text="Update Notification (DB)"/>
-
-    <Button
-        android:id="@+id/notifs_has_unread"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:enabled="false"
-        android:text="Check unread Notifications (db)"/>
-
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_notifications.xml
+++ b/example/src/main/res/layout/fragment_notifications.xml
@@ -46,6 +46,12 @@
         android:layout_height="wrap_content"
         android:text="Get Notifications by type or subtype (db)"/>
 
+    <Button
+        android:id="@+id/notifs_has_unread"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Check unread Notifications (db)"/>
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/example/src/main/res/layout/fragment_notifications.xml
+++ b/example/src/main/res/layout/fragment_notifications.xml
@@ -4,17 +4,17 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginBottom="10dp"
-    tools:context=".NotificationsFragment"
     android:layout_margin="8dp"
-    android:orientation="vertical">
+    android:layout_marginBottom="10dp"
+    android:orientation="vertical"
+    tools:context=".NotificationsFragment">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"
-        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-        android:text="Perform actions for user:"/>
+        android:text="Perform actions for user:"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
 
     <Button
         android:id="@+id/notifs_fetch_all"
@@ -46,18 +46,12 @@
         android:layout_height="wrap_content"
         android:text="Get Notifications by type or subtype (db)"/>
 
-    <Button
-        android:id="@+id/notifs_has_unread"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Check unread Notifications (db)"/>
-
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"
-        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-        android:text="Perform actions on a selected site:"/>
+        android:text="Perform actions on a selected site:"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -72,53 +66,61 @@
 
         <TextView
             android:id="@+id/notif_selected_site"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-            android:textColor="@android:color/holo_blue_bright"
             android:layout_width="wrap_content"
-            android:paddingStart="10dp"
+            android:layout_height="wrap_content"
             android:paddingLeft="10dp"
-            android:layout_height="wrap_content"/>
+            android:paddingStart="10dp"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+            android:textColor="@android:color/holo_blue_bright"/>
     </LinearLayout>
 
     <Button
         android:id="@+id/notifs_fetch_for_site"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Get Notifications (db)"
-        android:enabled="false"/>
+        android:enabled="false"
+        android:text="Get Notifications (db)"/>
 
     <Button
         android:id="@+id/notifs_mark_all_read"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Mark all unread notifications as read"
-        android:enabled="false"/>
+        android:enabled="false"
+        android:text="Mark all unread notifications as read"/>
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"
-        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-        android:text="Actions on the first notification for the selected site:"/>
+        android:text="Actions on the first notification for the selected site:"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
 
     <Button
         android:id="@+id/notifs_fetch_first"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Fetch Notification From API"
-        android:enabled="false"/>
+        android:enabled="false"
+        android:text="Fetch Notification From API"/>
 
     <Button
         android:id="@+id/notifs_mark_read"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Mark Read"
-        android:enabled="false"/>
+        android:enabled="false"
+        android:text="Mark Read"/>
 
     <Button
         android:id="@+id/notifs_update_first"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Update Notification (DB)"
-        android:enabled="false"/>
+        android:enabled="false"
+        android:text="Update Notification (DB)"/>
+
+    <Button
+        android:id="@+id/notifs_has_unread"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="Check unread Notifications (db)"/>
+
 </LinearLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -354,6 +354,23 @@ class NotificationSqlUtilsTest {
     }
 
     @Test
+    fun testHasUnreadNotifications () {
+        val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
+        val jsonString = UnitTestUtils
+                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
+        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
+        val notesList = apiResponse.notes?.map {
+            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
+        } ?: emptyList()
+        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
+        assertEquals(6, inserted)
+
+        val site = SiteModel().apply { id = 0 }
+        val hasUnread = notificationSqlUtils.hasUnreadNotificationsForSite(site)
+        assertEquals(hasUnread, true)
+    }
+
+    @Test
     fun testDeleteNotificationByRemoteId() {
         val noteId = 3616322875
 

--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -354,7 +354,7 @@ class NotificationSqlUtilsTest {
     }
 
     @Test
-    fun testHasUnreadNotifications () {
+    fun testHasUnreadNotifications() {
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -9,9 +9,9 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
-import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.notification.NoteIdSet
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.notification.NotificationModel.Kind
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableContentMapper
@@ -126,6 +126,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
         filterBySubtype: List<String>? = null
     ): Boolean {
         val conditionClauseBuilder = WellSql.select(NotificationModelBuilder::class.java)
+                .columns("1")
                 .where()
                 .equals(NotificationModelTable.LOCAL_SITE_ID, site.id)
                 .equals(NotificationModelTable.READ, 0)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -148,10 +148,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
             conditionClauseBuilder.endGroup()
         }
 
-        val unreadNotifs = conditionClauseBuilder.endWhere()
-                .asModel
-                .map { it.build(formattableContentMapper) }
-        return unreadNotifs.size > 0
+        return conditionClauseBuilder.endWhere().asCursor.count > 0
     }
 
     fun getNotificationByIdSet(idSet: NoteIdSet): NotificationModel? {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -123,7 +123,8 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
     fun hasUnreadNotificationsForSite(
         site: SiteModel,
         filterByType: List<String>? = null,
-        filterBySubtype: List<String>? = null): Boolean {
+        filterBySubtype: List<String>? = null
+    ): Boolean {
         val conditionClauseBuilder = WellSql.select(NotificationModelBuilder::class.java)
                 .where()
                 .equals(NotificationModelTable.LOCAL_SITE_ID, site.id)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -235,6 +235,20 @@ constructor(
             notificationSqlUtils.getNotificationsForSite(site, ORDER_DESCENDING, filterByType, filterBySubtype)
 
     /**
+     * Returns true if the given site has unread notifications
+     *
+     * @param site The [SiteModel] to check notifications for
+     * @param filterByType Optional. A list of notification type strings to filter by
+     * @param filterBySubtype Optional. A list of notification subtype strings to filter by
+     */
+    fun hasUnreadNotificationsForSite(
+        site: SiteModel,
+        filterByType: List<String>? = null,
+        filterBySubtype: List<String>? = null
+    ): Boolean =
+            notificationSqlUtils.hasUnreadNotificationsForSite(site, filterByType, filterBySubtype)
+
+    /**
      * Fetch the first notification matching the parameters specified in [NoteIdSet].
      *
      * @param idSet A [NoteIdSet] containing the localSiteId, remoteNoteId, and localNoteId


### PR DESCRIPTION
Resolves #1090 - adds a method to check if a site has unread notifications, optionally matching a type and subtype. This is required in order to tackle [this Woo issue](https://github.com/woocommerce/woocommerce-android/issues/639).

![screenshot_1548255403](https://user-images.githubusercontent.com/3903757/51615221-4da52480-1ef5-11e9-82df-96fda364bf99.png)
