### PR TITLE
Update test dependencies and a possible fix to mocked tests

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -110,15 +110,13 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation "android.arch.core:core-testing:$arch_lifecycle_version"
 
-    androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
-    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
-    androidTestImplementation 'org.mockito:mockito-core:1.10.19'
+    androidTestImplementation 'org.mockito:mockito-android:2.6.3'
     androidTestImplementation 'org.apache.commons:commons-lang3:3.5'
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
     androidTestCompileOnly 'org.glassfish:javax.annotation:10.0-b28'
     // Test orchestrator
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestUtil 'com.android.support.test:orchestrator:1.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
 
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
@@ -95,6 +95,7 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         mIsError = true;
         // Correct user we should get an OnAuthenticationChanged message
         mCountDownLatch = new CountDownLatch(1);
+        mInterceptor.respondWith("authentication-error-response.json");
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_AccountTest.java
@@ -79,6 +79,7 @@ public class MockedStack_AccountTest extends MockedStack_Base {
         // Correct user we should get an OnAuthenticationChanged message
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
+        mInterceptor.respondWith("authentication-success-response.json");
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Log out and clear stored dummy account

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -295,7 +295,9 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     @Suppress("unused")
     @Subscribe
     fun onAction(action: Action<*>) {
-        lastAction = action
-        countDownLatch.countDown()
+        if (action.type is WCStatsAction) {
+            lastAction = action
+            countDownLatch.countDown()
+        }
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -5,8 +5,6 @@ import android.content.Context;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.Volley;
 
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.OkHttpStack;
@@ -18,9 +16,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.ErrorListener;
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Listener;
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Token;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
@@ -36,13 +31,6 @@ import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
 import okhttp3.OkHttpClient;
-
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.spy;
 
 @Module
 public class MockedNetworkModule {
@@ -76,35 +64,7 @@ public class MockedNetworkModule {
     @Provides
     public Authenticator provideAuthenticator(Context appContext, Dispatcher dispatcher, AppSecrets appSecrets,
                                               RequestQueue requestQueue) {
-        Authenticator authenticator = new Authenticator(appContext, dispatcher, requestQueue, appSecrets);
-        Authenticator spy = spy(authenticator);
-
-        // Mock Authenticator with correct user: test/test
-        doAnswer(
-                new Answer() {
-                    public Object answer(InvocationOnMock invocation) {
-                        Object[] args = invocation.getArguments();
-                        Listener listener = (Listener) args[4];
-                        listener.onResponse(new Token("deadparrot", "", "", "", ""));
-                        return null;
-                    }
-                }
-        ).when(spy).authenticate(eq("test"), eq("test"), anyString(), anyBoolean(),
-                (Listener) any(), (ErrorListener) any());
-
-        // Mock Authenticator with erroneous user: error/error
-        doAnswer(
-                new Answer() {
-                    public Object answer(InvocationOnMock invocation) {
-                        Object[] args = invocation.getArguments();
-                        ErrorListener listener = (ErrorListener) args[5];
-                        listener.onErrorResponse(null);
-                        return null;
-                    }
-                }
-        ).when(spy).authenticate(eq("error"), eq("error"), anyString(), anyBoolean(),
-                (Listener) any(), (ErrorListener) any());
-        return spy;
+        return new Authenticator(appContext, dispatcher, requestQueue, appSecrets);
     }
 
     @Singleton

--- a/example/src/androidTest/resources/authentication-error-response.json
+++ b/example/src/androidTest/resources/authentication-error-response.json
@@ -1,0 +1,1 @@
+{"error":"invalid_request","error_description":"Incorrect username or password."}

--- a/example/src/androidTest/resources/authentication-success-response.json
+++ b/example/src/androidTest/resources/authentication-success-response.json
@@ -1,0 +1,1 @@
+{"access_token":"mocked_token","token_type":"bearer","blog_id":"0","blog_url":null,"scope":"global"}


### PR DESCRIPTION
This PR updates a few dependencies for connected tests and possibly fixes the connected test for `MockedStack_WCStatsTest`.

I believe we were using the `dexmaker` dependencies to be able to write mocked instrumentation tests, but since they were outdated I have been having some issues as I added more connected tests. It looks like the `org.mockito:mockito-android` no longer needs a separate `dexmaker` dependency and has been working pretty reliably for me. I've also updated `com.android.support.test:runner` and `com.android.support.test:orchestrator`, because why not :)

When I made that ^ `mockito-android` change, the `MockedStack_AccountTest.testAuthenticationOK` started failing for me. It looks like it doesn't have a specified response, or I couldn't find it, adding that response seems to have fixed the issue. I don't actually know if this is necessary or if there is a component that is injecting the response elsewhere. @aforcier I am hoping you'd know the history of that test.

Finally, since I have been looking at a lot of Travis failures, I noticed [this](https://travis-ci.org/wordpress-mobile/WordPress-FluxC-Android/jobs/496381979#L3648) (in a different branch) and thought maybe we are not having timeout issues, but there actually is a bug in the `MockedStack_WCStatsTest`. It looks like we are counting down the `countDownLatch` whenever there is a FluxC action. Even without any issues, that probably is not the best approach, because the test could end prematurely because another event is triggered in the base class or something. (like authentication) I've added a check for `WCStatsAction` which may or may not fix the issue. I don't know for sure how another action is triggered before the `countDownLatch` is initialized, for example whether running parallel tests could have any effect on this, but I don't think making that change could hurt our chances of fixing the issue. So, I'd love to try it out if I am not missing anything.