### PR TITLE
Fix ExifInterface warning when stripping location data

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -164,7 +164,7 @@ public class MediaUtils {
             exifInterface.setAttribute(ExifInterface.TAG_GPS_LATITUDE_REF, "0");
             exifInterface.setAttribute(ExifInterface.TAG_GPS_LONGITUDE, "0/0,0/0,000000/00000 ");
             exifInterface.setAttribute(ExifInterface.TAG_GPS_LONGITUDE_REF, "0");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_TIMESTAMP, "0:0:0 ");
+            exifInterface.setAttribute(ExifInterface.TAG_GPS_TIMESTAMP, "00:00:00");
             exifInterface.setAttribute(ExifInterface.TAG_GPS_PROCESSING_METHOD, "0");
             exifInterface.setAttribute(ExifInterface.TAG_GPS_DATESTAMP, " ");
             exifInterface.saveAttributes();


### PR DESCRIPTION
While working on connected test fixes in #1087 I noticed some warnings when running media tests:

```
org.wordpress.android.fluxc.example W/ExifInterface: Invalid value for GPSTimeStamp : 0:0:0 
```

It looks like the `ExifInterface` was expecting a more specific formatting for those values, so it seems it wasn't clearing the GPS timestamp.

### To test
1. In `develop`, upload a JPEG (or run a test, e.g. `ReleaseStack_MediaTestWPCom#testUploadImage`)
2. Notice a `ExifInterface: Invalid value for GPSTimeStamp : 0:0:0 ` warning in the logs
3. Checkout this branch, and repeat
4. Observe no warning is logged