### PR TITLE
Fetch and compare post status while fetching the post list

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -100,7 +100,7 @@ public class PostRestClient extends BaseWPComRestClient {
         String url = WPCOMREST.sites.site(listDescriptor.getSite().getSiteId()).posts.getUrlV1_1();
 
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
-        String fields = TextUtils.join(",", Arrays.asList("ID", "modified"));
+        String fields = TextUtils.join(",", Arrays.asList("ID", "modified", "status"));
         Map<String, String> params =
                 createFetchPostListParameters(false, offset, pageSize, listDescriptor.getStatusList(), fields,
                         listDescriptor.getOrder().getValue(), listDescriptor.getOrderBy().getValue(),
@@ -115,7 +115,8 @@ public class PostRestClient extends BaseWPComRestClient {
                     public void onResponse(PostsResponse response) {
                         List<PostListItem> postListItems = new ArrayList<>(response.posts.size());
                         for (PostWPComRestResponse postResponse : response.posts) {
-                            postListItems.add(new PostListItem(postResponse.ID, postResponse.modified));
+                            postListItems
+                                    .add(new PostListItem(postResponse.ID, postResponse.modified, postResponse.status));
                         }
                         boolean canLoadMore = postListItems.size() == pageSize;
                         FetchPostListResponsePayload responsePayload =

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -119,7 +119,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchPostList(final PostListDescriptorForXmlRpcSite listDescriptor, final int offset) {
         SiteModel site = listDescriptor.getSite();
-        List<String> fields = Arrays.asList("post_id", "post_modified_gmt");
+        List<String> fields = Arrays.asList("post_id", "post_modified_gmt", "post_status");
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
         List<Object> params =
                 createFetchPostListParameters(site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(), false,
@@ -337,10 +337,11 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         for (Object responseObject : response) {
             Map<?, ?> postMap = (Map<?, ?>) responseObject;
             String postID = MapUtils.getMapStr(postMap, "post_id");
+            String postStatus = MapUtils.getMapStr(postMap, "post_status");
             Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified_gmt");
             String lastModifiedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(lastModifiedGmt);
 
-            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601));
+            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus));
         }
         return postListItems;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -82,10 +82,12 @@ public class PostStore extends Store {
     public static class PostListItem {
         public Long remotePostId;
         public String lastModified;
+        public String status;
 
-        public PostListItem(Long remotePostId, String lastModified) {
+        public PostListItem(Long remotePostId, String lastModified, String status) {
             this.remotePostId = remotePostId;
             this.lastModified = lastModified;
+            this.status = status;
         }
     }
 
@@ -605,7 +607,15 @@ public class PostStore extends Store {
             Map<Long, PostModel> posts = getPostsByRemotePostIds(postIds, site);
             for (PostListItem item : payload.postListItems) {
                 PostModel post = posts.get(item.remotePostId);
-                if (post != null && !post.getLastModified().equals(item.lastModified)) {
+                if (post == null) {
+                    // Post doesn't exist in the DB, nothing to do.
+                    continue;
+                }
+                // Check if the post's last modified date or status has changed. We need to check status separately
+                // because when a scheduled post is published, its modified date will not be updated.
+                boolean isPostChanged =
+                        !post.getLastModified().equals(item.lastModified) || !post.getStatus().equals(item.status);
+                if (isPostChanged) {
                     // Dispatch a fetch action for the posts that are changed, but not for posts with local changes
                     // as we'd otherwise overwrite and lose these local changes forever
                     if (!post.isLocallyChanged()) {


### PR DESCRIPTION
This PR addresses the underlying issue for https://github.com/wordpress-mobile/WordPress-Android/issues/9018.

When we fetch post list, we only fetch the ids and modified dates of posts. Then, we compare the modified date of the posts with the local versions to see if we need to fetch them again to update it. It turns out when a scheduled post is auto-published the modified date is not updated. This PR adds the post status to the field list that's being fetched when we fetch post list so we can detect changes to it and refresh the post.

**To test:**

I've opened a draft pull request in WPAndroid to make the testing easier. Please follow the instructions in: https://github.com/wordpress-mobile/WordPress-Android/pull/9257