### PR TITLE
Remove bad password test property

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -88,7 +88,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     @Test
     public void testWPComAuthenticationIncorrectUsernameOrPassword() throws InterruptedException {
         mNextEvent = TestEvents.INCORRECT_USERNAME_OR_PASSWORD_ERROR;
-        authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_BAD_PASSWORD);
+        authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, "afakepassword19551105");
     }
 
     @Test

--- a/example/tests.properties-example
+++ b/example/tests.properties-example
@@ -4,7 +4,6 @@
 TEST_WPCOM_USERNAME_TEST1 = FIXME
 TEST_WPCOM_PASSWORD_TEST1 = FIXME
 TEST_WPCOM_EMAIL_TEST1 = FIXME
-TEST_WPCOM_BAD_PASSWORD = FIXME
 # Comma-separated list of valid media IDs for user's primary site (at least one is required)
 TEST_WPCOM_IMAGE_IDS_TEST1 = FIXME
 


### PR DESCRIPTION
Minor change removing a test property - part of ongoing cleanup work to `tests.properties`.

#### To test

1. Make sure project builds
1. Run `ReleaseStack_AccountTest#testWPComAuthenticationIncorrectUsernameOrPassword`, make sure it passes