### PR TITLE
Prepare all stores for view all screens

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -198,13 +198,13 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     fun testPublicizeModel() {
         val site = authenticate()
 
-        val pageSize = 5
-        val fetchedInsights = runBlocking { publicizeStore.fetchPublicizeData(site, pageSize) }
+        val limitMode = LimitMode.Top(5)
+        val fetchedInsights = runBlocking { publicizeStore.fetchPublicizeData(site, limitMode) }
 
         assertNotNull(fetchedInsights)
         assertNotNull(fetchedInsights.model)
 
-        val insightsFromDb = publicizeStore.getPublicizeData(site, pageSize)
+        val insightsFromDb = publicizeStore.getPublicizeData(site, limitMode)
 
         assertEquals(fetchedInsights.model, insightsFromDb)
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -184,8 +184,8 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 countryViewsStore.fetchCountryViews(
                         site,
-                        ITEMS_TO_LOAD,
                         granularity,
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         SELECTED_DATE,
                         true
                 )
@@ -194,7 +194,8 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = countryViewsStore.getCountryViews(site, granularity, ITEMS_TO_LOAD, SELECTED_DATE)
+            val insightsFromDb = countryViewsStore.getCountryViews(site, granularity, LimitMode.Top(ITEMS_TO_LOAD),
+                    SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -159,9 +159,9 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 visitsAndViewsStore.fetchVisits(
                         site,
-                        ITEMS_TO_LOAD,
-                        SELECTED_DATE,
                         granularity,
+                        LIMIT_MODE,
+                        SELECTED_DATE,
                         true
                 )
             }
@@ -169,7 +169,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                 assertNotNull(fetchedInsights)
                 assertNotNull(fetchedInsights.model)
 
-                val insightsFromDb = visitsAndViewsStore.getVisits(site, SELECTED_DATE, granularity)
+                val insightsFromDb = visitsAndViewsStore.getVisits(site, granularity, LIMIT_MODE, SELECTED_DATE)
 
                 assertEquals(fetchedInsights.model, insightsFromDb)
             }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 private const val ITEMS_TO_LOAD = 8
