### PR TITLE
Woo: Fix default stats refresh bug

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -1006,6 +1006,23 @@ class WCStatsStoreTest {
 
         /*
          * Test Scenario - II
+         * Generate default stats with a different date in the future
+         */
+        val defaultDayOrderStatsModel2 = WCStatsTestUtils.generateSampleStatsModel(endDate = "2019-03-20")
+        WCStatsSqlUtils.insertOrUpdateStats(defaultDayOrderStatsModel2)
+
+        WCStatsSqlUtils.getFirstRawStatsForSite(site)?.let {
+            assertEquals(defaultDayOrderStatsModel2.date, it.date)
+        }
+
+        val defaultDayOrderRevenueStats2 = wcStatsStore.getRevenueStats(site, StatsGranularity.DAYS)
+        val defaultDayOrderStats2 = wcStatsStore.getOrderStats(site, StatsGranularity.DAYS)
+
+        assertTrue(defaultDayOrderRevenueStats2.isNotEmpty())
+        assertTrue(defaultDayOrderStats2.isNotEmpty())
+
+        /*
+         * Test Scenario - III
          * Generate custom stats for same site:
          * granularity - DAYS
          * quantity - 1
@@ -1033,7 +1050,7 @@ class WCStatsStoreTest {
         assertTrue(customDayOrderStats.isNotEmpty())
 
         /*
-         * Test Scenario - III
+         * Test Scenario - IV
          * Query for custom stats that is not present in local cache: for same site, same quantity, different date
          * granularity - DAYS
          * quantity - 1
@@ -1057,7 +1074,7 @@ class WCStatsStoreTest {
         assertTrue(customDayOrderStats2.isEmpty())
 
         /*
-         * Test Scenario - IV
+         * Test Scenario - V
          * Query for custom stats that is not present in local cache:
          * for same site, different quantity, different date
          * granularity - DAYS
@@ -1083,7 +1100,7 @@ class WCStatsStoreTest {
         assertTrue(customDayOrderStats3.isEmpty())
 
         /*
-         * Test Scenario - IV
+         * Test Scenario - VI
          * Generate custom stats for same site with different granularity, same date, same quantity
          * granularity - WEEKS
          * quantity - 1
@@ -1125,7 +1142,7 @@ class WCStatsStoreTest {
         assertTrue(customDayOrderStats4.isEmpty())
 
         /*
-         * Test Scenario - V
+         * Test Scenario - VII
          * Generate custom stats for different site with same granularity, same date, same quantity
          * site - 8
          * granularity - WEEKS

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 57;
+        return 58;
     }
 
     @Override
@@ -450,6 +450,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
                 oldVersion++;
+            case 57:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -577,6 +581,9 @@ public class WellSqlConfig extends DefaultWellConfig {
                                + "IMAGES TEXT NOT NULL,ATTRIBUTES TEXT NOT NULL,"
                                + "VARIATIONS TEXT NOT NULL)");
                     break;
+                case 57:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("DELETE FROM WCOrderStatsModel");
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRe
 
 object WCStatsSqlUtils {
     fun insertOrUpdateStats(stats: WCOrderStatsModel): Int {
-        val statsResult = if(stats.isCustomField) {
+        val statsResult = if (stats.isCustomField) {
             WellSql.select(WCOrderStatsModel::class.java)
                     .where().beginGroup()
                     .equals(WCOrderStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -8,15 +8,25 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRe
 
 object WCStatsSqlUtils {
     fun insertOrUpdateStats(stats: WCOrderStatsModel): Int {
-        val statsResult = WellSql.select(WCOrderStatsModel::class.java)
-                .where().beginGroup()
-                .equals(WCOrderStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
-                .equals(WCOrderStatsModelTable.UNIT, stats.unit)
-                .equals(WCOrderStatsModelTable.DATE, stats.date)
-                .equals(WCOrderStatsModelTable.QUANTITY, stats.quantity)
-                .equals(WCOrderStatsModelTable.IS_CUSTOM_FIELD, stats.isCustomField)
-                .endGroup().endWhere()
-                .asModel
+        val statsResult = if(stats.isCustomField) {
+            WellSql.select(WCOrderStatsModel::class.java)
+                    .where().beginGroup()
+                    .equals(WCOrderStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
+                    .equals(WCOrderStatsModelTable.UNIT, stats.unit)
+                    .equals(WCOrderStatsModelTable.DATE, stats.date)
+                    .equals(WCOrderStatsModelTable.QUANTITY, stats.quantity)
+                    .equals(WCOrderStatsModelTable.IS_CUSTOM_FIELD, stats.isCustomField)
+                    .endGroup().endWhere()
+                    .asModel
+        } else {
+            WellSql.select(WCOrderStatsModel::class.java)
+                    .where().beginGroup()
+                    .equals(WCOrderStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
+                    .equals(WCOrderStatsModelTable.UNIT, stats.unit)
+                    .equals(WCOrderStatsModelTable.IS_CUSTOM_FIELD, stats.isCustomField)
+                    .endGroup().endWhere()
+                    .asModel
+        }
 
         if (statsResult.isEmpty()) {
             /*


### PR DESCRIPTION
This PR fixes https://github.com/woocommerce/woocommerce-android/issues/894 by only pulling stats by date if custom stats.

This fixes a bug where the default stats were creating multiple rows because
a different date was used each time. This in turn caused the logic that
polls for the default stats to only return the top row - making it
appear that stats was not refreshing on the device. The fix was to not use a date value when polling the database for default stats so only a single row ever exists. Special thanks to Anita Murthy finding and providing the snippets used in this fix.

## To Test
1. Manually change the device date to yesterday
2. Using a clean install of the Example app, click "FETCH 30 DAY REVENUE STATS" .
3. Change the device date back to today.
4. Click "FETCH 30 DAY REVENUE STATS" in the example app.
5. verify only a single row in the database for 30 day stats using Stethos.