### PR TITLE
Woo: Fetch and store WooCommerce store settings

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
@@ -10,10 +10,12 @@ import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCCoreAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.FetchApiVersionResponsePayload
+import org.wordpress.android.fluxc.store.WooCommerceStore.FetchWCSiteSettingsResponsePayload
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -57,6 +59,27 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
         val payload = lastAction!!.payload as FetchApiVersionResponsePayload
         assertNull(payload.error)
         assertEquals(WooCommerceStore.WOO_API_NAMESPACE_V3, payload.version)
+    }
+
+    @Test
+    fun testWCSiteSettingsGeneralFetch() {
+        interceptor.respondWith("wc-site-settings-general-response-success.json")
+        wcRestClient.getSiteSettingsGeneral(siteModel)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCCoreAction.FETCHED_SITE_SETTINGS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchWCSiteSettingsResponsePayload
+        assertNull(payload.error)
+        with(payload.settings!!) {
+            assertEquals(siteModel.id, localSiteId)
+            assertEquals("CAD", currencyCode)
+            assertEquals(CurrencyPosition.LEFT, currencyPosition)
+            assertEquals(",", currencyThousandSeparator)
+            assertEquals(".", currencyDecimalSeparator)
+            assertEquals(2, currencyDecimalNumber)
+        }
     }
 
     @Suppress("unused")

--- a/example/src/androidTest/resources/wc-fetch-order-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-order-response-success.json
@@ -110,12 +110,12 @@
     "_links": {
       "self": [
         {
-          "href": "https:\/\/alexforcier-test-store-1.blog\/wp-json\/wc\/v2\/orders\/88"
+          "href": "https:\/\/wordpress.com\/wp-json\/wc\/v2\/orders\/88"
         }
       ],
       "collection": [
         {
-          "href": "https:\/\/alexforcier-test-store-1.blog\/wp-json\/wc\/v2\/orders"
+          "href": "https:\/\/wordpress.com\/wp-json\/wc\/v2\/orders"
         }
       ]
     }

--- a/example/src/androidTest/resources/wc-order-update-response-success.json
+++ b/example/src/androidTest/resources/wc-order-update-response-success.json
@@ -110,12 +110,12 @@
     "_links": {
       "self": [
         {
-          "href": "https:\/\/alexforcier-test-store-1.blog\/wp-json\/wc\/v2\/orders\/88"
+          "href": "https:\/\/wordpress.com\/wp-json\/wc\/v2\/orders\/88"
         }
       ],
       "collection": [
         {
-          "href": "https:\/\/alexforcier-test-store-1.blog\/wp-json\/wc\/v2\/orders"
+          "href": "https:\/\/wordpress.com\/wp-json\/wc\/v2\/orders"
         }
       ]
     }

