### PR TITLE
Fix broken DateUtils unit test

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -171,7 +171,6 @@ class DateUtilsTest {
 
         var date = start.time
         while (start.before(end)) {
-            println(date)
             val testDateString = DateUtils.formatDate(DATE_FORMAT_DAY, date)
             val testCalendar = DateUtils.getCalendarInstance(testDateString)
             assertEquals(start.get(Calendar.YEAR), testCalendar.get(Calendar.YEAR))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -243,11 +243,7 @@ object DateUtils {
      *
      */
     fun getCalendarInstance(value: String): Calendar {
-        val cal = Calendar.getInstance()
-        cal.set(Calendar.MONTH, (value.split("-")[1].toInt()))
-        cal.add(Calendar.MONTH, -1)
-        cal.set(Calendar.DATE, value.split("-")[2].toInt())
-        cal.set(Calendar.YEAR, value.split("-")[0].toInt())
-        return cal
+        val (year, month, day) = value.split("-").map { it.toInt() }
+        return Calendar.getInstance().apply { set(year, month - 1, day) }
     }
 }


### PR DESCRIPTION
A unit test in `DateUtilsTest` abruptly started failing.

It looks like the issue is the way a `Calendar` instance is created in `DateUtils#getCalendarInstance`, by gradually setting the year/month/day values. The reason this broke now is that it's March 29th:

* The date `2011-01-01` is passed in
* The calendar is initialized to the current date, `2019-03-29`
* The calendar's month value is updated to `1` (which for `Calendar` is February, since it follows a 0-11 month counting system)
* `2019-02-29` is not a valid date - the `Calendar` rolls this over to `2019-03-01`
* `1` is subtracted from the month, to account for the offset mentioned above, date is `2019-02-01`
* The day and year are also set
* Date is now `2011-02-01`, and the test fails because the returned date doesn't match the expected value

The solution was to use the `Calendar#set` function that takes all the values at once.

#### To test
* Test this PR before April 1st in your timezone
* Run unit tests before and after