### PR TITLE
WooCommerce: Add support for fetching order status options

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
@@ -399,6 +400,25 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         assertNull(payload.error)
         assertTrue(payload.hasOrders)
         assertNull(payload.statusFilter)
+    }
+
+    @Test
+    fun testOrderStatusOptionsFetchSuccess() {
+        interceptor.respondWith("wc-fetch-order-status-options-success.json")
+        orderRestClient.fetchOrderStatusOptions(siteModel)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_ORDER_STATUS_OPTIONS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchOrderStatusOptionsResponsePayload
+        assertNull(payload.error)
+        assertEquals(8, payload.labels.size)
+
+        with(payload.labels[0]) {
+            assertEquals("pending", statusKey)
+            assertEquals("Pending payment", label)
+        }
     }
 
     @Suppress("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -436,15 +436,15 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
 
     @Test
     public void testXMLRPCDeletedXmlrpcFileDiscovery() throws InterruptedException {
-        mUrl = BuildConfig.TEST_WPORG_URL_DELETED_XMLRPC_PHP;
-
-        mNextEvent = TestEvents.MISSING_XMLRPC_METHOD;
-        mCountDownLatch = new CountDownLatch(1);
-
-        mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
-
-        // Wait for a network response / onChanged event
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+//        mUrl = BuildConfig.TEST_WPORG_URL_DELETED_XMLRPC_PHP;
+//
+//        mNextEvent = TestEvents.MISSING_XMLRPC_METHOD;
+//        mCountDownLatch = new CountDownLatch(1);
+//
+//        mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
+//
+//        // Wait for a network response / onChanged event
+//        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_DiscoveryTest.java
@@ -436,15 +436,15 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
 
     @Test
     public void testXMLRPCDeletedXmlrpcFileDiscovery() throws InterruptedException {
-//        mUrl = BuildConfig.TEST_WPORG_URL_DELETED_XMLRPC_PHP;
-//
-//        mNextEvent = TestEvents.MISSING_XMLRPC_METHOD;
-//        mCountDownLatch = new CountDownLatch(1);
-//
-//        mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
-//
-//        // Wait for a network response / onChanged event
-//        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        mUrl = BuildConfig.TEST_WPORG_URL_DELETED_XMLRPC_PHP;
+
+        mNextEvent = TestEvents.MISSING_XMLRPC_METHOD;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mUrl));
+
+        // Wait for a network response / onChanged event
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/example/src/androidTest/resources/wc-fetch-order-status-options-success.json
+++ b/example/src/androidTest/resources/wc-fetch-order-status-options-success.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "slug": "pending",
+      "name": "Pending payment",
+      "total": 0
+    },
+    {
+      "slug": "processing",
+      "name": "Processing",
+      "total": 0
+    },
+    {
+      "slug": "on-hold",
+      "name": "On hold",
+      "total": 2
+    },
+    {
+      "slug": "completed",
+      "name": "Completed",
+      "total": 0
+    },
+    {
+      "slug": "cancelled",
+      "name": "Cancelled",
+      "total": 0
+    },
+    {
+      "slug": "refunded",
+      "name": "Refunded",
+      "total": 0
+    },
+    {
+      "slug": "failed",
+      "name": "Failed",
+      "total": 0
+    },
+    {
+      "slug": "gold",
+      "name": "Gold Member",
+      "total": 0
+    }
+  ]
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -31,10 +31,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderStatusOptionsChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrdersSearched
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
@@ -191,6 +193,13 @@ class WooCommerceFragment : Fragment() {
                 pendingFetchCompletedOrders = true
                 val payload = FetchOrdersPayload(site, loadMore = false, statusFilter = CoreOrderStatus.COMPLETED.value)
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
+            }
+        }
+
+        fetch_order_status_options.setOnClickListener {
+            getFirstWCSite()?.let { site ->
+                dispatcher.dispatch(WCOrderActionBuilder
+                        .newFetchOrderStatusOptionsAction(FetchOrderStatusOptionsPayload(site)))
             }
         }
 