--- a/example/src/androidTest/resources/wc-site-settings-general-response-success.json
+++ b/example/src/androidTest/resources/wc-site-settings-general-response-success.json
@@ -1,0 +1,595 @@
+{
+  "data": [
+    {
+      "id": "woocommerce_store_address",
+      "label": "Address line 1",
+      "description": "The street address for your business location.",
+      "type": "text",
+      "default": "",
+      "tip": "The street address for your business location.",
+      "value": "",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_store_address"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_store_address_2",
+      "label": "Address line 2",
+      "description": "An additional, optional address line for your business location.",
+      "type": "text",
+      "default": "",
+      "tip": "An additional, optional address line for your business location.",
+      "value": "",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_store_address_2"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_store_city",
+      "label": "City",
+      "description": "The city in which your business is located.",
+      "type": "text",
+      "default": "",
+      "tip": "The city in which your business is located.",
+      "value": "Auburn",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_store_city"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_default_country",
+      "label": "Country \/ State",
+      "description": "The country and state or province, if any, in which your business is located.",
+      "type": "select",
+      "default": "GB",
+      "tip": "The country and state or province, if any, in which your business is located.",
+      "value": "US:NY",
+      "options": {
+        "AX": "&#197;land Islands",
+        "CA:AB": "Canada - Alberta",
+        "CA:BC": "Canada - British Columbia",
+        "CA:MB": "Canada - Manitoba",
+        "CA:NB": "Canada - New Brunswick",
+        "CA:NL": "Canada - Newfoundland and Labrador",
+        "CA:NT": "Canada - Northwest Territories",
+        "CA:NS": "Canada - Nova Scotia",
+        "CA:NU": "Canada - Nunavut",
+        "CA:ON": "Canada - Ontario",
+        "CA:PE": "Canada - Prince Edward Island",
+        "CA:QC": "Canada - Quebec",
+        "CA:SK": "Canada - Saskatchewan",
+        "CA:YT": "Canada - Yukon Territory",
+        "US": "United States (US)",
+        "UM": "United States (US) Minor Outlying Islands",
+        "VI": "United States (US) Virgin Islands"
+      },
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_all_except_countries"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_specific_allowed_countries",
+      "label": "Sell to specific countries",
+      "description": "",
+      "type": "multiselect",
+      "default": "",
+      "value": [],
+      "options": {
+        "AX": "&#197;land Islands",
+        "CA": "Canada",
+        "US": "United States (US)",
+        "UM": "United States (US) Minor Outlying Islands",
+        "VI": "United States (US) Virgin Islands"
+      },
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_specific_allowed_countries"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_ship_to_countries",
+      "label": "Shipping location(s)",
+      "description": "Choose which countries you want to ship to, or choose to ship to all locations you sell to.",
+      "type": "select",
+      "default": "",
+      "options": {
+        "all": "Ship to all countries",
+        "specific": "Ship to specific countries only",
+        "disabled": "Disable shipping &amp; shipping calculations"
+      },
+      "tip": "Choose which countries you want to ship to, or choose to ship to all locations you sell to.",
+      "value": "all",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_ship_to_countries"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_specific_ship_to_countries",
+      "label": "Ship to specific countries",
+      "description": "",
+      "type": "multiselect",
+      "default": "",
+      "value": [],
+      "options": {
+        "AX": "&#197;land Islands",
+        "CA": "Canada",
+        "US": "United States (US)",
+        "UM": "United States (US) Minor Outlying Islands",
+        "VI": "United States (US) Virgin Islands"
+      },
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_specific_ship_to_countries"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_default_customer_address",
+      "label": "Default customer location",
+      "description": "",
+      "type": "select",
+      "default": "geolocation",
+      "options": {
+        "base": "Shop base address",
+        "geolocation": "Geolocate",
+        "geolocation_ajax": "Geolocate (with page caching support)"
+      },
+      "tip": "This option determines a customers default location. The MaxMind GeoLite Database will be periodically downloaded to your wp-content directory if using geolocation.",
+      "value": "geolocation",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_default_customer_address"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_calc_taxes",
+      "label": "Enable taxes",
+      "description": "Enable tax rates and calculations",
+      "type": "checkbox",
+      "default": "no",
+      "tip": "Rates will be configurable and taxes will be calculated during checkout.",
+      "value": "yes",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_calc_taxes"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_enable_coupons",
+      "label": "Enable coupons",
+      "description": "Enable the use of coupon codes",
+      "type": "checkbox",
+      "default": "yes",
+      "tip": "Coupons can be applied from the cart and checkout pages.",
+      "value": "yes",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_enable_coupons"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_calc_discounts_sequentially",
+      "label": "",
+      "description": "Calculate coupon discounts sequentially",
+      "type": "checkbox",
+      "default": "no",
+      "tip": "When applying multiple coupons, apply the first coupon to the full price and the second coupon to the discounted price and so on.",
+      "value": "no",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_calc_discounts_sequentially"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_currency",
+      "label": "Currency",
+      "description": "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
+      "type": "select",
+      "default": "GBP",
+      "options": {
+        "AED": "United Arab Emirates dirham (&#x62f;.&#x625;)",
+        "AFN": "Afghan afghani (&#x60b;)",
+        "ALL": "Albanian lek (L)",
+        "AMD": "Armenian dram (AMD)",
+        "ANG": "Netherlands Antillean guilder (&fnof;)",
+        "AOA": "Angolan kwanza (Kz)",
+        "ARS": "Argentine peso (&#36;)",
+        "AUD": "Australian dollar (&#36;)",
+        "AWG": "Aruban florin (Afl.)",
+        "AZN": "Azerbaijani manat (AZN)",
+        "BAM": "Bosnia and Herzegovina convertible mark (KM)",
+        "BBD": "Barbadian dollar (&#36;)",
+        "BDT": "Bangladeshi taka (&#2547;&nbsp;)",
+        "BGN": "Bulgarian lev (&#1083;&#1074;.)",
+        "BHD": "Bahraini dinar (.&#x62f;.&#x628;)",
+        "BIF": "Burundian franc (Fr)",
+        "BMD": "Bermudian dollar (&#36;)",
+        "BND": "Brunei dollar (&#36;)",
+        "BOB": "Bolivian boliviano (Bs.)",
+        "BRL": "Brazilian real (&#82;&#36;)",
+        "BSD": "Bahamian dollar (&#36;)",
+        "BTC": "Bitcoin (&#3647;)",
+        "BTN": "Bhutanese ngultrum (Nu.)",
+        "BWP": "Botswana pula (P)",
+        "BYR": "Belarusian ruble (old) (Br)",
+        "BYN": "Belarusian ruble (Br)",
+        "BZD": "Belize dollar (&#36;)",
+        "CAD": "Canadian dollar (&#36;)",
+        "CDF": "Congolese franc (Fr)",
+        "CHF": "Swiss franc (&#67;&#72;&#70;)",
+        "CLP": "Chilean peso (&#36;)",
+        "CNY": "Chinese yuan (&yen;)",
+        "COP": "Colombian peso (&#36;)",
+        "CRC": "Costa Rican col&oacute;n (&#x20a1;)",
+        "CUC": "Cuban convertible peso (&#36;)",
+        "CUP": "Cuban peso (&#36;)",
+        "CVE": "Cape Verdean escudo (&#36;)",
+        "CZK": "Czech koruna (&#75;&#269;)",
+        "DJF": "Djiboutian franc (Fr)",
+        "DKK": "Danish krone (DKK)",
+        "DOP": "Dominican peso (RD&#36;)",
+        "DZD": "Algerian dinar (&#x62f;.&#x62c;)",
+        "EGP": "Egyptian pound (EGP)",
+        "ERN": "Eritrean nakfa (Nfk)",
+        "ETB": "Ethiopian birr (Br)",
+        "EUR": "Euro (&euro;)",
+        "FJD": "Fijian dollar (&#36;)",
+        "FKP": "Falkland Islands pound (&pound;)",
+        "GBP": "Pound sterling (&pound;)",
+        "GEL": "Georgian lari (&#x20be;)",
+        "GGP": "Guernsey pound (&pound;)",
+        "GHS": "Ghana cedi (&#x20b5;)",
+        "GIP": "Gibraltar pound (&pound;)",
+        "GMD": "Gambian dalasi (D)",
+        "GNF": "Guinean franc (Fr)",
+        "GTQ": "Guatemalan quetzal (Q)",
+        "GYD": "Guyanese dollar (&#36;)",
+        "HKD": "Hong Kong dollar (&#36;)",
+        "HNL": "Honduran lempira (L)",
+        "HRK": "Croatian kuna (kn)",
+        "HTG": "Haitian gourde (G)",
+        "HUF": "Hungarian forint (&#70;&#116;)",
+        "IDR": "Indonesian rupiah (Rp)",
+        "ILS": "Israeli new shekel (&#8362;)",
+        "IMP": "Manx pound (&pound;)",
+        "INR": "Indian rupee (&#8377;)",
+        "IQD": "Iraqi dinar (&#x639;.&#x62f;)",
+        "IRR": "Iranian rial (&#xfdfc;)",
+        "IRT": "Iranian toman (&#x062A;&#x0648;&#x0645;&#x0627;&#x0646;)",
+        "ISK": "Icelandic kr&oacute;na (kr.)",
+        "JEP": "Jersey pound (&pound;)",
+        "JMD": "Jamaican dollar (&#36;)",
+        "JOD": "Jordanian dinar (&#x62f;.&#x627;)",
+        "JPY": "Japanese yen (&yen;)",
+        "KES": "Kenyan shilling (KSh)",
+        "KGS": "Kyrgyzstani som (&#x441;&#x43e;&#x43c;)",
+        "KHR": "Cambodian riel (&#x17db;)",
+        "KMF": "Comorian franc (Fr)",
+        "KPW": "North Korean won (&#x20a9;)",
+        "KRW": "South Korean won (&#8361;)",
+        "KWD": "Kuwaiti dinar (&#x62f;.&#x643;)",
+        "KYD": "Cayman Islands dollar (&#36;)",
+        "KZT": "Kazakhstani tenge (KZT)",
+        "LAK": "Lao kip (&#8365;)",
+        "LBP": "Lebanese pound (&#x644;.&#x644;)",
+        "LKR": "Sri Lankan rupee (&#xdbb;&#xdd4;)",
+        "LRD": "Liberian dollar (&#36;)",
+        "LSL": "Lesotho loti (L)",
+        "LYD": "Libyan dinar (&#x644;.&#x62f;)",
+        "MAD": "Moroccan dirham (&#x62f;.&#x645;.)",
+        "MDL": "Moldovan leu (MDL)",
+        "MGA": "Malagasy ariary (Ar)",
+        "MKD": "Macedonian denar (&#x434;&#x435;&#x43d;)",
+        "MMK": "Burmese kyat (Ks)",
+        "MNT": "Mongolian t&ouml;gr&ouml;g (&#x20ae;)",
+        "MOP": "Macanese pataca (P)",
+        "MRO": "Mauritanian ouguiya (UM)",
+        "MUR": "Mauritian rupee (&#x20a8;)",
+        "MVR": "Maldivian rufiyaa (.&#x783;)",
+        "MWK": "Malawian kwacha (MK)",
+        "MXN": "Mexican peso (&#36;)",
+        "MYR": "Malaysian ringgit (&#82;&#77;)",
+        "MZN": "Mozambican metical (MT)",
+        "NAD": "Namibian dollar (&#36;)",
+        "NGN": "Nigerian naira (&#8358;)",
+        "NIO": "Nicaraguan c&oacute;rdoba (C&#36;)",
+        "NOK": "Norwegian krone (&#107;&#114;)",
+        "NPR": "Nepalese rupee (&#8360;)",
+        "NZD": "New Zealand dollar (&#36;)",
+        "OMR": "Omani rial (&#x631;.&#x639;.)",
+        "PAB": "Panamanian balboa (B\/.)",
+        "PEN": "Peruvian nuevo sol (S\/.)",
+        "PGK": "Papua New Guinean kina (K)",
+        "PHP": "Philippine peso (&#8369;)",
+        "PKR": "Pakistani rupee (&#8360;)",
+        "PLN": "Polish z&#x142;oty (&#122;&#322;)",
+        "PRB": "Transnistrian ruble (&#x440;.)",
+        "PYG": "Paraguayan guaran&iacute; (&#8370;)",
+        "QAR": "Qatari riyal (&#x631;.&#x642;)",
+        "RON": "Romanian leu (lei)",
+        "RSD": "Serbian dinar (&#x434;&#x438;&#x43d;.)",
+        "RUB": "Russian ruble (&#8381;)",
+        "RWF": "Rwandan franc (Fr)",
+        "SAR": "Saudi riyal (&#x631;.&#x633;)",
+        "SBD": "Solomon Islands dollar (&#36;)",
+        "SCR": "Seychellois rupee (&#x20a8;)",
+        "SDG": "Sudanese pound (&#x62c;.&#x633;.)",
+        "SEK": "Swedish krona (&#107;&#114;)",
+        "SGD": "Singapore dollar (&#36;)",
+        "SHP": "Saint Helena pound (&pound;)",
+        "SLL": "Sierra Leonean leone (Le)",
+        "SOS": "Somali shilling (Sh)",
+        "SRD": "Surinamese dollar (&#36;)",
+        "SSP": "South Sudanese pound (&pound;)",
+        "STD": "S&atilde;o Tom&eacute; and Pr&iacute;ncipe dobra (Db)",
+        "SYP": "Syrian pound (&#x644;.&#x633;)",
+        "SZL": "Swazi lilangeni (L)",
+        "THB": "Thai baht (&#3647;)",
+        "TJS": "Tajikistani somoni (&#x405;&#x41c;)",
+        "TMT": "Turkmenistan manat (m)",
+        "TND": "Tunisian dinar (&#x62f;.&#x62a;)",
+        "TOP": "Tongan pa&#x2bb;anga (T&#36;)",
+        "TRY": "Turkish lira (&#8378;)",
+        "TTD": "Trinidad and Tobago dollar (&#36;)",
+        "TWD": "New Taiwan dollar (&#78;&#84;&#36;)",
+        "TZS": "Tanzanian shilling (Sh)",
+        "UAH": "Ukrainian hryvnia (&#8372;)",
+        "UGX": "Ugandan shilling (UGX)",
+        "USD": "United States (US) dollar (&#36;)",
+        "UYU": "Uruguayan peso (&#36;)",
+        "UZS": "Uzbekistani som (UZS)",
+        "VEF": "Venezuelan bol&iacute;var (Bs F)",
+        "VND": "Vietnamese &#x111;&#x1ed3;ng (&#8363;)",
+        "VUV": "Vanuatu vatu (Vt)",
+        "WST": "Samoan t&#x101;l&#x101; (T)",
+        "XAF": "Central African CFA franc (CFA)",
+        "XCD": "East Caribbean dollar (&#36;)",
+        "XOF": "West African CFA franc (CFA)",
+        "XPF": "CFP franc (Fr)",
+        "YER": "Yemeni rial (&#xfdfc;)",
+        "ZAR": "South African rand (&#82;)",
+        "ZMW": "Zambian kwacha (ZK)"
+      },
+      "tip": "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
+      "value": "CAD",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_currency"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_currency_pos",
+      "label": "Currency position",
+      "description": "This controls the position of the currency symbol.",
+      "type": "select",
+      "default": "left",
+      "options": {
+        "left": "Left",
+        "right": "Right",
+        "left_space": "Left with space",
+        "right_space": "Right with space"
+      },
+      "tip": "This controls the position of the currency symbol.",
+      "value": "left",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_currency_pos"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_price_thousand_sep",
+      "label": "Thousand separator",
+      "description": "This sets the thousand separator of displayed prices.",
+      "type": "text",
+      "default": ",",
+      "tip": "This sets the thousand separator of displayed prices.",
+      "value": ",",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_price_thousand_sep"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_price_decimal_sep",
+      "label": "Decimal separator",
+      "description": "This sets the decimal separator of displayed prices.",
+      "type": "text",
+      "default": ".",
+      "tip": "This sets the decimal separator of displayed prices.",
+      "value": ".",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_price_decimal_sep"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_price_num_decimals",
+      "label": "Number of decimals",
+      "description": "This sets the number of decimal points shown in displayed prices.",
+      "type": "number",
+      "default": "2",
+      "tip": "This sets the number of decimal points shown in displayed prices.",
+      "value": "2",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_price_num_decimals"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_bookings_tz_calculation",
+      "label": "Enable Bookings Timezone Calculation",
+      "description": "Schedule Bookings events, such as reminder emails and auto-completions of bookings, using your site\u2019s configured timezone.",
+      "type": "checkbox",
+      "default": "no",
+      "value": "no",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_bookings_tz_calculation"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    },
+    {
+      "id": "woocommerce_bookings_timezone_conversion",
+      "label": "Timezone",
+      "description": "",
+      "type": "radio",
+      "default": "no",
+      "options": {
+        "yes": "Display visitor's local time",
+        "no": "Display your local time (America\/New_York)"
+      },
+      "value": "no",
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general\/woocommerce_bookings_timezone_conversion"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https:\/\/wordpress.com\/wp-json\/wc\/v3\/settings\/general"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -306,7 +306,11 @@ class WooCommerceFragment : Fragment() {
             return
         }
 
-        prependToLog("Updated site settings for ${event.site.name}")
+        with(event) {
+            prependToLog("Updated site settings for ${site.name}:\n" +
+                    wooCommerceStore.getSiteSettings(site).toString()
+            )
+        }
     }
 
     @Suppress("unused")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -48,6 +48,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.OnWCTopEarnersChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
+import org.wordpress.android.fluxc.store.WooCommerceStore.OnWCSiteSettingsChanged
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.ToastUtils
@@ -86,6 +87,12 @@ class WooCommerceFragment : Fragment() {
             for (site in wooCommerceStore.getWooCommerceSites()) {
                 dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteApiVersionAction(site))
             }
+        }
+
+        fetch_settings.setOnClickListener {
+            getFirstWCSite()?.let {
+                dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(it))
+            } ?: showNoWCSitesToast()
         }
 
         fetch_orders.setOnClickListener {
@@ -289,6 +296,17 @@ class WooCommerceFragment : Fragment() {
             val formattedVersion = apiVersion.substringAfterLast("/")
             prependToLog("Max Woo version for ${site.name}: $formattedVersion")
         }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCSiteSettingsChanged(event: OnWCSiteSettingsChanged) {
+        if (event.isError) {
+            prependToLog("Error in onWCSiteSettingsChanged: ${event.error.type} - ${event.error.message}")
+            return
+        }
+
+        prependToLog("Updated site settings for ${event.site.name}")
     }
 
     @Suppress("unused")

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -23,6 +23,12 @@
             android:text="Log Woo API versions"/>
 
         <Button
+            android:id="@+id/fetch_settings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fetch WC site settings"/>
+
+        <Button
             android:id="@+id/fetch_orders"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WCSettingsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WCSettingsSqlUtilsTest.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.fluxc.wc
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.WCSettingsModel
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
+import org.wordpress.android.fluxc.persistence.WCSettingsSqlUtils
+import org.wordpress.android.fluxc.persistence.WCSettingsSqlUtils.WCSettingsBuilder
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import kotlin.test.assertEquals
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCSettingsSqlUtilsTest {
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                WCSettingsBuilder::class.java,
+                WellSqlConfig.ADDON_WOOCOMMERCE)
+        WellSql.init(config)
+        config.reset()
+    }
+
+    @Test
+    fun testInsertOrUpdateSettings() {
+        val settingsModel = WCSettingsModel(
+                localSiteId = 5,
+                currencyCode = "CAD",
+                currencyPosition = CurrencyPosition.LEFT,
+                currencyThousandSeparator = ",",
+                currencyDecimalSeparator = ".",
+                currencyDecimalNumber = 2
+        )
+
+        // Test inserting settings
+        WCSettingsSqlUtils.insertOrUpdateSettings(settingsModel)
+
+        val returnedSettings = WellSql.select(WCSettingsBuilder::class.java).asModel.first().build()
+        assertEquals(settingsModel, returnedSettings)
+
+        // Test updating settings
+        val updatedSettingsModel = WCSettingsModel(
+                localSiteId = 5,
+                currencyCode = "EUR",
+                currencyPosition = CurrencyPosition.RIGHT_SPACE,
+                currencyThousandSeparator = ".",
+                currencyDecimalSeparator = ",",
+                currencyDecimalNumber = 2
+        )
+        WCSettingsSqlUtils.insertOrUpdateSettings(updatedSettingsModel)
+
+        val returnedUpdatedSettings = WellSql.select(WCSettingsBuilder::class.java).asModel.first().build()
+        assertEquals(updatedSettingsModel, returnedUpdatedSettings)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 49;
+        return 50;
     }
 
     @Override
@@ -404,6 +404,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("ALTER TABLE PostModel ADD REMOTE_LAST_MODIFIED TEXT");
                 oldVersion++;
+            case 49:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -471,6 +475,13 @@ public class WellSqlConfig extends DefaultWellConfig {
                 case 45:
                     AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
                     db.execSQL("ALTER TABLE WCOrderNoteModel ADD IS_SYSTEM_NOTE INTEGER");
+                    break;
+                case 49:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("CREATE TABLE WCSettingsModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                               + "LOCAL_SITE_ID INTEGER,CURRENCY_CODE TEXT NOT NULL,CURRENCY_POSITION TEXT NOT NULL,"
+                               + "CURRENCY_THOUSAND_SEPARATOR TEXT NOT NULL,CURRENCY_DECIMAL_SEPARATOR TEXT NOT NULL,"
+                               + "CURRENCY_DECIMAL_NUMBER INTEGER)");
                     break;
             }
         }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCCoreAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCCoreAction.java
