### PR TITLE
Add paging when loading the followers

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -18,7 +18,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
-import org.wordpress.android.fluxc.store.InsightsStore
+import org.wordpress.android.fluxc.store.stats.InsightsStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -14,7 +14,8 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.stats.LoadMode.Paged
+import org.wordpress.android.fluxc.model.stats.CacheMode
+import org.wordpress.android.fluxc.model.stats.FetchMode.Paged
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
@@ -124,7 +125,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = insightsStore.getWpComFollowers(site, Paged(pageSize, false))
+        val insightsFromDb = insightsStore.getWpComFollowers(site, CacheMode.Top(pageSize))
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }
@@ -139,7 +140,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = insightsStore.getEmailFollowers(site, Paged(pageSize, false))
+        val insightsFromDb = insightsStore.getEmailFollowers(site, CacheMode.Top(pageSize))
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LoadMode.Paged
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
@@ -118,12 +119,12 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         val pageSize = 5
-        val fetchedInsights = runBlocking { insightsStore.fetchWpComFollowers(site, pageSize) }
+        val fetchedInsights = runBlocking { insightsStore.fetchWpComFollowers(site, Paged(pageSize, false)) }
 
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = insightsStore.getWpComFollowers(site, pageSize)
+        val insightsFromDb = insightsStore.getWpComFollowers(site, Paged(pageSize, false))
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }
@@ -133,12 +134,12 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         val pageSize = 5
-        val fetchedInsights = runBlocking { insightsStore.fetchEmailFollowers(site, pageSize) }
+        val fetchedInsights = runBlocking { insightsStore.fetchEmailFollowers(site, Paged(pageSize, false) ) }
 
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = insightsStore.getEmailFollowers(site, pageSize)
+        val insightsFromDb = insightsStore.getEmailFollowers(site, Paged(pageSize, false))
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -135,7 +135,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         val pageSize = 5
-        val fetchedInsights = runBlocking { insightsStore.fetchEmailFollowers(site, Paged(pageSize, false) ) }
+        val fetchedInsights = runBlocking { insightsStore.fetchEmailFollowers(site, Paged(pageSize, false)) }
 
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
@@ -8,11 +8,13 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.FollowerType.WP_COM
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.VisitResponse
 import org.wordpress.android.fluxc.store.stats.ALL_TIME_RESPONSE
 import org.wordpress.android.fluxc.store.stats.COMMENT_COUNT
 import org.wordpress.android.fluxc.store.stats.FIRST_DAY
 import org.wordpress.android.fluxc.store.stats.FIRST_DAY_VIEWS
+import org.wordpress.android.fluxc.store.stats.FOLLOWER_RESPONSE
 import org.wordpress.android.fluxc.store.stats.LATEST_POST
 import org.wordpress.android.fluxc.store.stats.LIKE_COUNT
 import org.wordpress.android.fluxc.store.stats.MOST_POPULAR_RESPONSE
@@ -22,6 +24,7 @@ import org.wordpress.android.fluxc.store.stats.REBLOG_COUNT
 import org.wordpress.android.fluxc.store.stats.SECOND_DAY
 import org.wordpress.android.fluxc.store.stats.SECOND_DAY_VIEWS
 import org.wordpress.android.fluxc.store.stats.VIEWS
+import org.wordpress.android.fluxc.store.stats.VIEW_ALL_FOLLOWERS_RESPONSE
 import org.wordpress.android.fluxc.store.stats.VISITS_DATE
 import org.wordpress.android.fluxc.store.stats.VISITS_RESPONSE
 
