### PR TITLE
Issue/do not cache plan requests

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClientTest.kt
@@ -83,9 +83,9 @@ class PlanOffersRestClientTest {
                         urlCaptor.capture(),
                         paramsCaptor.capture(),
                         eq(PlanOffersResponse::class.java),
-                        eq(true),
+                        eq(false),
                         any(),
-                        eq(false)
+                        eq(true)
                 )
         ).thenReturn(response)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClient.kt
@@ -35,8 +35,8 @@ constructor(
                 url,
                 params,
                 PlanOffersResponse::class.java,
-                enableCaching = true,
-                forced = false
+                enableCaching = false,
+                forced = true
         )
         return when (response) {
             is Success -> {


### PR DESCRIPTION
This PR disables caching of request to Plans endpoint on network level. We are using local DB caching, and utilize a special error handling which network caching messes up with.