### PR TITLE
Add support for View all referrers

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -37,7 +37,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-private const val PAGE_SIZE = 8
+private const val ITEMS_TO_LOAD = 8
 private val SELECTED_DATE = Date(10)
 
 /**
@@ -84,7 +84,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                 postAndPageViewsStore.fetchPostAndPageViews(
                         site,
                         granularity,
-                        LimitMode.Top(PAGE_SIZE),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         SELECTED_DATE,
                         true
                 )
@@ -96,7 +96,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val insightsFromDb = postAndPageViewsStore.getPostAndPageViews(
                     site,
                     granularity,
-                    LimitMode.Top(PAGE_SIZE),
+                    LimitMode.Top(ITEMS_TO_LOAD),
                     SELECTED_DATE
             )
 
@@ -112,8 +112,8 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 referrersStore.fetchReferrers(
                         site,
-                        PAGE_SIZE,
                         granularity,
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         SELECTED_DATE,
                         true
                 )
@@ -122,7 +122,8 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = referrersStore.getReferrers(site, granularity, SELECTED_DATE, PAGE_SIZE)
+            val insightsFromDb = referrersStore.getReferrers(site, granularity, SELECTED_DATE,
+                    LimitMode.Top(ITEMS_TO_LOAD))
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -136,7 +137,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 clicksStore.fetchClicks(
                         site,
-                        PAGE_SIZE,
+                        ITEMS_TO_LOAD,
                         granularity,
                         SELECTED_DATE,
                         true
@@ -146,7 +147,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = clicksStore.getClicks(site, granularity, PAGE_SIZE, SELECTED_DATE)
+            val insightsFromDb = clicksStore.getClicks(site, granularity, ITEMS_TO_LOAD, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -160,7 +161,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 visitsAndViewsStore.fetchVisits(
                         site,
-                        PAGE_SIZE,
+                        ITEMS_TO_LOAD,
                         SELECTED_DATE,
                         granularity,
                         true
@@ -185,7 +186,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 countryViewsStore.fetchCountryViews(
                         site,
-                        PAGE_SIZE,
+                        ITEMS_TO_LOAD,
                         granularity,
                         SELECTED_DATE,
                         true
@@ -195,7 +196,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = countryViewsStore.getCountryViews(site, granularity, PAGE_SIZE, SELECTED_DATE)
+            val insightsFromDb = countryViewsStore.getCountryViews(site, granularity, ITEMS_TO_LOAD, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -206,12 +207,12 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         for (period in StatsGranularity.values()) {
-            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, PAGE_SIZE, period, SELECTED_DATE) }
+            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, ITEMS_TO_LOAD, period, SELECTED_DATE) }
 
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = authorsStore.getAuthors(site, period, PAGE_SIZE, SELECTED_DATE)
+            val insightsFromDb = authorsStore.getAuthors(site, period, ITEMS_TO_LOAD, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -225,7 +226,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 searchTermsStore.fetchSearchTerms(
                         site,
-                        PAGE_SIZE,
+                        ITEMS_TO_LOAD,
                         granularity,
                         SELECTED_DATE,
                         true
@@ -235,7 +236,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = searchTermsStore.getSearchTerms(site, granularity, PAGE_SIZE, SELECTED_DATE)
+            val insightsFromDb = searchTermsStore.getSearchTerms(site, granularity, ITEMS_TO_LOAD, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -249,7 +250,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 videoPlaysStore.fetchVideoPlays(
                         site,
-                        PAGE_SIZE,
+                        ITEMS_TO_LOAD,
                         granularity,
                         SELECTED_DATE,
                         true
@@ -259,7 +260,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = videoPlaysStore.getVideoPlays(site, granularity, PAGE_SIZE, SELECTED_DATE)
+            val insightsFromDb = videoPlaysStore.getVideoPlays(site, granularity, ITEMS_TO_LOAD, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/InsightsMapperTest.kt
@@ -9,7 +9,6 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.insights.PostingActivityModel.Day
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.InsightsRestClient.VisitResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse.Streak
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse.Streaks

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
@@ -30,7 +30,7 @@ class TimeStatsMapperTest {
     fun `parses empty referrers`() {
         val response = ReferrersResponse("DAYS", emptyMap())
 
-        val result = timeStatsMapper.map(response, 5)
+        val result = timeStatsMapper.map(response, LimitMode.Top(5))
 
         assertThat(result.groups).isEmpty()
         assertThat(result.hasMore).isFalse()

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsFixtures.kt
@@ -11,6 +11,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostI
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient.PostsResponse.PostResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient.PostsResponse.PostResponse.Discussion
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.MostPopularRestClient.MostPopularResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse.Streak
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse.Streaks
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient.PublicizeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient.PublicizeResponse.Service
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.ReferrersModel
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient
@@ -25,7 +26,7 @@ import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-private const val PAGE_SIZE = 8
+private const val ITEMS_TO_LOAD = 8
 private val DATE = Date(0)
 
 @RunWith(MockitoJUnitRunner::class)
@@ -51,13 +52,13 @@ class ReferrersStoreTest {
                 REFERRERS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchReferrers(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchReferrers(site, DAYS, DATE, ITEMS_TO_LOAD + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<ReferrersModel>()
-        whenever(mapper.map(REFERRERS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(REFERRERS_RESPONSE, LimitMode.Top(ITEMS_TO_LOAD))).thenReturn(model)
 
-        val responseModel = store.fetchReferrers(site, PAGE_SIZE, DAYS, DATE, forced)
+        val responseModel = store.fetchReferrers(site, DAYS, LimitMode.Top(ITEMS_TO_LOAD), DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, REFERRERS_RESPONSE, DAYS, DATE)
@@ -69,9 +70,9 @@ class ReferrersStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<ReferrersResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchReferrers(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchReferrers(site, DAYS, DATE, ITEMS_TO_LOAD + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchReferrers(site, PAGE_SIZE, DAYS, DATE, forced)
+        val responseModel = store.fetchReferrers(site, DAYS, LimitMode.Top(ITEMS_TO_LOAD), DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -83,9 +84,9 @@ class ReferrersStoreTest {
     fun `returns referrers from db`() {
         whenever(sqlUtils.selectReferrers(site, DAYS, DATE)).thenReturn(REFERRERS_RESPONSE)
         val model = mock<ReferrersModel>()
-        whenever(mapper.map(REFERRERS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(REFERRERS_RESPONSE, LimitMode.Top(ITEMS_TO_LOAD))).thenReturn(model)
 
-        val result = store.getReferrers(site, DAYS, DATE, PAGE_SIZE)
+        val result = store.getReferrers(site, DAYS, DATE, LimitMode.Top(ITEMS_TO_LOAD))
 
         assertThat(result).isEqualTo(model)
     }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -42,8 +42,6 @@ androidExtensions {
     experimental = true
 }
 
-kotlin { experimental { coroutines 'enable' } }
-
 android.buildTypes.all { buildType ->
     // Load gradle properties and add them to BuildConfig
     Properties gradleProperties = new Properties()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -50,10 +50,16 @@ class TimeStatsMapper
         return PostAndPageViewsModel(stats, cacheMode is LimitMode.Top && postViews.size > cacheMode.limit)
     }
 
-    fun map(response: ReferrersResponse, pageSize: Int): ReferrersModel {
+    fun map(response: ReferrersResponse, cacheMode: LimitMode): ReferrersModel {
         val first = response.groups.values.firstOrNull()
         val groups = first?.let {
-            first.groups.take(pageSize).map { group ->
+            first.groups.let {
+                if (cacheMode is LimitMode.Top) {
+                    it.take(cacheMode.limit)
+                } else {
+                    it
+                }
+            }.map { group ->
                 val children = group.referrers?.mapNotNull { result ->
                     if (result.name != null && result.views != null) {
                         val firstChildUrl = result.children?.firstOrNull()?.url

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/CommentsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/CommentsStore.kt
@@ -32,11 +32,7 @@ class CommentsStore @Inject constructor(
                     }
                     responsePayload.response != null -> {
                         sqlUtils.insert(siteModel, responsePayload.response)
-                        val cacheMode = if (limitMode is Top)
-                            LimitMode.Top(limitMode.limit)
-                        else
-                            All
-                        OnStatsFetched(insightsMapper.map(responsePayload.response, cacheMode))
+                        OnStatsFetched(insightsMapper.map(responsePayload.response, limitMode))
                     }
                     else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/CommentsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/CommentsStore.kt
@@ -3,8 +3,6 @@ package org.wordpress.android.fluxc.store.stats.insights
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
-import org.wordpress.android.fluxc.model.stats.LimitMode.All
-import org.wordpress.android.fluxc.model.stats.LimitMode.Top
 import org.wordpress.android.fluxc.model.stats.CommentsModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.CommentsRestClient

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/TagsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/TagsStore.kt
@@ -32,7 +32,7 @@ class TagsStore @Inject constructor(
                     response.response != null -> {
                         sqlUtils.insert(siteModel, response.response)
                         OnStatsFetched(
-                                insightsMapper.map(response.response, LimitMode.Top(limitMode.limit))
+                                insightsMapper.map(response.response, limitMode)
                         )
                     }
                     else -> OnStatsFetched(StatsError(INVALID_RESPONSE))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/PostAndPageViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/PostAndPageViewsStore.kt
@@ -37,7 +37,7 @@ class PostAndPageViewsStore
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
                 sqlUtils.insert(site, payload.response, granularity, date)
-                OnStatsFetched(timeStatsMapper.map(payload.response, LimitMode.Top(limitMode.limit)))
+                OnStatsFetched(timeStatsMapper.map(payload.response, limitMode))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }


### PR DESCRIPTION
This PR adds support for the View all referrers screen. It can be tested with the associated WPAndroid PR.