### PR TITLE
issue/1151-top-earners-parse-exception 

### DIFF
--- a/example/src/androidTest/resources/wc-top-earners-response-success.json
+++ b/example/src/androidTest/resources/wc-top-earners-response-success.json
@@ -2,7 +2,7 @@
   "data": [
     {
       "currency": "USD",
-      "ID": 373,
+      "ID": 10000000000000016,
       "image": "https://example.com/wp-content/uploads/2017/07/hm-black.jpg?w=640",
       "name": "Black Dress (H&M)",
       "price": 30,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCTopEarnerModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCTopEarnerModel.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.model
 
 class WCTopEarnerModel {
-    var id: Int = 0
+    var id: Long = 0
     var currency: String = ""
     var image: String = ""
     var name: String = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/TopEarnersStatsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/TopEarnersStatsApiResponse.kt
@@ -10,7 +10,7 @@ class TopEarnersStatsApiResponse : Response {
 
     class TopEarner {
         @SerializedName("ID")
-        val id: Int? = 0
+        val id: Long? = 0
         val currency: String? = ""
         val image: String? = ""
         val name: String? = ""


### PR DESCRIPTION
Fixes #1151 - the non-fatal crashes were caused by the remote top earner ID being a long, but we expected it to be an int. This PR corrects this by changing the top earner model ID to a long. I also changed the ID in the mocked test to a long to verify the fix.