### PR TITLE
Add cache to Insights

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/InsightsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/InsightsSqlUtilsTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.MostPopular
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient.PublicizeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.StatsRequestSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.ALL_TIME_INSIGHTS
@@ -28,29 +29,30 @@ import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.EMAIL_FOL
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.LATEST_POST_DETAIL_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.LATEST_POST_STATS_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.MOST_POPULAR_INSIGHTS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.PUBLICIZE_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.TAGS_AND_CATEGORIES_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.WP_COM_FOLLOWERS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.PUBLICIZE_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.INSIGHTS
 import org.wordpress.android.fluxc.store.stats.ALL_TIME_RESPONSE
 import org.wordpress.android.fluxc.store.stats.FOLLOWERS_RESPONSE
 import org.wordpress.android.fluxc.store.stats.LATEST_POST
 import org.wordpress.android.fluxc.store.stats.MOST_POPULAR_RESPONSE
 import org.wordpress.android.fluxc.store.stats.POST_STATS_RESPONSE
-import org.wordpress.android.fluxc.store.stats.TOP_COMMENTS_RESPONSE
 import org.wordpress.android.fluxc.store.stats.PUBLICIZE_RESPONSE
 import org.wordpress.android.fluxc.store.stats.TAGS_RESPONSE
+import org.wordpress.android.fluxc.store.stats.TOP_COMMENTS_RESPONSE
 import kotlin.test.assertEquals
 
 @RunWith(MockitoJUnitRunner::class)
 class InsightsSqlUtilsTest {
     @Mock lateinit var statsSqlUtils: StatsSqlUtils
+    @Mock lateinit var statsRequestSqlUtils: StatsRequestSqlUtils
     @Mock lateinit var site: SiteModel
     private lateinit var insightsSqlUtils: InsightsSqlUtils
 
     @Before
     fun setUp() {
-        insightsSqlUtils = InsightsSqlUtils(statsSqlUtils)
+        insightsSqlUtils = InsightsSqlUtils(statsSqlUtils, statsRequestSqlUtils)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/InsightsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistance/stats/InsightsSqlUtilsTest.kt
@@ -9,38 +9,13 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.AllTimeInsightsRestClient.AllTimeResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.CommentsRestClient.CommentsResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.EMAIL
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.WP_COM
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowersResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient.PostStatsResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient.PostsResponse.PostResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.MostPopularRestClient.MostPopularResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient.PublicizeResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsRequestSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.ALL_TIME_INSIGHTS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.COMMENTS_INSIGHTS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.EMAIL_FOLLOWERS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.LATEST_POST_DETAIL_INSIGHTS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.LATEST_POST_STATS_INSIGHTS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.MOST_POPULAR_INSIGHTS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.PUBLICIZE_INSIGHTS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.TAGS_AND_CATEGORIES_INSIGHTS
-import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.WP_COM_FOLLOWERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.INSIGHTS
 import org.wordpress.android.fluxc.store.stats.ALL_TIME_RESPONSE
-import org.wordpress.android.fluxc.store.stats.FOLLOWERS_RESPONSE
-import org.wordpress.android.fluxc.store.stats.LATEST_POST
-import org.wordpress.android.fluxc.store.stats.MOST_POPULAR_RESPONSE
-import org.wordpress.android.fluxc.store.stats.POST_STATS_RESPONSE
-import org.wordpress.android.fluxc.store.stats.PUBLICIZE_RESPONSE
-import org.wordpress.android.fluxc.store.stats.TAGS_RESPONSE
-import org.wordpress.android.fluxc.store.stats.TOP_COMMENTS_RESPONSE
 import kotlin.test.assertEquals
 
 @RunWith(MockitoJUnitRunner::class)
@@ -48,210 +23,38 @@ class InsightsSqlUtilsTest {
     @Mock lateinit var statsSqlUtils: StatsSqlUtils
     @Mock lateinit var statsRequestSqlUtils: StatsRequestSqlUtils
     @Mock lateinit var site: SiteModel
-    private lateinit var insightsSqlUtils: InsightsSqlUtils
+    private lateinit var insightsSqlUtils: TestSqlUtils
 
     @Before
     fun setUp() {
-        insightsSqlUtils = InsightsSqlUtils(statsSqlUtils, statsRequestSqlUtils)
+        insightsSqlUtils = TestSqlUtils(statsSqlUtils, statsRequestSqlUtils)
     }
 
     @Test
-    fun `returns all time response from stats utils`() {
+    fun `returns response from stats utils`() {
         whenever(statsSqlUtils.select(site, ALL_TIME_INSIGHTS, INSIGHTS, AllTimeResponse::class.java)).thenReturn(
                 ALL_TIME_RESPONSE
         )
 
-        val result = insightsSqlUtils.selectAllTimeInsights(site)
+        val result = insightsSqlUtils.select(site)
 
         assertEquals(result, ALL_TIME_RESPONSE)
     }
 
     @Test
-    fun `inserts all time response to stats utils`() {
+    fun `inserts response to stats utils`() {
         insightsSqlUtils.insert(site, ALL_TIME_RESPONSE)
 
         verify(statsSqlUtils).insert(site, ALL_TIME_INSIGHTS, INSIGHTS, ALL_TIME_RESPONSE, true)
     }
 
-    @Test
-    fun `returns most popular response from stats utils`() {
-        whenever(statsSqlUtils.select(site, MOST_POPULAR_INSIGHTS, INSIGHTS, MostPopularResponse::class.java))
-                .thenReturn(
-                        MOST_POPULAR_RESPONSE
-                )
-
-        val result = insightsSqlUtils.selectMostPopularInsights(site)
-
-        assertEquals(result, MOST_POPULAR_RESPONSE)
-    }
-
-    @Test
-    fun `inserts most popular response to stats utils`() {
-        insightsSqlUtils.insert(site, MOST_POPULAR_RESPONSE)
-
-        verify(statsSqlUtils).insert(site, MOST_POPULAR_INSIGHTS, INSIGHTS, MOST_POPULAR_RESPONSE, true)
-    }
-
-    @Test
-    fun `returns latest post detail response from stats utils`() {
-        whenever(statsSqlUtils.select(site, LATEST_POST_DETAIL_INSIGHTS, INSIGHTS, PostResponse::class.java))
-                .thenReturn(
-                        LATEST_POST
-                )
-
-        val result = insightsSqlUtils.selectLatestPostDetail(site)
-
-        assertEquals(result, LATEST_POST)
-    }
-
-    @Test
-    fun `inserts latest post detail response to stats utils`() {
-        insightsSqlUtils.insert(site, LATEST_POST)
-
-        verify(statsSqlUtils).insert(site, LATEST_POST_DETAIL_INSIGHTS, INSIGHTS, LATEST_POST, true)
-    }
-
-    @Test
-    fun `returns latest post views response from stats utils`() {
-        whenever(
-                statsSqlUtils.select(
-                        site,
-                        LATEST_POST_STATS_INSIGHTS,
-                        INSIGHTS,
-                        PostStatsResponse::class.java
-                )
-        ).thenReturn(
-                POST_STATS_RESPONSE
-        )
-
-        val result = insightsSqlUtils.selectLatestPostStats(site)
-
-        assertEquals(result, POST_STATS_RESPONSE)
-    }
-
-    @Test
-    fun `inserts latest post views response to stats utils`() {
-        insightsSqlUtils.insert(site, POST_STATS_RESPONSE)
-
-        verify(statsSqlUtils).insert(site, LATEST_POST_STATS_INSIGHTS, INSIGHTS, POST_STATS_RESPONSE, true)
-    }
-
-    @Test
-    fun `returns WPCOM followers response from stats utils`() {
-        assertReturnsFollowers(WP_COM, WP_COM_FOLLOWERS)
-    }
-
-    @Test
-    fun `returns email followers response from stats utils`() {
-        assertReturnsFollowers(EMAIL, EMAIL_FOLLOWERS)
-    }
-
-    private fun assertReturnsFollowers(
-        followerType: FollowerType,
-        blockType: BlockType
-    ) {
-        whenever(
-                statsSqlUtils.select(
-                        site,
-                        blockType,
-                        INSIGHTS,
-                        FollowersResponse::class.java
-                )
-        ).thenReturn(
-                FOLLOWERS_RESPONSE
-        )
-
-        val result = insightsSqlUtils.selectFollowers(site, followerType)
-
-        assertEquals(result, FOLLOWERS_RESPONSE)
-    }
-
-    @Test
-    fun `inserts WPCOM followers response to stats utils`() {
-        insightsSqlUtils.insert(site, FOLLOWERS_RESPONSE, WP_COM, true)
-
-        verify(statsSqlUtils).insert(site, WP_COM_FOLLOWERS, INSIGHTS, FOLLOWERS_RESPONSE, true)
-    }
-
-    @Test
-    fun `inserts email followers response to stats utils`() {
-        insightsSqlUtils.insert(site, FOLLOWERS_RESPONSE, EMAIL, true)
-
-        verify(statsSqlUtils).insert(site, EMAIL_FOLLOWERS, INSIGHTS, FOLLOWERS_RESPONSE, true)
-    }
-
-    @Test
-    fun `returns comments response from stats utils`() {
-        whenever(
-                statsSqlUtils.select(
-                        site,
-                        COMMENTS_INSIGHTS,
-                        INSIGHTS,
-                        CommentsResponse::class.java
-                )
-        ).thenReturn(
-                TOP_COMMENTS_RESPONSE
-        )
-
-        val result = insightsSqlUtils.selectCommentInsights(site)
-
-        assertEquals(result, TOP_COMMENTS_RESPONSE)
-    }
-
-    @Test
-    fun `inserts comments response to stats utils`() {
-        insightsSqlUtils.insert(site, TOP_COMMENTS_RESPONSE)
-
-        verify(statsSqlUtils).insert(site, COMMENTS_INSIGHTS, INSIGHTS, TOP_COMMENTS_RESPONSE, true)
-    }
-
-    @Test
-    fun `returns tags response from stats utils`() {
-        whenever(
-                statsSqlUtils.select(
-                        site,
-                        TAGS_AND_CATEGORIES_INSIGHTS,
-                        INSIGHTS,
-                        TagsResponse::class.java
-                )
-        ).thenReturn(
-                TAGS_RESPONSE
-        )
-
-        val result = insightsSqlUtils.selectTags(site)
-
-        assertEquals(result, TAGS_RESPONSE)
-    }
-
-    @Test
-    fun `inserts tags response to stats utils`() {
-        insightsSqlUtils.insert(site, TAGS_RESPONSE)
-
-        verify(statsSqlUtils).insert(site, TAGS_AND_CATEGORIES_INSIGHTS, INSIGHTS, TAGS_RESPONSE, true)
-    }
-
-    @Test
-    fun `returns publicize response from stats utils`() {
-        whenever(
-                statsSqlUtils.select(
-                        site,
-                        PUBLICIZE_INSIGHTS,
-                        INSIGHTS,
-                        PublicizeResponse::class.java
-                )
-        ).thenReturn(
-                PUBLICIZE_RESPONSE
-        )
-
-        val result = insightsSqlUtils.selectPublicizeInsights(site)
-
-        assertEquals(result, PUBLICIZE_RESPONSE)
-    }
-
-    @Test
-    fun `inserts publicize response to stats utils`() {
-        insightsSqlUtils.insert(site, PUBLICIZE_RESPONSE)
-
-        verify(statsSqlUtils).insert(site, PUBLICIZE_INSIGHTS, INSIGHTS, PUBLICIZE_RESPONSE, true)
-    }
+    class TestSqlUtils(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<AllTimeResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            BlockType.ALL_TIME_INSIGHTS,
+            AllTimeResponse::class.java
+    )
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -46,9 +46,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TodayInsigh
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.AllTimeSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.CommentsInsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.DetailedPostStatsSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.EmailFollowersSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.LatestPostDetailSqlUtils
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.LatestPostStatsSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.MostPopularSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.PublicizeSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.TagsSqlUtils
@@ -92,7 +92,7 @@ class InsightsStoreTest {
     @Mock lateinit var wpComFollowersSqlUtils: WpComFollowersSqlUtils
     @Mock lateinit var emailFollowersSqlUtils: EmailFollowersSqlUtils
     @Mock lateinit var latestPostDetailSqlUtils: LatestPostDetailSqlUtils
-    @Mock lateinit var latestPostStatsSqlUtils: LatestPostStatsSqlUtils
+    @Mock lateinit var detailedPostStatsSqlUtils: DetailedPostStatsSqlUtils
     @Mock lateinit var mostPopularSqlUtils: MostPopularSqlUtils
     @Mock lateinit var publicizeSqlUtils: PublicizeSqlUtils
     @Mock lateinit var tagsSqlUtils: TagsSqlUtils
@@ -132,7 +132,7 @@ class InsightsStoreTest {
         latestPostStore = LatestPostInsightsStore(
                 latestPostInsightsRestClient,
                 latestPostDetailSqlUtils,
-                latestPostStatsSqlUtils,
+                detailedPostStatsSqlUtils,
                 mapper,
                 Unconfined
         )
@@ -275,13 +275,13 @@ class InsightsStoreTest {
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(latestPostDetailSqlUtils).insert(site, LATEST_POST)
-        verify(latestPostStatsSqlUtils).insert(site, LATEST_POST.id, viewsResponse)
+        verify(detailedPostStatsSqlUtils).insert(site, viewsResponse, postId = LATEST_POST.id)
     }
 
     @Test
     fun `returns latest post insights from db`() {
         whenever(latestPostDetailSqlUtils.select(site)).thenReturn(LATEST_POST)
-        whenever(latestPostStatsSqlUtils.select(site, LATEST_POST.id)).thenReturn(POST_STATS_RESPONSE)
+        whenever(detailedPostStatsSqlUtils.select(site, LATEST_POST.id)).thenReturn(POST_STATS_RESPONSE)
         val model = mock<InsightsLatestPostModel>()
         whenever(mapper.map(
                 LATEST_POST,

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -11,13 +11,13 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.CommentsModel
 import org.wordpress.android.fluxc.model.stats.FollowersModel
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.InsightsMostPopularModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.PagedMode
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
 import org.wordpress.android.fluxc.model.stats.TagsModel
@@ -44,7 +44,16 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestCli
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TodayInsightsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TodayInsightsRestClient.VisitResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.AllTimeSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.CommentsInsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.EmailFollowersSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.LatestPostDetailSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.LatestPostStatsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.MostPopularSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.PublicizeSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.TagsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.TodayInsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.WpComFollowersSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
@@ -78,7 +87,16 @@ class InsightsStoreTest {
     @Mock lateinit var publicizeRestClient: PublicizeRestClient
     @Mock lateinit var tagsRestClient: TagsRestClient
     @Mock lateinit var todayInsightsRestClient: TodayInsightsRestClient
-    @Mock lateinit var sqlUtils: InsightsSqlUtils
+    @Mock lateinit var allTimeSqlUtils: AllTimeSqlUtils
+    @Mock lateinit var commentInsightsSqlUtils: CommentsInsightsSqlUtils
+    @Mock lateinit var wpComFollowersSqlUtils: WpComFollowersSqlUtils
+    @Mock lateinit var emailFollowersSqlUtils: EmailFollowersSqlUtils
+    @Mock lateinit var latestPostDetailSqlUtils: LatestPostDetailSqlUtils
+    @Mock lateinit var latestPostStatsSqlUtils: LatestPostStatsSqlUtils
+    @Mock lateinit var mostPopularSqlUtils: MostPopularSqlUtils
+    @Mock lateinit var publicizeSqlUtils: PublicizeSqlUtils
+    @Mock lateinit var tagsSqlUtils: TagsSqlUtils
+    @Mock lateinit var todaySqlUtils: TodayInsightsSqlUtils
     @Mock lateinit var mapper: InsightsMapper
     @Mock lateinit var timeProvider: CurrentTimeProvider
     private lateinit var allTimeStore: AllTimeInsightsStore
@@ -94,49 +112,51 @@ class InsightsStoreTest {
     fun setUp() {
         allTimeStore = AllTimeInsightsStore(
                 allTimeInsightsRestClient,
-                sqlUtils,
+                allTimeSqlUtils,
                 mapper,
                 Unconfined
         )
         commentsStore = CommentsStore(
                 commentsRestClient,
-                sqlUtils,
+                commentInsightsSqlUtils,
                 mapper,
                 Unconfined
         )
         followersStore = FollowersStore(
                 followersRestClient,
-                sqlUtils,
+                wpComFollowersSqlUtils,
+                emailFollowersSqlUtils,
                 mapper,
                 Unconfined
         )
         latestPostStore = LatestPostInsightsStore(
                 latestPostInsightsRestClient,
-                sqlUtils,
+                latestPostDetailSqlUtils,
+                latestPostStatsSqlUtils,
                 mapper,
                 Unconfined
         )
         mostPopularStore = MostPopularInsightsStore(
                 mostPopularRestClient,
-                sqlUtils,
+                mostPopularSqlUtils,
                 mapper,
                 Unconfined
         )
         publicizeStore = PublicizeStore(
                 publicizeRestClient,
-                sqlUtils,
+                publicizeSqlUtils,
                 mapper,
                 Unconfined
         )
         tagsStore = TagsStore(
                 tagsRestClient,
-                sqlUtils,
+                tagsSqlUtils,
                 mapper,
                 Unconfined
         )
         todayStore = TodayInsightsStore(
                 todayInsightsRestClient,
-                sqlUtils,
+                todaySqlUtils,
                 mapper,
                 timeProvider,
                 Unconfined
@@ -157,7 +177,7 @@ class InsightsStoreTest {
         val responseModel = allTimeStore.fetchAllTimeInsights(site, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, ALL_TIME_RESPONSE)
+        verify(allTimeSqlUtils).insert(site, ALL_TIME_RESPONSE)
     }
 
     @Test
@@ -178,7 +198,7 @@ class InsightsStoreTest {
 
     @Test
     fun `returns all time insights from db`() {
-        whenever(sqlUtils.selectAllTimeInsights(site)).thenReturn(ALL_TIME_RESPONSE)
+        whenever(allTimeSqlUtils.select(site)).thenReturn(ALL_TIME_RESPONSE)
         val model = mock<InsightsAllTimeModel>()
         whenever(mapper.map(ALL_TIME_RESPONSE, site)).thenReturn(model)
 
@@ -200,7 +220,7 @@ class InsightsStoreTest {
         val responseModel = mostPopularStore.fetchMostPopularInsights(site, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, MOST_POPULAR_RESPONSE)
+        verify(mostPopularSqlUtils).insert(site, MOST_POPULAR_RESPONSE)
     }
 
     @Test
@@ -221,7 +241,7 @@ class InsightsStoreTest {
 
     @Test
     fun `returns most popular insights from db`() {
-        whenever(sqlUtils.selectMostPopularInsights(site)).thenReturn(MOST_POPULAR_RESPONSE)
+        whenever(mostPopularSqlUtils.select(site)).thenReturn(MOST_POPULAR_RESPONSE)
         val model = mock<InsightsMostPopularModel>()
         whenever(mapper.map(MOST_POPULAR_RESPONSE, site)).thenReturn(model)
 
@@ -254,14 +274,14 @@ class InsightsStoreTest {
         val responseModel = latestPostStore.fetchLatestPostInsights(site, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, LATEST_POST)
-        verify(sqlUtils).insert(site, viewsResponse)
+        verify(latestPostDetailSqlUtils).insert(site, LATEST_POST)
+        verify(latestPostStatsSqlUtils).insert(site, viewsResponse)
     }
 
     @Test
     fun `returns latest post insights from db`() {
-        whenever(sqlUtils.selectLatestPostDetail(site)).thenReturn(LATEST_POST)
-        whenever(sqlUtils.selectLatestPostStats(site)).thenReturn(POST_STATS_RESPONSE)
+        whenever(latestPostDetailSqlUtils.select(site)).thenReturn(LATEST_POST)
+        whenever(latestPostStatsSqlUtils.select(site)).thenReturn(POST_STATS_RESPONSE)
         val model = mock<InsightsLatestPostModel>()
         whenever(mapper.map(
                 LATEST_POST,
@@ -334,12 +354,12 @@ class InsightsStoreTest {
         val responseModel = todayStore.fetchTodayInsights(site, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, VISITS_RESPONSE)
+        verify(todaySqlUtils).insert(site, VISITS_RESPONSE)
     }
 
     @Test
     fun `returns today stats from db`() {
-        whenever(sqlUtils.selectTodayInsights(site)).thenReturn(VISITS_RESPONSE)
+        whenever(todaySqlUtils.select(site)).thenReturn(VISITS_RESPONSE)
         val model = mock<VisitsModel>()
         whenever(mapper.map(VISITS_RESPONSE)).thenReturn(model)
 
@@ -374,13 +394,13 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
-        whenever(sqlUtils.selectAllFollowers(site, WP_COM)).thenReturn(listOf(FOLLOWERS_RESPONSE))
+        whenever(wpComFollowersSqlUtils.selectAll(site)).thenReturn(listOf(FOLLOWERS_RESPONSE))
         whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, LimitMode.All))
                 .thenReturn(model)
         val responseModel = followersStore.fetchWpComFollowers(site, LOAD_MODE_INITIAL, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, WP_COM, true)
+        verify(wpComFollowersSqlUtils).insert(site, FOLLOWERS_RESPONSE, requestedItems = PAGE_SIZE, replaceExistingData = true)
     }
 
     @Test
@@ -393,19 +413,19 @@ class InsightsStoreTest {
                 fetchInsightsPayload
         )
         val model = FollowersModel(0, emptyList(), false)
-        whenever(sqlUtils.selectAllFollowers(site, EMAIL)).thenReturn(listOf(FOLLOWERS_RESPONSE))
+        whenever(emailFollowersSqlUtils.selectAll(site)).thenReturn(listOf(FOLLOWERS_RESPONSE))
         whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, LimitMode.All))
                 .thenReturn(model)
         val responseModel = followersStore.fetchEmailFollowers(site, LOAD_MODE_INITIAL, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, FOLLOWERS_RESPONSE, EMAIL, true)
+        verify(emailFollowersSqlUtils).insert(site, FOLLOWERS_RESPONSE, requestedItems = PAGE_SIZE, replaceExistingData = true)
     }
 
     @Test
     fun `returns WPCOM followers from db`() {
         val model = mock<FollowersModel>()
-        whenever(sqlUtils.selectAllFollowers(site, WP_COM)).thenReturn(listOf(FOLLOWERS_RESPONSE))
+        whenever(wpComFollowersSqlUtils.selectAll(site)).thenReturn(listOf(FOLLOWERS_RESPONSE))
         whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), WP_COM, LimitMode.Top(PAGE_SIZE)))
                 .thenReturn(model)
 
@@ -417,7 +437,7 @@ class InsightsStoreTest {
     @Test
     fun `returns email followers from db`() {
         val model = mock<FollowersModel>()
-        whenever(sqlUtils.selectAllFollowers(site, EMAIL)).thenReturn(listOf(FOLLOWERS_RESPONSE))
+        whenever(emailFollowersSqlUtils.selectAll(site)).thenReturn(listOf(FOLLOWERS_RESPONSE))
         whenever(mapper.mapAndMergeFollowersModels(listOf(FOLLOWERS_RESPONSE), EMAIL, LimitMode.Top(PAGE_SIZE)))
                 .thenReturn(model)
 
@@ -473,12 +493,12 @@ class InsightsStoreTest {
         val responseModel = commentsStore.fetchComments(site, LimitMode.Top(PAGE_SIZE), forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, TOP_COMMENTS_RESPONSE)
+        verify(commentInsightsSqlUtils).insert(site, TOP_COMMENTS_RESPONSE, requestedItems = PAGE_SIZE)
     }
 
     @Test
     fun `returns top comments from db`() {
-        whenever(sqlUtils.selectCommentInsights(site)).thenReturn(TOP_COMMENTS_RESPONSE)
+        whenever(commentInsightsSqlUtils.select(site)).thenReturn(TOP_COMMENTS_RESPONSE)
         val model = mock<CommentsModel>()
         whenever(mapper.map(TOP_COMMENTS_RESPONSE, LimitMode.Top(PAGE_SIZE))).thenReturn(model)
 
@@ -518,12 +538,12 @@ class InsightsStoreTest {
         val responseModel = tagsStore.fetchTags(site, LimitMode.Top(PAGE_SIZE), forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, TAGS_RESPONSE)
+        verify(tagsSqlUtils).insert(site, TAGS_RESPONSE)
     }
 
     @Test
     fun `returns tags and categories from db`() {
-        whenever(sqlUtils.selectTags(site)).thenReturn(TAGS_RESPONSE)
+        whenever(tagsSqlUtils.select(site)).thenReturn(TAGS_RESPONSE)
         val model = mock<TagsModel>()
         whenever(mapper.map(TAGS_RESPONSE, LimitMode.Top(PAGE_SIZE))).thenReturn(model)
 
@@ -563,12 +583,12 @@ class InsightsStoreTest {
         val responseModel = publicizeStore.fetchPublicizeData(site, PAGE_SIZE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, PUBLICIZE_RESPONSE)
+        verify(publicizeSqlUtils).insert(site, PUBLICIZE_RESPONSE)
     }
 
     @Test
     fun `returns publicize data from db`() {
-        whenever(sqlUtils.selectPublicizeInsights(site)).thenReturn(PUBLICIZE_RESPONSE)
+        whenever(publicizeSqlUtils.select(site)).thenReturn(PUBLICIZE_RESPONSE)
         val model = mock<PublicizeModel>()
         whenever(mapper.map(PUBLICIZE_RESPONSE, PAGE_SIZE)).thenReturn(model)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -538,7 +538,7 @@ class InsightsStoreTest {
         val responseModel = tagsStore.fetchTags(site, LimitMode.Top(PAGE_SIZE), forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(tagsSqlUtils).insert(site, TAGS_RESPONSE)
+        verify(tagsSqlUtils).insert(site, TAGS_RESPONSE, requestedItems = PAGE_SIZE)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -400,7 +400,12 @@ class InsightsStoreTest {
         val responseModel = followersStore.fetchWpComFollowers(site, LOAD_MODE_INITIAL, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(wpComFollowersSqlUtils).insert(site, FOLLOWERS_RESPONSE, requestedItems = PAGE_SIZE, replaceExistingData = true)
+        verify(wpComFollowersSqlUtils).insert(
+                site,
+                FOLLOWERS_RESPONSE,
+                requestedItems = PAGE_SIZE,
+                replaceExistingData = true
+        )
     }
 
     @Test
@@ -419,7 +424,12 @@ class InsightsStoreTest {
         val responseModel = followersStore.fetchEmailFollowers(site, LOAD_MODE_INITIAL, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
-        verify(emailFollowersSqlUtils).insert(site, FOLLOWERS_RESPONSE, requestedItems = PAGE_SIZE, replaceExistingData = true)
+        verify(emailFollowersSqlUtils).insert(
+                site,
+                FOLLOWERS_RESPONSE,
+                requestedItems = PAGE_SIZE,
+                replaceExistingData = true
+        )
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/PostDetailStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/PostDetailStoreTest.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.fluxc.model.stats.PostDetailStatsMapper
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient.PostStatsResponse
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.DetailedPostStatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
@@ -27,7 +27,7 @@ import kotlin.test.assertNotNull
 class PostDetailStoreTest {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var restClient: LatestPostInsightsRestClient
-    @Mock lateinit var sqlUtils: InsightsSqlUtils
+    @Mock lateinit var sqlUtils: DetailedPostStatsSqlUtils
     @Mock lateinit var mapper: PostDetailStatsMapper
     private lateinit var store: PostDetailStore
     private val postId: Long = 1L
@@ -55,7 +55,7 @@ class PostDetailStoreTest {
         val responseModel = store.fetchPostDetail(site, postId, forced)
 
         Assertions.assertThat(responseModel.model).isEqualTo(model)
-        verify(sqlUtils).insert(site, postId, POST_STATS_RESPONSE)
+        verify(sqlUtils).insert(site, POST_STATS_RESPONSE, postId = postId)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/insights/PostingActivityStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/insights/PostingActivityStoreTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.model.stats.insights.PostingActivityModel
 import org.wordpress.android.fluxc.model.stats.insights.PostingActivityModel.Day
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.PostingActivitySqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
@@ -29,7 +29,7 @@ import kotlin.test.assertNotNull
 class PostingActivityStoreTest {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var restClient: PostingActivityRestClient
-    @Mock lateinit var sqlUtils: InsightsSqlUtils
+    @Mock lateinit var sqlUtils: PostingActivitySqlUtils
     @Mock lateinit var mapper: InsightsMapper
     private lateinit var store: PostingActivityStore
     private val startDate = Day(2018, 1, 1)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -3,9 +3,6 @@ package org.wordpress.android.fluxc.persistence
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.AllTimeInsightsRestClient.AllTimeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.CommentsRestClient.CommentsResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.EMAIL
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.WP_COM
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient.PostStatsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient.PostsResponse.PostResponse
@@ -28,128 +25,161 @@ import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.TODAYS_IN
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.WP_COM_FOLLOWERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType.INSIGHTS
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-class InsightsSqlUtils
-@Inject constructor(private val statsSqlUtils: StatsSqlUtils, private val statsRequestSqlUtils: StatsRequestSqlUtils) {
-    fun insert(site: SiteModel, data: AllTimeResponse) {
-        insert(site, ALL_TIME_INSIGHTS, data)
-    }
-
-    fun insert(site: SiteModel, data: MostPopularResponse) {
-        insert(site, MOST_POPULAR_INSIGHTS, data)
-    }
-
-    fun insert(site: SiteModel, data: PostResponse) {
-        insert(site, LATEST_POST_DETAIL_INSIGHTS, data)
-    }
-
-    fun insert(site: SiteModel, data: PostStatsResponse) {
-        insert(site, LATEST_POST_STATS_INSIGHTS, data)
-    }
-
-    fun insert(site: SiteModel, data: VisitResponse) {
-        insert(site, TODAYS_INSIGHTS, data)
-    }
-
+open class InsightsSqlUtils<RESPONSE_TYPE>
+constructor(
+    private val statsSqlUtils: StatsSqlUtils,
+    private val statsRequestSqlUtils: StatsRequestSqlUtils,
+    private val blockType: BlockType,
+    private val classOfResponse: Class<RESPONSE_TYPE>
+) {
     fun insert(
         site: SiteModel,
-        data: FollowersResponse,
-        followerType: FollowerType,
-        replaceExistingData: Boolean,
-        requestedItems: Int
+        data: RESPONSE_TYPE,
+        requestedItems: Int? = null,
+        replaceExistingData: Boolean = true
     ) {
-        insert(site, followerType.toDbKey(), data, replaceExistingData)
-        if (replaceExistingData){
-            insertRequest(site, followerType.toDbKey(), requestedItems)
+        statsSqlUtils.insert(site, blockType, INSIGHTS, data, replaceExistingData)
+        if (replaceExistingData) {
+            statsRequestSqlUtils.insert(
+                    site,
+                    blockType,
+                    INSIGHTS,
+                    requestedItems
+            )
         }
     }
 
-    fun insert(site: SiteModel, data: CommentsResponse) {
-        insert(site, COMMENTS_INSIGHTS, data)
+    fun select(site: SiteModel): RESPONSE_TYPE? {
+        return statsSqlUtils.select(site, blockType, INSIGHTS, classOfResponse)
     }
 
-    fun insert(site: SiteModel, data: TagsResponse) {
-        insert(site, TAGS_AND_CATEGORIES_INSIGHTS, data)
+    fun selectAll(site: SiteModel): List<RESPONSE_TYPE> {
+        return statsSqlUtils.selectAll(site, blockType, INSIGHTS, classOfResponse)
     }
 
-    fun insert(site: SiteModel, data: PublicizeResponse) {
-        insert(site, PUBLICIZE_INSIGHTS, data)
-    }
-
-    fun insert(site: SiteModel, data: PostingActivityResponse) {
-        insert(site, POSTING_ACTIVITY, data)
-    }
-
-    fun selectAllTimeInsights(site: SiteModel): AllTimeResponse? {
-        return select(site, ALL_TIME_INSIGHTS, AllTimeResponse::class.java)
-    }
-
-    fun selectMostPopularInsights(site: SiteModel): MostPopularResponse? {
-        return select(site, MOST_POPULAR_INSIGHTS, MostPopularResponse::class.java)
-    }
-
-    fun selectLatestPostDetail(site: SiteModel): PostResponse? {
-        return select(site, LATEST_POST_DETAIL_INSIGHTS, PostResponse::class.java)
-    }
-
-    fun selectLatestPostStats(site: SiteModel): PostStatsResponse? {
-        return select(site, LATEST_POST_STATS_INSIGHTS, PostStatsResponse::class.java)
-    }
-
-    fun selectTodayInsights(site: SiteModel): VisitResponse? {
-        return select(site, TODAYS_INSIGHTS, VisitResponse::class.java)
-    }
-
-    fun selectFollowers(site: SiteModel, followerType: FollowerType): FollowersResponse? {
-        return select(site, followerType.toDbKey(), FollowersResponse::class.java)
-    }
-
-    fun selectAllFollowers(site: SiteModel, followerType: FollowerType): List<FollowersResponse> {
-        return selectAll(site, followerType.toDbKey(), FollowersResponse::class.java)
-    }
-
-    fun selectPublicizeInsights(site: SiteModel): PublicizeResponse? {
-        return select(site, PUBLICIZE_INSIGHTS, PublicizeResponse::class.java)
-    }
-
-    fun selectPostingActivity(site: SiteModel): PostingActivityResponse? {
-        return select(site, POSTING_ACTIVITY, PostingActivityResponse::class.java)
-    }
-
-    fun selectCommentInsights(site: SiteModel): CommentsResponse? {
-        return select(site, COMMENTS_INSIGHTS, CommentsResponse::class.java)
-    }
-
-    fun selectTags(site: SiteModel): TagsResponse? {
-        return select(site, TAGS_AND_CATEGORIES_INSIGHTS, TagsResponse::class.java)
-    }
-
-    private fun <T> insert(site: SiteModel, blockType: BlockType, data: T, replaceExistingData: Boolean = true) {
-        statsSqlUtils.insert(site, blockType, INSIGHTS, data, replaceExistingData)
-    }
-
-    private fun <T> select(site: SiteModel, blockType: BlockType, classOfT: Class<T>): T? {
-        return statsSqlUtils.select(site, blockType, INSIGHTS, classOfT)
-    }
-
-    private fun <T> selectAll(site: SiteModel, blockType: BlockType, classOfT: Class<T>): List<T> {
-        return statsSqlUtils.selectAll(site, blockType, INSIGHTS, classOfT)
-    }
-
-    fun hasFreshRequest(site: SiteModel, blockType: BlockType, requestedItems: Int): Boolean {
+    fun hasFreshRequest(site: SiteModel, requestedItems: Int? = null): Boolean {
         return statsRequestSqlUtils.hasFreshRequest(site, blockType, INSIGHTS, requestedItems)
     }
 
-    private fun insertRequest(site: SiteModel, blockType: BlockType, requestedItems: Int) {
-        statsRequestSqlUtils.insert(site, blockType, INSIGHTS, requestedItems)
-    }
-}
+    class AllTimeSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<AllTimeResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            ALL_TIME_INSIGHTS,
+            AllTimeResponse::class.java
+    )
 
-fun FollowerType.toDbKey(): StatsSqlUtils.BlockType {
-    return when (this) {
-        WP_COM -> WP_COM_FOLLOWERS
-        EMAIL -> EMAIL_FOLLOWERS
-    }
+    class MostPopularSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<MostPopularResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            MOST_POPULAR_INSIGHTS,
+            MostPopularResponse::class.java
+    )
+
+    class LatestPostDetailSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<PostResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            LATEST_POST_DETAIL_INSIGHTS,
+            PostResponse::class.java
+    )
+
+    class LatestPostStatsSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<PostStatsResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            LATEST_POST_STATS_INSIGHTS,
+            PostStatsResponse::class.java
+    )
+
+    class TodayInsightsSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<VisitResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            TODAYS_INSIGHTS,
+            VisitResponse::class.java
+    )
+
+    class CommentsInsightsSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<CommentsResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            COMMENTS_INSIGHTS,
+            CommentsResponse::class.java
+    )
+
+    class WpComFollowersSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<FollowersResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            WP_COM_FOLLOWERS,
+            FollowersResponse::class.java
+    )
+
+    class EmailFollowersSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<FollowersResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            EMAIL_FOLLOWERS,
+            FollowersResponse::class.java
+    )
+
+    class TagsSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<TagsResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            TAGS_AND_CATEGORIES_INSIGHTS,
+            TagsResponse::class.java
+    )
+
+    class PublicizeSqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<PublicizeResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            PUBLICIZE_INSIGHTS,
+            PublicizeResponse::class.java
+    )
+
+    class PostingActivitySqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<PostingActivityResponse>(
+            statsSqlUtils,
+            statsRequestSqlUtils,
+            POSTING_ACTIVITY,
+            PostingActivityResponse::class.java
+    )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -32,7 +32,7 @@ import javax.inject.Singleton
 
 @Singleton
 class InsightsSqlUtils
-@Inject constructor(private val statsSqlUtils: StatsSqlUtils) {
+@Inject constructor(private val statsSqlUtils: StatsSqlUtils, private val statsRequestSqlUtils: StatsRequestSqlUtils) {
     fun insert(site: SiteModel, data: AllTimeResponse) {
         insert(site, ALL_TIME_INSIGHTS, data)
     }
@@ -109,13 +109,6 @@ class InsightsSqlUtils
         return select(site, POSTING_ACTIVITY, PostingActivityResponse::class.java)
     }
 
-    private fun FollowerType.toDbKey(): StatsSqlUtils.BlockType {
-        return when (this) {
-            WP_COM -> WP_COM_FOLLOWERS
-            EMAIL -> EMAIL_FOLLOWERS
-        }
-    }
-
     fun selectCommentInsights(site: SiteModel): CommentsResponse? {
         return select(site, COMMENTS_INSIGHTS, CommentsResponse::class.java)
     }
@@ -134,5 +127,20 @@ class InsightsSqlUtils
 
     private fun <T> selectAll(site: SiteModel, blockType: BlockType, classOfT: Class<T>): List<T> {
         return statsSqlUtils.selectAll(site, blockType, INSIGHTS, classOfT)
+    }
+
+    fun hasFreshRequest(site: SiteModel, blockType: BlockType, requestedItems: Int): Boolean {
+        return statsRequestSqlUtils.hasFreshRequest(site, blockType, INSIGHTS, requestedItems)
+    }
+
+    fun insertRequest(site: SiteModel, blockType: BlockType, requestedItems: Int) {
+        statsRequestSqlUtils.insert(site, blockType, INSIGHTS, requestedItems)
+    }
+}
+
+fun FollowerType.toDbKey(): StatsSqlUtils.BlockType {
+    return when (this) {
+        WP_COM -> WP_COM_FOLLOWERS
+        EMAIL -> EMAIL_FOLLOWERS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -53,8 +53,17 @@ class InsightsSqlUtils
         insert(site, TODAYS_INSIGHTS, data)
     }
 
-    fun insert(site: SiteModel, data: FollowersResponse, followerType: FollowerType, replaceExistingData: Boolean) {
+    fun insert(
+        site: SiteModel,
+        data: FollowersResponse,
+        followerType: FollowerType,
+        replaceExistingData: Boolean,
+        requestedItems: Int
+    ) {
         insert(site, followerType.toDbKey(), data, replaceExistingData)
+        if (replaceExistingData){
+            insertRequest(site, followerType.toDbKey(), requestedItems)
+        }
     }
 
     fun insert(site: SiteModel, data: CommentsResponse) {
@@ -133,7 +142,7 @@ class InsightsSqlUtils
         return statsRequestSqlUtils.hasFreshRequest(site, blockType, INSIGHTS, requestedItems)
     }
 
-    fun insertRequest(site: SiteModel, blockType: BlockType, requestedItems: Int) {
+    private fun insertRequest(site: SiteModel, blockType: BlockType, requestedItems: Int) {
         statsRequestSqlUtils.insert(site, blockType, INSIGHTS, requestedItems)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -46,7 +46,8 @@ constructor(
                     site,
                     blockType,
                     INSIGHTS,
-                    requestedItems
+                    requestedItems,
+                    postId = postId
             )
         }
     }
@@ -59,8 +60,8 @@ constructor(
         return statsSqlUtils.selectAll(site, blockType, INSIGHTS, classOfResponse)
     }
 
-    fun hasFreshRequest(site: SiteModel, requestedItems: Int? = null): Boolean {
-        return statsRequestSqlUtils.hasFreshRequest(site, blockType, INSIGHTS, requestedItems)
+    fun hasFreshRequest(site: SiteModel, requestedItems: Int? = null, postId: Long? = null): Boolean {
+        return statsRequestSqlUtils.hasFreshRequest(site, blockType, INSIGHTS, requestedItems, postId = postId)
     }
 
     class AllTimeSqlUtils

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsRequestSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsRequestSqlUtils.kt
@@ -22,7 +22,8 @@ class StatsRequestSqlUtils
         blockType: BlockType,
         statsType: StatsType,
         requestedItems: Int? = null,
-        date: String? = null
+        date: String? = null,
+        postId: Long? = null
     ) {
         var deleteStatement = WellSql.delete(StatsRequestBuilder::class.java)
                 .where()
@@ -39,6 +40,7 @@ class StatsRequestSqlUtils
                         blockType = blockType.name,
                         statsType = statsType.name,
                         date = date,
+                        postId =  postId,
                         timeStamp = System.currentTimeMillis(),
                         requestedItems = requestedItems
                 )
@@ -51,13 +53,15 @@ class StatsRequestSqlUtils
         statsType: StatsType,
         requestedItems: Int? = null,
         after: Long = System.currentTimeMillis() - STALE_PERIOD,
-        date: String? = null
+        date: String? = null,
+        postId: Long? = null
     ): Boolean {
         return createSelectStatement(
                 site,
                 blockType,
                 statsType,
                 date,
+                postId,
                 after,
                 requestedItems
         ).asModel.firstOrNull<StatsRequestBuilder?>() != null
@@ -68,6 +72,7 @@ class StatsRequestSqlUtils
         blockType: BlockType,
         statsType: StatsType,
         date: String?,
+        postId: Long?,
         after: Long,
         requestedItems: Int? = null
     ): SelectQuery<StatsRequestBuilder> {
@@ -83,6 +88,9 @@ class StatsRequestSqlUtils
         if (date != null) {
             select = select.equals(StatsRequestTable.DATE, date)
         }
+        if (postId != null) {
+            select = select.equals(StatsRequestTable.POST_ID, postId)
+        }
         return select.endWhere()
     }
 
@@ -93,10 +101,11 @@ class StatsRequestSqlUtils
         @Column var blockType: String,
         @Column var statsType: String,
         @Column var date: String?,
+        @Column var postId: Long?,
         @Column var timeStamp: Long,
         @Column var requestedItems: Int?
     ) : Identifiable {
-        constructor() : this(-1, -1, "", "", null, 0, null)
+        constructor() : this(-1, -1, "", "", null, null, 0, null)
 
         override fun setId(id: Int) {
             this.mId = id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsRequestSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsRequestSqlUtils.kt
@@ -1,0 +1,110 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.StatsBlockTable
+import com.wellsql.generated.StatsRequestTable
+import com.yarolegovich.wellsql.SelectQuery
+import com.yarolegovich.wellsql.WellSql
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.StatsType
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StatsRequestSqlUtils
+@Inject constructor() {
+    fun insert(
+        site: SiteModel,
+        blockType: BlockType,
+        statsType: StatsType,
+        requestedItems: Int,
+        date: String? = null
+    ) {
+        var deleteStatement = WellSql.delete(StatsRequestBuilder::class.java)
+                .where()
+                .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
+                .equals(StatsBlockTable.BLOCK_TYPE, blockType.name)
+                .equals(StatsBlockTable.STATS_TYPE, statsType.name)
+        if (date != null) {
+            deleteStatement = deleteStatement.equals(StatsBlockTable.DATE, date)
+        }
+        deleteStatement.endWhere().execute()
+        WellSql.insert(
+                StatsRequestBuilder(
+                        localSiteId = site.id,
+                        blockType = blockType.name,
+                        statsType = statsType.name,
+                        date = date,
+                        timeStamp = System.currentTimeMillis(),
+                        requestedItems = requestedItems
+                )
+        )
+                .execute()
+    }
+
+    fun hasFreshRequest(
+        site: SiteModel,
+        blockType: BlockType,
+        statsType: StatsType,
+        requestedItems: Int,
+        after: Long = System.currentTimeMillis() - STALE_PERIOD,
+        date: String? = null
+    ): Boolean {
+        return createSelectStatement(
+                site,
+                blockType,
+                statsType,
+                date,
+                after,
+                requestedItems
+        ).asModel.firstOrNull<StatsRequestBuilder?>() != null
+    }
+
+    private fun createSelectStatement(
+        site: SiteModel,
+        blockType: BlockType,
+        statsType: StatsType,
+        date: String?,
+        after: Long,
+        requestedItems: Int
+    ): SelectQuery<StatsRequestBuilder> {
+        var select = WellSql.select(StatsRequestBuilder::class.java)
+                .where()
+                .equals(StatsRequestTable.LOCAL_SITE_ID, site.id)
+                .equals(StatsRequestTable.BLOCK_TYPE, blockType.name)
+                .equals(StatsRequestTable.STATS_TYPE, statsType.name)
+                .greaterThen(StatsRequestTable.TIME_STAMP, after)
+                .greaterThenOrEqual(StatsRequestTable.REQUESTED_ITEMS, requestedItems)
+        if (date != null) {
+            select = select.equals(StatsRequestTable.DATE, date)
+        }
+        return select.endWhere()
+    }
+
+    @Table(name = "StatsRequest")
+    data class StatsRequestBuilder(
+        @PrimaryKey @Column private var mId: Int = -1,
+        @Column var localSiteId: Int,
+        @Column var blockType: String,
+        @Column var statsType: String,
+        @Column var date: String?,
+        @Column var timeStamp: Long,
+        @Column var requestedItems: Int
+    ) : Identifiable {
+        constructor() : this(-1, -1, "", "", null, 0, 0)
+
+        override fun setId(id: Int) {
+            this.mId = id
+        }
+
+        override fun getId() = mId
+    }
+
+    companion object {
+        private const val STALE_PERIOD = 5 * 60 * 1000
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsRequestSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsRequestSqlUtils.kt
@@ -40,7 +40,7 @@ class StatsRequestSqlUtils
                         blockType = blockType.name,
                         statsType = statsType.name,
                         date = date,
-                        postId =  postId,
+                        postId = postId,
                         timeStamp = System.currentTimeMillis(),
                         requestedItems = requestedItems
                 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsRequestSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsRequestSqlUtils.kt
@@ -21,7 +21,7 @@ class StatsRequestSqlUtils
         site: SiteModel,
         blockType: BlockType,
         statsType: StatsType,
-        requestedItems: Int,
+        requestedItems: Int? = null,
         date: String? = null
     ) {
         var deleteStatement = WellSql.delete(StatsRequestBuilder::class.java)
@@ -42,15 +42,14 @@ class StatsRequestSqlUtils
                         timeStamp = System.currentTimeMillis(),
                         requestedItems = requestedItems
                 )
-        )
-                .execute()
+        ).execute()
     }
 
     fun hasFreshRequest(
         site: SiteModel,
         blockType: BlockType,
         statsType: StatsType,
-        requestedItems: Int,
+        requestedItems: Int? = null,
         after: Long = System.currentTimeMillis() - STALE_PERIOD,
         date: String? = null
     ): Boolean {
@@ -70,7 +69,7 @@ class StatsRequestSqlUtils
         statsType: StatsType,
         date: String?,
         after: Long,
-        requestedItems: Int
+        requestedItems: Int? = null
     ): SelectQuery<StatsRequestBuilder> {
         var select = WellSql.select(StatsRequestBuilder::class.java)
                 .where()
@@ -78,7 +77,9 @@ class StatsRequestSqlUtils
                 .equals(StatsRequestTable.BLOCK_TYPE, blockType.name)
                 .equals(StatsRequestTable.STATS_TYPE, statsType.name)
                 .greaterThen(StatsRequestTable.TIME_STAMP, after)
-                .greaterThenOrEqual(StatsRequestTable.REQUESTED_ITEMS, requestedItems)
+        if (requestedItems != null) {
+            select = select.greaterThenOrEqual(StatsRequestTable.REQUESTED_ITEMS, requestedItems)
+        }
         if (date != null) {
             select = select.equals(StatsRequestTable.DATE, date)
         }
@@ -93,9 +94,9 @@ class StatsRequestSqlUtils
         @Column var statsType: String,
         @Column var date: String?,
         @Column var timeStamp: Long,
-        @Column var requestedItems: Int
+        @Column var requestedItems: Int?
     ) : Identifiable {
-        constructor() : this(-1, -1, "", "", null, 0, 0)
+        constructor() : this(-1, -1, "", "", null, 0, null)
 
         override fun setId(id: Int) {
             this.mId = id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ"
+const val DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ"
 
 @Singleton
 class StatsSqlUtils

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -456,19 +456,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 58:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL(
-                        "CREATE TABLE StatsBlockTemp (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
-                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT,JSON TEXT NOT NULL)");
-                db.execSQL("INSERT INTO StatsBlockTemp SELECT * FROM StatsBlock");
-                db.execSQL("DROP TABLE StatsBlock");
-                db.execSQL("ALTER TABLE StatsBlockTemp RENAME TO StatsBlock");
-                oldVersion++;
-            case 58:
-                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("DROP TABLE StatsBlock");
                 db.execSQL(
                         "CREATE TABLE StatsBlock (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
-                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT,JSON TEXT NOT NULL)");
+                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT,POST_ID INTEGER,JSON TEXT NOT "
+                        + "NULL)");
                 db.execSQL(
                         "CREATE TABLE StatsRequest (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
                         + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT,TIME_STAMP INTEGER,"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 58;
+        return 59;
     }
 
     @Override
@@ -458,6 +458,17 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("INSERT INTO StatsBlockTemp SELECT * FROM StatsBlock");
                 db.execSQL("DROP TABLE StatsBlock");
                 db.execSQL("ALTER TABLE StatsBlockTemp RENAME TO StatsBlock");
+                oldVersion++;
+            case 58:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE StatsBlock");
+                db.execSQL(
+                        "CREATE TABLE StatsBlock (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT,JSON TEXT NOT NULL)");
+                db.execSQL(
+                        "CREATE TABLE StatsRequest (_id INTEGER PRIMARY KEY AUTOINCREMENT,LOCAL_SITE_ID INTEGER,"
+                        + "BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT,TIME_STAMP INTEGER,"
+                        + "REQUESTED_ITEMS INTEGER)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -98,7 +98,7 @@ class StatsStore
         VIDEOS
     }
 
-    data class OnStatsFetched<T>(val model: T? = null) : Store.OnChanged<StatsError>() {
+    data class OnStatsFetched<T>(val model: T? = null, val cached: Boolean = false) : Store.OnChanged<StatsError>() {
         constructor(error: StatsError) : this() {
             this.error = error
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/PostDetailStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/PostDetailStore.kt
@@ -26,6 +26,9 @@ class PostDetailStore
         postId: Long,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
+        if (!forced && sqlUtils.hasFreshRequest(site, postId = postId)) {
+            return@withContext OnStatsFetched(getPostDetail(site, postId), cached = true)
+        }
         val payload = restClient.fetchPostStats(site, postId, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/PostDetailStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/PostDetailStore.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsMapper
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.DetailedPostStatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
@@ -17,7 +17,7 @@ import kotlin.coroutines.CoroutineContext
 class PostDetailStore
 @Inject constructor(
     private val restClient: LatestPostInsightsRestClient,
-    private val sqlUtils: InsightsSqlUtils,
+    private val sqlUtils: DetailedPostStatsSqlUtils,
     private val coroutineContext: CoroutineContext,
     private val mapper: PostDetailStatsMapper
 ) {
@@ -30,7 +30,7 @@ class PostDetailStore
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
-                sqlUtils.insert(site, postId, payload.response)
+                sqlUtils.insert(site, payload.response, postId = postId)
                 OnStatsFetched(mapper.map(payload.response))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
@@ -38,6 +38,6 @@ class PostDetailStore
     }
 
     fun getPostDetail(site: SiteModel, postId: Long): PostDetailStatsModel? {
-        return sqlUtils.selectDetailedPostStats(site, postId)?.let { mapper.map(it) }
+        return sqlUtils.select(site, postId)?.let { mapper.map(it) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/AllTimeInsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/AllTimeInsightsStore.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.AllTimeInsightsRestClient
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.AllTimeSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
@@ -16,11 +16,14 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 class AllTimeInsightsStore @Inject constructor(
     private val restClient: AllTimeInsightsRestClient,
-    private val sqlUtils: InsightsSqlUtils,
+    private val sqlUtils: AllTimeSqlUtils,
     private val insightsMapper: InsightsMapper,
     private val coroutineContext: CoroutineContext
 ) {
     suspend fun fetchAllTimeInsights(site: SiteModel, forced: Boolean = false) = withContext(coroutineContext) {
+        if (!forced && sqlUtils.hasFreshRequest(site)) {
+            return@withContext OnStatsFetched(getAllTimeInsights(site), cached = true)
+        }
         val payload = restClient.fetchAllTimeInsights(site, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
@@ -33,6 +36,6 @@ class AllTimeInsightsStore @Inject constructor(
     }
 
     fun getAllTimeInsights(site: SiteModel): InsightsAllTimeModel? {
-        return sqlUtils.selectAllTimeInsights(site)?.let { insightsMapper.map(it, site) }
+        return sqlUtils.select(site)?.let { insightsMapper.map(it, site) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/CommentsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/CommentsStore.kt
@@ -2,11 +2,12 @@ package org.wordpress.android.fluxc.store.stats.insights
 
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.CommentsModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.model.stats.LimitMode.Top
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.CommentsRestClient
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.CommentsInsightsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
@@ -17,19 +18,27 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 class CommentsStore @Inject constructor(
     private val restClient: CommentsRestClient,
-    private val sqlUtils: InsightsSqlUtils,
+    private val sqlUtils: CommentsInsightsSqlUtils,
     private val insightsMapper: InsightsMapper,
     private val coroutineContext: CoroutineContext
 ) {
     suspend fun fetchComments(siteModel: SiteModel, limitMode: LimitMode, forced: Boolean = false) =
             withContext(coroutineContext) {
+                val requestedItems = if (limitMode is Top) limitMode.limit else Int.MAX_VALUE
+                if (!forced && sqlUtils.hasFreshRequest(siteModel, requestedItems)) {
+                    return@withContext OnStatsFetched(getComments(siteModel, limitMode), cached = true)
+                }
                 val responsePayload = restClient.fetchTopComments(siteModel, forced = forced)
                 return@withContext when {
                     responsePayload.isError -> {
                         OnStatsFetched(responsePayload.error)
                     }
                     responsePayload.response != null -> {
-                        sqlUtils.insert(siteModel, responsePayload.response)
+                        sqlUtils.insert(
+                                siteModel,
+                                responsePayload.response,
+                                requestedItems
+                        )
                         OnStatsFetched(insightsMapper.map(responsePayload.response, limitMode))
                     }
                     else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
@@ -37,6 +46,6 @@ class CommentsStore @Inject constructor(
             }
 
     fun getComments(site: SiteModel, cacheMode: LimitMode): CommentsModel? {
-        return sqlUtils.selectCommentInsights(site)?.let { insightsMapper.map(it, cacheMode) }
+        return sqlUtils.select(site)?.let { insightsMapper.map(it, cacheMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
@@ -2,10 +2,10 @@ package org.wordpress.android.fluxc.store.stats.insights
 
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.stats.LimitMode
-import org.wordpress.android.fluxc.model.stats.LimitMode.All
 import org.wordpress.android.fluxc.model.stats.FollowersModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.model.stats.LimitMode.All
 import org.wordpress.android.fluxc.model.stats.PagedMode
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType
@@ -58,7 +58,7 @@ class FollowersStore @Inject constructor(
                     getFollowers(
                             siteModel,
                             followerType,
-                            cacheMode = CacheMode.Top(fetchMode.pageSize)
+                            cacheMode = LimitMode.Top(fetchMode.pageSize)
                     )
             )
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
@@ -23,7 +23,8 @@ import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 @Singleton
-class FollowersStore @Inject constructor(
+class FollowersStore
+@Inject constructor(
     private val restClient: FollowersRestClient,
     private val wpComFollowersSqlUtils: WpComFollowersSqlUtils,
     private val emailFollowersSqlUtils: EmailFollowersSqlUtils,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
@@ -65,7 +65,8 @@ class FollowersStore @Inject constructor(
                             siteModel,
                             followerType,
                             cacheMode = LimitMode.Top(fetchMode.pageSize)
-                    )
+                    ),
+                    cached = true
             )
         }
         val nextPage = if (fetchMode.loadMore) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
@@ -54,7 +54,7 @@ class FollowersStore @Inject constructor(
                 "followers_log",
                 "Fetching followers: forced - $forced, type - $followerType, fetchedItems: ${fetchMode.pageSize}, loadMore: ${fetchMode.loadMore}"
         )
-        if (!forced && !fetchMode.loadMore && !sqlUtils.hasFreshRequest(
+        if (!forced && !fetchMode.loadMore && sqlUtils.hasFreshRequest(
                         siteModel,
                         followerType.toDbKey(),
                         fetchMode.pageSize

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
@@ -76,8 +76,7 @@ class FollowersStore @Inject constructor(
             }
             responsePayload.response != null -> {
                 val replace = !fetchMode.loadMore
-                sqlUtils.insert(siteModel, responsePayload.response, followerType, replaceExistingData = replace)
-                sqlUtils.insertRequest(siteModel, followerType.toDbKey(), fetchMode.pageSize)
+                sqlUtils.insert(siteModel, responsePayload.response, followerType, replaceExistingData = replace, requestedItems = fetchMode.pageSize)
                 val followerResponses = sqlUtils.selectAllFollowers(siteModel, followerType)
                 val allFollowers = insightsMapper.mapAndMergeFollowersModels(
                         followerResponses,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/LatestPostInsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/LatestPostInsightsStore.kt
@@ -5,7 +5,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostInsightsRestClient
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.LatestPostDetailSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.LatestPostStatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -14,11 +15,15 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 class LatestPostInsightsStore @Inject constructor(
     private val restClient: LatestPostInsightsRestClient,
-    private val sqlUtils: InsightsSqlUtils,
+    private val latestPostDetailSqlUtils: LatestPostDetailSqlUtils,
+    private val latestPostStatsSqlUtils: LatestPostStatsSqlUtils,
     private val insightsMapper: InsightsMapper,
     private val coroutineContext: CoroutineContext
 ) {
     suspend fun fetchLatestPostInsights(site: SiteModel, forced: Boolean = false) = withContext(coroutineContext) {
+        if (!forced && latestPostDetailSqlUtils.hasFreshRequest(site)) {
+            return@withContext OnStatsFetched(getLatestPostInsights(site), cached = true)
+        }
         val latestPostPayload = restClient.fetchLatestPostForInsights(site, forced)
         val postsFound = latestPostPayload.response?.postsFound
 
@@ -28,8 +33,8 @@ class LatestPostInsightsStore @Inject constructor(
             val postStats = restClient.fetchPostStats(site, latestPost.id, forced)
             when {
                 postStats.response != null -> {
-                    sqlUtils.insert(site, latestPost)
-                    sqlUtils.insert(site, postStats.response)
+                    latestPostDetailSqlUtils.insert(site, latestPost)
+                    latestPostStatsSqlUtils.insert(site, postStats.response)
                     OnStatsFetched(insightsMapper.map(latestPost, postStats.response, site))
                 }
                 postStats.isError -> OnStatsFetched(postStats.error)
@@ -43,8 +48,8 @@ class LatestPostInsightsStore @Inject constructor(
     }
 
     fun getLatestPostInsights(site: SiteModel): InsightsLatestPostModel? {
-        val latestPostDetailResponse = sqlUtils.selectLatestPostDetail(site)
-        val latestPostViewsResponse = sqlUtils.selectLatestPostStats(site)
+        val latestPostDetailResponse = latestPostDetailSqlUtils.select(site)
+        val latestPostViewsResponse = latestPostStatsSqlUtils.select(site)
         return if (latestPostDetailResponse != null && latestPostViewsResponse != null) {
             insightsMapper.map(latestPostDetailResponse, latestPostViewsResponse, site)
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/MostPopularInsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/MostPopularInsightsStore.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.InsightsMostPopularModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.MostPopularRestClient
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.MostPopularSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
@@ -16,11 +16,14 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 class MostPopularInsightsStore @Inject constructor(
     private val restClient: MostPopularRestClient,
-    private val sqlUtils: InsightsSqlUtils,
+    private val sqlUtils: MostPopularSqlUtils,
     private val insightsMapper: InsightsMapper,
     private val coroutineContext: CoroutineContext
 ) {
     suspend fun fetchMostPopularInsights(site: SiteModel, forced: Boolean = false) = withContext(coroutineContext) {
+        if (!forced && sqlUtils.hasFreshRequest(site)) {
+            return@withContext OnStatsFetched(getMostPopularInsights(site), cached = true)
+        }
         val payload = restClient.fetchMostPopularInsights(site, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
@@ -36,6 +39,6 @@ class MostPopularInsightsStore @Inject constructor(
     }
 
     fun getMostPopularInsights(site: SiteModel): InsightsMostPopularModel? {
-        return sqlUtils.selectMostPopularInsights(site)?.let { insightsMapper.map(it, site) }
+        return sqlUtils.select(site)?.let { insightsMapper.map(it, site) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/PublicizeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/PublicizeStore.kt
@@ -23,6 +23,9 @@ class PublicizeStore
 ) {
     suspend fun fetchPublicizeData(siteModel: SiteModel, pageSize: Int, forced: Boolean = false) =
             withContext(coroutineContext) {
+                if (!forced && sqlUtils.hasFreshRequest(siteModel)) {
+                    return@withContext OnStatsFetched(getPublicizeData(siteModel, pageSize), cached = true)
+                }
                 val response = restClient.fetchPublicizeData(siteModel, pageSize = pageSize + 1, forced = forced)
                 return@withContext when {
                     response.isError -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/PublicizeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/PublicizeStore.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.PublicizeSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
@@ -17,7 +17,7 @@ import kotlin.coroutines.CoroutineContext
 class PublicizeStore
 @Inject constructor(
     private val restClient: PublicizeRestClient,
-    private val sqlUtils: InsightsSqlUtils,
+    private val sqlUtils: PublicizeSqlUtils,
     private val insightsMapper: InsightsMapper,
     private val coroutineContext: CoroutineContext
 ) {
@@ -37,6 +37,6 @@ class PublicizeStore
             }
 
     fun getPublicizeData(site: SiteModel, pageSize: Int): PublicizeModel? {
-        return sqlUtils.selectPublicizeInsights(site)?.let { insightsMapper.map(it, pageSize) }
+        return sqlUtils.select(site)?.let { insightsMapper.map(it, pageSize) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/TagsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/TagsStore.kt
@@ -2,12 +2,12 @@ package org.wordpress.android.fluxc.store.stats.insights
 
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.LimitMode.Top
-import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.TagsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.TagsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
@@ -18,7 +18,7 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 class TagsStore @Inject constructor(
     private val restClient: TagsRestClient,
-    private val sqlUtils: InsightsSqlUtils,
+    private val sqlUtils: TagsSqlUtils,
     private val insightsMapper: InsightsMapper,
     private val coroutineContext: CoroutineContext
 ) {
@@ -40,6 +40,6 @@ class TagsStore @Inject constructor(
             }
 
     fun getTags(site: SiteModel, cacheMode: LimitMode): TagsModel? {
-        return sqlUtils.selectTags(site)?.let { insightsMapper.map(it, cacheMode) }
+        return sqlUtils.select(site)?.let { insightsMapper.map(it, cacheMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/TodayInsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/TodayInsightsStore.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.fluxc.model.stats.InsightsMapper
 import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TodayInsightsRestClient
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
-import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.TodayInsightsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
@@ -18,7 +18,7 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 class TodayInsightsStore @Inject constructor(
     private val restClient: TodayInsightsRestClient,
-    private val sqlUtils: InsightsSqlUtils,
+    private val sqlUtils: TodayInsightsSqlUtils,
     private val insightsMapper: InsightsMapper,
     private val timeProvider: CurrentTimeProvider,
     private val coroutineContext: CoroutineContext
@@ -38,6 +38,6 @@ class TodayInsightsStore @Inject constructor(
     }
 
     fun getTodayInsights(site: SiteModel): VisitsModel? {
-        return sqlUtils.selectTodayInsights(site)?.let { insightsMapper.map(it) }
+        return sqlUtils.select(site)?.let { insightsMapper.map(it) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/TodayInsightsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/TodayInsightsStore.kt
@@ -24,6 +24,9 @@ class TodayInsightsStore @Inject constructor(
     private val coroutineContext: CoroutineContext
 ) {
     suspend fun fetchTodayInsights(siteModel: SiteModel, forced: Boolean = false) = withContext(coroutineContext) {
+        if (!forced && sqlUtils.hasFreshRequest(siteModel)) {
+            return@withContext OnStatsFetched(getTodayInsights(siteModel), cached = true)
+        }
         val response = restClient.fetchTimePeriodStats(siteModel, DAYS, timeProvider.currentDate, forced)
         return@withContext when {
             response.isError -> {


### PR DESCRIPTION
This PR adds cache to all Insight stores. There is also some refactoring/simplification of the InsightsSqlUtils (which are now separated by type). This allows us to remove quite a lot of boilerplate code. This PR should be tested with the related WPAndroid PR. 

I've added a 5 min stale period - we only return cached data if it was updated in the last 5 minutes. This should lower the data consumption and shouldn't affect the user experience.