### PR TITLE
Add explicit get list items count query to ListItemSqlUtils

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/list/ListItemSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/ListItemSqlUtilsTest.kt
@@ -43,6 +43,16 @@ class ListItemSqlUtilsTest {
     }
 
     @Test
+    fun testGetListItemsCount() {
+        val count = 17
+        val testList = generateInsertAndAssertListItems(
+                listDescriptor = PostListDescriptorForRestSite(testSite()),
+                count = count
+        )
+        assertEquals(count.toLong(), listItemSqlUtils.getListItemsCount(testList.id))
+    }
+
+    @Test
     fun testListIdForeignKeyCascadeDelete() {
         val listDescriptor = PostListDescriptorForRestSite(testSite())
         val testList = generateInsertAndAssertListItems(listDescriptor)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datastore/ListDataStoreInterface.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datastore/ListDataStoreInterface.kt
@@ -14,7 +14,7 @@ interface ListDataStoreInterface<T> {
     /**
      * Should fetch the list for the given [ListDescriptor] and an offset.
      */
-    fun fetchList(listDescriptor: ListDescriptor, offset: Int)
+    fun fetchList(listDescriptor: ListDescriptor, offset: Long)
 
     /**
      * Should return the item for the given [ListDescriptor] and [remoteItemId] or null if it's not available.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datastore/PostListDataStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datastore/PostListDataStore.kt
@@ -37,7 +37,7 @@ class PostListDataStore(
         }
     }
 
-    override fun fetchList(listDescriptor: ListDescriptor, offset: Int) {
+    override fun fetchList(listDescriptor: ListDescriptor, offset: Long) {
         if (listDescriptor is PostListDescriptor) {
             val fetchPostListPayload = FetchPostListPayload(listDescriptor, offset)
             dispatcher.dispatch(PostActionBuilder.newFetchPostListAction(fetchPostListPayload))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -96,7 +96,7 @@ public class PostRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void fetchPostList(final PostListDescriptorForRestSite listDescriptor, final int offset) {
+    public void fetchPostList(final PostListDescriptorForRestSite listDescriptor, final long offset) {
         String url = WPCOMREST.sites.site(listDescriptor.getSite().getSiteId()).posts.getUrlV1_1();
 
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
@@ -510,7 +510,7 @@ public class PostRestClient extends BaseWPComRestClient {
     }
 
     private Map<String, String> createFetchPostListParameters(final boolean getPages,
-                                                              final int offset,
+                                                              final long offset,
                                                               final int number,
                                                               @Nullable final List<PostStatus> statusList,
                                                               @Nullable final String fields,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -117,7 +117,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void fetchPostList(final PostListDescriptorForXmlRpcSite listDescriptor, final int offset) {
+    public void fetchPostList(final PostListDescriptorForXmlRpcSite listDescriptor, final long offset) {
         SiteModel site = listDescriptor.getSite();
         List<String> fields = Arrays.asList("post_id", "post_modified_gmt", "post_status");
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
@@ -609,7 +609,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             final String username,
             final String password,
             final boolean getPages,
-            final int offset,
+            final long offset,
             final int number,
             @Nullable final List<PostStatus> statusList,
             @Nullable final List<String> fields,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
@@ -24,13 +24,22 @@ class ListItemSqlUtils @Inject constructor() {
     /**
      * This function returns a list of [ListItemModel] records for the given [listId].
      */
-    fun getListItems(listId: Int): List<ListItemModel> =
+    fun getListItems(listId: Int): List<ListItemModel> = getListItemsQuery(listId).asModel
+
+    /**
+     * This function returns the number of records a list has for the given [listId].
+     */
+    fun getListItemsCount(listId: Int): Long = getListItemsQuery(listId).count()
+
+    /**
+     * A helper function that returns the select query for a list of [ListItemModel] records for the given [listId].
+     */
+    private fun getListItemsQuery(listId: Int): SelectQuery<ListItemModel> =
             WellSql.select(ListItemModel::class.java)
                     .where()
                     .equals(ListItemModelTable.LIST_ID, listId)
                     .endWhere()
                     .orderBy(ListModelTable.ID, SelectQuery.ORDER_ASCENDING)
-                    .asModel
 
     /**
      * This function deletes [ListItemModel] records for the [listIds].

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -95,9 +95,7 @@ class ListStore @Inject constructor(
                 dataStore.fetchList(listDescriptor, offset)
             }
         }
-        val isEmpty = {
-            getListItems(listDescriptor).isEmpty()
-        }
+        val isEmpty = { getListItemsCount(listDescriptor) == 0L }
 
         // Create the PagedList
         val factory = PagedListFactory(dataStore, listDescriptor, getList, isListFullyFetched, transform)
@@ -136,6 +134,14 @@ class ListStore @Inject constructor(
         return if (listModel != null) {
             listItemSqlUtils.getListItems(listModel.id).map { it.remoteItemId }
         } else emptyList()
+    }
+
+    /**
+     * A helper function that returns if the list is empty for the given [ListDescriptor].
+     */
+    private fun getListItemsCount(listDescriptor: ListDescriptor): Long {
+        val listModel = listSqlUtils.getList(listDescriptor)
+        return if (listModel != null) listItemSqlUtils.getListItemsCount(listModel.id) else 0L
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -137,7 +137,7 @@ class ListStore @Inject constructor(
     }
 
     /**
-     * A helper function that returns if the list is empty for the given [ListDescriptor].
+     * A helper function that returns the number of records a list has for the given [ListDescriptor].
      */
     private fun getListItemsCount(listDescriptor: ListDescriptor): Long {
         val listModel = listSqlUtils.getList(listDescriptor)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -154,7 +154,7 @@ class ListStore @Inject constructor(
     private fun handleFetchList(
         listDescriptor: ListDescriptor,
         loadMore: Boolean,
-        fetchList: (Int) -> Unit
+        fetchList: (Long) -> Unit
     ) {
         val currentState = getListState(listDescriptor)
         if (!loadMore && currentState.isFetchingFirstPage()) {
@@ -172,7 +172,7 @@ class ListStore @Inject constructor(
         val listModel = requireNotNull(listSqlUtils.getList(listDescriptor)) {
             "The `ListModel` can never be `null` here since either a new list is inserted or existing one updated"
         }
-        val offset = if (loadMore) listItemSqlUtils.getListItems(listModel.id).size else 0
+        val offset = if (loadMore) listItemSqlUtils.getListItemsCount(listModel.id) else 0L
         fetchList(offset)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -71,9 +71,9 @@ public class PostStore extends Store {
 
     public static class FetchPostListPayload extends Payload<BaseNetworkError> {
         public PostListDescriptor listDescriptor;
-        public int offset;
+        public long offset;
 
-        public FetchPostListPayload(PostListDescriptor listDescriptor, int offset) {
+        public FetchPostListPayload(PostListDescriptor listDescriptor, long offset) {
             this.listDescriptor = listDescriptor;
             this.offset = offset;
         }


### PR DESCRIPTION
This PR adds `ListItemSqlUtils.getListItemsCount` which takes advantage of the `count()` query recently added to `WellSql` by @aforcier in https://github.com/wordpress-mobile/wellsql/pull/13. I've added a unit test for the change and updated the relevant code to use `Long` instead of `Int` so that we don't lose the precision.

**To test:**
It'd be good to test WPAndroid with the updated hash to make sure post list still works as it should and the data is still loading fine. (I'll be adding some connected tests for this flow, so this won't be necessary 🤞 )