### PR TITLE
Parcelize plan offers model and drop UNIQUE constraint from plan feature table

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PlanOffersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PlanOffersTest.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 
 class ReleaseStack_PlanOffersTest : ReleaseStack_Base() {
+    @Suppress("unused")
     @Inject lateinit var planOffersStore: PlanOffersStore // needs to be injected for test to work properly
     private var nextEvent: TestEvents? = null
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plans/PlanOffersModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plans/PlanOffersModel.kt
@@ -1,5 +1,11 @@
 package org.wordpress.android.fluxc.model.plans
 
+import android.annotation.SuppressLint
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+@SuppressLint("ParcelCreator")
 data class PlanOffersModel(
     var planIds: List<Int>?,
     var features: List<Feature>?,
@@ -8,12 +14,14 @@ data class PlanOffersModel(
     var tagline: String?,
     var description: String?,
     var iconUrl: String?
-) {
+) : Parcelable {
+    @Parcelize
+    @SuppressLint("ParcelCreator")
     data class Feature(
         var id: String?,
         var name: String?,
         var description: String?
-    ) {
+    ) : Parcelable {
         override fun equals(other: Any?): Boolean {
             if (this === other) {
                 return true

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersSqlUtils.kt
@@ -7,7 +7,6 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
-import com.yarolegovich.wellsql.core.annotation.Unique
 import org.wordpress.android.fluxc.model.plans.PlanOffersModel
 import org.wordpress.android.fluxc.model.plans.PlanOffersModel.Feature
 import javax.inject.Inject

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersSqlUtils.kt
@@ -69,7 +69,7 @@ class PlanOffersSqlUtils @Inject constructor() {
     data class PlanOffersFeatureBuilder(
         @PrimaryKey @Column private var id: Int = 0,
         @Column var internalPlanId: Int = 0,
-        @Column @Unique var stringId: String? = null,
+        @Column var stringId: String? = null,
         @Column var name: String? = null,
         @Column var description: String? = null
     ) : Identifiable {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -418,7 +418,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "INTERNAL_PLAN_ID INTEGER)");
                 db.execSQL(
                         "CREATE TABLE PlanOffersFeature (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                        + "INTERNAL_PLAN_ID INTEGER,STRING_ID TEXT UNIQUE,NAME TEXT,DESCRIPTION TEXT)");
+                        + "INTERNAL_PLAN_ID INTEGER,STRING_ID TEXT,NAME TEXT,DESCRIPTION TEXT)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -43,7 +43,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 51;
+        return 52;
     }
 
     @Override
@@ -408,7 +408,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
                 oldVersion++;
-             case 50:
+            case 50:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL(
                         "CREATE TABLE PlanOffers (_id INTEGER PRIMARY KEY AUTOINCREMENT,INTERNAL_PLAN_ID INTEGER,"
@@ -418,7 +418,15 @@ public class WellSqlConfig extends DefaultWellConfig {
                         + "INTERNAL_PLAN_ID INTEGER)");
                 db.execSQL(
                         "CREATE TABLE PlanOffersFeature (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                        + "INTERNAL_PLAN_ID INTEGER,STRING_ID TEXT,NAME TEXT,DESCRIPTION TEXT)");
+                        + "INTERNAL_PLAN_ID INTEGER,STRING_ID TEXT UNIQUE,NAME TEXT,DESCRIPTION TEXT)");
+                oldVersion++;
+            case 51:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("CREATE TABLE PlanOffersFeatureTemp (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                           + "INTERNAL_PLAN_ID INTEGER,STRING_ID TEXT,NAME TEXT,DESCRIPTION TEXT)");
+                db.execSQL("INSERT INTO PlanOffersFeatureTemp SELECT * FROM PlanOffersFeature");
+                db.execSQL("DROP TABLE PlanOffersFeature");
+                db.execSQL("ALTER TABLE PlanOffersFeatureTemp RENAME TO PlanOffersFeature");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
This PR parcelizes the PlanOffersModel used in the client app.

In addition, I removed UNIQUE constraint from feature id column, which was there originally with a different data structure in mind. This was causing a non-fatal error message in logcat on client app.
There is no way to drop constraint in SQLite, so I had to migrate the table's content.