### PR TITLE
Address AutoService-based annotation processor warnings

### DIFF
--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -1,5 +1,16 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt'
 
 repositories {
     jcenter()
@@ -10,6 +21,7 @@ targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
     implementation project (':fluxc-annotations')
-    implementation 'com.google.auto.service:auto-service:1.0-rc2'
+    implementation 'com.google.auto.service:auto-service:1.0-rc4'
+    kapt 'com.google.auto.service:auto-service:1.0-rc4'
     implementation 'com.squareup:javapoet:1.7.0'
 }

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -27,8 +27,11 @@ import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 import javax.tools.StandardLocation;
+
+import static javax.lang.model.SourceVersion.latestSupported;
 
 @SuppressWarnings("unused")
 @AutoService(Processor.class)
@@ -84,6 +87,11 @@ public class EndpointProcessor extends AbstractProcessor {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return latestSupported();
     }
 
     @Override


### PR DESCRIPTION
In #1172 @drspaceboo ran into the missing `XMLRPC.java` (and other annotation processor-generated files) issue, though for her it's happening very consistently. She also pointed out that as of `Gradle 4.6` there's a warning that can be surfaced about the annotation processor:

> Detecting annotation processors on the compile classpath has been deprecated. Gradle 5.0 will ignore annotation processors on the compile classpath. The following annotation processors were detected on the compile classpath: 'com.google.auto.service.processor.AutoServiceProcessor'.  Please add them to the annotation processor path instead. If you did not intend to use annotation processors, you can use the '-proc:none' compiler argument to ignore them.

I don't believe the problem is related to Gradle `4.6` (we've been running into this issue since Gradle `4.1` at least). But it turns out this warning led the `AutoService` team to resolve it a few months ago by separating their annotation processor into two separate packages: https://github.com/google/auto/commit/af1e5daff849b4762062018b9e8bce1716bfc8b0.

Addressing the warning is only supposed to potentially increase speed (and needs to be resolved before we can update to Gradle 5.0 in the future, when presumably the build will be broken as the annotation process will be ignored). However, I'm hopeful adding `ktlint` and calling the `AutoService` processor in a more canonical way is enough to resolve whatever issue `ktlint` was having all along and get rid of the missing `XMLRPC.java` issue 🤞.

I also fixed another annotation processor warning - I'm less confident this has any relation to the build issue but we may as well fix it):

> w: warning: Supported source version 'RELEASE_6' from annotation processor 'org.jetbrains.kotlin.kapt3.base.ProcessorWrapper' less than -source '1.8'

(There's one more warning: `[options] bootstrap class path not set in conjunction with -source 1.7`. I have an idea how to fix this but I'm not sure it's safe just yet - I'll look at it some more and either file an issue or open a separate PR.)

@drspaceboo could you please give this branch a try and see if you're able to build the project from Android Studio with it?

It would also be great for multiple people to give this a try in case something _else_ breaks. Pinging a few folks I know have run into this build issue recently: @oguzkocer @0nko 