### PR TITLE
Return null when order status not found

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
@@ -239,6 +240,26 @@ class OrderSqlUtilsTest {
         // Get the first option from the database by the status key
         val firstOption = OrderSqlUtils.getOrderStatusOptionForSiteByKey(siteModel, orderStatusOptions[0].statusKey)
         assertNotNull(firstOption)
-        assertEquals(firstOption!!.label, orderStatusOptions[0].label)
+        assertEquals(firstOption.label, orderStatusOptions[0].label)
+    }
+
+    @Test
+    fun testGetOrderStatusOptions_Empty() {
+        val siteModel = SiteModel().apply { id = 1 }
+
+        // Attempt to fetch order status options from database.
+        // No options will be available.
+        val options = OrderSqlUtils.getOrderStatusOptionsForSite(siteModel)
+        assertNotNull(options)
+        assertEquals(0, options.size)
+    }
+
+    @Test
+    fun testGetOrderStatusOption_NotExists() {
+        val siteModel = SiteModel().apply { id = 1 }
+
+        // Get the first option from the database by the status key
+        val option = OrderSqlUtils.getOrderStatusOptionForSiteByKey(siteModel, "missing")
+        assertNull(option)
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -139,7 +139,7 @@ object OrderSqlUtils {
         }
     }
 
-    fun getOrderStatusOptionsForSite(site: SiteModel) =
+    fun getOrderStatusOptionsForSite(site: SiteModel): List<WCOrderStatusModel> =
             WellSql.select(WCOrderStatusModel::class.java)
                     .where()
                     .equals(WCOrderStatusModelTable.LOCAL_SITE_ID, site.id)
@@ -150,7 +150,7 @@ object OrderSqlUtils {
                     .where().beginGroup()
                     .equals(WCOrderStatusModelTable.STATUS_KEY, key)
                     .equals(WCOrderStatusModelTable.LOCAL_SITE_ID, site.id)
-                    .endGroup().endWhere().asModel.first()
+                    .endGroup().endWhere().asModel.firstOrNull()
 
     fun deleteOrderStatusOption(orderStatus: WCOrderStatusModel): Int =
             WellSql.delete(WCOrderStatusModel::class.java).whereId(orderStatus.id)


### PR DESCRIPTION
Fixes an issue (https://github.com/woocommerce/woocommerce-android/issues/781) where if an order status key is not found in the database, a `NoSuchElementException` is thrown and the app crashes.

While I was in there I also added tests to cover such scenarios to make sure the fixes work and continue work:
- `OrderSqlUtilsTest.testGetOrderStatusOption_NotExists()`
- `OrderSqlUtilsTest.testGetOrderStatusOptions_Empty`