+private val LIMIT_MODE = LimitMode.Top(ITEMS_TO_LOAD)
 private val SELECTED_DATE = Date(10)
 
 /**
@@ -84,7 +85,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                 postAndPageViewsStore.fetchPostAndPageViews(
                         site,
                         granularity,
-                        LimitMode.Top(ITEMS_TO_LOAD),
+                        LIMIT_MODE,
                         SELECTED_DATE,
                         true
                 )
@@ -96,7 +97,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val insightsFromDb = postAndPageViewsStore.getPostAndPageViews(
                     site,
                     granularity,
-                    LimitMode.Top(ITEMS_TO_LOAD),
+                    LIMIT_MODE,
                     SELECTED_DATE
             )
 
@@ -113,7 +114,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                 referrersStore.fetchReferrers(
                         site,
                         granularity,
-                        LimitMode.Top(ITEMS_TO_LOAD),
+                        LIMIT_MODE,
                         SELECTED_DATE,
                         true
                 )
@@ -122,8 +123,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = referrersStore.getReferrers(site, granularity, LimitMode.Top(ITEMS_TO_LOAD),
-                    SELECTED_DATE)
+            val insightsFromDb = referrersStore.getReferrers(site, granularity, LIMIT_MODE, SELECTED_DATE)
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
     }
@@ -137,7 +137,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                 clicksStore.fetchClicks(
                         site,
                         granularity,
-                        LimitMode.Top(ITEMS_TO_LOAD),
+                        LIMIT_MODE,
                         SELECTED_DATE,
                         true
                 )
@@ -146,7 +146,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = clicksStore.getClicks(site, granularity, LimitMode.Top(ITEMS_TO_LOAD), SELECTED_DATE)
+            val insightsFromDb = clicksStore.getClicks(site, granularity, LIMIT_MODE, SELECTED_DATE)
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
     }
@@ -185,7 +185,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                 countryViewsStore.fetchCountryViews(
                         site,
                         granularity,
-                        LimitMode.Top(ITEMS_TO_LOAD),
+                        LIMIT_MODE,
                         SELECTED_DATE,
                         true
                 )
@@ -194,8 +194,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = countryViewsStore.getCountryViews(site, granularity, LimitMode.Top(ITEMS_TO_LOAD),
-                    SELECTED_DATE)
+            val insightsFromDb = countryViewsStore.getCountryViews(site, granularity, LIMIT_MODE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -206,13 +205,12 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         for (period in StatsGranularity.values()) {
-            val limitMode = LimitMode.Top(ITEMS_TO_LOAD)
-            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, period, limitMode, SELECTED_DATE) }
+            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, period, LIMIT_MODE, SELECTED_DATE) }
 
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = authorsStore.getAuthors(site, period, limitMode, SELECTED_DATE)
+            val insightsFromDb = authorsStore.getAuthors(site, period, LIMIT_MODE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -227,7 +225,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
                 searchTermsStore.fetchSearchTerms(
                         site,
                         granularity,
-                        LimitMode.Top(ITEMS_TO_LOAD),
+                        LIMIT_MODE,
                         SELECTED_DATE,
                         true
                 )
@@ -236,8 +234,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = searchTermsStore.getSearchTerms(site, granularity,
-                    LimitMode.Top(ITEMS_TO_LOAD), SELECTED_DATE)
+            val insightsFromDb = searchTermsStore.getSearchTerms(site, granularity, LIMIT_MODE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
@@ -251,8 +248,8 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 videoPlaysStore.fetchVideoPlays(
                         site,
-                        ITEMS_TO_LOAD,
                         granularity,
+                        LIMIT_MODE,
                         SELECTED_DATE,
                         true
                 )
@@ -261,7 +258,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = videoPlaysStore.getVideoPlays(site, granularity, ITEMS_TO_LOAD, SELECTED_DATE)
+            val insightsFromDb = videoPlaysStore.getVideoPlays(site, granularity, LIMIT_MODE, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -122,8 +122,8 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = referrersStore.getReferrers(site, granularity, SELECTED_DATE,
-                    LimitMode.Top(ITEMS_TO_LOAD))
+            val insightsFromDb = referrersStore.getReferrers(site, granularity, LimitMode.Top(ITEMS_TO_LOAD),
+                    SELECTED_DATE)
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -146,7 +146,7 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = clicksStore.getClicks(site, granularity, SELECTED_DATE, LimitMode.Top(ITEMS_TO_LOAD))
+            val insightsFromDb = clicksStore.getClicks(site, granularity, LimitMode.Top(ITEMS_TO_LOAD), SELECTED_DATE)
             assertEquals(fetchedInsights.model, insightsFromDb)
         }
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -205,12 +205,13 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
         val site = authenticate()
 
         for (period in StatsGranularity.values()) {
-            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, ITEMS_TO_LOAD, period, SELECTED_DATE) }
+            val limitMode = LimitMode.Top(ITEMS_TO_LOAD)
+            val fetchedInsights = runBlocking { authorsStore.fetchAuthors(site, period, limitMode, SELECTED_DATE) }
 
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = authorsStore.getAuthors(site, period, ITEMS_TO_LOAD, SELECTED_DATE)
+            val insightsFromDb = authorsStore.getAuthors(site, period, limitMode, SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -226,8 +226,8 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             val fetchedInsights = runBlocking {
                 searchTermsStore.fetchSearchTerms(
                         site,
-                        ITEMS_TO_LOAD,
                         granularity,
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         SELECTED_DATE,
                         true
                 )
@@ -236,7 +236,8 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
             assertNotNull(fetchedInsights)
             assertNotNull(fetchedInsights.model)
 
-            val insightsFromDb = searchTermsStore.getSearchTerms(site, granularity, ITEMS_TO_LOAD, SELECTED_DATE)
+            val insightsFromDb = searchTermsStore.getSearchTerms(site, granularity,
+                    LimitMode.Top(ITEMS_TO_LOAD), SELECTED_DATE)
 
             assertEquals(fetchedInsights.model, insightsFromDb)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
@@ -64,7 +64,7 @@ class TimeStatsMapperTest {
     fun `parses empty country views`() {
         val response = CountryViewsResponse(emptyMap(), emptyMap())
 
-        val result = timeStatsMapper.map(response, 5)
+        val result = timeStatsMapper.map(response, LimitMode.Top(5))
 
         assertThat(result.countries).isEmpty()
         assertThat(result.hasMore).isFalse()
@@ -76,7 +76,7 @@ class TimeStatsMapperTest {
     fun `parses empty authors`() {
         val response = AuthorsResponse(null, emptyMap())
 
-        val result = timeStatsMapper.map(response, 5)
+        val result = timeStatsMapper.map(response, LimitMode.Top(5))
 
         assertThat(result.authors).isEmpty()
         assertThat(result.hasMore).isFalse()
@@ -87,7 +87,7 @@ class TimeStatsMapperTest {
     fun `parses empty search terms`() {
         val response = SearchTermsResponse(null, emptyMap())
 
-        val result = timeStatsMapper.map(response, 5)
+        val result = timeStatsMapper.map(response, LimitMode.Top(5))
 
         assertThat(result.searchTerms).isEmpty()
         assertThat(result.hasMore).isFalse()
@@ -99,7 +99,7 @@ class TimeStatsMapperTest {
     fun `parses empty videos`() {
         val response = VideoPlaysResponse(null, emptyMap())
 
-        val result = timeStatsMapper.map(response, 5)
+        val result = timeStatsMapper.map(response, LimitMode.Top(5))
 
         assertThat(result.plays).isEmpty()
         assertThat(result.hasMore).isFalse()

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -464,11 +464,6 @@ class InsightsRestClientTest {
         assertThat(responseModel.response).isEqualTo(PUBLICIZE_RESPONSE)
         val url = "https://public-api.wordpress.com/rest/v1.1/sites/12/stats/publicize/"
         assertThat(urlCaptor.lastValue).isEqualTo(url)
-        assertThat(paramsCaptor.lastValue).isEqualTo(
-                mapOf(
-                        "max" to "$pageSize"
-                )
-        )
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -458,7 +458,7 @@ class InsightsRestClientTest {
         initPublicizeResponse(PUBLICIZE_RESPONSE)
 
         val pageSize = 10
-        val responseModel = publicizeRestClient.fetchPublicizeData(site, pageSize, forced = false)
+        val responseModel = publicizeRestClient.fetchPublicizeData(site, forced = false)
 
         assertThat(responseModel.response).isNotNull
         assertThat(responseModel.response).isEqualTo(PUBLICIZE_RESPONSE)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -457,7 +457,6 @@ class InsightsRestClientTest {
     fun `returns publicize`() = test {
         initPublicizeResponse(PUBLICIZE_RESPONSE)
 
-        val pageSize = 10
         val responseModel = publicizeRestClient.fetchPublicizeData(site, forced = false)
 
         assertThat(responseModel.response).isNotNull

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -554,13 +554,13 @@ class InsightsStoreTest {
                 PUBLICIZE_RESPONSE
         )
         val forced = true
-        whenever(publicizeRestClient.fetchPublicizeData(site, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(publicizeRestClient.fetchPublicizeData(site, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<PublicizeModel>()
-        whenever(mapper.map(PUBLICIZE_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(PUBLICIZE_RESPONSE, LimitMode.Top(PAGE_SIZE))).thenReturn(model)
 
-        val responseModel = publicizeStore.fetchPublicizeData(site, PAGE_SIZE, forced)
+        val responseModel = publicizeStore.fetchPublicizeData(site, LimitMode.Top(PAGE_SIZE), forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, PUBLICIZE_RESPONSE)
@@ -570,9 +570,9 @@ class InsightsStoreTest {
     fun `returns publicize data from db`() {
         whenever(sqlUtils.selectPublicizeInsights(site)).thenReturn(PUBLICIZE_RESPONSE)
         val model = mock<PublicizeModel>()
-        whenever(mapper.map(PUBLICIZE_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(PUBLICIZE_RESPONSE, LimitMode.Top(PAGE_SIZE))).thenReturn(model)
 
-        val result = publicizeStore.getPublicizeData(site, PAGE_SIZE)
+        val result = publicizeStore.getPublicizeData(site, LimitMode.Top(PAGE_SIZE))
 
         assertThat(result).isEqualTo(model)
     }
@@ -583,9 +583,9 @@ class InsightsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<PublicizeResponse>(StatsError(type, message))
         val forced = true
-        whenever(publicizeRestClient.fetchPublicizeData(site, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(publicizeRestClient.fetchPublicizeData(site, forced)).thenReturn(errorPayload)
 
-        val responseModel = publicizeStore.fetchPublicizeData(site, PAGE_SIZE, forced)
+        val responseModel = publicizeStore.fetchPublicizeData(site, LimitMode.Top(PAGE_SIZE), forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStoreTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.AuthorsModel
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient
@@ -25,7 +26,8 @@ import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-private const val PAGE_SIZE = 8
+private const val ITEMS_TO_LOAD = 8
+private val LIMIT_MODE = LimitMode.Top(ITEMS_TO_LOAD)
 private val DATE = Date(0)
 
 @RunWith(MockitoJUnitRunner::class)
@@ -51,13 +53,13 @@ class AuthorsStoreTest {
                 AUTHORS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchAuthors(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchAuthors(site, DAYS, DATE, ITEMS_TO_LOAD + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<AuthorsModel>()
-        whenever(mapper.map(AUTHORS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(AUTHORS_RESPONSE, LIMIT_MODE)).thenReturn(model)
 
-        val responseModel = store.fetchAuthors(site, PAGE_SIZE, DAYS, DATE, forced)
+        val responseModel = store.fetchAuthors(site, DAYS, LIMIT_MODE, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, AUTHORS_RESPONSE, DAYS, DATE)
@@ -69,9 +71,9 @@ class AuthorsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<AuthorsResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchAuthors(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchAuthors(site, DAYS, DATE, ITEMS_TO_LOAD + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchAuthors(site, PAGE_SIZE, DAYS, DATE, forced)
+        val responseModel = store.fetchAuthors(site, DAYS, LIMIT_MODE, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -83,9 +85,9 @@ class AuthorsStoreTest {
     fun `returns data from db`() {
         whenever(sqlUtils.selectAuthors(site, DAYS, DATE)).thenReturn(AUTHORS_RESPONSE)
         val model = mock<AuthorsModel>()
-        whenever(mapper.map(AUTHORS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(AUTHORS_RESPONSE, LIMIT_MODE)).thenReturn(model)
 
-        val result = store.getAuthors(site, DAYS, PAGE_SIZE, DATE)
+        val result = store.getAuthors(site, DAYS, LIMIT_MODE, DATE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ClicksStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ClicksStoreTest.kt
@@ -87,7 +87,7 @@ class ClicksStoreTest {
         val model = mock<ClicksModel>()
         whenever(mapper.map(CLICKS_RESPONSE, limitMode)).thenReturn(model)
 
-        val result = store.getClicks(site, DAYS, DATE, limitMode)
+        val result = store.getClicks(site, DAYS, limitMode, DATE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
@@ -86,7 +86,7 @@ class ReferrersStoreTest {
         val model = mock<ReferrersModel>()
         whenever(mapper.map(REFERRERS_RESPONSE, LimitMode.Top(ITEMS_TO_LOAD))).thenReturn(model)
 
-        val result = store.getReferrers(site, DAYS, DATE, LimitMode.Top(ITEMS_TO_LOAD))
+        val result = store.getReferrers(site, DAYS, LimitMode.Top(ITEMS_TO_LOAD), DATE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/SearchTermsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/SearchTermsStoreTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.SearchTermsModel
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient
@@ -25,7 +26,8 @@ import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-private const val PAGE_SIZE = 8
+private const val ITEMS_TO_LOAD = 8
+private val LIMIT_MODE = LimitMode.Top(ITEMS_TO_LOAD)
 private val DATE = Date(0)
 
 @RunWith(MockitoJUnitRunner::class)
@@ -51,13 +53,13 @@ class SearchTermsStoreTest {
                 SEARCH_TERMS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchSearchTerms(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchSearchTerms(site, DAYS, DATE, ITEMS_TO_LOAD + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<SearchTermsModel>()
-        whenever(mapper.map(SEARCH_TERMS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(SEARCH_TERMS_RESPONSE, LIMIT_MODE)).thenReturn(model)
 
-        val responseModel = store.fetchSearchTerms(site, PAGE_SIZE, DAYS, DATE, forced)
+        val responseModel = store.fetchSearchTerms(site, DAYS, LIMIT_MODE, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, SEARCH_TERMS_RESPONSE, DAYS, DATE)
@@ -69,9 +71,9 @@ class SearchTermsStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<SearchTermsResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchSearchTerms(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchSearchTerms(site, DAYS, DATE, ITEMS_TO_LOAD + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchSearchTerms(site, PAGE_SIZE, DAYS, DATE, forced)
+        val responseModel = store.fetchSearchTerms(site, DAYS, LIMIT_MODE, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -83,9 +85,9 @@ class SearchTermsStoreTest {
     fun `returns search terms from db`() {
         whenever(sqlUtils.selectSearchTerms(site, DAYS, DATE)).thenReturn(SEARCH_TERMS_RESPONSE)
         val model = mock<SearchTermsModel>()
-        whenever(mapper.map(SEARCH_TERMS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(SEARCH_TERMS_RESPONSE, LIMIT_MODE)).thenReturn(model)
 
-        val result = store.getSearchTerms(site, DAYS, PAGE_SIZE, DATE)
+        val result = store.getSearchTerms(site, DAYS, LIMIT_MODE, DATE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VideoPlaysStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VideoPlaysStoreTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.model.stats.time.VideoPlaysModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient
@@ -25,7 +26,8 @@ import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-private const val PAGE_SIZE = 8
+private const val ITEMS_TO_LOAD = 8
+private val LIMIT_MODE = LimitMode.Top(ITEMS_TO_LOAD)
 private val DATE = Date(0)
 
 @RunWith(MockitoJUnitRunner::class)
@@ -51,13 +53,13 @@ class VideoPlaysStoreTest {
                 VIDEO_PLAYS_RESPONSE
         )
         val forced = true
-        whenever(restClient.fetchVideoPlays(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(
+        whenever(restClient.fetchVideoPlays(site, DAYS, DATE, ITEMS_TO_LOAD + 1, forced)).thenReturn(
                 fetchInsightsPayload
         )
         val model = mock<VideoPlaysModel>()
-        whenever(mapper.map(VIDEO_PLAYS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(VIDEO_PLAYS_RESPONSE, LIMIT_MODE)).thenReturn(model)
 
-        val responseModel = store.fetchVideoPlays(site, PAGE_SIZE, DAYS, DATE, forced)
+        val responseModel = store.fetchVideoPlays(site, DAYS, LIMIT_MODE, DATE, forced)
 
         assertThat(responseModel.model).isEqualTo(model)
         verify(sqlUtils).insert(site, VIDEO_PLAYS_RESPONSE, DAYS, DATE)
@@ -69,9 +71,9 @@ class VideoPlaysStoreTest {
         val message = "message"
         val errorPayload = FetchStatsPayload<VideoPlaysResponse>(StatsError(type, message))
         val forced = true
-        whenever(restClient.fetchVideoPlays(site, DAYS, DATE, PAGE_SIZE + 1, forced)).thenReturn(errorPayload)
+        whenever(restClient.fetchVideoPlays(site, DAYS, DATE, ITEMS_TO_LOAD + 1, forced)).thenReturn(errorPayload)
 
-        val responseModel = store.fetchVideoPlays(site, PAGE_SIZE, DAYS, DATE, forced)
+        val responseModel = store.fetchVideoPlays(site, DAYS, LIMIT_MODE, DATE, forced)
 
         assertNotNull(responseModel.error)
         val error = responseModel.error!!
@@ -83,9 +85,9 @@ class VideoPlaysStoreTest {
     fun `returns video plays from db`() {
         whenever(sqlUtils.selectVideoPlays(site, DAYS, DATE)).thenReturn(VIDEO_PLAYS_RESPONSE)
         val model = mock<VideoPlaysModel>()
-        whenever(mapper.map(VIDEO_PLAYS_RESPONSE, PAGE_SIZE)).thenReturn(model)
+        whenever(mapper.map(VIDEO_PLAYS_RESPONSE, LIMIT_MODE)).thenReturn(model)
 
-        val result = store.getVideoPlays(site, DAYS, PAGE_SIZE, DATE)
+        val result = store.getVideoPlays(site, DAYS, LIMIT_MODE, DATE)
 
         assertThat(result).isEqualTo(model)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -221,10 +221,16 @@ class InsightsMapper
         }
     }
 
-    fun map(response: PublicizeResponse, pageSize: Int): PublicizeModel {
+    fun map(response: PublicizeResponse, limitMode: LimitMode): PublicizeModel {
         return PublicizeModel(
-                response.services.take(pageSize).map { PublicizeModel.Service(it.service, it.followers) },
-                response.services.size > pageSize
+                response.services.sortedBy { it.followers }.let {
+                    if (limitMode is LimitMode.Top) {
+                        return@let it.take(limitMode.limit)
+                    } else {
+                        return@let it
+                    }
+                }.map { PublicizeModel.Service(it.service, it.followers) },
+                limitMode is LimitMode.Top && response.services.size > limitMode.limit
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -113,7 +113,7 @@ class TimeStatsMapper
         )
     }
 
-    fun map(response: VisitsAndViewsResponse): VisitsAndViewsModel {
+    fun map(response: VisitsAndViewsResponse, cacheMode: LimitMode): VisitsAndViewsModel {
         val periodIndex = response.fields?.indexOf("period")
         val viewsIndex = response.fields?.indexOf("views")
         val visitorsIndex = response.fields?.indexOf("visitors")
@@ -137,6 +137,12 @@ class TimeStatsMapper
                 } else {
                     null
                 }
+            }
+        }?.let {
+            if (cacheMode is LimitMode.Top) {
+                it.take(cacheMode.limit)
+            } else {
+                it
             }
         }
         if (response.data == null || response.date == null || dataPerPeriod == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -181,10 +181,16 @@ class TimeStatsMapper
         )
     }
 
-    fun map(response: AuthorsResponse, pageSize: Int): AuthorsModel {
+    fun map(response: AuthorsResponse, cacheMode: LimitMode): AuthorsModel {
         val first = response.groups.values.firstOrNull()
         val authors = first?.let {
-            first.authors.take(pageSize).map { author ->
+            first.authors.let {
+                if (cacheMode is LimitMode.Top) {
+                    it.take(cacheMode.limit)
+                } else {
+                    it
+                }
+            }.map { author ->
                 val posts = author.mappedPosts?.mapNotNull { result ->
                     if (result.postId != null && result.title != null) {
                         Post(result.postId, result.title, result.views ?: 0, result.url)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -243,10 +243,16 @@ class TimeStatsMapper
         )
     }
 
-    fun map(response: VideoPlaysResponse, pageSize: Int): VideoPlaysModel {
+    fun map(response: VideoPlaysResponse, cacheMode: LimitMode): VideoPlaysModel {
         val first = response.days.values.firstOrNull()
         val groups = first?.let {
-            first.plays.take(pageSize).mapNotNull { result ->
+            first.plays.let {
+                if (cacheMode is LimitMode.Top) {
+                    it.take(cacheMode.limit)
+                } else {
+                    it
+                }
+            }.mapNotNull { result ->
                 if (result.postId != null && result.title != null) {
                     VideoPlaysModel.VideoPlays(result.postId, result.title, result.url, result.plays ?: 0)
                 } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -152,11 +152,17 @@ class TimeStatsMapper
         } ?: 0
     }
 
-    fun map(response: CountryViewsResponse, pageSize: Int): CountryViewsModel {
+    fun map(response: CountryViewsResponse, cacheMode: LimitMode): CountryViewsModel {
         val first = response.days.values.firstOrNull()
         val countriesInfo = response.countryInfo
         val groups = first?.let {
-            first.views.take(pageSize).mapNotNull { countryViews ->
+            first.views.let {
+                if (cacheMode is LimitMode.Top) {
+                    it.take(cacheMode.limit)
+                } else {
+                    it
+                }
+            }.mapNotNull { countryViews ->
                 val countryInfo = countriesInfo[countryViews.countryCode]
                 if (countryViews.countryCode != null && countryInfo != null && countryInfo.countryFull != null) {
                     CountryViewsModel.Country(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PublicizeRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PublicizeRestClient.kt
@@ -30,16 +30,14 @@ constructor(
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchPublicizeData(
         site: SiteModel,
-        pageSize: Int = 6,
         forced: Boolean
     ): FetchStatsPayload<PublicizeResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.publicize.urlV1_1
 
-        val params = mapOf("max" to pageSize.toString())
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,
                 url,
-                params,
+                emptyMap(),
                 PublicizeResponse::class.java,
                 enableCaching = true,
                 forced = forced

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
@@ -41,13 +41,13 @@ class AuthorsRestClient
         site: SiteModel,
         granularity: StatsGranularity,
         date: Date,
-        pageSize: Int,
+        itemsToLoad: Int,
         forced: Boolean
     ): FetchStatsPayload<AuthorsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.top_authors.urlV1_1
         val params = mapOf(
                 "period" to granularity.toString(),
-                "max" to pageSize.toString(),
+                "max" to itemsToLoad.toString(),
                 "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
@@ -35,13 +35,13 @@ class CountryViewsRestClient
         site: SiteModel,
         granularity: StatsGranularity,
         date: Date,
-        pageSize: Int,
+        itemsToLoad: Int,
         forced: Boolean
     ): FetchStatsPayload<CountryViewsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.country_views.urlV1_1
         val params = mapOf(
                 "period" to granularity.toString(),
-                "max" to pageSize.toString(),
+                "max" to itemsToLoad.toString(),
                 "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClient.kt
@@ -35,13 +35,13 @@ class SearchTermsRestClient
         site: SiteModel,
         granularity: StatsGranularity,
         date: Date,
-        pageSize: Int,
+        itemsToLoad: Int,
         forced: Boolean
     ): FetchStatsPayload<SearchTermsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.search_terms.urlV1_1
         val params = mapOf(
                 "period" to granularity.toString(),
-                "max" to pageSize.toString(),
+                "max" to itemsToLoad.toString(),
                 "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
@@ -37,13 +37,13 @@ class VideoPlaysRestClient
         site: SiteModel,
         granularity: StatsGranularity,
         date: Date,
-        pageSize: Int,
+        itemsToLoad: Int,
         forced: Boolean
     ): FetchStatsPayload<VideoPlaysResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.video_plays.urlV1_1
         val params = mapOf(
                 "period" to granularity.toString(),
-                "max" to pageSize.toString(),
+                "max" to itemsToLoad.toString(),
                 "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
@@ -35,13 +35,13 @@ class VisitAndViewsRestClient
         site: SiteModel,
         date: Date,
         granularity: StatsGranularity,
-        pageSize: Int,
+        itemsToLoad: Int,
         forced: Boolean
     ): FetchStatsPayload<VisitsAndViewsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).stats.visits.urlV1_1
         val params = mapOf(
                 "unit" to granularity.toString(),
-                "quantity" to pageSize.toString(),
+                "quantity" to itemsToLoad.toString(),
                 "date" to statsUtils.getFormattedDate(date)
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/AuthorsStore.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.store.stats.time
 
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.model.stats.LimitMode.Top
 import org.wordpress.android.fluxc.model.stats.time.AuthorsModel
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient
@@ -25,23 +27,23 @@ class AuthorsStore
 ) {
     suspend fun fetchAuthors(
         site: SiteModel,
-        pageSize: Int,
         period: StatsGranularity,
+        limitMode: Top,
         date: Date,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
-        val payload = restClient.fetchAuthors(site, period, date, pageSize + 1, forced)
+        val payload = restClient.fetchAuthors(site, period, date, limitMode.limit + 1, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
                 sqlUtils.insert(site, payload.response, period, date)
-                OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
+                OnStatsFetched(timeStatsMapper.map(payload.response, limitMode))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
     }
 
-    fun getAuthors(site: SiteModel, period: StatsGranularity, pageSize: Int, date: Date): AuthorsModel? {
-        return sqlUtils.selectAuthors(site, period, date)?.let { timeStatsMapper.map(it, pageSize) }
+    fun getAuthors(site: SiteModel, period: StatsGranularity, limitMode: LimitMode, date: Date): AuthorsModel? {
+        return sqlUtils.selectAuthors(site, period, date)?.let { timeStatsMapper.map(it, limitMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ClicksStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ClicksStore.kt
@@ -42,7 +42,7 @@ class ClicksStore
         }
     }
 
-    fun getClicks(site: SiteModel, period: StatsGranularity, date: Date, limitMode: Top): ClicksModel? {
+    fun getClicks(site: SiteModel, period: StatsGranularity, limitMode: Top, date: Date): ClicksModel? {
         return sqlUtils.selectClicks(site, period, date)?.let { timeStatsMapper.map(it, limitMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/CountryViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/CountryViewsStore.kt
@@ -42,7 +42,12 @@ class CountryViewsStore
         }
     }
 
-    fun getCountryViews(site: SiteModel, period: StatsGranularity, limitMode: LimitMode, date: Date): CountryViewsModel? {
+    fun getCountryViews(
+        site: SiteModel,
+        period: StatsGranularity,
+        limitMode: LimitMode,
+        date: Date
+    ): CountryViewsModel? {
         return sqlUtils.selectCountryViews(site, period, date)?.let { timeStatsMapper.map(it, limitMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/CountryViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/CountryViewsStore.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store.stats.time
 
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.CountryViewsModel
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient
@@ -25,23 +26,23 @@ class CountryViewsStore
 ) {
     suspend fun fetchCountryViews(
         site: SiteModel,
-        pageSize: Int,
         granularity: StatsGranularity,
+        limitMode: LimitMode.Top,
         date: Date,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
-        val payload = restClient.fetchCountryViews(site, granularity, date, pageSize + 1, forced)
+        val payload = restClient.fetchCountryViews(site, granularity, date, limitMode.limit + 1, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
                 sqlUtils.insert(site, payload.response, granularity, date)
-                OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
+                OnStatsFetched(timeStatsMapper.map(payload.response, limitMode))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
     }
 
-    fun getCountryViews(site: SiteModel, period: StatsGranularity, pageSize: Int, date: Date): CountryViewsModel? {
-        return sqlUtils.selectCountryViews(site, period, date)?.let { timeStatsMapper.map(it, pageSize) }
+    fun getCountryViews(site: SiteModel, period: StatsGranularity, limitMode: LimitMode, date: Date): CountryViewsModel? {
+        return sqlUtils.selectCountryViews(site, period, date)?.let { timeStatsMapper.map(it, limitMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
@@ -42,7 +42,7 @@ class ReferrersStore
         }
     }
 
-    fun getReferrers(site: SiteModel, granularity: StatsGranularity, date: Date, limitMode: Top): ReferrersModel? {
+    fun getReferrers(site: SiteModel, granularity: StatsGranularity, limitMode: Top, date: Date): ReferrersModel? {
         return sqlUtils.selectReferrers(site, granularity, date)?.let { timeStatsMapper.map(it, limitMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/SearchTermsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/SearchTermsStore.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.store.stats.time
 
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.model.stats.LimitMode.Top
 import org.wordpress.android.fluxc.model.stats.time.SearchTermsModel
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient
@@ -25,23 +27,23 @@ class SearchTermsStore
 ) {
     suspend fun fetchSearchTerms(
         site: SiteModel,
-        pageSize: Int,
         granularity: StatsGranularity,
+        limitMode: LimitMode.Top,
         date: Date,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
-        val payload = restClient.fetchSearchTerms(site, granularity, date, pageSize + 1, forced)
+        val payload = restClient.fetchSearchTerms(site, granularity, date, limitMode.limit + 1, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
                 sqlUtils.insert(site, payload.response, granularity, date)
-                OnStatsFetched(timeStatsMapper.map(payload.response, pageSize))
+                OnStatsFetched(timeStatsMapper.map(payload.response, limitMode))
             }
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
     }
 
-    fun getSearchTerms(site: SiteModel, period: StatsGranularity, pageSize: Int, date: Date): SearchTermsModel? {
-        return sqlUtils.selectSearchTerms(site, period, date)?.let { timeStatsMapper.map(it, pageSize) }
+    fun getSearchTerms(site: SiteModel, period: StatsGranularity, limitMode: LimitMode, date: Date): SearchTermsModel? {
+        return sqlUtils.selectSearchTerms(site, period, date)?.let { timeStatsMapper.map(it, limitMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -46,7 +46,12 @@ class VisitsAndViewsStore
         }
     }
 
-    fun getVisits(site: SiteModel, granularity: StatsGranularity, limitMode: LimitMode, date: Date): VisitsAndViewsModel? {
+    fun getVisits(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        limitMode: LimitMode,
+        date: Date
+    ): VisitsAndViewsModel? {
         return sqlUtils.selectVisitsAndViews(site, granularity, date)?.let { timeStatsMapper.map(it, limitMode) }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store.stats.time
 
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient
@@ -25,17 +26,17 @@ class VisitsAndViewsStore
 ) {
     suspend fun fetchVisits(
         site: SiteModel,
-        pageSize: Int,
-        date: Date,
         granularity: StatsGranularity,
+        limitMode: LimitMode.Top,
+        date: Date,
         forced: Boolean = false
     ) = withContext(coroutineContext) {
-        val payload = restClient.fetchVisits(site, date, granularity, pageSize, forced)
+        val payload = restClient.fetchVisits(site, date, granularity, limitMode.limit, forced)
         return@withContext when {
             payload.isError -> OnStatsFetched(payload.error)
             payload.response != null -> {
                 sqlUtils.insert(site, payload.response, granularity, date)
-                val overviewResponse = timeStatsMapper.map(payload.response)
+                val overviewResponse = timeStatsMapper.map(payload.response, limitMode)
                 if (overviewResponse.period.isBlank() || overviewResponse.dates.isEmpty())
                     OnStatsFetched(StatsError(INVALID_RESPONSE, "Overview: Required data 'period' or 'dates' missing"))
                 else
@@ -45,7 +46,7 @@ class VisitsAndViewsStore
         }
     }
 
-    fun getVisits(site: SiteModel, date: Date, granularity: StatsGranularity): VisitsAndViewsModel? {
-        return sqlUtils.selectVisitsAndViews(site, granularity, date)?.let { timeStatsMapper.map(it) }
+    fun getVisits(site: SiteModel, granularity: StatsGranularity, limitMode: LimitMode, date: Date): VisitsAndViewsModel? {
+        return sqlUtils.selectVisitsAndViews(site, granularity, date)?.let { timeStatsMapper.map(it, limitMode) }
     }
 }


### PR DESCRIPTION
This PR makes the necessary updates all leftover Stats types in order to support the new View all stats screens. These can be tested with the associated WPAndroid PR.