### PR TITLE
Remove date block from the stats

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.AUTHORS
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.CLICKS
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.COUNTRIES
-import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.DATE
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.OVERVIEW
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.POSTS_AND_PAGES
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.REFERRERS
@@ -59,7 +58,6 @@ class StatsStore
     suspend fun getTimeStatsTypes(): List<TimeStatsTypes> = withContext(coroutineContext) {
         return@withContext listOf(
                 OVERVIEW,
-                DATE,
                 POSTS_AND_PAGES,
                 REFERRERS,
                 CLICKS,
@@ -88,7 +86,6 @@ class StatsStore
 
     enum class TimeStatsTypes : StatsTypes {
         OVERVIEW,
-        DATE,
         POSTS_AND_PAGES,
         REFERRERS,
         CLICKS,


### PR DESCRIPTION
- this PR removes the DATE time stats type because it's no longer necessary in the Stats. We've replaced that with the `Date selector` tab which also serves as the date indicator.