@@ -446,6 +455,20 @@ class WooCommerceFragment : Fragment() {
                 "Fetched ${event.topEarners.size} top earner stats for ${event.granularity.toString()
                         .toLowerCase()} from ${getFirstWCSite()?.name}"
         )
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onOrderStatusOptionsChanged(event: OnOrderStatusOptionsChanged) {
+        if (event.isError) {
+            prependToLog("Error fetching order status options from the api: ${event.error.message}")
+            return
+        }
+
+        val orderStatusOptions = getFirstWCSite()?.let {
+            wcOrderStore.getOrderStatusOptionsForSite(it)
+        }?.map { it.label }
+        prependToLog("Fetched ${event.rowsAffected} order status options from the api: $orderStatusOptions")
     }
 
     private fun getFirstWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(0)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -468,7 +468,8 @@ class WooCommerceFragment : Fragment() {
         val orderStatusOptions = getFirstWCSite()?.let {
             wcOrderStore.getOrderStatusOptionsForSite(it)
         }?.map { it.label }
-        prependToLog("Fetched ${event.rowsAffected} order status options from the api: $orderStatusOptions")
+        prependToLog("Fetched order status options from the api: $orderStatusOptions " +
+                "- updated ${event.rowsAffected} in the db")
     }
 
     private fun getFirstWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(0)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
@@ -191,7 +190,7 @@ class WooCommerceFragment : Fragment() {
             getFirstWCSite()?.let { site ->
                 prependToLog("Submitting request to fetch only completed orders from the api")
                 pendingFetchCompletedOrders = true
-                val payload = FetchOrdersPayload(site, loadMore = false, statusFilter = CoreOrderStatus.COMPLETED.value)
+                val payload = FetchOrdersPayload(site, loadMore = false, statusFilter = "completed")
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
             }
         }

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -65,6 +65,12 @@
             android:text="Fetch Completed Orders (API)"/>
 
         <Button
+            android:id="@+id/fetch_order_status_options"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fetch Order Status Options"/>
+
+        <Button
             android:id="@+id/search_orders"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
@@ -26,7 +27,7 @@ class OrderSqlUtilsTest {
         val appContext = RuntimeEnvironment.application.applicationContext
         val config = SingleStoreWellSqlConfigForTests(
                 appContext,
-                listOf(WCOrderModel::class.java, WCOrderNoteModel::class.java),
+                listOf(WCOrderModel::class.java, WCOrderNoteModel::class.java, WCOrderStatusModel::class.java),
                 WellSqlConfig.ADDON_WOOCOMMERCE)
         WellSql.init(config)
         config.reset()
@@ -184,11 +185,20 @@ class OrderSqlUtilsTest {
 
         // Save full list, but only all but the first 2 should be inserted
         rowsAffected = orderStatusOptions.sumBy { OrderSqlUtils.insertOrUpdateOrderStatusOption(it) }
-        assertEquals(7, rowsAffected)
+        assertEquals(8, rowsAffected)
+
+        // Update a single option
+        val newLabel = "New Label"
+        firstOption.apply { label = newLabel }
+        rowsAffected = OrderSqlUtils.insertOrUpdateOrderStatusOption(firstOption)
+        assertEquals(1, rowsAffected)
+        val newFirstOption = OrderSqlUtils.getOrderStatusOptionsForSite(siteModel).first {
+            it.statusKey == firstOption.statusKey
+        }
+        assertEquals(firstOption.label, newFirstOption.label)
 
         // Get order status options from the database
         val orderStatusOptionsDb = OrderSqlUtils.getOrderStatusOptionsForSite(siteModel)
         assertEquals(8, orderStatusOptionsDb.size)
-
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -4,8 +4,10 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderNoteApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatusApiResponse
 
 object OrderTestUtils {
     fun generateSampleOrder(remoteId: Long, orderStatus: String = CoreOrderStatus.PROCESSING.value): WCOrderModel {
@@ -42,6 +44,18 @@ object OrderTestUtils {
             dateCreated = "1955-11-05T14:15:00Z"
             note = "This is a test note"
             isCustomerNote = true
+        }
+    }
+
+    fun getOrderStatusOptionsFromJson(json: String, siteId: Int): List<WCOrderStatusModel> {
+        val responseType = object : TypeToken<List<OrderStatusApiResponse>>() {}.type
+        val converted = Gson().fromJson(json, responseType) as? List<OrderStatusApiResponse> ?: emptyList()
+        return converted.map {
+            WCOrderStatusModel().apply {
+                localSiteId = siteId
+                statusKey = it.slug ?: ""
+                label = it.name ?: ""
+            }
         }
     }
 }

--- a/example/src/test/resources/wc/order_status_options.json
+++ b/example/src/test/resources/wc/order_status_options.json
@@ -1,0 +1,42 @@
+[
+  {
+    "slug": "pending",
+    "name": "Pending payment",
+    "total": 0
+  },
+  {
+    "slug": "processing",
+    "name": "Processing",
+    "total": 0
+  },
+  {
+    "slug": "on-hold",
+    "name": "On hold",
+    "total": 2
+  },
+  {
+    "slug": "completed",
+    "name": "Completed",
+    "total": 0
+  },
+  {
+    "slug": "cancelled",
+    "name": "Cancelled",
+    "total": 0
+  },
+  {
+    "slug": "refunded",
+    "name": "Refunded",
+    "total": 0
+  },
+  {
+    "slug": "failed",
+    "name": "Failed",
+    "total": 0
+  },
+  {
+    "slug": "gold",
+    "name": "Gold Member",
+    "total": 0
+  }
+]

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -422,9 +422,6 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 51:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                oldVersion++;
-            case 52:
-                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
                 oldVersion++;
         }
@@ -502,7 +499,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                                + "CURRENCY_THOUSAND_SEPARATOR TEXT NOT NULL,CURRENCY_DECIMAL_SEPARATOR TEXT NOT NULL,"
                                + "CURRENCY_DECIMAL_NUMBER INTEGER)");
                     break;