@@ -11,6 +11,8 @@ public enum WCCoreAction implements IAction {
     // Remote actions
     @Action(payloadType = SiteModel.class)
     FETCH_SITE_API_VERSION,
+    @Action(payloadType = SiteModel.class)
+    FETCH_SITE_SETTINGS,
 
     // Remote responses
     @Action(payloadType = FetchApiVersionResponsePayload.class)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCCoreAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCCoreAction.java
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.WooCommerceStore.FetchApiVersionResponsePayload;
+import org.wordpress.android.fluxc.store.WooCommerceStore.FetchWCSiteSettingsResponsePayload;
 
 @ActionEnum
 public enum WCCoreAction implements IAction {
@@ -16,5 +17,7 @@ public enum WCCoreAction implements IAction {
 
     // Remote responses
     @Action(payloadType = FetchApiVersionResponsePayload.class)
-    FETCHED_SITE_API_VERSION
+    FETCHED_SITE_API_VERSION,
+    @Action(payloadType = FetchWCSiteSettingsResponsePayload.class)
+    FETCHED_SITE_SETTINGS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSettingsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSettingsModel.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.model
+
+import java.util.Locale
+
+data class WCSettingsModel(
+    val localSiteId: Int,
+    val currencyCode: String, // The currency code for the site in 3-letter ISO 4217 format
+    val currencyPosition: CurrencyPosition, // Where the currency symbol should be placed
+    val currencyThousandSeparator: String, // The thousands separator character (e.g. the comma in 3,000)
+    val currencyDecimalSeparator: String, // The decimal separator character (e.g. the dot in 41.12)
+    val currencyDecimalNumber: Int // How many decimal points to display
+) {
+    enum class CurrencyPosition {
+        LEFT, RIGHT, LEFT_SPACE, RIGHT_SPACE;
+
+        companion object {
+            private val reverseMap = CurrencyPosition.values().associateBy(CurrencyPosition::name)
+            fun fromString(type: String?) = CurrencyPosition.reverseMap[type?.toUpperCase(Locale.US)] ?: LEFT
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/SiteSettingsGeneralResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/SiteSettingsGeneralResponse.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc
+
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.network.Response
+
+class SiteSettingsGeneralResponse : Response {
+    val id: String? = null
+    val value: JsonElement? = null // JsonElement because this field can be a string or an array (at least)
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -8,6 +8,8 @@ import org.wordpress.android.fluxc.action.WCCoreAction
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCSettingsModel
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
@@ -85,6 +87,14 @@ class WooCommerceRestClient(
                         val currencyThousandSep = getValueForSettingsField(it, "woocommerce_price_thousand_sep")
                         val currencyDecimalSep = getValueForSettingsField(it, "woocommerce_price_decimal_sep")
                         val currencyNumDecimals = getValueForSettingsField(it, "woocommerce_price_num_decimals")
+                        val settings = WCSettingsModel(
+                                localSiteId = site.id,
+                                currencyCode = currencyCode ?: "",
+                                currencyPosition = CurrencyPosition.fromString(currencyPosition),
+                                currencyThousandSeparator = currencyThousandSep ?: "",
+                                currencyDecimalSeparator = currencyDecimalSep ?: "",
+                                currencyDecimalNumber = currencyNumDecimals?.toIntOrNull() ?: 2
+                        )
                         // TODO Create model and dispatch
                     } ?: run {
                         // TODO Handle invalid response

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCSettingsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCSettingsSqlUtils.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.WCSettingsModelTable
+import com.yarolegovich.wellsql.WellSql
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.WCSettingsModel
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
+
+object WCSettingsSqlUtils {
+    fun insertOrUpdateSettings(settings: WCSettingsModel): Int {
+        val orderResult = WellSql.select(WCSettingsBuilder::class.java)
+                .where()
+                .equals(WCSettingsModelTable.LOCAL_SITE_ID, settings.localSiteId)
+                .endWhere()
+                .asModel
+
+        return if (orderResult.isEmpty()) {
+            // Insert
+            WellSql.insert(settings.toBuilder()).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            val oldId = orderResult[0].id
+            WellSql.update(WCSettingsBuilder::class.java).whereId(oldId)
+                    .put(settings.toBuilder(), UpdateAllExceptId(WCSettingsBuilder::class.java)).execute()
+        }
+    }
+
+    @Table(name = "WCSettingsModel", addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+    data class WCSettingsBuilder(
+        @PrimaryKey @Column private var id: Int = 0,
+        @Column var localSiteId: Int = 0,
+        @Column var currencyCode: String = "",
+        @Column var currencyPosition: String = "",
+        @Column var currencyThousandSeparator: String = "",
+        @Column var currencyDecimalSeparator: String = "",
+        @Column var currencyDecimalNumber: Int = 2
+    ) : Identifiable {
+        override fun getId() = id
+
+        override fun setId(id: Int) {
+            this.id = id
+        }
+
+        fun build(): WCSettingsModel {
+            return WCSettingsModel(
+                    localSiteId = localSiteId,
+                    currencyCode = currencyCode,
+                    currencyPosition = CurrencyPosition.fromString(currencyPosition),
+                    currencyThousandSeparator = currencyThousandSeparator,
+                    currencyDecimalSeparator = currencyDecimalSeparator,
+                    currencyDecimalNumber = currencyDecimalNumber
+            )
+        }
+    }
+
+    private fun WCSettingsModel.toBuilder(): WCSettingsBuilder {
+        return WCSettingsBuilder(
+                localSiteId = this.localSiteId,
+                currencyCode = this.currencyCode,
+                currencyPosition = this.currencyPosition.name.toLowerCase(),
+                currencyThousandSeparator = this.currencyThousandSeparator,
+                currencyDecimalSeparator = this.currencyDecimalSeparator,
+                currencyDecimalNumber = this.currencyDecimalNumber
+        )
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCSettingsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCSettingsSqlUtils.kt
@@ -6,6 +6,7 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCSettingsModel
 import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
 
@@ -27,6 +28,14 @@ object WCSettingsSqlUtils {
             WellSql.update(WCSettingsBuilder::class.java).whereId(oldId)
                     .put(settings.toBuilder(), UpdateAllExceptId(WCSettingsBuilder::class.java)).execute()
         }
+    }
+
+    fun getSettingsForSite(site: SiteModel): WCSettingsModel? {
+        return WellSql.select(WCSettingsBuilder::class.java)
+                .where()
+                .equals(WCSettingsModelTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .asModel.firstOrNull()?.build()
     }
 
     @Table(name = "WCSettingsModel", addOn = WellSqlConfig.ADDON_WOOCOMMERCE)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -56,6 +56,7 @@ class WooCommerceStore @Inject constructor(dispatcher: Dispatcher, private val w
         when (actionType) {
             // Remote actions
             WCCoreAction.FETCH_SITE_API_VERSION -> getApiVersion(action.payload as SiteModel)
+            WCCoreAction.FETCH_SITE_SETTINGS -> fetchSiteSettings(action.payload as SiteModel)
             // Remote responses
             WCCoreAction.FETCHED_SITE_API_VERSION ->
                 handleGetApiVersionCompleted(action.payload as FetchApiVersionResponsePayload)
@@ -66,6 +67,8 @@ class WooCommerceStore @Inject constructor(dispatcher: Dispatcher, private val w
             SiteSqlUtils.getSitesWith(SiteModelTable.HAS_WOO_COMMERCE, true).asModel
 
     private fun getApiVersion(site: SiteModel) = wcCoreRestClient.getSupportedWooApiVersion(site)
+
+    private fun fetchSiteSettings(site: SiteModel) = wcCoreRestClient.getSiteSettingsGeneral(site)
 
     private fun handleGetApiVersionCompleted(payload: FetchApiVersionResponsePayload) {
         val onApiVersionFetched: OnApiVersionFetched

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -110,7 +110,8 @@ class WooCommerceStore @Inject constructor(dispatcher: Dispatcher, private val w
     private fun handleFetchSiteSettingsCompleted(payload: FetchWCSiteSettingsResponsePayload) {
         val onWCSiteSettingsChanged = OnWCSiteSettingsChanged(payload.site)
         if (payload.isError || payload.settings == null) {
-            onWCSiteSettingsChanged.error = payload.error
+            onWCSiteSettingsChanged.error =
+                    payload.error ?: WCSiteSettingsError(WCSiteSettingsErrorType.INVALID_RESPONSE)
         } else {
             WCSettingsSqlUtils.insertOrUpdateSettings(payload.settings)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -97,6 +97,12 @@ class WooCommerceStore @Inject constructor(dispatcher: Dispatcher, private val w
     fun getWooCommerceSites(): MutableList<SiteModel> =
             SiteSqlUtils.getSitesWith(SiteModelTable.HAS_WOO_COMMERCE, true).asModel
 
+    /**
+     * Given a [SiteModel], returns its WooCommerce site settings, or null if no settings are stored for this site.
+     */
+    fun getSiteSettings(site: SiteModel): WCSettingsModel? =
+            WCSettingsSqlUtils.getSettingsForSite(site)
+
     private fun getApiVersion(site: SiteModel) = wcCoreRestClient.getSupportedWooApiVersion(site)
 
     private fun fetchSiteSettings(site: SiteModel) = wcCoreRestClient.getSiteSettingsGeneral(site)

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -3,3 +3,5 @@
 /orders/<id>/notes/
 
 /reports/orders/totals/
+
+/settings/general/


### PR DESCRIPTION
Adds a new action, `FETCH_SITE_SETTINGS`, which fetches some WooCommerce-specific settings from `/wc/v3/settings/general/` and stores them in the database. The specific settings being stored for now are all related to the site's currency settings.

Not much is done with this yet - I'll be following up with a second PR that uses the site settings to format currencies for display according to the user's preferences on the site.

See https://github.com/woocommerce/woocommerce-android/issues/148 for the full issue being addressed.

(Don't be too alarmed by the PR size: 600 lines alone are test response data.)

### To test

You can inspect the site settings for your site through a new button in the example app.

The settings the API is returning can be found (and changed) in wp-admin from the WooCommerce > Settings screen:

![Screen Shot 2018-02-08 at 5.18.06 PM.png](https://images.zenhubusercontent.com/5a0ae8908a75884b908759ea/c1b5c9d2-0471-4377-bd6e-356530efef90)