### PR TITLE
issue/1136-woo-api-version-check-fields

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -45,7 +45,8 @@ class WooCommerceRestClient(
      */
     fun getSupportedWooApiVersion(site: SiteModel) {
         val url = "/"
-        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, emptyMap(),
+        val params = mapOf("_fields" to "authentication,namespaces")
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params,
                 RootWPAPIRestResponse::class.java,
                 { response: RootWPAPIRestResponse? ->
                     val namespaces = response?.namespaces


### PR DESCRIPTION
Fixes #1136 - This PR limits the fields returned by the Woo API version check, reducing the response from 719KB to just 200KB.