### PR TITLE
Update sites/new endpoint to use v1.1

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -199,7 +199,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     public void newSite(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
                         @NonNull SiteVisibility visibility, @Nullable String verticalId, @Nullable Long segmentId,
                         @Nullable String tagLine, final boolean dryRun) {
-        String url = WPCOMREST.sites.new_.getUrlV1();
+        String url = WPCOMREST.sites.new_.getUrlV1_1();
         Map<String, Object> body = new HashMap<>();
         body.put("blog_name", siteName);
         body.put("blog_title", siteTitle);


### PR DESCRIPTION
Fixes #1167. This PR updates the `sites/new` endpoint to use v1.1 instead of v1. It doesn't look like there are any connected tests for this call, so I suggest using WPAndroid PR to test these changes. I believe it's also possible to test them in the example app, but the WPAndroid should cover more.