@@ -96,5 +99,13 @@ class InsightsMapperTest {
 
         assertThat(model.views).isEqualTo(10)
         assertThat(model.comments).isEqualTo(0)
+    }
+
+    @Test
+    fun `maps and merges followers responses`() {
+        val model = mapper.mapAndMergeFollowersModels(VIEW_ALL_FOLLOWERS_RESPONSE, WP_COM, LoadMode.Paged(1, false))
+
+        assertThat(model.followers.size).isEqualTo(1)
+        assertThat(model.followers.first().label).isEqualTo(FOLLOWER_RESPONSE.label)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
@@ -103,7 +103,7 @@ class InsightsMapperTest {
 
     @Test
     fun `maps and merges followers responses`() {
-        val model = mapper.mapAndMergeFollowersModels(VIEW_ALL_FOLLOWERS_RESPONSE, WP_COM, LoadMode.Paged(1, false))
+        val model = mapper.mapAndMergeFollowersModels(VIEW_ALL_FOLLOWERS_RESPONSE, WP_COM, FetchMode.Paged(1, false))
 
         assertThat(model.followers.size).isEqualTo(1)
         assertThat(model.followers.first().label).isEqualTo(FOLLOWER_RESPONSE.label)

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
@@ -103,7 +103,7 @@ class InsightsMapperTest {
 
     @Test
     fun `maps and merges followers responses`() {
-        val model = mapper.mapAndMergeFollowersModels(VIEW_ALL_FOLLOWERS_RESPONSE, WP_COM, FetchMode.Paged(1, false))
+        val model = mapper.mapAndMergeFollowersModels(VIEW_ALL_FOLLOWERS_RESPONSE, WP_COM, CacheMode.Top(1))
 
         assertThat(model.followers.size).isEqualTo(1)
         assertThat(model.followers.first().label).isEqualTo(FOLLOWER_RESPONSE.label)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -276,7 +276,8 @@ class InsightsRestClientTest {
         initFollowersResponse(FOLLOWERS_RESPONSE)
 
         val pageSize = 10
-        val responseModel = insightsRestClient.fetchFollowers(site, followerType, pageSize, false)
+        val page = 1
+        val responseModel = insightsRestClient.fetchFollowers(site, followerType, page, pageSize, false)
 
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(FOLLOWERS_RESPONSE)
@@ -285,7 +286,8 @@ class InsightsRestClientTest {
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
                         "max" to "$pageSize",
-                        "type" to path
+                        "type" to path,
+                        "page" to "$page"
                 )
         )
     }
@@ -303,7 +305,7 @@ class InsightsRestClientTest {
                 )
         )
 
-        val responseModel = insightsRestClient.fetchFollowers(site, WP_COM, 10, false)
+        val responseModel = insightsRestClient.fetchFollowers(site, WP_COM, 1,10, false)
 
         assertThat(responseModel.error).isNotNull()
         assertThat(responseModel.error.type).isEqualTo(API_ERROR)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -305,7 +305,7 @@ class InsightsRestClientTest {
                 )
         )
 
-        val responseModel = insightsRestClient.fetchFollowers(site, WP_COM, 1,10, false)
+        val responseModel = insightsRestClient.fetchFollowers(site, WP_COM, 1, 10, false)
 
         assertThat(responseModel.error).isNotNull()
         assertThat(responseModel.error.type).isEqualTo(API_ERROR)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -286,8 +286,7 @@ class InsightsRestClientTest {
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
                         "max" to "$pageSize",
-                        "type" to path,
-                        "page" to "$page"
+                        "type" to path
                 )
         )
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/InsightsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/InsightsSqlUtilsTest.kt
@@ -68,7 +68,7 @@ class InsightsSqlUtilsTest {
     fun `inserts all time response to stats utils`() {
         insightsSqlUtils.insert(site, ALL_TIME_RESPONSE)
 
-        verify(statsSqlUtils).insert(site, ALL_TIME_INSIGHTS, INSIGHTS, ALL_TIME_RESPONSE)
+        verify(statsSqlUtils).insert(site, ALL_TIME_INSIGHTS, INSIGHTS, ALL_TIME_RESPONSE, true)
     }
 
     @Test
@@ -87,7 +87,7 @@ class InsightsSqlUtilsTest {
     fun `inserts most popular response to stats utils`() {
         insightsSqlUtils.insert(site, MOST_POPULAR_RESPONSE)
 
-        verify(statsSqlUtils).insert(site, MOST_POPULAR_INSIGHTS, INSIGHTS, MOST_POPULAR_RESPONSE)
+        verify(statsSqlUtils).insert(site, MOST_POPULAR_INSIGHTS, INSIGHTS, MOST_POPULAR_RESPONSE, true)
     }
 
     @Test
@@ -106,7 +106,7 @@ class InsightsSqlUtilsTest {
     fun `inserts latest post detail response to stats utils`() {
         insightsSqlUtils.insert(site, LATEST_POST)
 
-        verify(statsSqlUtils).insert(site, LATEST_POST_DETAIL_INSIGHTS, INSIGHTS, LATEST_POST)
+        verify(statsSqlUtils).insert(site, LATEST_POST_DETAIL_INSIGHTS, INSIGHTS, LATEST_POST, true)
     }
 
     @Test
@@ -131,7 +131,7 @@ class InsightsSqlUtilsTest {
     fun `inserts latest post views response to stats utils`() {
         insightsSqlUtils.insert(site, POST_STATS_RESPONSE)
 
-        verify(statsSqlUtils).insert(site, LATEST_POST_STATS_INSIGHTS, INSIGHTS, POST_STATS_RESPONSE)
+        verify(statsSqlUtils).insert(site, LATEST_POST_STATS_INSIGHTS, INSIGHTS, POST_STATS_RESPONSE, true)
     }
 
     @Test
@@ -166,16 +166,16 @@ class InsightsSqlUtilsTest {
 
     @Test
     fun `inserts WPCOM followers response to stats utils`() {
-        insightsSqlUtils.insert(site, FOLLOWERS_RESPONSE, WP_COM)
+        insightsSqlUtils.insert(site, FOLLOWERS_RESPONSE, WP_COM, true)
 
-        verify(statsSqlUtils).insert(site, WP_COM_FOLLOWERS, INSIGHTS, FOLLOWERS_RESPONSE)
+        verify(statsSqlUtils).insert(site, WP_COM_FOLLOWERS, INSIGHTS, FOLLOWERS_RESPONSE, true)
     }
 
     @Test
     fun `inserts email followers response to stats utils`() {
-        insightsSqlUtils.insert(site, FOLLOWERS_RESPONSE, EMAIL)
+        insightsSqlUtils.insert(site, FOLLOWERS_RESPONSE, EMAIL, true)
 
-        verify(statsSqlUtils).insert(site, EMAIL_FOLLOWERS, INSIGHTS, FOLLOWERS_RESPONSE)
+        verify(statsSqlUtils).insert(site, EMAIL_FOLLOWERS, INSIGHTS, FOLLOWERS_RESPONSE, true)
     }
 
     @Test
@@ -200,7 +200,7 @@ class InsightsSqlUtilsTest {
     fun `inserts comments response to stats utils`() {
         insightsSqlUtils.insert(site, TOP_COMMENTS_RESPONSE)
 
-        verify(statsSqlUtils).insert(site, COMMENTS_INSIGHTS, INSIGHTS, TOP_COMMENTS_RESPONSE)
+        verify(statsSqlUtils).insert(site, COMMENTS_INSIGHTS, INSIGHTS, TOP_COMMENTS_RESPONSE, true)
     }
 
     @Test
@@ -225,7 +225,7 @@ class InsightsSqlUtilsTest {
     fun `inserts tags response to stats utils`() {
         insightsSqlUtils.insert(site, TAGS_RESPONSE)
 
-        verify(statsSqlUtils).insert(site, TAGS_AND_CATEGORIES_INSIGHTS, INSIGHTS, TAGS_RESPONSE)
+        verify(statsSqlUtils).insert(site, TAGS_AND_CATEGORIES_INSIGHTS, INSIGHTS, TAGS_RESPONSE, true)
     }
 
     @Test
@@ -250,6 +250,6 @@ class InsightsSqlUtilsTest {
     fun `inserts publicize response to stats utils`() {
         insightsSqlUtils.insert(site, PUBLICIZE_RESPONSE)
 
-        verify(statsSqlUtils).insert(site, PUBLICIZE_INSIGHTS, INSIGHTS, PUBLICIZE_RESPONSE)
+        verify(statsSqlUtils).insert(site, PUBLICIZE_INSIGHTS, INSIGHTS, PUBLICIZE_RESPONSE, true)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/AuthorsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/AuthorsSqlUtilsTest.kt
@@ -63,7 +63,7 @@ class AuthorsSqlUtilsTest {
         mappedTypes.forEach { statsType, dbGranularity ->
             timeStatsSqlUtils.insert(site, AUTHORS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, AUTHORS, statsType, AUTHORS_RESPONSE, STRING_DATE)
+            verify(statsSqlUtils).insert(site, AUTHORS, statsType, AUTHORS_RESPONSE, true, STRING_DATE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ClicksSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ClicksSqlUtilsTest.kt
@@ -63,7 +63,7 @@ class ClicksSqlUtilsTest {
         mappedTypes.forEach { statsType, dbGranularity ->
             timeStatsSqlUtils.insert(site, CLICKS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, CLICKS, statsType, CLICKS_RESPONSE, DATE_VALUE)
+            verify(statsSqlUtils).insert(site, CLICKS, statsType, CLICKS_RESPONSE, true, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/CountryViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/CountryViewsSqlUtilsTest.kt
@@ -63,7 +63,7 @@ class CountryViewsSqlUtilsTest {
         mappedTypes.forEach { statsType, dbGranularity ->
             timeStatsSqlUtils.insert(site, COUNTRY_VIEWS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, COUNTRY_VIEWS, statsType, COUNTRY_VIEWS_RESPONSE, DATE_VALUE)
+            verify(statsSqlUtils).insert(site, COUNTRY_VIEWS, statsType, COUNTRY_VIEWS_RESPONSE, true, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/PostAndPageViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/PostAndPageViewsSqlUtilsTest.kt
@@ -72,7 +72,8 @@ class PostAndPageViewsSqlUtilsTest {
                 DAY_POST_AND_PAGE_VIEWS_RESPONSE, DAYS, DATE
         )
 
-        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, DAY, DAY_POST_AND_PAGE_VIEWS_RESPONSE, DATE_VALUE)
+        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, DAY, DAY_POST_AND_PAGE_VIEWS_RESPONSE,
+                true, DATE_VALUE)
     }
 
     @Test
@@ -102,7 +103,8 @@ class PostAndPageViewsSqlUtilsTest {
                 WEEK_POST_AND_PAGE_VIEWS_RESPONSE, WEEKS, DATE
         )
 
-        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, WEEK, WEEK_POST_AND_PAGE_VIEWS_RESPONSE, DATE_VALUE)
+        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, WEEK, WEEK_POST_AND_PAGE_VIEWS_RESPONSE,
+                true, DATE_VALUE)
     }
 
     @Test
@@ -132,7 +134,8 @@ class PostAndPageViewsSqlUtilsTest {
                 MONTH_POST_AND_PAGE_VIEWS_RESPONSE, MONTHS, DATE
         )
 
-        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, MONTH, MONTH_POST_AND_PAGE_VIEWS_RESPONSE, DATE_VALUE)
+        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, MONTH, MONTH_POST_AND_PAGE_VIEWS_RESPONSE,
+                true, DATE_VALUE)
     }
 
     @Test
@@ -162,6 +165,7 @@ class PostAndPageViewsSqlUtilsTest {
                 YEAR_POST_AND_PAGE_VIEWS_RESPONSE, YEARS, DATE
         )
 
-        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, YEAR, YEAR_POST_AND_PAGE_VIEWS_RESPONSE, DATE_VALUE)
+        verify(statsSqlUtils).insert(site, POSTS_AND_PAGES_VIEWS, YEAR, YEAR_POST_AND_PAGE_VIEWS_RESPONSE,
+                true, DATE_VALUE)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ReferrersSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/ReferrersSqlUtilsTest.kt
@@ -63,7 +63,8 @@ class ReferrersSqlUtilsTest {
         mappedTypes.forEach { statsType, dbGranularity ->
             timeStatsSqlUtils.insert(site, REFERRERS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, REFERRERS, statsType, REFERRERS_RESPONSE, DATE_VALUE)
+            verify(statsSqlUtils).insert(site, REFERRERS, statsType, REFERRERS_RESPONSE,
+                    true, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/SearchTermsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/SearchTermsSqlUtilsTest.kt
@@ -63,7 +63,8 @@ class SearchTermsSqlUtilsTest {
         mappedTypes.forEach { statsType, dbGranularity ->
             timeStatsSqlUtils.insert(site, SEARCH_TERMS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, SEARCH_TERMS, statsType, SEARCH_TERMS_RESPONSE, DATE_VALUE)
+            verify(statsSqlUtils).insert(site, SEARCH_TERMS, statsType, SEARCH_TERMS_RESPONSE,
+                    true, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VideoPlaysSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VideoPlaysSqlUtilsTest.kt
@@ -63,7 +63,8 @@ class VideoPlaysSqlUtilsTest {
         mappedTypes.forEach { statsType, dbGranularity ->
             timeStatsSqlUtils.insert(site, VIDEO_PLAYS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, VIDEO_PLAYS, statsType, VIDEO_PLAYS_RESPONSE, DATE_VALUE)
+            verify(statsSqlUtils).insert(site, VIDEO_PLAYS, statsType, VIDEO_PLAYS_RESPONSE,
+                    true, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VisitAndViewsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/time/VisitAndViewsSqlUtilsTest.kt
@@ -71,7 +71,8 @@ class VisitAndViewsSqlUtilsTest {
         mappedTypes.forEach { statsType, dbGranularity ->
             timeStatsSqlUtils.insert(site, VISITS_AND_VIEWS_RESPONSE, dbGranularity, DATE)
 
-            verify(statsSqlUtils).insert(site, VISITS_AND_VIEWS, statsType, VISITS_AND_VIEWS_RESPONSE, DATE_VALUE)
+            verify(statsSqlUtils).insert(site, VISITS_AND_VIEWS, statsType, VISITS_AND_VIEWS_RESPONSE,
+                    true, DATE_VALUE)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsFixtures.kt
@@ -99,7 +99,18 @@ val FOLLOWER_RESPONSE = FollowerResponse(
         DATE,
         FollowData("type", PARAMS)
 )
+val FOLLOWER_RESPONSE_2 = FollowerResponse(
+        "Two",
+        AVATAR,
+        URL,
+        DATE,
+        FollowData("type", PARAMS)
+)
 val FOLLOWERS_RESPONSE = FollowersResponse(0, 10, 100, 70, 30, listOf(FOLLOWER_RESPONSE))
+val VIEW_ALL_FOLLOWERS_RESPONSE = listOf(
+        FollowersResponse(0, 10, 100, 70, 30, listOf(FOLLOWER_RESPONSE)),
+        FollowersResponse(0, 10, 100, 70, 30, listOf(FOLLOWER_RESPONSE_2)))
+
 val AUTHOR = CommentsResponse.Author(
         USER_LABEL,
         URL,

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -301,8 +301,9 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
-        whenever(mapper.mergeFollowersModels(sqlUtils, site, WP_COM, LOAD_MODE_INITIAL)).thenReturn(model)
-        val responseModel = store.fetchWpComFollowers(site, forced, LOAD_MODE_INITIAL)
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, LOAD_MODE_INITIAL))
+                .thenReturn(model)
+        val responseModel = store.fetchWpComFollowers(site, LOAD_MODE_INITIAL, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, WP_COM, true)
@@ -318,8 +319,9 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
-        whenever(mapper.mergeFollowersModels(sqlUtils, site, EMAIL, LOAD_MODE_INITIAL)).thenReturn(model)
-        val responseModel = store.fetchEmailFollowers(site, forced, LOAD_MODE_INITIAL)
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, LOAD_MODE_INITIAL))
+                .thenReturn(model)
+        val responseModel = store.fetchEmailFollowers(site, LOAD_MODE_INITIAL, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, EMAIL, true)
@@ -329,7 +331,9 @@ class InsightsStoreTest {
     fun `returns WPCOM followers from db`() {
         whenever(sqlUtils.selectFollowers(site, WP_COM)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, WP_COM, LOAD_MODE_INITIAL)).thenReturn(model)
+        whenever(sqlUtils.selectAllFollowers(site, WP_COM)).thenReturn(listOf(FOLLOWERS_RESPONSE))
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, LOAD_MODE_INITIAL))
+                .thenReturn(model)
 
         val result = store.getWpComFollowers(site, LOAD_MODE_INITIAL)
 
@@ -340,7 +344,8 @@ class InsightsStoreTest {
     fun `returns email followers from db`() {
         whenever(sqlUtils.selectFollowers(site, EMAIL)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, EMAIL, LOAD_MODE_INITIAL)).thenReturn(model)
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, LOAD_MODE_INITIAL))
+                .thenReturn(model)
 
         val result = store.getEmailFollowers(site, LOAD_MODE_INITIAL)
 
@@ -355,7 +360,7 @@ class InsightsStoreTest {
         val forced = true
         whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchWpComFollowers(site, forced, LOAD_MODE_INITIAL)
+        val responseModel = store.fetchWpComFollowers(site, LOAD_MODE_INITIAL, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -371,7 +376,7 @@ class InsightsStoreTest {
         val forced = true
         whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchEmailFollowers(site, forced, LOAD_MODE_INITIAL)
+        val responseModel = store.fetchEmailFollowers(site, LOAD_MODE_INITIAL, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -36,7 +36,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.T
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.VisitResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
-import org.wordpress.android.fluxc.store.InsightsStore
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -46,6 +46,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 private const val PAGE_SIZE = 8
+private const val PAGE = 1
 
 @RunWith(MockitoJUnitRunner::class)
 class InsightsStoreTest {
@@ -294,7 +295,7 @@ class InsightsStoreTest {
                 FOLLOWERS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<FollowersModel>()
@@ -303,7 +304,7 @@ class InsightsStoreTest {
         val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, WP_COM)
+        verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, WP_COM, true)
     }
 
     @Test
@@ -312,7 +313,7 @@ class InsightsStoreTest {
                 FOLLOWERS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<FollowersModel>()
@@ -321,7 +322,7 @@ class InsightsStoreTest {
         val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, EMAIL)
+        verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, EMAIL, true)
     }
 
     @Test
@@ -352,7 +353,7 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<FollowersResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
         val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
 
@@ -368,7 +369,7 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<FollowersResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE,PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
         val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -298,9 +298,7 @@ class InsightsStoreTest {
         whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE, forced)).thenReturn(
                 fetchInsightsPayload
         )
-        val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, WP_COM, PAGE_SIZE)).thenReturn(model)
-
+        val model = FollowersModel(0, emptyList(), false)
         val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
@@ -316,9 +314,7 @@ class InsightsStoreTest {
         whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE, forced)).thenReturn(
                 fetchInsightsPayload
         )
-        val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, EMAIL, PAGE_SIZE)).thenReturn(model)
-
+        val model = FollowersModel(0, emptyList(), false)
         val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -299,6 +299,7 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
+        whenever(mapper.mergeFollowersModels(sqlUtils, site, WP_COM, PAGE_SIZE)).thenReturn(model)
         val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
@@ -315,6 +316,7 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
+        whenever(mapper.mergeFollowersModels(sqlUtils, site, EMAIL, PAGE_SIZE)).thenReturn(model)
         val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.InsightsMostPopularModel
+import org.wordpress.android.fluxc.model.stats.LoadMode
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
 import org.wordpress.android.fluxc.model.stats.TagsModel
 import org.wordpress.android.fluxc.model.stats.VisitsModel
@@ -47,6 +48,7 @@ import kotlin.test.assertNotNull
 
 private const val PAGE_SIZE = 8
 private const val PAGE = 1
+private val LOAD_MODE_INITIAL = LoadMode.Paged(PAGE_SIZE, false)
 
 @RunWith(MockitoJUnitRunner::class)
 class InsightsStoreTest {
@@ -299,8 +301,8 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
-        whenever(mapper.mergeFollowersModels(sqlUtils, site, WP_COM, PAGE_SIZE)).thenReturn(model)
-        val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
+        whenever(mapper.mergeFollowersModels(sqlUtils, site, WP_COM, LOAD_MODE_INITIAL)).thenReturn(model)
+        val responseModel = store.fetchWpComFollowers(site, forced, LOAD_MODE_INITIAL)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, WP_COM, true)
@@ -316,8 +318,8 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
-        whenever(mapper.mergeFollowersModels(sqlUtils, site, EMAIL, PAGE_SIZE)).thenReturn(model)
-        val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
+        whenever(mapper.mergeFollowersModels(sqlUtils, site, EMAIL, LOAD_MODE_INITIAL)).thenReturn(model)
+        val responseModel = store.fetchEmailFollowers(site, forced, LOAD_MODE_INITIAL)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, EMAIL, true)
@@ -327,9 +329,9 @@ class InsightsStoreTest {
     fun `returns WPCOM followers from db`() {
         whenever(sqlUtils.selectFollowers(site, WP_COM)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, WP_COM, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(FOLLOWERS_RESPONSE, WP_COM, LOAD_MODE_INITIAL)).thenReturn(model)
 
-        val result = store.getWpComFollowers(site, PAGE_SIZE)
+        val result = store.getWpComFollowers(site, LOAD_MODE_INITIAL)
 
         assertThat(result).isEqualTo(model)
     }
@@ -338,9 +340,9 @@ class InsightsStoreTest {
     fun `returns email followers from db`() {
         whenever(sqlUtils.selectFollowers(site, EMAIL)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
-        whenever(mapper.map(FOLLOWERS_RESPONSE, EMAIL, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(FOLLOWERS_RESPONSE, EMAIL, LOAD_MODE_INITIAL)).thenReturn(model)
 
-        val result = store.getEmailFollowers(site, PAGE_SIZE)
+        val result = store.getEmailFollowers(site, LOAD_MODE_INITIAL)
 
         assertThat(result).isEqualTo(model)
     }
@@ -353,7 +355,7 @@ class InsightsStoreTest {
         val forced = true
         whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
+        val responseModel = store.fetchWpComFollowers(site, forced, LOAD_MODE_INITIAL)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -369,7 +371,7 @@ class InsightsStoreTest {
         val forced = true
         whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
+        val responseModel = store.fetchEmailFollowers(site, forced, LOAD_MODE_INITIAL)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -295,7 +295,7 @@ class InsightsStoreTest {
                 FOLLOWERS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<FollowersModel>()
@@ -313,7 +313,7 @@ class InsightsStoreTest {
                 FOLLOWERS_RESPONSE
         )
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<FollowersModel>()
@@ -353,7 +353,7 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<FollowersResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchFollowers(site, WP_COM, PAGE, PAGE_SIZE, forced)).thenReturn(errorPayload)
 
         val responseModel = store.fetchWpComFollowers(site, PAGE_SIZE, forced)
 
@@ -369,7 +369,7 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<FollowersResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE, forced)).thenReturn(errorPayload)
 
         val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -333,10 +333,9 @@ class InsightsStoreTest {
 
     @Test
     fun `returns WPCOM followers from db`() {
-        whenever(sqlUtils.selectFollowers(site, WP_COM)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
         whenever(sqlUtils.selectAllFollowers(site, WP_COM)).thenReturn(listOf(FOLLOWERS_RESPONSE))
-        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, CacheMode.All))
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, CacheMode.Top(PAGE_SIZE)))
                 .thenReturn(model)
 
         val result = store.getWpComFollowers(site, CACHE_MODE_TOP)
@@ -346,10 +345,9 @@ class InsightsStoreTest {
 
     @Test
     fun `returns email followers from db`() {
-        whenever(sqlUtils.selectFollowers(site, EMAIL)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
         whenever(sqlUtils.selectAllFollowers(site, EMAIL)).thenReturn(listOf(FOLLOWERS_RESPONSE))
-        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, CacheMode.All))
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, CacheMode.Top(PAGE_SIZE)))
                 .thenReturn(model)
 
         val result = store.getEmailFollowers(site, CACHE_MODE_TOP)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -11,13 +11,14 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.CacheMode
 import org.wordpress.android.fluxc.model.stats.CommentsModel
 import org.wordpress.android.fluxc.model.stats.FollowersModel
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.InsightsMostPopularModel
-import org.wordpress.android.fluxc.model.stats.LoadMode
+import org.wordpress.android.fluxc.model.stats.FetchMode
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
 import org.wordpress.android.fluxc.model.stats.TagsModel
 import org.wordpress.android.fluxc.model.stats.VisitsModel
@@ -48,7 +49,8 @@ import kotlin.test.assertNotNull
 
 private const val PAGE_SIZE = 8
 private const val PAGE = 1
-private val LOAD_MODE_INITIAL = LoadMode.Paged(PAGE_SIZE, false)
+private val LOAD_MODE_INITIAL = FetchMode.Paged(PAGE_SIZE, false)
+private val CACHE_MODE_TOP = CacheMode.Top(PAGE_SIZE)
 
 @RunWith(MockitoJUnitRunner::class)
 class InsightsStoreTest {
@@ -302,7 +304,7 @@ class InsightsStoreTest {
         )
         val model = FollowersModel(0, emptyList(), false)
         whenever(sqlUtils.selectAllFollowers(site, WP_COM)).thenReturn(listOf(FOLLOWERS_RESPONSE))
-        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, LOAD_MODE_INITIAL))
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, CacheMode.All))
                 .thenReturn(model)
         val responseModel = store.fetchWpComFollowers(site, LOAD_MODE_INITIAL, forced)
 
@@ -321,7 +323,7 @@ class InsightsStoreTest {
         )
         val model = FollowersModel(0, emptyList(), false)
         whenever(sqlUtils.selectAllFollowers(site, EMAIL)).thenReturn(listOf(FOLLOWERS_RESPONSE))
-        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, LOAD_MODE_INITIAL))
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, CacheMode.All))
                 .thenReturn(model)
         val responseModel = store.fetchEmailFollowers(site, LOAD_MODE_INITIAL, forced)
 
@@ -334,10 +336,10 @@ class InsightsStoreTest {
         whenever(sqlUtils.selectFollowers(site, WP_COM)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
         whenever(sqlUtils.selectAllFollowers(site, WP_COM)).thenReturn(listOf(FOLLOWERS_RESPONSE))
-        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, LOAD_MODE_INITIAL))
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, CacheMode.All))
                 .thenReturn(model)
 
-        val result = store.getWpComFollowers(site, LOAD_MODE_INITIAL)
+        val result = store.getWpComFollowers(site, CACHE_MODE_TOP)
 
         assertThat(result).isEqualTo(model)
     }
@@ -347,10 +349,10 @@ class InsightsStoreTest {
         whenever(sqlUtils.selectFollowers(site, EMAIL)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
         whenever(sqlUtils.selectAllFollowers(site, EMAIL)).thenReturn(listOf(FOLLOWERS_RESPONSE))
-        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, LOAD_MODE_INITIAL))
+        whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, CacheMode.All))
                 .thenReturn(model)
 
-        val result = store.getEmailFollowers(site, LOAD_MODE_INITIAL)
+        val result = store.getEmailFollowers(site, CACHE_MODE_TOP)
 
         assertThat(result).isEqualTo(model)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -369,7 +369,7 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<FollowersResponse>(StatsError(type, message))
         val forced = true
-        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE,PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(insightsRestClient.fetchFollowers(site, EMAIL, PAGE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
 
         val responseModel = store.fetchEmailFollowers(site, PAGE_SIZE, forced)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -301,6 +301,7 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
+        whenever(sqlUtils.selectAllFollowers(site, WP_COM)).thenReturn(listOf(FOLLOWERS_RESPONSE))
         whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, LOAD_MODE_INITIAL))
                 .thenReturn(model)
         val responseModel = store.fetchWpComFollowers(site, LOAD_MODE_INITIAL, forced)
@@ -319,6 +320,7 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
+        whenever(sqlUtils.selectAllFollowers(site, EMAIL)).thenReturn(listOf(FOLLOWERS_RESPONSE))
         whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, LOAD_MODE_INITIAL))
                 .thenReturn(model)
         val responseModel = store.fetchEmailFollowers(site, LOAD_MODE_INITIAL, forced)