-                case 52:
+                case 51:
                     AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
                     db.execSQL("CREATE TABLE WCOrderStatusModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                                + "LOCAL_SITE_ID INTEGER,STATUS_KEY TEXT NOT NULL,LABEL TEXT NOT NULL)");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 51;
+        return 52;
     }
 
     @Override
@@ -420,6 +420,13 @@ public class WellSqlConfig extends DefaultWellConfig {
                         "CREATE TABLE PlanOffersFeature (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                         + "INTERNAL_PLAN_ID INTEGER,STRING_ID TEXT UNIQUE,NAME TEXT,DESCRIPTION TEXT)");
                 oldVersion++;
+            case 51:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                oldVersion++;
+            case 52:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -494,6 +501,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                                + "LOCAL_SITE_ID INTEGER,CURRENCY_CODE TEXT NOT NULL,CURRENCY_POSITION TEXT NOT NULL,"
                                + "CURRENCY_THOUSAND_SEPARATOR TEXT NOT NULL,CURRENCY_DECIMAL_SEPARATOR TEXT NOT NULL,"
                                + "CURRENCY_DECIMAL_NUMBER INTEGER)");
+                    break;
+                case 52:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("CREATE TABLE WCOrderStatusModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                               + "LOCAL_SITE_ID INTEGER,STATUS_KEY TEXT NOT NULL,LABEL TEXT NOT NULL)");
                     break;
             }
         }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -7,6 +7,8 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
@@ -38,6 +40,8 @@ public enum WCOrderAction implements IAction {
     FETCH_HAS_ORDERS,
     @Action(payloadType = SearchOrdersPayload.class)
     SEARCH_ORDERS,
+    @Action(payloadType = FetchOrderStatusOptionsPayload.class)
+    FETCH_ORDER_STATUS_OPTIONS,
 
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
@@ -55,5 +59,7 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = FetchHasOrdersResponsePayload.class)
     FETCHED_HAS_ORDERS,
     @Action(payloadType = SearchOrdersResponsePayload.class)
-    SEARCHED_ORDERS
+    SEARCHED_ORDERS,
+    @Action(payloadType = FetchOrderStatusOptionsResponsePayload.class)
+    FETCHED_ORDER_STATUS_OPTIONS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatusModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatusModel.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+data class WCOrderStatusModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var key = ""
+    @Column var label = ""
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    override fun getId() = id
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatusModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatusModel.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCOrderStatusModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var localSiteId = 0
-    @Column var key = ""
+    @Column var statusKey = ""
     @Column var label = ""
 
     override fun setId(id: Int) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -20,6 +21,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
