### PR TITLE
Remove caching from stats

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -537,14 +537,14 @@ class InsightsRestClientTest {
         data: CommentsResponse? = null,
         error: WPComGsonNetworkError? = null
     ): Response<CommentsResponse> {
-        return initResponse(CommentsResponse::class.java, data ?: mock(), error)
+        return initResponse(CommentsResponse::class.java, data ?: mock(), error, cachingEnabled = false)
     }
 
     private suspend fun initTagsResponse(
         data: TagsResponse? = null,
         error: WPComGsonNetworkError? = null
     ): Response<TagsResponse> {
-        return initResponse(TagsResponse::class.java, data ?: mock(), error)
+        return initResponse(TagsResponse::class.java, data ?: mock(), error, cachingEnabled = false)
     }
 
     private suspend fun initPublicizeResponse(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/CommentsRestClient.kt
@@ -39,7 +39,7 @@ constructor(
                 url,
                 emptyMap(),
                 CommentsResponse::class.java,
-                enableCaching = true,
+                enableCaching = false,
                 forced = forced
         )
         return when (response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/TagsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/TagsRestClient.kt
@@ -43,7 +43,7 @@ constructor(
                 url,
                 params,
                 TagsResponse::class.java,
-                enableCaching = true,
+                enableCaching = false,
                 forced = forced
         )
         return when (response) {


### PR DESCRIPTION
- this PR disables caching in Comments and Tags. The cache returns the same result and ignores the query params (in this case needed for loading the next pages). 