@@ -344,6 +346,7 @@ class InsightsStoreTest {
     fun `returns email followers from db`() {
         whenever(sqlUtils.selectFollowers(site, EMAIL)).thenReturn(FOLLOWERS_RESPONSE)
         val model = mock<FollowersModel>()
+        whenever(sqlUtils.selectAllFollowers(site, EMAIL)).thenReturn(listOf(FOLLOWERS_RESPONSE))
         whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, LOAD_MODE_INITIAL))
                 .thenReturn(model)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.model.stats
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.FollowersModel.FollowerModel
-import org.wordpress.android.fluxc.model.stats.LoadMode.Paged
 import org.wordpress.android.fluxc.model.stats.TagsModel.TagModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.AllTimeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.CommentsResponse
@@ -132,7 +131,7 @@ class InsightsMapper
     fun mapAndMergeFollowersModels(
         followerResponses: List<FollowersResponse>,
         followerType: FollowerType,
-        loadMode: LoadMode
+        cacheMode: CacheMode
     ): FollowersModel {
         return followerResponses.fold(FollowersModel(0, emptyList(), false)) { accumulator, next ->
                 val nextModel = map(next, followerType)
@@ -143,8 +142,8 @@ class InsightsMapper
                 )
             }
             .apply {
-                if (loadMode is Paged) {
-                    return copy(followers = followers.take(loadMode.pageSize))
+                if (cacheMode is CacheMode.Top) {
+                    return copy(followers = followers.take(cacheMode.limit))
                 }
             }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -120,7 +120,12 @@ class InsightsMapper
             WP_COM -> response.totalWpCom
             EMAIL -> response.totalEmail
         }