@@ -74,6 +76,33 @@ class OrderRestClient(
                     val orderError = networkErrorToOrderError(networkError)
                     val payload = FetchOrdersResponsePayload(orderError, site)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
+                },
+                { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
+    /**
+     * Makes a GET call to `/wc/v3/reports/orders/totals` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
+     * retrieving a list of available order status options for the given WooCommerce [SiteModel].
+     *
+     * Dispatches a [WCOrderAction.FETCHED_ORDER_STATUS_OPTIONS] action with the resulting list of order status labels.
+     */
+    fun fetchOrderStatusOptions(site: SiteModel) {
+        val url = WOOCOMMERCE.reports.orders.totals.pathV3
+        val params = emptyMap<String, String>()
+        val responseType = object : TypeToken<List<OrderStatusApiResponse>>() {}.type
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
+                { response: List<OrderStatusApiResponse>? ->
+                    val orderStatusOptions = response?.map {
+                        orderStatusResponseToOrderStatusModel(it, site)
+                    }.orEmpty()
+                    val payload = FetchOrderStatusOptionsResponsePayload(site, orderStatusOptions)
+                    dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderStatusOptionsAction(payload))
+                },
+                WPComErrorListener { networkError ->
+                    val orderError = networkErrorToOrderError(networkError)
+                    val payload = FetchOrderStatusOptionsResponsePayload(orderError, site)
+                    dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderStatusOptionsAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })
         add(request)
@@ -389,5 +418,16 @@ class OrderRestClient(
             else -> OrderErrorType.fromString(wpComError.apiError)
         }
         return OrderError(orderErrorType, wpComError.message)
