### PR TITLE
Fixes a range check in InternalPagedListDataSource and adds unit tests for it

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/list/InternalPagedListDataSourceRangeTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/InternalPagedListDataSourceRangeTest.kt
@@ -1,0 +1,94 @@
+package org.wordpress.android.fluxc.list
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import org.wordpress.android.fluxc.model.list.datasource.InternalPagedListDataSource
+import org.wordpress.android.fluxc.model.list.datasource.ListItemDataSourceInterface
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+private const val IS_LIST_FULLY_FETCHED = false
+private val MOCKED_GET_ITEM_IDENTIFIERS_RESULT = listOf(1L, 3L, 5L)
+
+internal data class InternalPagedListDataSourceRangeTestCase(
+    val startPosition: Int,
+    val endPosition: Int,
+    val isValid: Boolean,
+    val message: String? = null
+)
+
+@RunWith(Parameterized::class)
+internal class InternalPagedListDataSourceRangeTest(
+    private val testCase: InternalPagedListDataSourceRangeTestCase
+) {
+    companion object {
+        @JvmStatic
+        @Parameters
+        fun testCases(): List<InternalPagedListDataSourceRangeTestCase> =
+                listOf(
+                        InternalPagedListDataSourceRangeTestCase(
+                                startPosition = 0,
+                                endPosition = 1,
+                                isValid = true
+                        ),
+                        InternalPagedListDataSourceRangeTestCase(
+                                startPosition = 0,
+                                endPosition = 0,
+                                isValid = false,
+                                message = "End position can't be 0"
+                        ),
+                        InternalPagedListDataSourceRangeTestCase(
+                                startPosition = -1,
+                                endPosition = 0,
+                                isValid = false,
+                                message = "Start position can't be less than 0"
+                        ),
+                        InternalPagedListDataSourceRangeTestCase(
+                                startPosition = 1,
+                                endPosition = 0,
+                                isValid = false,
+                                message = "Start position can't be more than end position"
+                        ),
+                        InternalPagedListDataSourceRangeTestCase(
+                                startPosition = 1,
+                                endPosition = MOCKED_GET_ITEM_IDENTIFIERS_RESULT.size + 1,
+                                isValid = false,
+                                message = "End position can't be more than the total size"
+                        )
+                )
+    }
+
+    @Test
+    fun `test range`() {
+        val getItemsInRange = {
+            createDataSource().getItemsInRange(testCase.startPosition, testCase.endPosition)
+        }
+        if (testCase.isValid) {
+            val items = getItemsInRange()
+            assertNotNull(items, testCase.message)
+        } else {
+            assertFailsWith(IllegalArgumentException::class, testCase.message) {
+                getItemsInRange()
+            }
+        }
+    }
+
+    private fun createDataSource(): InternalPagedListDataSource<TestListDescriptor, Long, TestPagedListResultType> {
+        val itemDataSource = mock<ListItemDataSourceInterface<TestListDescriptor, Long, TestPagedListResultType>>()
+        whenever(itemDataSource.getItemIdentifiers(any(), any(), eq(IS_LIST_FULLY_FETCHED))).thenReturn(
+                MOCKED_GET_ITEM_IDENTIFIERS_RESULT
+        )
+        return InternalPagedListDataSource(
+                listDescriptor = mock(),
+                remoteItemIds = mock(),
+                isListFullyFetched = IS_LIST_FULLY_FETCHED,
+                itemDataSource = itemDataSource
+        )
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/list/InternalPagedListDataSourceTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/InternalPagedListDataSourceTest.kt
@@ -17,7 +17,7 @@ private const val IS_LIST_FULLY_FETCHED = false
 private val testListDescriptor = TestListDescriptor()
 private val testStartAndEndPosition = Pair(5, 10)
 
-class InternalPagedListDataSourceTest {
+internal class InternalPagedListDataSourceTest {
     private val remoteItemIds = mock<List<RemoteId>>()
     private val mockIdentifiers = mock<List<TestListIdentifier>>()
     private val mockItemDataSource = mock<ListItemDataSourceInterface<TestListDescriptor, TestListIdentifier, String>>()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datasource/InternalPagedListDataSource.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datasource/InternalPagedListDataSource.kt
@@ -58,7 +58,7 @@ class InternalPagedListDataSource<LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIF
      * @param endPosition End position that's exclusive
      */
     private fun getItemIds(startPosition: Int, endPosition: Int): List<ITEM_IDENTIFIER> {
-        require(startPosition in 0..endPosition && endPosition <= totalSize) {
+        require(startPosition in 0 until endPosition && endPosition <= totalSize) {
             "Illegal start($startPosition) or end($endPosition) position for totalSize($totalSize)"
         }
 


### PR DESCRIPTION
This PR fixes the `InternalPagedListDataSource.getItemIds`s range check by making the end position exclusive. It addresses [this comment](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1193#discussion_r272485840).

For some reason I thought Kotlin created open ranges not closed ones when I made the initial change after @malinajirka's initial suggestion. Since this PR is separated, I thought this was a good opportunity to add a few parametrized tests for the range check. It's doubtful how much value they'll carry, but it was pretty quick to write them, so I thought it can't hurt to have more tests :)