### PR TITLE
Update Gradle plugin/Kotlin/ktlint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.3.11'
+    ext.kotlinVersion = '1.3.21'
     ext.kotlinCoroutinesVersion = '1.1.0'
 
     repositories {
@@ -52,7 +52,7 @@ subprojects {
     }
 
     dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.29.0'
+        ktlint 'com.github.shyiko:ktlint:0.31.0'
     }
 
     task ktlint(type: JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.automattic.android:fetchstyle:1.1'
     }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -57,8 +57,6 @@ android {
     }
 }
 
-kotlin { experimental { coroutines 'enable' } }
-
 android.buildTypes.all { buildType ->
     // Add properties named "wp.xxx" to our BuildConfig
     project.properties.any { property ->

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -42,8 +42,6 @@ androidExtensions {
     experimental = true
 }
 
-kotlin { experimental { coroutines 'enable' } }
-
 android.buildTypes.all { buildType ->
     // Load gradle properties and add them to BuildConfig
     Properties gradleProperties = new Properties()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListItemModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListItemModel.kt
@@ -12,7 +12,7 @@ import com.yarolegovich.wellsql.core.annotation.Table
         "UNIQUE(LIST_ID, REMOTE_ITEM_ID) ON CONFLICT IGNORE"
 )
 class ListItemModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
-    constructor(listId: Int, remoteItemId: Long): this() {
+    constructor(listId: Int, remoteItemId: Long) : this() {
         this.listId = listId
         this.remoteItemId = remoteItemId
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -27,8 +27,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrderRestClient: OrderRestClient)
-    : Store(dispatcher) {
+class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrderRestClient: OrderRestClient) :
+        Store(dispatcher) {
     companion object {
         const val NUM_ORDERS_PER_FETCH = 25
         const val DEFAULT_ORDER_STATUS = "any"
@@ -138,8 +138,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         val site: SiteModel,
         val note: WCOrderNoteModel
     ) : Payload<OrderError>() {
-        constructor(error: OrderError, order: WCOrderModel, site: SiteModel, note: WCOrderNoteModel)
-                : this(order, site, note) { this.error = error }
+        constructor(error: OrderError, order: WCOrderModel, site: SiteModel, note: WCOrderNoteModel) :
+                this(order, site, note) { this.error = error }
     }
 
     class FetchOrderStatusOptionsPayload(val site: SiteModel) : Payload<BaseNetworkError>()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -17,8 +17,8 @@ import org.wordpress.android.util.AppLog.T
 import java.util.Locale
 import javax.inject.Inject
 
-class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcProductRestClient: ProductRestClient)
-    : Store(dispatcher) {
+class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcProductRestClient: ProductRestClient) :
+        Store(dispatcher) {
     class FetchSingleProductPayload(
         var site: SiteModel,
         var remoteProductId: Long


### PR DESCRIPTION
Routine updates to our Gradle plugin version, Kotlin, and ktlint (plus a few lint fixes from the latter).

Also, I was seeing some warnings around coroutines:

```
w: -Xcoroutines has no effect: coroutines are enabled anyway in 1.3 and beyond
```

and removed the `kotlin { experimental { coroutines 'enable' } }` I believe are no longer needed - does this seem right @planarvoid or have I missed something?