### PR TITLE
Update to Wellsql 1.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ subprojects {
 
 ext {
     daggerVersion = '2.11'
+    wellSqlVersion = '1.4.0'
     supportLibraryVersion = '27.1.1'
     arch_paging_version = '1.0.1'
 }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -81,8 +81,8 @@ dependencies {
     }
 
     // Custom WellSql version
-    api 'org.wordpress:wellsql:1.4.0'
-    kapt 'org.wordpress:wellsql-processor:1.4.0'
+    api "org.wordpress:wellsql:$wellSqlVersion"
+    kapt "org.wordpress:wellsql-processor:$wellSqlVersion"
 
     // FluxC annotations
     api project(':fluxc-annotations')

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -81,8 +81,8 @@ dependencies {
     }
 
     // Custom WellSql version
-    api 'org.wordpress:wellsql:1.3.0'
-    kapt 'org.wordpress:wellsql-processor:1.3.0'
+    api 'org.wordpress:wellsql:1.4.0'
+    kapt 'org.wordpress:wellsql-processor:1.4.0'
 
     // FluxC annotations
     api project(':fluxc-annotations')

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -50,7 +50,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
     /**
      * @return The total records in the notification table.
      */
-    fun getNotificationsCount() = WellSql.select(NotificationModelBuilder::class.java).asCursor.count
+    fun getNotificationsCount() = WellSql.select(NotificationModelBuilder::class.java).count()
 
     @SuppressLint("WrongConstant")
     fun getNotifications(
@@ -126,7 +126,6 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
         filterBySubtype: List<String>? = null
     ): Boolean {
         val conditionClauseBuilder = WellSql.select(NotificationModelBuilder::class.java)
-                .columns("1")
                 .where()
                 .equals(NotificationModelTable.LOCAL_SITE_ID, site.id)
                 .equals(NotificationModelTable.READ, 0)
@@ -149,7 +148,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
             conditionClauseBuilder.endGroup()
         }
 
-        return conditionClauseBuilder.endWhere().asCursor.count > 0
+        return conditionClauseBuilder.endWhere().exists()
     }
 
     fun getNotificationByIdSet(idSet: NoteIdSet): NotificationModel? {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -51,8 +51,8 @@ dependencies {
         exclude group: "com.android.support"
     }
 
-    api 'org.wordpress:wellsql:1.3.0'
-    kapt 'org.wordpress:wellsql-processor:1.3.0'
+    api 'org.wordpress:wellsql:1.4.0'
+    kapt 'org.wordpress:wellsql-processor:1.4.0'
 
     // FluxC annotations
     api project(':fluxc-annotations')

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -51,8 +51,8 @@ dependencies {
         exclude group: "com.android.support"
     }
 
-    api 'org.wordpress:wellsql:1.4.0'
-    kapt 'org.wordpress:wellsql-processor:1.4.0'
+    api "org.wordpress:wellsql:$wellSqlVersion"
+    kapt "org.wordpress:wellsql-processor:$wellSqlVersion"
 
     // FluxC annotations
     api project(':fluxc-annotations')


### PR DESCRIPTION
Updates to `1.4.0` of our Wellsql fork, which includes support for `exists()` and `count()` in select queries.

See full changes from `1.3.0` here: https://github.com/wordpress-mobile/wellsql/compare/1.3.0...wordpress-mobile:1.4.0

Also updates `NotificationSqlUtils` to use these new functions.