### PR TITLE
Update Gradle to 4.10.3 and Android Gradle Plugin to 3.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
 
 env:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.automattic.android:fetchstyle:1.1'
     }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.example"
@@ -38,6 +38,7 @@ android {
 
     lintOptions {
         warning 'InvalidPackage'
+        disable 'ExpiredTargetSdkVersion'
     }
 
     testOptions {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -22,13 +22,13 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         versionCode 4
         versionName "0.1"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 26
     }
     buildTypes {
         release {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import android.annotation.SuppressLint
 import com.yarolegovich.wellsql.SelectQuery
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -55,6 +56,7 @@ class ActivityLogStore
         }
     }
 
+    @SuppressLint("WrongConstant")
     fun getActivityLogForSite(site: SiteModel, ascending: Boolean = true): List<ActivityLogModel> {
         val order = if (ascending) SelectQuery.ORDER_ASCENDING else SelectQuery.ORDER_DESCENDING
         return activityLogSqlUtils.getActivitiesForSite(site, order)
@@ -76,6 +78,7 @@ class ActivityLogStore
         AppLog.d(AppLog.T.API, this.javaClass.name + ": onRegister")
     }
 
+    @SuppressLint("WrongConstant")
     suspend fun fetchActivities(fetchActivityLogPayload: FetchActivityLogPayload): OnActivityLogFetched {
         var offset = 0
         if (fetchActivityLogPayload.loadMore) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store;
 
+import android.annotation.SuppressLint;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -187,6 +188,7 @@ public class CommentStore extends Store {
      *                             If false, order the results by descending published date.
      * @param statuses Array of status or CommentStatus.ALL to get all of them.
      */
+    @SuppressLint("WrongConstant")
     public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending,
                                                  CommentStatus... statuses) {
         @Order int order = orderByDateAscending ? SelectQuery.ORDER_ASCENDING : SelectQuery.ORDER_DESCENDING;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -17,12 +17,12 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.instaflux"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 before_install:
 - yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
-- yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.3"
+- yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;28.0.3"

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -19,13 +19,13 @@ repositories {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         versionCode 1
         versionName "0.1"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 26
     }
     buildTypes {
         release {


### PR DESCRIPTION
This updates Gradle and the Android Gradle Plugin to recent versions. It was also neccesary to update the build tools to `28.0.3`.

A similar change has been live in WPAndroid for some time: https://github.com/wordpress-mobile/WordPress-Android/pull/9044

This will be helpful when moving the project to CircleCI as recent Gradle versions are more memory efficient.