### PR TITLE
Use _locale as localization parameter name for wpcom v2 endpoints

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -20,6 +20,10 @@ import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError;
 import org.wordpress.android.util.LanguageUtils;
 
 public abstract class BaseWPComRestClient {
+    private static final String WPCOM_V2_PREFIX = "/wpcom/v2";
+    private static final String LOCALE_PARAM_NAME_FOR_V1 = "locale";
+    private static final String LOCALE_PARAM_NAME_FOR_V2 = "_locale";
+
     private AccessToken mAccessToken;
     private final RequestQueue mRequestQueue;
 
@@ -65,7 +69,7 @@ public abstract class BaseWPComRestClient {
 
     protected Request add(WPComGsonRequest request, boolean addLocaleParameter) {
         if (addLocaleParameter) {
-            request.addQueryParameter("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
+            addLocaleToRequest(request);
         }
         // TODO: If !mAccountToken.exists() then trigger the mOnAuthFailedListener
         return addRequest(setRequestAuthParams(request, true));
@@ -78,7 +82,7 @@ public abstract class BaseWPComRestClient {
 
     protected Request addUnauthedRequest(AccountSocialRequest request, boolean addLocaleParameter) {
         if (addLocaleParameter) {
-            request.addQueryParameter("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
+            addLocaleToRequest(request);
             request.setOnParseErrorListener(mOnParseErrorListener);
             request.setUserAgent(mUserAgent.getUserAgent());
         }
@@ -92,7 +96,7 @@ public abstract class BaseWPComRestClient {
 
     protected Request addUnauthedRequest(WPComGsonRequest request, boolean addLocaleParameter) {
         if (addLocaleParameter) {
-            request.addQueryParameter("locale", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
+            addLocaleToRequest(request);
         }
         return addRequest(setRequestAuthParams(request, false));
     }
@@ -115,5 +119,16 @@ public abstract class BaseWPComRestClient {
             mRequestQueue.getCache().invalidate(request.mUri.toString(), true);
         }
         return mRequestQueue.add(request);
+    }
+
+    private void addLocaleToRequest(BaseRequest request) {
+        String url = request.getUrl();
+        // Sanity check
+        if (url != null) {
+            // WPCOM V2 endpoints use a different locale parameter than other endpoints
+            String localeParamName =
+                    url.contains(WPCOM_V2_PREFIX) ? LOCALE_PARAM_NAME_FOR_V2 : LOCALE_PARAM_NAME_FOR_V1;
+            request.addQueryParameter(localeParamName, LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
+        }
     }
 }


### PR DESCRIPTION
Fixes #1083. Wpcom v2 endpoints use `_locale` as parameter name instead of `locale`, this PR is a proposal for that change.

With our current setup, I can’t find a good way to do this without a major refactor. Specifically, I believe the endpoint should be the one carrying this information, however since endpoints are not exposed to lower layers and used to built the request in the network clients (i.e. `xxRestClient`) that's not possible without a refactor.

The approach I took in this PR is to check the `url` for whether it's a wpcom v2 endpoint or not and then add the appropriate locale parameter name. This is a pretty sad approach, but it's the only one I can find that doesn't require a refactor. (possibly a major one at that) Having said that, I don't think it's likely to cause any major issues.

I'd love to get some more eyes on this in case I am missing a better approach. I'd appreciate everyone's opinion that stumbles upon this PR. Just pinging a few people that comes to mind to make sure at least a few people take a look at it: @aforcier @malinajirka @planarvoid @0nko @kwonye.

Please note that this PR needs to land fairly quickly, but keep the feedback coming as we can always update the approach even after it's merged.

**To test:**

In order to test this in FluxC, probably the best approach is to add a breakpoint [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java#L67), use connected tests to initiate a few different requests and verify that correct locale parameter name is used. Here is a couple such tests:

* Add a breakpoint [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java#L67)
* Run a test in `ReleaseStack_PostTestWPCom` (all tests use v1 endpoints I believe)
* Verify that `_locale=xx_XX` parameter is added to the request

---

* Add a breakpoint [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java#L67)
* Run a test in `ReleaseStack_VerticalTest` (all verticals endpoints are 
* Verify that `_locale=xx_XX` parameter is added to the request

In order to test the changes in more detail, probably the best way is to test WPAndroid with the new FluxC hash. Here is my current branch for this: https://github.com/wordpress-mobile/WordPress-Android/tree/issue/update-fluxc-hash-for-v2-locale-and-enable-new-site-creation