### PR TITLE
Issue/wc fix product tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -10,7 +10,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.annotations.action.Action
-import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -30,7 +30,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     private var lastAction: Action<*>? = null
     private var countDownLatch: CountDownLatch by notNull()
 
-    private val remoteProductId = BuildConfig.TEST_WC_PRODUCT_ID.toLong()
+    private val remoteProductId = 1537L
 
     private val siteModel = SiteModel().apply {
         id = 5

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
@@ -29,7 +30,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     private var lastAction: Action<*>? = null
     private var countDownLatch: CountDownLatch by notNull()
 
-    private val remoteProductId = 1537L
+    private val remoteProductId = BuildConfig.TEST_WC_PRODUCT_ID.toLong()
 
     private val siteModel = SiteModel().apply {
         id = 5

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCProductAction
+import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
@@ -28,7 +29,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
     private var nextEvent: TestEvent = TestEvent.NONE
     private val productModel = WCProductModel(8).apply {
-        remoteProductId = 1537
+        remoteProductId = BuildConfig.TEST_WC_PRODUCT_ID.toLong()
         dateCreated = "2018-04-20T15:45:14Z"
     }
     private var lastEvent: OnProductChanged? = null

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -69,13 +69,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onProductChanged(event: OnProductChanged) {
         event.error?.let {
-            when (event.causeOfChange) {
-                WCProductAction.FETCH_SINGLE_PRODUCT -> {
-                    assertEquals(TestEvent.FETCHED_SINGLE_PRODUCT, nextEvent)
-                    mCountDownLatch.countDown()
-                    return
-                } else -> throw AssertionError("OnProductChanged has unexpected error: " + it.type)
-            }
+            throw AssertionError("OnProductChanged has unexpected error: " + it.type)
         }
 
         lastEvent = event

--- a/example/tests.properties-example
+++ b/example/tests.properties-example
@@ -190,6 +190,7 @@ TEST_WPCOM_USERNAME_JETPACK_BETA_SITE = FIXME
 TEST_WPCOM_PASSWORD_JETPACK_BETA_SITE = FIXME
 
 ## Woo
+TEST_WC_PRODUCT_ID = FIXME
 
 # WP.com - Account with only one site: a Jetpack site with WooCommerce set up: http://do.wpmt.co/woo-jetpack
 TEST_WPCOM_USERNAME_WOO_JETPACK = FIXME


### PR DESCRIPTION
As @aforcier pointed out on Slack, the WC product tests were failing due to a hard-coded product ID. I've replaced that with a new `TEST_WC_PRODUCT_ID` parameter in `tests.properties`.

I also removed some unnecessary logic when fetching a single product fails.