### PR TITLE
Jitpack: Fix build failures due to license issue

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+- yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
+- yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.3"


### PR DESCRIPTION
Adds a `jitpack.yml` file with a workaround to manually accept licenses, since builds are failing recently due to unaccepted licenses.

Some background:
Issue: https://issuetracker.google.com/issues/123054726
Solution:
https://stackoverflow.com/questions/54268074/jitpack-failed-to-install-the-following-android-sdk-packages-as-some-licences-h/54292533#54292533

(We've had to do the same for [gutenberg-mobile](https://github.com/wordpress-mobile/gutenberg-mobile/pull/486/commits/237f6ca849b4b869e4796eed8c4482fff95b2e69).)

### To test
Attempt to use this branch's commit hash from another project.

Also, you can inspect Jitpack's build logs:

Current FluxC `develop` (fails): https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/cfdaffc80a/build.log
This branch (succeeds): https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/c47a5deba2/build.log