+    }
+
+    private fun orderStatusResponseToOrderStatusModel(
+        response: OrderStatusApiResponse,
+        site: SiteModel
+    ): WCOrderStatusModel {
+        return WCOrderStatusModel().apply {
+            localSiteId = site.id
+            key = response.slug ?: ""
+            label = response.name ?: ""
+        }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -426,7 +426,7 @@ class OrderRestClient(
     ): WCOrderStatusModel {
         return WCOrderStatusModel().apply {
             localSiteId = site.id
-            key = response.slug ?: ""
+            statusKey = response.slug ?: ""
             label = response.name ?: ""
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderStatusApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderStatusApiResponse.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
+
+class OrderStatusApiResponse {
+    val slug: String? = null
+    val name: String? = null
+    val total: Int = 0
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -2,11 +2,13 @@ package org.wordpress.android.fluxc.persistence
 
 import com.wellsql.generated.WCOrderModelTable
 import com.wellsql.generated.WCOrderNoteModelTable
+import com.wellsql.generated.WCOrderStatusModelTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdSet
 
 object OrderSqlUtils {
@@ -115,5 +117,25 @@ object OrderSqlUtils {
                 .equals(WCOrderNoteModelTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
                 .execute()
+    }
+
+    fun insertOrUpdateOrderStatusOption(label: WCOrderStatusModel): Int {
+        val result = WellSql.select(WCOrderStatusModel::class.java)
+                .where().beginGroup()
+                .equals(WCOrderStatusModelTable.ID, label.id)
+                .or()
+                .equals(WCOrderStatusModelTable.KEY, label.key)
+                .endGroup().endWhere().asModel
+
+        return if (result.isEmpty()) {
+            // Insert
+            WellSql.insert(label).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            val oldId = result[0].id
+            WellSql.update(WCOrderStatusModel::class.java).whereId(oldId)
+                    .put(label, UpdateAllExceptId(WCOrderStatusModel::class.java)).execute()
+        }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -124,7 +124,7 @@ object OrderSqlUtils {
                 .where().beginGroup()
                 .equals(WCOrderStatusModelTable.ID, label.id)
                 .or()
-                .equals(WCOrderStatusModelTable.KEY, label.key)
+                .equals(WCOrderStatusModelTable.STATUS_KEY, label.statusKey)
                 .endGroup().endWhere().asModel
 
         return if (result.isEmpty()) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -144,4 +144,14 @@ object OrderSqlUtils {
                     .where()
                     .equals(WCOrderStatusModelTable.LOCAL_SITE_ID, site.id)
                     .endWhere().asModel
+
+    fun getOrderStatusOptionForSiteByKey(site: SiteModel, key: String): WCOrderStatusModel? =
+            WellSql.select(WCOrderStatusModel::class.java)
+                    .where().beginGroup()
+                    .equals(WCOrderStatusModelTable.STATUS_KEY, key)
+                    .equals(WCOrderStatusModelTable.LOCAL_SITE_ID, site.id)
+                    .endGroup().endWhere().asModel.first()
+
+    fun deleteOrderStatusOption(orderStatus: WCOrderStatusModel): Int =
+            WellSql.delete(WCOrderStatusModel::class.java).whereId(orderStatus.id)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -119,23 +119,29 @@ object OrderSqlUtils {
                 .execute()
     }
 
-    fun insertOrUpdateOrderStatusOption(label: WCOrderStatusModel): Int {
+    fun insertOrUpdateOrderStatusOption(orderStatus: WCOrderStatusModel): Int {
         val result = WellSql.select(WCOrderStatusModel::class.java)
                 .where().beginGroup()
-                .equals(WCOrderStatusModelTable.ID, label.id)
+                .equals(WCOrderStatusModelTable.ID, orderStatus.id)
                 .or()
-                .equals(WCOrderStatusModelTable.STATUS_KEY, label.statusKey)
+                .equals(WCOrderStatusModelTable.STATUS_KEY, orderStatus.statusKey)
                 .endGroup().endWhere().asModel
 
         return if (result.isEmpty()) {
             // Insert
-            WellSql.insert(label).asSingleTransaction(true).execute()
+            WellSql.insert(orderStatus).asSingleTransaction(true).execute()
             1
         } else {
             // Update
             val oldId = result[0].id
             WellSql.update(WCOrderStatusModel::class.java).whereId(oldId)
-                    .put(label, UpdateAllExceptId(WCOrderStatusModel::class.java)).execute()
+                    .put(orderStatus, UpdateAllExceptId(WCOrderStatusModel::class.java)).execute()
         }
     }
+
+    fun getOrderStatusOptionsForSite(site: SiteModel) =
+            WellSql.select(WCOrderStatusModel::class.java)
+                    .where()
+                    .equals(WCOrderStatusModelTable.LOCAL_SITE_ID, site.id)
+                    .endWhere().asModel
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -190,8 +190,6 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     /**
      * Given a [SiteModel] and optional statuses, returns all orders for that site matching any of those statuses.
-     *
-     * The default WooCommerce statuses are defined in [CoreOrderStatus]. Custom order statuses are also supported.
      */
     fun getOrdersForSite(site: SiteModel, vararg status: String): List<WCOrderModel> =
             OrderSqlUtils.getOrdersForSite(site, status = status.asList())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -209,6 +209,12 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     fun getOrderNotesForOrder(order: WCOrderModel): List<WCOrderNoteModel> =
             OrderSqlUtils.getOrderNotesForOrder(order.id)
 
+    /**
+     * Returns the order status options available for the provided site [SiteModel] as a list of [WCOrderStatusModel].
+     */
+    fun getOrderStatusOptionsForSite(site: SiteModel): List<WCOrderStatusModel> =
+            OrderSqlUtils.getOrderStatusOptionsForSite(site)
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? WCOrderAction ?: return

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -215,6 +215,12 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     fun getOrderStatusOptionsForSite(site: SiteModel): List<WCOrderStatusModel> =
             OrderSqlUtils.getOrderStatusOptionsForSite(site)
 
+    /**
+     * Returns the order status as a [WCOrderStatusModel] that matches the provided order status key.
+     */
+    fun getOrderStatusForSiteAndKey(site: SiteModel, key: String): WCOrderStatusModel? =
+            OrderSqlUtils.getOrderStatusOptionForSiteByKey(site, key)
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? WCOrderAction ?: return


### PR DESCRIPTION
Fixes #1100 

This PR adds the following:
- Fetches order status options available for a single site from the API
- Parses and caches the response in the db
- Adds a new `OnOrderStatusOptionsChanged` event to the WC plugin. 
- Unit, Mocked and Release tests included
- Also includes a new button on the **Woo** screen of the **example** app: **FETCH ORDER STATUS OPTIONS**

<img src="https://user-images.githubusercontent.com/5810477/52300095-00916b80-2955-11e9-86fe-21f0c298179b.png" width="300"/>

## Testing Notes
- This feature includes a new db table - be sure to test upgrading the app. 