### PR TITLE
issue/1108-woo-use-gross-sales-in-stats

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -184,7 +184,7 @@ class WCStatsStore @Inject constructor(
      * [StatsGranularity.YEARS]: "2018"
      */
     fun getRevenueStats(site: SiteModel, granularity: StatsGranularity): Map<String, Double> {
-        return getStatsForField(site, OrderStatsField.TOTAL_SALES, granularity)
+        return getStatsForField(site, OrderStatsField.GROSS_SALES, granularity)
     }
 
     /**


### PR DESCRIPTION
Fixes #1108 - uses GROSS_SALES in getRevenueStats to match Calypso. For details, see [this WCAndroid issue](https://github.com/woocommerce/woocommerce-android/issues/740).

To test, open Julia's test site in the app and verify that it shows the same total for 2017 that Calypso does.