### PR TITLE
Improve network interceptor support

### DIFF
--- a/example/src/debug/java/org/wordpress/android/fluxc/example/di/InterceptorModule.kt
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/di/InterceptorModule.kt
@@ -1,13 +1,14 @@
 package org.wordpress.android.fluxc.example.di
 
 import com.facebook.stetho.okhttp3.StethoInterceptor
-
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import okhttp3.Interceptor
+import javax.inject.Named
 
 @Module
 class InterceptorModule {
-    @Provides
-    fun provideNetworkInterceptor(): Interceptor = StethoInterceptor()
+    @Provides @IntoSet @Named("network-interceptors")
+    fun provideStethoInterceptor(): Interceptor = StethoInterceptor()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
@@ -8,6 +8,7 @@ import org.wordpress.android.util.AppLog.T;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
@@ -25,14 +26,25 @@ import okhttp3.OkHttpClient;
 public class DebugOkHttpClientModule {
     @Provides
     @Named("regular")
-    public OkHttpClient.Builder provideOkHttpClientBuilder(Interceptor interceptor) {
-        return new OkHttpClient.Builder().addNetworkInterceptor(interceptor);
+    public OkHttpClient.Builder provideOkHttpClientBuilder(
+            @Named("interceptors") Set<Interceptor> interceptors,
+            @Named("network-interceptors") Set<Interceptor> networkInterceptors) {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        for (Interceptor interceptor : interceptors) {
+            builder.addInterceptor(interceptor);
+        }
+        for (Interceptor networkInterceptor : networkInterceptors) {
+            builder.addNetworkInterceptor(networkInterceptor);
+        }
+        return builder;
     }
 
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(MemorizingTrustManager memorizingTrustManager,
-                                                                    Interceptor interceptor) {
+    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(
+            MemorizingTrustManager memorizingTrustManager,
+            @Named("interceptors") Set<Interceptor> interceptors,
+            @Named("network-interceptors") Set<Interceptor> networkInterceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -42,7 +54,12 @@ public class DebugOkHttpClientModule {
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             AppLog.e(T.API, e);
         }
-        builder.addNetworkInterceptor(interceptor);
+        for (Interceptor interceptor : interceptors) {
+            builder.addInterceptor(interceptor);
+        }
+        for (Interceptor networkInterceptor : networkInterceptors) {
+            builder.addNetworkInterceptor(networkInterceptor);
+        }
         return builder;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
@@ -23,10 +23,10 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 
 @Module
-public class DebugOkHttpClientModule {
+public abstract class DebugOkHttpClientModule {
     @Provides
     @Named("regular")
-    public OkHttpClient.Builder provideOkHttpClientBuilder(
+    public static OkHttpClient.Builder provideOkHttpClientBuilder(
             @Named("interceptors") Set<Interceptor> interceptors,
             @Named("network-interceptors") Set<Interceptor> networkInterceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
@@ -41,7 +41,7 @@ public class DebugOkHttpClientModule {
 
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(
+    public static OkHttpClient.Builder provideOkHttpClientBuilderCustomSSL(
             MemorizingTrustManager memorizingTrustManager,
             @Named("interceptors") Set<Interceptor> interceptors,
             @Named("network-interceptors") Set<Interceptor> networkInterceptors) {
@@ -66,7 +66,8 @@ public class DebugOkHttpClientModule {
     @Singleton
     @Provides
     @Named("custom-ssl")
-    public OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(@Named("custom-ssl") OkHttpClient.Builder builder) {
+    public static OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(
+            @Named("custom-ssl") OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)
@@ -77,7 +78,8 @@ public class DebugOkHttpClientModule {
     @Singleton
     @Provides
     @Named("regular")
-    public OkHttpClient provideMediaOkHttpClientInstance(@Named("regular") OkHttpClient.Builder builder) {
+    public static OkHttpClient provideMediaOkHttpClientInstance(
+            @Named("regular") OkHttpClient.Builder builder) {
         return builder
                 .connectTimeout(BaseRequest.DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(BaseRequest.UPLOAD_REQUEST_READ_TIMEOUT, TimeUnit.MILLISECONDS)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
@@ -19,11 +19,16 @@ import javax.net.ssl.TrustManager;
 
 import dagger.Module;
 import dagger.Provides;
+import dagger.multibindings.Multibinds;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 
 @Module
 public abstract class DebugOkHttpClientModule {
+    // These allow a library client to use this module without contributing any interceptors
+    @Multibinds abstract @Named("interceptors") Set<Interceptor> interceptorSet();
+    @Multibinds abstract @Named("network-interceptors") Set<Interceptor> networkInterceptorSet();
+
     @Provides
     @Named("regular")
     public static OkHttpClient.Builder provideOkHttpClientBuilder(

--- a/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/InterceptorModule.java
+++ b/instaflux/src/debug/java/org/wordpress/android/fluxc/instaflux/InterceptorModule.java
@@ -2,14 +2,17 @@ package org.wordpress.android.fluxc.instaflux;
 
 import com.facebook.stetho.okhttp3.StethoInterceptor;
 
+import javax.inject.Named;
+
 import dagger.Module;
 import dagger.Provides;
+import dagger.multibindings.IntoSet;
 import okhttp3.Interceptor;
 
 @Module
 public class InterceptorModule {
-    @Provides
-    public Interceptor provideNetworkInterceptor() {
+    @Provides @IntoSet @Named("network-interceptors")
+    public Interceptor provideStethoInterceptor() {
         return new StethoInterceptor();
     }
 }


### PR DESCRIPTION
This PR makes a few changes to our `DebugOkHttpClientModule`, which is used by FluxC clients for debug builds.

Previously, it was possible to use the `DebugOkHttpClientModule` to inject an `okhttp` `NetworkInterceptor` into the FluxC network stack. We've been using this to hook up Stetho network listening for debug builds of our apps.

In order to support mocking aspects of FluxC's network stack from outside FluxC (e.g. for Espresso tests from WPAndroid), a few modifications to `DebugOkHttpClientModule` are made:

1. Both `NetworkInterceptors` and `Interceptors` can be declared and used with FluxC

`NetworkInterceptors` are less permissive, used mainly for logging - they aren't allowed, for instance, to change the host of a network request. This is exactly what we needed for mocking, so we can now use `Interceptors` for mocking and continue using `NetworkInterceptors` for things like Stetho, which only need (and require) that level of access.

2. Multiple interceptors of either type can be declared and used

This is done by declaring named `Set`s for each interceptor type. Any module function returning an `Interceptor` can be injected into the okhttp stack by using:

```kotlin
@Provides @IntoSet @Named("interceptors")
```
or
```kotlin
@Provides @IntoSet @Named("network-interceptors")
```

Also, we're now using `@Multibinds` declarations to declare the sets of interceptors. This is required for the sets to be allowed to be empty, so client apps aren't required to declare any interceptors (but can still use `DebugOkHttpClientModule` in a build).

**Note**: While this diff doesn't cause breaking changes, it will cause Stetho network listening to stop working in client apps. I'll be opening PRs in WPAndroid and WooAndroid to use the new injection method introduced in this PR.

### To test

I'll provide a way to test the new `Interceptor` functionality from a WPAndroid PR, but to test that everything in FluxC works as before:

1. From this branch, build the example app and `instaflux`
2. With the app running, open `chrome://inspect` from your computer and open the appropriate instance of the app on the device
3. Visit the Network tab and make sure you're seeing networking traffic