### PR TITLE
ListStore Cleanup: Post list DB query improvements

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -304,7 +304,10 @@ public class PostSqlUtils {
     public static List<LocalId> getLocalPostIdsForFilter(SiteModel site, boolean isPage, String searchQuery,
                                                          String orderBy, @Order int order) {
         ConditionClauseBuilder<SelectQuery<PostModel>> clauseBuilder =
-                WellSql.select(PostModel.class).where().beginGroup()
+                WellSql.select(PostModel.class)
+                       // We only need the local ids
+                       .columns(PostModelTable.ID)
+                       .where().beginGroup()
                        .equals(PostModelTable.IS_LOCAL_DRAFT, true)
                        .equals(PostModelTable.LOCAL_SITE_ID, site.getId())
                        .equals(PostModelTable.IS_PAGE, isPage)
@@ -313,7 +316,10 @@ public class PostSqlUtils {
             clauseBuilder = clauseBuilder.beginGroup().contains(PostModelTable.TITLE, searchQuery).or()
                                          .contains(PostModelTable.CONTENT, searchQuery).endGroup();
         }
-        // TODO: We should only query the id and return that instead
+        /*
+         * Remember that, since we are only querying the `PostModelTable.ID` column, the rest of the fields for the
+         * post won't be there which is exactly what we want.
+         */
         List<PostModel> localPosts = clauseBuilder.endWhere().orderBy(orderBy, order).getAsModel();
         List<LocalId> localPostIds = new ArrayList<>();
         for (PostModel post : localPosts) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -135,8 +135,8 @@ public class PostSqlUtils {
         return Collections.emptyList();
     }
 
-    public static List<PostModel> getPostsByLocalOrRemotePostIds(@NonNull List<LocalOrRemoteId> localOrRemoteIds,
-                                                                 int localSiteId) {
+    public static List<PostModel> getPostsByLocalOrRemotePostIds(
+            @NonNull List<? extends LocalOrRemoteId> localOrRemoteIds, int localSiteId) {
         if (localOrRemoteIds.isEmpty()) {
             return Collections.emptyList();
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -150,14 +150,19 @@ public class PostSqlUtils {
             }
         }
         ConditionClauseBuilder<SelectQuery<PostModel>> whereQuery =
-                WellSql.select(PostModel.class).where().equals(PostModelTable.LOCAL_SITE_ID, localSiteId);
-        if (!localIds.isEmpty()) {
+                WellSql.select(PostModel.class).where().equals(PostModelTable.LOCAL_SITE_ID, localSiteId).beginGroup();
+        boolean addIsInLocalIdsCondition = !localIds.isEmpty();
+        if (addIsInLocalIdsCondition) {
             whereQuery = whereQuery.isIn(PostModelTable.ID, localIds);
         }
         if (!remoteIds.isEmpty()) {
+            if (addIsInLocalIdsCondition) {
+                // Add `or` only if we are checking for both local and remote ids
+                whereQuery = whereQuery.or();
+            }
             whereQuery = whereQuery.isIn(PostModelTable.REMOTE_POST_ID, remoteIds);
         }
-        return whereQuery.endWhere().getAsModel();
+        return whereQuery.endGroup().endWhere().getAsModel();
     }
 
     public static PostModel insertPostForResult(PostModel post) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -405,7 +405,8 @@ public class PostStore extends Store {
         }
     }
 
-    public List<PostModel> getPostsByLocalOrRemotePostIds(List<LocalOrRemoteId> localOrRemoteIds, SiteModel site) {
+    public List<PostModel> getPostsByLocalOrRemotePostIds(List<? extends LocalOrRemoteId> localOrRemoteIds,
+                                                          SiteModel site) {
         if (localOrRemoteIds == null || site == null) {
             return Collections.emptyList();
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.FetchPosts;
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.RemoveAllPosts;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -406,20 +405,11 @@ public class PostStore extends Store {
         }
     }
 
-    public Map<LocalOrRemoteId, PostModel> getPostsByLocalOrRemotePostIds(List<LocalOrRemoteId> localOrRemoteIds,
-                                                                          SiteModel site) {
-        // TODO: This should run a single query, this solution is only temporary
-        Map<LocalOrRemoteId, PostModel> postMap = new HashMap<>();
-        for (LocalOrRemoteId localOrRemoteId : localOrRemoteIds) {
-            PostModel postModel = null;
-            if (localOrRemoteId instanceof LocalId) {
-                postModel = getPostByLocalPostId(((LocalId) localOrRemoteId).getValue());
-            } else if (localOrRemoteId instanceof RemoteId) {
-                postModel = getPostByRemotePostId(((RemoteId) localOrRemoteId).getValue(), site);
-            }
-            postMap.put(localOrRemoteId, postModel);
+    public List<PostModel> getPostsByLocalOrRemotePostIds(List<LocalOrRemoteId> localOrRemoteIds, SiteModel site) {
+        if (localOrRemoteIds == null || site == null) {
+            return Collections.emptyList();
         }
-        return postMap;
+        return PostSqlUtils.getPostsByLocalOrRemotePostIds(localOrRemoteIds, site.getId());
     }
 
     /**


### PR DESCRIPTION
This PR improves two DB queries we are making to get the post list from `PostStore`.

**Getting posts by local or remote ids: `getPostsByLocalOrRemotePostIds`**

In #1193, just as a temporary solution, I used a very direct solution where I walk over the ids and make individual DB queries for each one. In this PR this is changed to a single query.

One important change I've made in this PR is to change the return type of this method from a `Map` with `LocalOrRemoteId` as its key to a simple list. I've spent quite a bit of time thinking about this and at the end decided to go with this, because:

1. Just because we query a post with either a local id or a remote id doesn't mean that the post doesn't have both ids. By mapping to a specific type of id, we are limiting its usage and might be conveying the wrong intention. (meaning the consumer might think that it'll only have one type of valid id) We could add another type to describe this situation, but it didn't feel like it's worth it, but I'd be curious to hear what other people think about it.
2. I feel that the matching from local or remote ids to posts is an implementation detail for a specific feature. When we return a list of posts for the given local and remote ids, it feels like the library is already doing its job.

**Querying just ids for local posts**

`PostSqlUtils.getLocalPostIdsForFilter` was querying all the columns just to map it to its `id`, so `.columns(PostModelTable.ID)` was added to make this query more efficient. Since there is no type conversation 😭 I've added couple comments about this to make sure it's not confused to be a full model.

_This PR is opened as a draft PR as we should merge #1193 and change the base branch before merging this. It's separated from #1193 as it's self contained and should be easier to understand and discuss here._