### PR TITLE
Add an underscore to match the WellSql auto-generated columns

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 55;
+        return 56;
     }
 
     @Override
@@ -442,6 +442,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
                 oldVersion++;
+            case 55:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -529,6 +533,21 @@ public class WellSqlConfig extends DefaultWellConfig {
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD ENDDATE TEXT");
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD STARTDATE TEXT");
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD QUANTITY TEXT");
+                    break;
+                case 55:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("DROP TABLE IF EXISTS WCOrderStatsModel");
+                    db.execSQL("CREATE TABLE WCOrderStatsModel(\n"
+                               + "  LOCAL_SITE_ID INTEGER,\n"
+                               + "  UNIT TEXT NOT NULL,\n"
+                               + "  DATE TEXT NOT NULL,\n"
+                               + "  START_DATE TEXT NOT NULL,\n"
+                               + "  END_DATE TEXT NOT NULL,\n"
+                               + "  QUANTITY TEXT NOT NULL,\n"
+                               + "  IS_CUSTOM_FIELD INTEGER,\n"
+                               + "  FIELDS TEXT NOT NULL,\n"
+                               + "  DATA TEXT NOT NULL,\n"
+                               + "  _id INTEGER PRIMARY KEY AUTOINCREMENT)");
                     break;
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -526,8 +526,8 @@ public class WellSqlConfig extends DefaultWellConfig {
                     AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD IS_CUSTOM_FIELD INTEGER");
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD DATE TEXT");
-                    db.execSQL("ALTER TABLE WCOrderStatsModel ADD END_DATE TEXT");
-                    db.execSQL("ALTER TABLE WCOrderStatsModel ADD START_DATE TEXT");
+                    db.execSQL("ALTER TABLE WCOrderStatsModel ADD ENDDATE TEXT");
+                    db.execSQL("ALTER TABLE WCOrderStatsModel ADD STARTDATE TEXT");
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD QUANTITY TEXT");
                     break;
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -526,8 +526,8 @@ public class WellSqlConfig extends DefaultWellConfig {
                     AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD IS_CUSTOM_FIELD INTEGER");
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD DATE TEXT");
-                    db.execSQL("ALTER TABLE WCOrderStatsModel ADD ENDDATE TEXT");
-                    db.execSQL("ALTER TABLE WCOrderStatsModel ADD STARTDATE TEXT");
+                    db.execSQL("ALTER TABLE WCOrderStatsModel ADD END_DATE TEXT");
+                    db.execSQL("ALTER TABLE WCOrderStatsModel ADD START_DATE TEXT");
                     db.execSQL("ALTER TABLE WCOrderStatsModel ADD QUANTITY TEXT");
                     break;
             }


### PR DESCRIPTION
Fixes #1140 by properly inserting an `_` to the `endDate` and `startDate` fields of `WCOrderStatsModel` to match the way WellSql auto-generates these fields. 

To Test:
1. Check out a version of the repo before these new fields were added: `git checkout 421e402b9f52d0a07c486ac809e917642db2d296`
2. Build and run.
3. Check out this branch
4. build and run
5. verify no issues fetching custom stats