-        return FollowersModel(total ?: 0, followers, response.subscribers.size > pageSize)
+        val hasMore = if (response.page != null && response.pages != null) {
+            response.page < response.pages
+        } else {
+            false
+        }
+        return FollowersModel(total ?: 0, followers, hasMore)
     }
 
     fun map(response: CommentsResponse, pageSize: Int): CommentsModel {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -141,9 +141,11 @@ class InsightsMapper
                         hasMore = nextModel.hasMore
                 )
             }
-            .apply {
+            .let {
                 if (cacheMode is CacheMode.Top) {
-                    return copy(followers = followers.take(cacheMode.limit))
+                    return@let it.copy(followers = it.followers.take(cacheMode.limit))
+                } else {
+                    return@let it
                 }
             }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -102,7 +102,7 @@ class InsightsMapper
         )
     }
 
-    fun map(response: FollowersResponse, followerType: FollowerType, pageSize: Int, page: Int): FollowersModel {
+    fun map(response: FollowersResponse, followerType: FollowerType, pageSize: Int): FollowersModel {
         val followers = response.subscribers.mapNotNull {
             if (it.avatar != null && it.label != null && it.dateSubscribed != null) {
                 FollowerModel(
@@ -115,7 +115,7 @@ class InsightsMapper
                 AppLog.e(STATS, "CommentsResponse.posts: Non-null field is coming as null from API")
                 null
             }
-        }.drop((page - 1) * pageSize).take(pageSize)
+        }.take(pageSize)
         val total = when (followerType) {
             WP_COM -> response.totalWpCom
             EMAIL -> response.totalEmail
@@ -123,8 +123,8 @@ class InsightsMapper
         return FollowersModel(total ?: 0, followers, response.subscribers.size > pageSize)
     }
 
-    fun map(response: CommentsResponse, pageSize: Int, page: Int): CommentsModel {
-        val authors = response.authors?.drop((page - 1) * pageSize)?.take(pageSize)?.mapNotNull {
+    fun map(response: CommentsResponse, pageSize: Int): CommentsModel {
+        val authors = response.authors?.take(pageSize)?.mapNotNull {
             if (it.name != null && it.comments != null && it.link != null && it.gravatar != null) {
                 CommentsModel.Author(it.name, it.comments, it.link, it.gravatar)
             } else {
@@ -132,7 +132,7 @@ class InsightsMapper
                 null
             }
         }
-        val posts = response.posts?.drop((page - 1) * pageSize)?.take(pageSize)?.mapNotNull {
+        val posts = response.posts?.take(pageSize)?.mapNotNull {
             if (it.id != null && it.name != null && it.comments != null && it.link != null) {
                 CommentsModel.Post(it.id, it.name, it.comments, it.link)
             } else {
@@ -145,8 +145,8 @@ class InsightsMapper
         return CommentsModel(posts ?: listOf(), authors ?: listOf(), hasMorePosts, hasMoreAuthors)
     }
 
-    fun map(response: TagsResponse, pageSize: Int, page: Int): TagsModel {
-        return TagsModel(response.tags.drop((page - 1) * pageSize).take(pageSize).map { tag ->
+    fun map(response: TagsResponse, pageSize: Int): TagsModel {
+        return TagsModel(response.tags.take(pageSize).map { tag ->
             TagModel(tag.tags.mapNotNull { it.toItem() }.take(pageSize), tag.views ?: 0)
         }, response.tags.size > pageSize)
     }
@@ -160,13 +160,10 @@ class InsightsMapper
         }
     }
 
-    fun map(response: PublicizeResponse, pageSize: Int, page: Int): PublicizeModel {
+    fun map(response: PublicizeResponse, pageSize: Int): PublicizeModel {
         return PublicizeModel(
-                response.services.drop((page - 1) * pageSize).take(pageSize)
-                        .map {
-                            PublicizeModel.Service(it.service, it.followers)
-                        }
-                ,response.services.size > pageSize
+                response.services.take(pageSize).map { PublicizeModel.Service(it.service, it.followers) },
+                response.services.size > pageSize
         )
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -144,7 +144,7 @@ class InsightsMapper
             }
             .apply {
                 if (loadMode is Paged) {
-                    copy(followers = followers.take(loadMode.pageSize))
+                    return copy(followers = followers.take(loadMode.pageSize))
                 }
             }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/LoadMode.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/LoadMode.kt
@@ -1,7 +1,8 @@
 package org.wordpress.android.fluxc.model.stats
 
-enum class LoadMode {
-    INITIAL,
-    MORE,
-    ALL
+const val ALL_PAGE_SIZE = 100
+
+sealed class LoadMode(open val pageSize: Int) {
+    class Paged(pageSize: Int, val loadMore: Boolean = false) : LoadMode(pageSize)
+    object All : LoadMode(ALL_PAGE_SIZE)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/LoadMode.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/LoadMode.kt
@@ -1,8 +1,12 @@
 package org.wordpress.android.fluxc.model.stats
 
-const val ALL_PAGE_SIZE = 100
+sealed class FetchMode {
+    data class Paged(val pageSize: Int, val loadMore: Boolean = false) : FetchMode()
+    data class Top(val limit: Int) : FetchMode()
+    object All : FetchMode()
+}
 
-sealed class LoadMode(open val pageSize: Int) {
-    data class Paged(override val pageSize: Int, val loadMore: Boolean = false) : LoadMode(pageSize)
-    object All : LoadMode(ALL_PAGE_SIZE)
+sealed class CacheMode {
+    data class Top(val limit: Int) : CacheMode()
+    object All : CacheMode()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/LoadMode.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/LoadMode.kt
@@ -3,6 +3,6 @@ package org.wordpress.android.fluxc.model.stats
 const val ALL_PAGE_SIZE = 100
 
 sealed class LoadMode(open val pageSize: Int) {
-    class Paged(pageSize: Int, val loadMore: Boolean = false) : LoadMode(pageSize)
+    data class Paged(override val pageSize: Int, val loadMore: Boolean = false) : LoadMode(pageSize)
     object All : LoadMode(ALL_PAGE_SIZE)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/LoadMode.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/LoadMode.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.fluxc.model.stats
+
+enum class LoadMode {
+    INITIAL,
+    MORE,
+    ALL
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -21,9 +21,9 @@ import javax.inject.Inject
 
 class TimeStatsMapper
 @Inject constructor(val gson: Gson) {
-    fun map(response: PostAndPageViewsResponse, pageSize: Int): PostAndPageViewsModel {
+    fun map(response: PostAndPageViewsResponse, pageSize: Int, page: Int): PostAndPageViewsModel {
         val postViews = response.days.entries.firstOrNull()?.value?.postViews ?: listOf()
-        val stats = postViews.take(pageSize).mapNotNull { item ->
+        val stats = postViews.drop((page - 1) * pageSize).take(pageSize).mapNotNull { item ->
             val type = when (item.type) {
                 "post" -> ViewsType.POST
                 "page" -> ViewsType.PAGE
@@ -43,10 +43,10 @@ class TimeStatsMapper
         return PostAndPageViewsModel(stats, postViews.size > pageSize)
     }
 
-    fun map(response: ReferrersResponse, pageSize: Int): ReferrersModel {
+    fun map(response: ReferrersResponse, pageSize: Int, page: Int): ReferrersModel {
         val first = response.groups.values.firstOrNull()
         val groups = first?.let {
-            first.groups.take(pageSize).map { group ->
+            first.groups.drop((page - 1) * pageSize).take(pageSize).map { group ->
                 val children = group.referrers?.mapNotNull { result ->
                     if (result.name != null && result.views != null) {
                         val firstChildUrl = result.children?.firstOrNull()?.url
@@ -70,10 +70,10 @@ class TimeStatsMapper
         return ReferrersModel(first?.otherViews ?: 0, first?.totalViews ?: 0, groups ?: listOf(), hasMore)
     }
 
-    fun map(response: ClicksResponse, pageSize: Int): ClicksModel {
+    fun map(response: ClicksResponse, pageSize: Int, page: Int): ClicksModel {
         val first = response.groups.values.firstOrNull()
         val groups = first?.let {
-            first.clicks.take(pageSize).map { group ->
+            first.clicks.drop((page - 1) * pageSize).take(pageSize).map { group ->
                 val children = group.clicks?.mapNotNull { result ->
                     if (result.name != null && result.views != null) {
                         Click(result.name, result.views, result.icon, result.url)
@@ -133,11 +133,11 @@ class TimeStatsMapper
         } ?: 0
     }
 
-    fun map(response: CountryViewsResponse, pageSize: Int): CountryViewsModel {
+    fun map(response: CountryViewsResponse, pageSize: Int, page: Int): CountryViewsModel {
         val first = response.days.values.firstOrNull()
         val countriesInfo = response.countryInfo
         val groups = first?.let {
-            first.views.take(pageSize).mapNotNull { countryViews ->
+            first.views.drop((page - 1) * pageSize).take(pageSize).mapNotNull { countryViews ->
                 val countryInfo = countriesInfo[countryViews.countryCode]
                 if (countryViews.countryCode != null && countryInfo != null && countryInfo.countryFull != null) {
                     CountryViewsModel.Country(
@@ -162,10 +162,10 @@ class TimeStatsMapper
         )
     }
 
-    fun map(response: AuthorsResponse, pageSize: Int): AuthorsModel {
+    fun map(response: AuthorsResponse, pageSize: Int, page: Int): AuthorsModel {
         val first = response.groups.values.firstOrNull()
         val authors = first?.let {
-            first.authors.take(pageSize).map { author ->
+            first.authors.drop((page - 1) * pageSize).take(pageSize).map { author ->
                 val posts = author.mappedPosts?.mapNotNull { result ->
                     if (result.postId != null && result.title != null) {
                         Post(result.postId, result.title, result.views ?: 0, result.url)
@@ -184,7 +184,7 @@ class TimeStatsMapper
         return AuthorsModel(first?.otherViews ?: 0, authors ?: listOf(), hasMore)
     }
 
-    fun map(response: SearchTermsResponse, pageSize: Int): SearchTermsModel {
+    fun map(response: SearchTermsResponse, pageSize: Int, page: Int): SearchTermsModel {
         val first = response.days.values.firstOrNull()
         val groups = first?.let {
             first.searchTerms.mapNotNull { searchTerm ->
@@ -194,7 +194,7 @@ class TimeStatsMapper
                     AppLog.e(STATS, "SearchTermsResponse: Missing term field on a Search terms object")
                     null
                 }
-            }.take(pageSize)
+            }.drop((page - 1) * pageSize).take(pageSize)
         }
         val hasMore = if (first != null && groups != null) first.searchTerms.size > groups.size else false
         return SearchTermsModel(
@@ -206,10 +206,10 @@ class TimeStatsMapper
         )
     }
 
-    fun map(response: VideoPlaysResponse, pageSize: Int): VideoPlaysModel {
+    fun map(response: VideoPlaysResponse, pageSize: Int, page: Int): VideoPlaysModel {
         val first = response.days.values.firstOrNull()
         val groups = first?.let {
-            first.plays.take(pageSize).mapNotNull { result ->
+            first.plays.drop((page - 1) * pageSize).take(pageSize).mapNotNull { result ->
                 if (result.postId != null && result.title != null) {
                     VideoPlaysModel.VideoPlays(result.postId, result.title, result.url, result.plays ?: 0)
                 } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -21,9 +21,9 @@ import javax.inject.Inject
 
 class TimeStatsMapper
 @Inject constructor(val gson: Gson) {
-    fun map(response: PostAndPageViewsResponse, pageSize: Int, page: Int): PostAndPageViewsModel {
+    fun map(response: PostAndPageViewsResponse, pageSize: Int): PostAndPageViewsModel {
         val postViews = response.days.entries.firstOrNull()?.value?.postViews ?: listOf()
-        val stats = postViews.drop((page - 1) * pageSize).take(pageSize).mapNotNull { item ->
+        val stats = postViews.take(pageSize).mapNotNull { item ->
             val type = when (item.type) {
                 "post" -> ViewsType.POST
                 "page" -> ViewsType.PAGE
@@ -43,10 +43,10 @@ class TimeStatsMapper
         return PostAndPageViewsModel(stats, postViews.size > pageSize)
     }
 
-    fun map(response: ReferrersResponse, pageSize: Int, page: Int): ReferrersModel {
+    fun map(response: ReferrersResponse, pageSize: Int): ReferrersModel {
         val first = response.groups.values.firstOrNull()
         val groups = first?.let {
-            first.groups.drop((page - 1) * pageSize).take(pageSize).map { group ->
+            first.groups.take(pageSize).map { group ->
                 val children = group.referrers?.mapNotNull { result ->
                     if (result.name != null && result.views != null) {
                         val firstChildUrl = result.children?.firstOrNull()?.url
@@ -70,10 +70,10 @@ class TimeStatsMapper
         return ReferrersModel(first?.otherViews ?: 0, first?.totalViews ?: 0, groups ?: listOf(), hasMore)
     }
 
-    fun map(response: ClicksResponse, pageSize: Int, page: Int): ClicksModel {
+    fun map(response: ClicksResponse, pageSize: Int): ClicksModel {
         val first = response.groups.values.firstOrNull()
         val groups = first?.let {
-            first.clicks.drop((page - 1) * pageSize).take(pageSize).map { group ->
+            first.clicks.take(pageSize).map { group ->
                 val children = group.clicks?.mapNotNull { result ->
                     if (result.name != null && result.views != null) {
                         Click(result.name, result.views, result.icon, result.url)
@@ -133,11 +133,11 @@ class TimeStatsMapper
         } ?: 0
     }
 
-    fun map(response: CountryViewsResponse, pageSize: Int, page: Int): CountryViewsModel {
+    fun map(response: CountryViewsResponse, pageSize: Int): CountryViewsModel {
         val first = response.days.values.firstOrNull()
         val countriesInfo = response.countryInfo
         val groups = first?.let {
-            first.views.drop((page - 1) * pageSize).take(pageSize).mapNotNull { countryViews ->
+            first.views.take(pageSize).mapNotNull { countryViews ->
                 val countryInfo = countriesInfo[countryViews.countryCode]
                 if (countryViews.countryCode != null && countryInfo != null && countryInfo.countryFull != null) {
                     CountryViewsModel.Country(
@@ -162,10 +162,10 @@ class TimeStatsMapper
         )
     }
 
-    fun map(response: AuthorsResponse, pageSize: Int, page: Int): AuthorsModel {
+    fun map(response: AuthorsResponse, pageSize: Int): AuthorsModel {
         val first = response.groups.values.firstOrNull()
         val authors = first?.let {
-            first.authors.drop((page - 1) * pageSize).take(pageSize).map { author ->
+            first.authors.take(pageSize).map { author ->
                 val posts = author.mappedPosts?.mapNotNull { result ->
                     if (result.postId != null && result.title != null) {
                         Post(result.postId, result.title, result.views ?: 0, result.url)
@@ -184,7 +184,7 @@ class TimeStatsMapper
         return AuthorsModel(first?.otherViews ?: 0, authors ?: listOf(), hasMore)
     }
 
-    fun map(response: SearchTermsResponse, pageSize: Int, page: Int): SearchTermsModel {
+    fun map(response: SearchTermsResponse, pageSize: Int): SearchTermsModel {
         val first = response.days.values.firstOrNull()
         val groups = first?.let {
             first.searchTerms.mapNotNull { searchTerm ->
@@ -194,7 +194,7 @@ class TimeStatsMapper
                     AppLog.e(STATS, "SearchTermsResponse: Missing term field on a Search terms object")
                     null
                 }
-            }.drop((page - 1) * pageSize).take(pageSize)
+            }.take(pageSize)
         }
         val hasMore = if (first != null && groups != null) first.searchTerms.size > groups.size else false
         return SearchTermsModel(
@@ -206,10 +206,10 @@ class TimeStatsMapper
         )
     }
 
-    fun map(response: VideoPlaysResponse, pageSize: Int, page: Int): VideoPlaysModel {
+    fun map(response: VideoPlaysResponse, pageSize: Int): VideoPlaysModel {
         val first = response.days.values.firstOrNull()
         val groups = first?.let {
-            first.plays.drop((page - 1) * pageSize).take(pageSize).mapNotNull { result ->
+            first.plays.take(pageSize).mapNotNull { result ->
                 if (result.postId != null && result.title != null) {
                     VideoPlaysModel.VideoPlays(result.postId, result.title, result.url, result.plays ?: 0)
                 } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClient.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
@@ -159,15 +160,21 @@ constructor(
     suspend fun fetchFollowers(
         site: SiteModel,
         type: FollowerType,
+        page: Int,
         pageSize: Int,
         forced: Boolean
     ): FetchStatsPayload<FollowersResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.followers.urlV1_1
 
-        val params = mapOf(
+        val params = mutableMapOf(
                 "type" to type.path,
                 "max" to pageSize.toString()
         )
+
+        if (page > 1) {
+            params["page"] = page.toString()
+        }
+
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,
                 url,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -51,8 +51,8 @@ class InsightsSqlUtils
         insert(site, TODAYS_INSIGHTS, data)
     }
 
-    fun insert(site: SiteModel, data: FollowersResponse, followerType: FollowerType, deleteOldDataFirst: Boolean) {
-        insert(site, followerType.toDbKey(), data, deleteOldDataFirst)
+    fun insert(site: SiteModel, data: FollowersResponse, followerType: FollowerType, replaceExistingData: Boolean) {
+        insert(site, followerType.toDbKey(), data, replaceExistingData)
     }
 
     fun insert(site: SiteModel, data: CommentsResponse) {
@@ -114,8 +114,8 @@ class InsightsSqlUtils
         return select(site, TAGS_AND_CATEGORIES_INSIGHTS, TagsResponse::class.java)
     }
 
-    private fun <T> insert(site: SiteModel, blockType: BlockType, data: T, deleteOldDataFirst: Boolean = true) {
-        statsSqlUtils.insert(site, blockType, INSIGHTS, data, deleteOldDataFirst)
+    private fun <T> insert(site: SiteModel, blockType: BlockType, data: T, replaceExistingData: Boolean = true) {
+        statsSqlUtils.insert(site, blockType, INSIGHTS, data, replaceExistingData)
     }
 
     private fun <T> select(site: SiteModel, blockType: BlockType, classOfT: Class<T>): T? {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -91,6 +91,10 @@ class InsightsSqlUtils
         return select(site, followerType.toDbKey(), FollowersResponse::class.java)
     }
 
+    fun selectAllFollowers(site: SiteModel, followerType: FollowerType): List<FollowersResponse> {
+        return selectAll(site, followerType.toDbKey(), FollowersResponse::class.java)
+    }
+
     fun selectPublicizeInsights(site: SiteModel): PublicizeResponse? {
         return select(site, PUBLICIZE_INSIGHTS, PublicizeResponse::class.java)
     }
@@ -116,5 +120,9 @@ class InsightsSqlUtils
 
     private fun <T> select(site: SiteModel, blockType: BlockType, classOfT: Class<T>): T? {
         return statsSqlUtils.select(site, blockType, INSIGHTS, classOfT)
+    }
+
+    private fun <T> selectAll(site: SiteModel, blockType: BlockType, classOfT: Class<T>): List<T> {
+        return statsSqlUtils.selectAll(site, blockType, INSIGHTS, classOfT)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -51,8 +51,8 @@ class InsightsSqlUtils
         insert(site, TODAYS_INSIGHTS, data)
     }
 
-    fun insert(site: SiteModel, data: FollowersResponse, followerType: FollowerType) {
-        insert(site, followerType.toDbKey(), data)
+    fun insert(site: SiteModel, data: FollowersResponse, followerType: FollowerType, deleteOldDataFirst: Boolean) {
+        insert(site, followerType.toDbKey(), data, deleteOldDataFirst)
     }
 
     fun insert(site: SiteModel, data: CommentsResponse) {
@@ -110,8 +110,8 @@ class InsightsSqlUtils
         return select(site, TAGS_AND_CATEGORIES_INSIGHTS, TagsResponse::class.java)
     }
 
-    private fun <T> insert(site: SiteModel, blockType: BlockType, data: T) {
-        statsSqlUtils.insert(site, blockType, INSIGHTS, data)
+    private fun <T> insert(site: SiteModel, blockType: BlockType, data: T, deleteOldDataFirst: Boolean = true) {
+        statsSqlUtils.insert(site, blockType, INSIGHTS, data, deleteOldDataFirst)
     }
 
     private fun <T> select(site: SiteModel, blockType: BlockType, classOfT: Class<T>): T? {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.wellsql.generated.StatsBlockTable
+import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
@@ -28,18 +29,19 @@ class StatsSqlUtils
         statsType: StatsType,
         item: T,
         replaceExistingData: Boolean,
-        date: String = ""
+        date: String? = null
     ) {
         val json = gson.toJson(item)
         if (replaceExistingData) {
-            WellSql.delete(StatsBlockBuilder::class.java)
+            var deleteStatement = WellSql.delete(StatsBlockBuilder::class.java)
                     .where()
                     .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
                     .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
                     .equals(StatsBlockTable.STATS_TYPE, statsType.name)
-                    .equals(StatsBlockTable.DATE, date)
-                    .endWhere()
-                    .execute()
+            if (date != null) {
+                deleteStatement = deleteStatement.equals(StatsBlockTable.DATE, date)
+            }
+            deleteStatement.endWhere().execute()
         }
         WellSql.insert(
                 StatsBlockBuilder(
@@ -58,15 +60,9 @@ class StatsSqlUtils
         blockType: BlockType,
         statsType: StatsType,
         classOfT: Class<T>,
-        date: String = ""
+        date: String? = null
     ): List<T> {
-        val models = WellSql.select(StatsBlockBuilder::class.java)
-                .where()
-                .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
-                .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
-                .equals(StatsBlockTable.STATS_TYPE, statsType.name)
-                .equals(StatsBlockTable.DATE, date)
-                .endWhere().asModel
+        val models = createSelectStatement(site, blockType, statsType, date).asModel
         return models.map { gson.fromJson(it.json, classOfT) }
     }
 
@@ -75,19 +71,30 @@ class StatsSqlUtils
         blockType: BlockType,
         statsType: StatsType,
         classOfT: Class<T>,
-        date: String = ""
+        date: String? = null
     ): T? {
-        val model = WellSql.select(StatsBlockBuilder::class.java)
-                .where()
-                .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
-                .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
-                .equals(StatsBlockTable.STATS_TYPE, statsType.name)
-                .equals(StatsBlockTable.DATE, date)
-                .endWhere().asModel.firstOrNull()
+        val model = createSelectStatement(site, blockType, statsType, date).asModel.firstOrNull()
         if (model != null) {
             return gson.fromJson(model.json, classOfT)
         }
         return null
+    }
+
+    private fun createSelectStatement(
+        site: SiteModel,
+        blockType: BlockType,
+        statsType: StatsType,
+        date: String?
+    ): SelectQuery<StatsBlockBuilder> {
+        var select = WellSql.select(StatsBlockBuilder::class.java)
+                .where()
+                .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
+                .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
+                .equals(StatsBlockTable.STATS_TYPE, statsType.name)
+        if (date != null) {
+            select = select.equals(StatsBlockTable.DATE, date)
+        }
+        return select.endWhere()
     }
 
     @Table(name = "StatsBlock")
@@ -96,10 +103,10 @@ class StatsSqlUtils
         @Column var localSiteId: Int,
         @Column var blockType: String,
         @Column var statsType: String,
-        @Column var date: String,
+        @Column var date: String?,
         @Column var json: String
     ) : Identifiable {
-        constructor() : this(-1, -1, "", "", "", "")
+        constructor() : this(-1, -1, "", "", null, "")
 
         override fun setId(id: Int) {
             this.mId = id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -22,15 +22,24 @@ class StatsSqlUtils
         builder.setDateFormat(DATE_FORMAT)
         builder.create()
     }
-    fun <T> insert(site: SiteModel, blockType: BlockType, statsType: StatsType, item: T, date: String = "") {
+    fun <T> insert(
+        site: SiteModel,
+        blockType: BlockType,
+        statsType: StatsType,
+        item: T,
+        deleteOldDataFirst: Boolean,
+        date: String = ""
+    ) {
         val json = gson.toJson(item)
-        WellSql.delete(StatsBlockBuilder::class.java)
-                .where()
-                .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
-                .equals(StatsBlockTable.STATS_TYPE, statsType.name)
-                .equals(StatsBlockTable.DATE, date)
-                .endWhere()
-                .execute()
+        if (deleteOldDataFirst) {
+            WellSql.delete(StatsBlockBuilder::class.java)
+                    .where()
+                    .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
+                    .equals(StatsBlockTable.STATS_TYPE, statsType.name)
+                    .equals(StatsBlockTable.DATE, date)
+                    .endWhere()
+                    .execute()
+        }
         WellSql.insert(
                 StatsBlockBuilder(
                         localSiteId = site.id,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -34,6 +34,7 @@ class StatsSqlUtils
         if (replaceExistingData) {
             WellSql.delete(StatsBlockBuilder::class.java)
                     .where()
+                    .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
                     .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
                     .equals(StatsBlockTable.STATS_TYPE, statsType.name)
                     .equals(StatsBlockTable.DATE, date)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -52,6 +52,23 @@ class StatsSqlUtils
                 .execute()
     }
 
+    fun <T> selectAll(
+        site: SiteModel,
+        blockType: BlockType,
+        statsType: StatsType,
+        classOfT: Class<T>,
+        date: String = ""
+    ): List<T> {
+        val models = WellSql.select(StatsBlockBuilder::class.java)
+                .where()
+                .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
+                .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
+                .equals(StatsBlockTable.STATS_TYPE, statsType.name)
+                .equals(StatsBlockTable.DATE, date)
+                .endWhere().asModel
+        return models.map { gson.fromJson(it.json, classOfT) }
+    }
+
     fun <T> select(
         site: SiteModel,
         blockType: BlockType,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -27,11 +27,11 @@ class StatsSqlUtils
         blockType: BlockType,
         statsType: StatsType,
         item: T,
-        deleteOldDataFirst: Boolean,
+        replaceExistingData: Boolean,
         date: String = ""
     ) {
         val json = gson.toJson(item)
-        if (deleteOldDataFirst) {
+        if (replaceExistingData) {
             WellSql.delete(StatsBlockBuilder::class.java)
                     .where()
                     .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -37,6 +37,7 @@ class TimeStatsSqlUtils
                 POSTS_AND_PAGES_VIEWS,
                 granularity.toStatsType(),
                 data,
+                true,
                 statsUtils.getFormattedDate(date)
         )
     }
@@ -47,6 +48,7 @@ class TimeStatsSqlUtils
                 REFERRERS,
                 granularity.toStatsType(),
                 data,
+                true,
                 statsUtils.getFormattedDate(date)
         )
     }
@@ -57,6 +59,7 @@ class TimeStatsSqlUtils
                 CLICKS,
                 granularity.toStatsType(),
                 data,
+                true,
                 statsUtils.getFormattedDate(date)
         )
     }
@@ -67,6 +70,7 @@ class TimeStatsSqlUtils
                 VISITS_AND_VIEWS,
                 granularity.toStatsType(),
                 data,
+                true,
                 statsUtils.getFormattedDate(date)
         )
     }
@@ -77,6 +81,7 @@ class TimeStatsSqlUtils
                 COUNTRY_VIEWS,
                 granularity.toStatsType(),
                 data,
+                true,
                 statsUtils.getFormattedDate(date)
         )
     }
@@ -87,6 +92,7 @@ class TimeStatsSqlUtils
                 AUTHORS,
                 granularity.toStatsType(),
                 data,
+                true,
                 statsUtils.getFormattedDate(date)
         )
     }
@@ -97,6 +103,7 @@ class TimeStatsSqlUtils
                 SEARCH_TERMS,
                 granularity.toStatsType(),
                 data,
+                true,
                 statsUtils.getFormattedDate(date)
         )
     }
@@ -107,6 +114,7 @@ class TimeStatsSqlUtils
                 VIDEO_PLAYS,
                 granularity.toStatsType(),
                 data,
+                true,
                 statsUtils.getFormattedDate(date)
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 54;
+        return 55;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -438,6 +438,15 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("ALTER TABLE QuickStartTaskModel ADD TASK_TYPE TEXT");
                 oldVersion++;
+            case 54:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL(
+                        "CREATE TABLE StatsBlockTemp (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT,JSON TEXT NOT NULL)");
+                db.execSQL("INSERT INTO StatsBlockTemp SELECT * FROM StatsBlock");
+                db.execSQL("DROP TABLE StatsBlock");
+                db.execSQL("ALTER TABLE StatsBlockTemp RENAME TO StatsBlock");
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -156,8 +156,7 @@ class InsightsStore
             val savedFollowers = sqlUtils.selectAllFollowers(siteModel, followerType).sumBy { it.subscribers.size }
             nextPage = savedFollowers / pageSize
         }
-        val response = restClient.fetchFollowers(siteModel, followerType, page = nextPage, pageSize = pageSize,
-                forced = forced)
+        val response = restClient.fetchFollowers(siteModel, followerType, nextPage, pageSize, forced)
         return@withContext when {
             response.isError -> {
                 OnStatsFetched(response.error)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -164,7 +164,7 @@ class InsightsStore
                 OnStatsFetched(response.error)
             }
             response.response != null -> {
-                sqlUtils.insert(siteModel, response.response, followerType, deleteOldDataFirst = !loadMore)
+                sqlUtils.insert(siteModel, response.response, followerType, replaceExistingData = !loadMore)
                 val allFollowers = mergeFollowersModels(siteModel, followerType, pageSize)
                 OnStatsFetched(allFollowers)
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -156,7 +156,7 @@ class InsightsStore
             val savedFollowers = sqlUtils.selectAllFollowers(siteModel, followerType).sumBy { it.subscribers.size }
             nextPage = savedFollowers / pageSize
         }
-        val response = restClient.fetchFollowers(siteModel, followerType, page = nextPage, pageSize = pageSize + 1,
+        val response = restClient.fetchFollowers(siteModel, followerType, page = nextPage, pageSize = pageSize,
                 forced = forced)
         return@withContext when {
             response.isError -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -129,17 +129,19 @@ class InsightsStore
     suspend fun fetchWpComFollowers(
         siteModel: SiteModel,
         pageSize: Int,
-        forced: Boolean = false
+        forced: Boolean = false,
+        loadMore: Boolean = false
     ): OnStatsFetched<FollowersModel> {
-        return fetchFollowers(siteModel, pageSize, forced, WP_COM)
+        return fetchFollowers(siteModel, pageSize, forced, WP_COM, loadMore)
     }
 
     suspend fun fetchEmailFollowers(
         siteModel: SiteModel,
         pageSize: Int,
-        forced: Boolean = false
+        forced: Boolean = false,
+        loadMore: Boolean = false
     ): OnStatsFetched<FollowersModel> {
-        return fetchFollowers(siteModel, pageSize, forced, EMAIL)
+        return fetchFollowers(siteModel, pageSize, forced, EMAIL, loadMore)
     }
 
     private suspend fun fetchFollowers(
@@ -147,7 +149,7 @@ class InsightsStore
         pageSize: Int,
         forced: Boolean = false,
         followerType: FollowerType,
-        loadMore: Boolean = false
+        loadMore: Boolean
     ) = withContext(coroutineContext) {
         var nextPage = 1
         if (loadMore) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -150,8 +150,12 @@ class InsightsStore
         followerType: FollowerType,
         fetchMode: Paged
     ) = withContext(coroutineContext) {
-        val savedFollowers = sqlUtils.selectAllFollowers(siteModel, followerType).sumBy { it.subscribers.size }
-        val nextPage = savedFollowers / fetchMode.pageSize + 1
+        val nextPage = if (fetchMode.loadMore) {
+            val savedFollowers = sqlUtils.selectAllFollowers(siteModel, followerType).sumBy { it.subscribers.size }
+            savedFollowers / fetchMode.pageSize + 1
+        } else {
+            1
+        }
 
         val response = restClient.fetchFollowers(siteModel, followerType, nextPage, fetchMode.pageSize, forced)
         return@withContext when {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -130,16 +130,16 @@ class InsightsStore
     // Followers stats
     suspend fun fetchWpComFollowers(
         siteModel: SiteModel,
-        forced: Boolean = false,
-        loadMode: LoadMode
+        loadMode: LoadMode,
+        forced: Boolean = false
     ): OnStatsFetched<FollowersModel> {
         return fetchFollowers(siteModel, forced, WP_COM, loadMode)
     }
 
     suspend fun fetchEmailFollowers(
         siteModel: SiteModel,
-        forced: Boolean = false,
-        loadMode: LoadMode
+        loadMode: LoadMode,
+        forced: Boolean = false
     ): OnStatsFetched<FollowersModel> {
         return fetchFollowers(siteModel, forced, EMAIL, loadMode)
     }
@@ -165,9 +165,9 @@ class InsightsStore
             response.response != null -> {
                 val replace = loadMode is Paged && !loadMode.loadMore
                 sqlUtils.insert(siteModel, response.response, followerType, replaceExistingData = replace)
-                val allFollowers = insightsMapper.mergeFollowersModels(
-                        sqlUtils,
-                        siteModel,
+                val followerResponses = sqlUtils.selectAllFollowers(siteModel, followerType)
+                val allFollowers = insightsMapper.mapAndMergeFollowersModels(
+                        followerResponses,
                         followerType,
                         loadMode
                 )
@@ -185,13 +185,9 @@ class InsightsStore
         return getFollowers(site, EMAIL, loadMode)
     }
 
-    private fun getFollowers(
-        site: SiteModel,
-        followerType: FollowerType,
-        loadMode: LoadMode
-    ): FollowersModel? {
-        val wpComResponse = sqlUtils.selectFollowers(site, followerType)
-        return wpComResponse?.let { insightsMapper.map(wpComResponse, followerType, loadMode) }
+    private fun getFollowers(site: SiteModel, followerType: FollowerType, loadMode: LoadMode): FollowersModel? {
+        val followerResponses = sqlUtils.selectAllFollowers(site, followerType)
+        return insightsMapper.mapAndMergeFollowersModels(followerResponses, followerType, loadMode)
     }
 
     // Comments stats

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.store
+package org.wordpress.android.fluxc.store.stats
 
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -151,11 +151,13 @@ class InsightsStore
         followerType: FollowerType,
         loadMore: Boolean
     ) = withContext(coroutineContext) {
-        var nextPage = 1
-        if (loadMore) {
+        val nextPage = if (loadMore) {
             val savedFollowers = sqlUtils.selectAllFollowers(siteModel, followerType).sumBy { it.subscribers.size }
-            nextPage = savedFollowers / pageSize
+            savedFollowers / pageSize + 1
+        } else {
+            1
         }
+
         val response = restClient.fetchFollowers(siteModel, followerType, nextPage, pageSize, forced)
         return@withContext when {
             response.isError -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -183,7 +183,7 @@ class InsightsStore
                     accumulator.copy(
                             totalCount = nextModel.totalCount,
                             followers = accumulator.followers + nextModel.followers,
-                            hasMore = accumulator.hasMore
+                            hasMore = nextModel.hasMore
                     )
                 }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -165,27 +165,11 @@ class InsightsStore
             }
             response.response != null -> {
                 sqlUtils.insert(siteModel, response.response, followerType, replaceExistingData = !loadMore)
-                val allFollowers = mergeFollowersModels(siteModel, followerType, pageSize)
+                val allFollowers = insightsMapper.mergeFollowersModels(sqlUtils, siteModel, followerType, pageSize)
                 OnStatsFetched(allFollowers)
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
-    }
-
-    private fun mergeFollowersModels(
-        siteModel: SiteModel,
-        followerType: FollowerType,
-        pageSize: Int
-    ): FollowersModel {
-        return sqlUtils.selectAllFollowers(siteModel, followerType)
-                .fold(FollowersModel(0, emptyList(), false)) { accumulator, next ->
-                    val nextModel = insightsMapper.map(next, followerType, pageSize)
-                    accumulator.copy(
-                            totalCount = nextModel.totalCount,
-                            followers = accumulator.followers + nextModel.followers,
-                            hasMore = nextModel.hasMore
-                    )
-                }
     }
 
     fun getWpComFollowers(site: SiteModel, pageSize: Int): FollowersModel? {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/InsightsStore.kt
@@ -73,10 +73,10 @@ class InsightsStore
 
     // Latest post insights
     suspend fun fetchLatestPostInsights(site: SiteModel, forced: Boolean = false) = withContext(coroutineContext) {
-        val latestPost = restClient.fetchLatestPostForInsights(site, forced)
-        val postsFound = latestPost.response?.postsFound
+        val latestPostPayload = restClient.fetchLatestPostForInsights(site, forced)
+        val postsFound = latestPostPayload.response?.postsFound
 
-        val posts = latestPost.response?.posts
+        val posts = latestPostPayload.response?.posts
         return@withContext if (postsFound != null && postsFound > 0 && posts != null && posts.isNotEmpty()) {
             val latestPost = posts[0]
             val postStats = restClient.fetchPostStats(site, latestPost.id, forced)
@@ -89,8 +89,8 @@ class InsightsStore
                 postStats.isError -> OnStatsFetched(postStats.error)
                 else -> OnStatsFetched()
             }
-        } else if (latestPost.isError) {
-            OnStatsFetched(latestPost.error)
+        } else if (latestPostPayload.isError) {
+            OnStatsFetched(latestPostPayload.error)
         } else {
             OnStatsFetched()
         }


### PR DESCRIPTION
This PR adds paging functionality, when fetching the followers and adds a way to request how the data is loaded from the cache (`CacheMode`) and the server (`FetchMode`)