### PR TITLE
Woo: Support localized currency formatting

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/TestUtils.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/TestUtils.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
@@ -12,6 +13,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Locale;
 import java.util.UUID;
 
 public class TestUtils {
@@ -77,5 +79,10 @@ public class TestUtils {
         }
         return copyAndGetAssetPath(context, targetContext, SAMPLE_VIDEO);
     }
-}
 
+    public static Context updateLocale(Context context, Locale locale) {
+        Configuration config = context.getApplicationContext().getResources().getConfiguration();
+        config.setLocale(locale);
+        return context.createConfigurationContext(config);
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.fluxc.mocked
 
+import android.os.Build
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.TestUtils
@@ -88,6 +90,11 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
     // stubbed in a unit test environment, giving results inconsistent with a normal running app
     @Test
     fun testGetLocalizedCurrencySymbolForCode() {
+        assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                Build.VERSION.SDK_INT >= 23
+        )
+
         Locale("en", "US").let { localeEnUS ->
             assertEquals("$", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("USD", localeEnUS))
             assertEquals("CA$", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("CAD", localeEnUS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
@@ -16,6 +16,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.FetchApiVersionResponsePayload
 import org.wordpress.android.fluxc.store.WooCommerceStore.FetchWCSiteSettingsResponsePayload
+import org.wordpress.android.fluxc.utils.WCCurrencyUtils
+import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -79,6 +81,32 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
             assertEquals(",", currencyThousandSeparator)
             assertEquals(".", currencyDecimalSeparator)
             assertEquals(2, currencyDecimalNumber)
+        }
+    }
+
+    // This is a connected test instead of a unit test because some of the internals of java.util.Currency seem to be
+    // stubbed in a unit test environment, giving results inconsistent with a normal running app
+    @Test
+    fun testGetLocalizedCurrencySymbolForCode() {
+        Locale("en", "US").let { localeEnUS ->
+            assertEquals("$", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("USD", localeEnUS))
+            assertEquals("CA$", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("CAD", localeEnUS))
+            assertEquals("€", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("EUR", localeEnUS))
+            assertEquals("¥", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("JPY", localeEnUS))
+        }
+
+        Locale("en", "CA").let { localeEnCA ->
+            assertEquals("US$", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("USD", localeEnCA))
+            assertEquals("$", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("CAD", localeEnCA))
+            assertEquals("€", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("EUR", localeEnCA))
+            assertEquals("JP¥", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("JPY", localeEnCA))
+        }
+
+        Locale("fr", "FR").let { localeFrFR ->
+            assertEquals("\$US", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("USD", localeFrFR))
+            assertEquals("\$CA", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("CAD", localeFrFR))
+            assertEquals("€", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("EUR", localeFrFR))
+            assertEquals("JPY", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("JPY", localeFrFR))
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import android.os.Build
+import com.yarolegovich.wellsql.WellSql
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -12,9 +13,12 @@ import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCCoreAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCSettingsModel
 import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
+import org.wordpress.android.fluxc.persistence.WCSettingsSqlUtils
+import org.wordpress.android.fluxc.persistence.WCSettingsSqlUtils.WCSettingsBuilder
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.FetchApiVersionResponsePayload
 import org.wordpress.android.fluxc.store.WooCommerceStore.FetchWCSiteSettingsResponsePayload
@@ -31,6 +35,7 @@ import kotlin.properties.Delegates.notNull
  */
 class MockedStack_WCBaseStoreTest : MockedStack_Base() {
     @Inject internal lateinit var wcRestClient: WooCommerceRestClient
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var dispatcher: Dispatcher
 
     @Inject internal lateinit var interceptor: ResponseMockingInterceptor
@@ -114,6 +119,130 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
             assertEquals("\$CA", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("CAD", localeFrFR))
             assertEquals("€", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("EUR", localeFrFR))
             assertEquals("JPY", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("JPY", localeFrFR))
+        }
+    }
+
+    @Test
+    fun testFormatCurrencyForDisplay() {
+        assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                Build.VERSION.SDK_INT >= 23
+        )
+
+        // Override device locale and use en_US so currency symbols can be predicted
+        TestUtils.updateLocale(mAppContext, Locale("en", "US"))
+
+        // -- Site using CAD
+        val cadSettings = WCSettingsModel(
+                localSiteId = siteModel.id,
+                currencyCode = "CAD",
+                currencyPosition = CurrencyPosition.LEFT,
+                currencyThousandSeparator = ",",
+                currencyDecimalSeparator = ".",
+                currencyDecimalNumber = 2)
+        WCSettingsSqlUtils.insertOrUpdateSettings(cadSettings)
+
+        with(wooCommerceStore) {
+            val formattedCurrencyDouble = formatCurrencyForDisplay(1234.12, siteModel, "CAD", true)
+            assertEquals("CA$1,234.12", formattedCurrencyDouble)
+
+            val formattedCurrencyString = formatCurrencyForDisplay("1234.12", siteModel, "CAD", true)
+            assertEquals("CA$1,234.12", formattedCurrencyString)
+
+            val formattedCurrencyPretty = formatCurrencyForDisplay("1.2k", siteModel, "CAD", false)
+            assertEquals("CA$1.2k", formattedCurrencyPretty)
+
+            val formattedCurrencyNegative = formatCurrencyForDisplay(-1234.12, siteModel, "CAD", true)
+            assertEquals("-CA$1,234.12", formattedCurrencyNegative)
+
+            val formattedCurrencyUseSiteCurrency = formatCurrencyForDisplay(1234.12, siteModel, null, true)
+            assertEquals("CA$1,234.12", formattedCurrencyUseSiteCurrency)
+
+            val formattedCurrencyDifferentCurrency = formatCurrencyForDisplay(1234.12, siteModel, "EUR", true)
+            assertEquals("€1,234.12", formattedCurrencyDifferentCurrency)
+        }
+
+        // -- Site using EUR
+        val eurSettings = WCSettingsModel(
+                localSiteId = siteModel.id,
+                currencyCode = "EUR",
+                currencyPosition = CurrencyPosition.RIGHT_SPACE,
+                currencyThousandSeparator = ".",
+                currencyDecimalSeparator = ",",
+                currencyDecimalNumber = 2)
+        WCSettingsSqlUtils.insertOrUpdateSettings(eurSettings)
+
+        with(wooCommerceStore) {
+            val formattedCurrencyDouble = formatCurrencyForDisplay(1234.12, siteModel, "EUR", true)
+            assertEquals("1.234,12 €", formattedCurrencyDouble)
+
+            val formattedCurrencyString = formatCurrencyForDisplay("1234.12", siteModel, "EUR", true)
+            assertEquals("1.234,12 €", formattedCurrencyString)
+
+            val formattedCurrencyPretty = formatCurrencyForDisplay("1.2k", siteModel, "EUR", false)
+            assertEquals("1.2k €", formattedCurrencyPretty)
+
+            val formattedCurrencyNegative = formatCurrencyForDisplay(-1234.12, siteModel, "EUR", true)
+            assertEquals("-1.234,12 €", formattedCurrencyNegative)
+
+            val formattedCurrencyUseSiteCurrency = formatCurrencyForDisplay(1234.12, siteModel, null, true)
+            assertEquals("1.234,12 €", formattedCurrencyUseSiteCurrency)
+
+            val formattedCurrencyDifferentCurrency = formatCurrencyForDisplay(1234.12, siteModel, "USD", true)
+            assertEquals("1.234,12 \$", formattedCurrencyDifferentCurrency)
+        }
+
+        // -- Site using JPY
+        val jpySettings = WCSettingsModel(
+                localSiteId = siteModel.id,
+                currencyCode = "JPY",
+                currencyPosition = CurrencyPosition.LEFT,
+                currencyThousandSeparator = "",
+                currencyDecimalSeparator = "",
+                currencyDecimalNumber = 0)
+        WCSettingsSqlUtils.insertOrUpdateSettings(jpySettings)
+
+        with(wooCommerceStore) {
+            val formattedCurrencyDouble = formatCurrencyForDisplay(1234.0, siteModel, "JPY", true)
+            assertEquals("¥1234", formattedCurrencyDouble)
+
+            val formattedCurrencyString = formatCurrencyForDisplay("1234", siteModel, "JPY", true)
+            assertEquals("¥1234", formattedCurrencyString)
+
+            val formattedCurrencyPretty = formatCurrencyForDisplay("1.2k", siteModel, "JPY", false)
+            assertEquals("¥1.2k", formattedCurrencyPretty)
+
+            val formattedCurrencyNegative = formatCurrencyForDisplay(-1234.12, siteModel, "JPY", true)
+            assertEquals("-¥1234", formattedCurrencyNegative)
+
+            val formattedCurrencyUseSiteCurrency = formatCurrencyForDisplay(1234.0, siteModel, null, true)
+            assertEquals("¥1234", formattedCurrencyUseSiteCurrency)
+
+            val formattedCurrencyDifferentCurrency = formatCurrencyForDisplay(1234.0, siteModel, "USD", true)
+            assertEquals("$1234", formattedCurrencyDifferentCurrency)
+        }
+
+        // -- No site settings stored
+        WellSql.delete(WCSettingsBuilder::class.java).execute()
+
+        with(wooCommerceStore) {
+            val formattedCurrencyDouble = formatCurrencyForDisplay(1234.12, siteModel, "CAD", true)
+            assertEquals("CA$1234.12", formattedCurrencyDouble)
+
+            val formattedCurrencyString = formatCurrencyForDisplay("1234.12", siteModel, "CAD", true)
+            assertEquals("CA$1234.12", formattedCurrencyString)
+
+            val formattedCurrencyPretty = formatCurrencyForDisplay("1.2k", siteModel, "CAD", false)
+            assertEquals("CA$1.2k", formattedCurrencyPretty)
+
+            val formattedCurrencyNegative = formatCurrencyForDisplay(-1234.12, siteModel, "CAD", true)
+            assertEquals("-CA$1234.12", formattedCurrencyNegative)
+
+            val formattedCurrencyUseSiteCurrency = formatCurrencyForDisplay(1234.12, siteModel, null, true)
+            assertEquals("1234.12", formattedCurrencyUseSiteCurrency)
+
+            val formattedCurrencyDifferentCurrency = formatCurrencyForDisplay(1234.12, siteModel, "EUR", true)
+            assertEquals("€1234.12", formattedCurrencyDifferentCurrency)
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -18,12 +18,11 @@ import kotlin.test.assertEquals
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
 class WooCommerceStoreTest {
-    private val wooCommerceStore = WooCommerceStore(Dispatcher(), mock())
+    private val appContext = RuntimeEnvironment.application.applicationContext
+    private val wooCommerceStore = WooCommerceStore(appContext, Dispatcher(), mock())
 
     @Before
     fun setUp() {
-        val appContext = RuntimeEnvironment.application.applicationContext
-
         val config = SingleStoreWellSqlConfigForTests(appContext, SiteModel::class.java,
                 WellSqlConfig.ADDON_WOOCOMMERCE)
         WellSql.init(config)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/WCCurrencyUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/WCCurrencyUtilsTest.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.fluxc.wc.utils
+
+import org.junit.Test
+import org.wordpress.android.fluxc.model.WCSettingsModel
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
+import org.wordpress.android.fluxc.utils.WCCurrencyUtils.formatCurrencyForDisplay
+import kotlin.test.assertEquals
+
+class WCCurrencyUtilsTest {
+    @Test
+    fun testDecimalFormat() {
+        val cadSettings = WCSettingsModel(
+                localSiteId = 6,
+                currencyCode = "CAD",
+                currencyPosition = CurrencyPosition.LEFT,
+                currencyThousandSeparator = ",",
+                currencyDecimalSeparator = ".",
+                currencyDecimalNumber = 2)
+
+        val eurSettings = WCSettingsModel(
+                localSiteId = 6,
+                currencyCode = "EUR",
+                currencyPosition = CurrencyPosition.RIGHT_SPACE,
+                currencyThousandSeparator = ".",
+                currencyDecimalSeparator = ",",
+                currencyDecimalNumber = 2)
+
+        val jpySettings = WCSettingsModel(
+                localSiteId = 6,
+                currencyCode = "JPY",
+                currencyPosition = CurrencyPosition.LEFT,
+                currencyThousandSeparator = "",
+                currencyDecimalSeparator = "",
+                currencyDecimalNumber = 0)
+
+        with(3.22) {
+            val cadFormat = formatCurrencyForDisplay(this, cadSettings)
+            assertEquals("3.22", cadFormat)
+
+            val eurFormat = formatCurrencyForDisplay(this, eurSettings)
+            assertEquals("3,22", eurFormat)
+
+            val jpyFormat = formatCurrencyForDisplay(this, jpySettings)
+            assertEquals("3", jpyFormat)
+        }
+
+        with(1234.22) {
+            val cadFormat = formatCurrencyForDisplay(this, cadSettings)
+            assertEquals("1,234.22", cadFormat)
+
+            val eurFormat = formatCurrencyForDisplay(this, eurSettings)
+            assertEquals("1.234,22", eurFormat)
+
+            val jpyFormat = formatCurrencyForDisplay(this, jpySettings)
+            assertEquals("1234", jpyFormat)
+        }
+
+        with(1234.toDouble()) {
+            val cadFormat = formatCurrencyForDisplay(this, cadSettings)
+            assertEquals("1,234.00", cadFormat)
+
+            val eurFormat = formatCurrencyForDisplay(this, eurSettings)
+            assertEquals("1.234,00", eurFormat)
+
+            val jpyFormat = formatCurrencyForDisplay(this, jpySettings)
+            assertEquals("1234", jpyFormat)
+        }
+
+        with(1234567.11) {
+            val cadFormat = formatCurrencyForDisplay(this, cadSettings)
+            assertEquals("1,234,567.11", cadFormat)
+
+            val eurFormat = formatCurrencyForDisplay(this, eurSettings)
+            assertEquals("1.234.567,11", eurFormat)
+
+            val jpyFormat = formatCurrencyForDisplay(this, jpySettings)
+            assertEquals("1234567", jpyFormat)
+        }
+
+        with(-1234.22) {
+            val cadFormat = formatCurrencyForDisplay(this, cadSettings)
+            assertEquals("-1,234.22", cadFormat)
+
+            val eurFormat = formatCurrencyForDisplay(this, eurSettings)
+            assertEquals("-1.234,22", eurFormat)
+
+            val jpyFormat = formatCurrencyForDisplay(this, jpySettings)
+            assertEquals("-1234", jpyFormat)
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.util.LanguageUtils
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.absoluteValue
 
 @Singleton
 class WooCommerceStore @Inject constructor(
@@ -139,17 +140,21 @@ class WooCommerceStore @Inject constructor(
 
             // Format the amount for display according to the site's currency settings
             val decimalFormattedValue = if (applyDecimalFormatting) {
-                WCCurrencyUtils.formatCurrencyForDisplay(rawValue.toDoubleOrNull() ?: 0.0, it)
+                WCCurrencyUtils.formatCurrencyForDisplay(rawValue.toDoubleOrNull()?.absoluteValue ?: 0.0, it)
             } else {
                 rawValue
             }
 
             // Append or prepend the currency symbol according to the site's settings
-            return when (it.currencyPosition) {
-                LEFT -> "$currencySymbol$decimalFormattedValue"
-                LEFT_SPACE -> "$currencySymbol $decimalFormattedValue"
-                RIGHT -> "$decimalFormattedValue$currencySymbol"
-                RIGHT_SPACE -> "$decimalFormattedValue $currencySymbol"
+            with(StringBuilder()) {
+                if (rawValue.startsWith("-")) { append("-") }
+                append(when (it.currencyPosition) {
+                    LEFT -> "$currencySymbol$decimalFormattedValue"
+                    LEFT_SPACE -> "$currencySymbol $decimalFormattedValue"
+                    RIGHT -> "$decimalFormattedValue$currencySymbol"
+                    RIGHT_SPACE -> "$decimalFormattedValue $currencySymbol"
+                })
+                return toString()
             }
         } ?: return rawValue
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -126,7 +126,7 @@ class WooCommerceStore @Inject constructor(
      * currency symbol and positioning will be applied. This is useful for values for 'pretty' display, e.g. $1.2k.
      */
     fun formatCurrencyForDisplay(
-        rawValue: Double,
+        rawValue: String,
         site: SiteModel,
         currencyCode: String? = null,
         applyDecimalFormatting: Boolean
@@ -139,9 +139,9 @@ class WooCommerceStore @Inject constructor(
 
             // Format the amount for display according to the site's currency settings
             val decimalFormattedValue = if (applyDecimalFormatting) {
-                WCCurrencyUtils.formatCurrencyForDisplay(rawValue, it)
+                WCCurrencyUtils.formatCurrencyForDisplay(rawValue.toDoubleOrNull() ?: 0.0, it)
             } else {
-                rawValue.toString()
+                rawValue
             }
 
             // Append or prepend the currency symbol according to the site's settings
@@ -151,7 +151,16 @@ class WooCommerceStore @Inject constructor(
                 RIGHT -> "$decimalFormattedValue$currencySymbol"
                 RIGHT_SPACE -> "$decimalFormattedValue $currencySymbol"
             }
-        } ?: return rawValue.toString()
+        } ?: return rawValue
+    }
+
+    fun formatCurrencyForDisplay(
+        amount: Double,
+        site: SiteModel,
+        currencyCode: String? = null,
+        applyDecimalFormatting: Boolean
+    ): String {
+        return formatCurrencyForDisplay(amount.toString(), site, currencyCode, applyDecimalFormatting)
     }
 
     private fun getApiVersion(site: SiteModel) = wcCoreRestClient.getSupportedWooApiVersion(site)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.utils
 
 import org.wordpress.android.fluxc.model.WCSettingsModel
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import java.text.DecimalFormat
 import java.util.Currency
 import java.util.Locale
@@ -42,6 +44,8 @@ object WCCurrencyUtils {
         return try {
             Currency.getInstance(currencyCode).getSymbol(locale)
         } catch (e: IllegalArgumentException) {
+            AppLog.e(T.UTILS,
+                    "Error finding valid currency symbol for currency code [$currencyCode] in locale [$locale]", e)
             currencyCode
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.utils
 
 import org.wordpress.android.fluxc.model.WCSettingsModel
 import java.text.DecimalFormat
+import java.util.Currency
+import java.util.Locale
 
 object WCCurrencyUtils {
     /**
@@ -28,5 +30,19 @@ object WCCurrencyUtils {
         }
 
         return decimalFormat.format(rawValue)
+    }
+
+    /**
+     * Given a locale and an ISO 4217 currency code (e.g. USD), returns the currency symbol for that currency,
+     * localized to the locale.
+     *
+     * Will return the [currencyCode] if it's found not to be a valid currency code.
+     */
+    fun getLocalizedCurrencySymbolForCode(currencyCode: String, locale: Locale): String {
+        return try {
+            Currency.getInstance(currencyCode).getSymbol(locale)
+        } catch (e: IllegalArgumentException) {
+            currencyCode
+        }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.fluxc.utils
+
+import org.wordpress.android.fluxc.model.WCSettingsModel
+import java.text.DecimalFormat
+
+object WCCurrencyUtils {
+    /**
+     * Formats the given [rawValue] as a decimal based on the site's currency settings as stored in [siteSettings].
+     *
+     * Currency symbol and placement are not handled.
+     */
+    fun formatCurrencyForDisplay(rawValue: Double, siteSettings: WCSettingsModel): String {
+        val decimalFormat = if (siteSettings.currencyDecimalNumber > 0) {
+            DecimalFormat("#,##0.${"0".repeat(siteSettings.currencyDecimalNumber)}")
+        } else {
+            DecimalFormat("#,##0")
+        }
+
+        decimalFormat.decimalFormatSymbols = decimalFormat.decimalFormatSymbols.apply {
+            // If no decimal separator is set, keep whatever the system default is
+            siteSettings.currencyDecimalSeparator.takeIf { it.isNotEmpty() }?.let {
+                decimalSeparator = it[0]
+            }
+            // If no thousands separator is set, assume it's intentional and clear it in the formatter
+            siteSettings.currencyThousandSeparator.takeIf { it.isNotEmpty() }?.let {
+                groupingSeparator = it[0]
+            } ?: run { decimalFormat.isGroupingUsed = false }
+        }
+
+        return decimalFormat.format(rawValue)
+    }
+}


### PR DESCRIPTION
Uses the `WCSettingsModel` added in #1093 to support formatting currency values for display according to the site's settings.

See https://github.com/woocommerce/woocommerce-android/issues/148 for more background, and the WooCommerce app counterpart PR https://github.com/woocommerce/woocommerce-android/pull/730.

~_Marking as not ready to review until I'm finished with the WooAndroid-side implementation._~

A few notes:
* The currency symbol used depends on the currency code (`USD`, `CAD`, etc) provided, and on the device's primary locale. For example, CAD are shown as `$` in `en_CA`, and as `CA$` in `en_US`.
* I added a few 'mocked network' tests that involve the currency localization. These tests don't work in a unit test environment, and I also found that older Android versions have different localized currency values in some cases. I've disabled these from running on older APIs (including Travis' API 15 emulator) for now - if they cause trouble on local tests as well we can just get rid of the tests.