### PR TITLE
issue/wc-order-stats-fields 

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -50,6 +50,8 @@ class OrderStatsRestClient(
         override fun toString() = name.toLowerCase()
     }
 
+    private final val STATS_FIELDS = "data,fields"
+
     /**
      * Makes a GET call to `/wpcom/v2/sites/$site/data/orders/`, retrieving data for the given
      * WooCommerce [SiteModel].
@@ -76,7 +78,8 @@ class OrderStatsRestClient(
         val params = mapOf(
                 "unit" to unit.toString(),
                 "date" to date,
-                "quantity" to quantity.toString())
+                "quantity" to quantity.toString(),
+                "_fields" to STATS_FIELDS)
 
         val request = WPComGsonRequest.buildGetRequest(url, params, OrderStatsApiResponse::class.java,
                 { apiResponse ->


### PR DESCRIPTION
Related to #1138, this PR uses the `_fields` param when requesting stats to  significantly reduce the response size. Before and after shots below:

<img width="994" alt="fluxc-order-stats" src="https://user-images.githubusercontent.com/3903757/54143061-6a42e080-43ff-11e9-8cda-5c10b855e59a.png">
