### PR TITLE
Don't delete trashed posts from DB

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
@@ -88,7 +88,7 @@ class PostsFragment : Fragment() {
                 event.causeOfChange is CauseOfOnPostChanged.FetchPages) {
                 prependToLog("Fetched " + event.rowsAffected + " posts from: " + firstSite.name)
             } else if (event.causeOfChange == PostAction.DELETE_POST) {
-                prependToLog("Post deleted!")
+                prependToLog("Post trashed!")
             }
         }
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.store.ListStore.OnListChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChange
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChange.FIRST_PAGE_FETCHED
 import org.wordpress.android.fluxc.store.ListStore.OnListItemsChanged
+import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
 
 // TODO: It turns out Mockito internally uses `times(1)` when that parameter is missing. Remove this in a subsequent PR
@@ -160,6 +161,12 @@ class PagedListWrapperTest {
         verify(mockIsListEmpty, times(2)).invoke()
     }
 
+    @Test
+    fun `onListRequiresRefresh invokes refresh`() {
+        triggerOnListRequiresRefresh()
+        verify(mockRefresh).invoke()
+    }
+
     private fun testListStateIsPropagatedCorrectly(listState: ListState, listError: ListError? = null) {
         val pagedListWrapper = createPagedListWrapper()
         val isFetchingFirstPageObserver = mock<Observer<Boolean>>()
@@ -206,5 +213,12 @@ class PagedListWrapperTest {
                 error = error
         )
         pagedListWrapper.onListItemsChanged(event)
+    }
+
+    private fun triggerOnListRequiresRefresh() {
+        val pagedListWrapper = createPagedListWrapper()
+        whenever(mockListDescriptor.typeIdentifier).thenReturn(ListDescriptorTypeIdentifier(0))
+        val event = OnListRequiresRefresh(type = mockListDescriptor.typeIdentifier)
+        pagedListWrapper.onListRequiresRefresh(event)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType.TRASH
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNKNOWN_POST
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
@@ -149,7 +150,7 @@ class PageStoreTest {
     fun deletePageTest() = test {
         val post = pageHierarchy[0]
         whenever(postStore.getPostByLocalPostId(post.id)).thenReturn(post)
-        val event = OnPostChanged(CauseOfOnPostChanged.DeletePost(post.id, post.remotePostId), 0)
+        val event = OnPostChanged(CauseOfOnPostChanged.DeletePost(post.id, post.remotePostId, TRASH), 0)
         val page = PageModel(site, post.id, post.title, PageStatus.fromPost(post), Date(), post.isLocallyChanged,
                 post.remotePostId, null, post.featuredImageId)
         var result: OnPostChanged? = null
@@ -172,7 +173,7 @@ class PageStoreTest {
     fun deletePageWithErrorTest() = test {
         val post = pageHierarchy[0]
         whenever(postStore.getPostByLocalPostId(post.id)).thenReturn(null)
-        val event = OnPostChanged(CauseOfOnPostChanged.DeletePost(post.id, post.remotePostId), 0)
+        val event = OnPostChanged(CauseOfOnPostChanged.DeletePost(post.id, post.remotePostId, TRASH), 0)
         event.error = PostError(UNKNOWN_POST)
         val page = PageModel(site, post.id, post.title, PageStatus.fromPost(post), Date(), post.isLocallyChanged,
             post.remotePostId, null, post.featuredImageId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.action
 import org.wordpress.android.fluxc.annotations.Action
 import org.wordpress.android.fluxc.annotations.ActionEnum
 import org.wordpress.android.fluxc.annotations.action.IAction
+import org.wordpress.android.fluxc.model.list.ListDescriptorTypeIdentifier
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.ListItemsChangedPayload
 import org.wordpress.android.fluxc.store.ListStore.ListItemsRemovedPayload
@@ -16,6 +17,8 @@ enum class ListAction : IAction {
     LIST_ITEMS_CHANGED,
     @Action(payloadType = ListItemsRemovedPayload::class)
     LIST_ITEMS_REMOVED,
+    @Action(payloadType = ListDescriptorTypeIdentifier::class)
+    LIST_REQUIRES_REFRESH,
     @Action(payloadType = RemoveExpiredListsPayload::class)
     REMOVE_EXPIRED_LISTS,
     @Action

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.store.PostStore.DeletedPostPayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostListPayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostListResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
@@ -42,7 +43,7 @@ public enum PostAction implements IAction {
     FETCHED_POST,
     @Action(payloadType = RemotePostPayload.class)
     PUSHED_POST,
-    @Action(payloadType = RemotePostPayload.class)
+    @Action(payloadType = DeletedPostPayload.class)
     DELETED_POST,
     @Action(payloadType = RemotePostPayload.class)
     RESTORED_POST,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.fluxc.model
 
+import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType
+
 sealed class CauseOfOnPostChanged {
-    class DeletePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
+    class DeletePost(val localPostId: Int, val remotePostId: Long, val postDeleteActionType: PostDeleteActionType) :
+            CauseOfOnPostChanged()
     class RestorePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
     object FetchPages : CauseOfOnPostChanged()
     object FetchPosts : CauseOfOnPostChanged()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListItemsChanged
+import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
 import kotlin.coroutines.CoroutineContext
 
@@ -139,6 +140,18 @@ class PagedListWrapper<T>(
         }
         invalidateData()
         updateIsEmpty()
+    }
+
+    /**
+     * Handles the [OnListRequiresRefresh] `ListStore` event. It'll refresh the list if the type of this list matches
+     * the type of list that requires a refresh.
+     */
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    @Suppress("unused")
+    fun onListRequiresRefresh(event: OnListRequiresRefresh) {
+        if (listDescriptor.typeIdentifier == event.type) {
+            fetchFirstPage()
+        }
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -226,7 +226,7 @@ public class PostRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void deletePost(final @NonNull SiteModel site, final @NonNull PostModel post,
+    public void deletePost(final @NonNull PostModel post, final @NonNull SiteModel site,
                            final @NonNull PostDeleteActionType postDeleteActionType) {
         String url = WPCOMREST.sites.site(site.getSiteId()).posts.post(post.getRemotePostId()).delete.getUrlV1_1();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -236,7 +236,7 @@ public class PostRestClient extends BaseWPComRestClient {
                         deletedPost.setId(post.getId());
                         deletedPost.setLocalSiteId(post.getLocalSiteId());
 
-                        RemotePostPayload payload = new RemotePostPayload(post, site);
+                        RemotePostPayload payload = new RemotePostPayload(deletedPost, site);
                         mDispatcher.dispatch(PostActionBuilder.newDeletedPostAction(payload));
                     }
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -37,10 +37,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsRespons
 import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsResponse.DiffResponsePart;
 import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsResponse.RevisionResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse;
+import org.wordpress.android.fluxc.store.PostStore.DeletedPostPayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostListResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchRevisionsResponsePayload;
+import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostListItem;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
@@ -224,7 +226,8 @@ public class PostRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void deletePost(final PostModel post, final SiteModel site) {
+    public void deletePost(final @NonNull SiteModel site, final @NonNull PostModel post,
+                           final @NonNull PostDeleteActionType postDeleteActionType) {
         String url = WPCOMREST.sites.site(site.getSiteId()).posts.post(post.getRemotePostId()).delete.getUrlV1_1();
 
         final WPComGsonRequest<PostWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
@@ -236,7 +239,8 @@ public class PostRestClient extends BaseWPComRestClient {
                         deletedPost.setId(post.getId());
                         deletedPost.setLocalSiteId(post.getLocalSiteId());
 
-                        RemotePostPayload payload = new RemotePostPayload(deletedPost, site);
+                        DeletedPostPayload payload =
+                                new DeletedPostPayload(post, site, postDeleteActionType, deletedPost);
                         mDispatcher.dispatch(PostActionBuilder.newDeletedPostAction(payload));
                     }
                 },
@@ -244,8 +248,9 @@ public class PostRestClient extends BaseWPComRestClient {
                     @Override
                     public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                         // Possible non-generic errors: 404 unknown_post (invalid post ID)
-                        RemotePostPayload payload = new RemotePostPayload(post, site);
-                        payload.error = new PostError(error.apiError, error.message);
+                        PostError deletePostError = new PostError(error.apiError, error.message);
+                        DeletedPostPayload payload =
+                                new DeletedPostPayload(post, site, postDeleteActionType, deletePostError);
                         mDispatcher.dispatch(PostActionBuilder.newDeletedPostAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -269,7 +269,7 @@ public class PostRestClient extends BaseWPComRestClient {
                         restoredPost.setId(post.getId());
                         restoredPost.setLocalSiteId(post.getLocalSiteId());
 
-                        RemotePostPayload payload = new RemotePostPayload(post, site);
+                        RemotePostPayload payload = new RemotePostPayload(restoredPost, site);
                         mDispatcher.dispatch(PostActionBuilder.newRestoredPostAction(payload));
                     }
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -291,7 +291,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void deletePost(final @NonNull SiteModel site, final @NonNull PostModel post,
+    public void deletePost(final @NonNull PostModel post, final @NonNull SiteModel site,
                            final @NonNull PostDeleteActionType postDeleteActionType) {
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.action.ListAction
 import org.wordpress.android.fluxc.action.ListAction.FETCHED_LIST_ITEMS
 import org.wordpress.android.fluxc.action.ListAction.LIST_ITEMS_CHANGED
 import org.wordpress.android.fluxc.action.ListAction.LIST_ITEMS_REMOVED
+import org.wordpress.android.fluxc.action.ListAction.LIST_REQUIRES_REFRESH
 import org.wordpress.android.fluxc.action.ListAction.REMOVE_ALL_LISTS
 import org.wordpress.android.fluxc.action.ListAction.REMOVE_EXPIRED_LISTS
 import org.wordpress.android.fluxc.annotations.action.Action
@@ -63,6 +64,7 @@ class ListStore @Inject constructor(
             FETCHED_LIST_ITEMS -> handleFetchedListItems(action.payload as FetchedListItemsPayload)
             LIST_ITEMS_CHANGED -> handleListItemsChanged(action.payload as ListItemsChangedPayload)
             LIST_ITEMS_REMOVED -> handleListItemsRemoved(action.payload as ListItemsRemovedPayload)
+            LIST_REQUIRES_REFRESH -> handleListRequiresRefresh(action.payload as ListDescriptorTypeIdentifier)
             REMOVE_EXPIRED_LISTS -> handleRemoveExpiredLists(action.payload as RemoveExpiredListsPayload)
             REMOVE_ALL_LISTS -> handleRemoveAllLists()
         }
@@ -283,6 +285,16 @@ class ListStore @Inject constructor(
     }
 
     /**
+     * Handles the [ListAction.LIST_REQUIRES_REFRESH] action.
+     *
+     * Whenever a type of list needs to be refreshed, [OnListRequiresRefresh] event will be emitted so the listening
+     * lists can refresh themselves.
+     */
+    private fun handleListRequiresRefresh(typeIdentifier: ListDescriptorTypeIdentifier) {
+        emitChange(OnListRequiresRefresh(type = typeIdentifier))
+    }
+
+    /**
      * Handles the [ListAction.REMOVE_EXPIRED_LISTS] action.
      *
      * It deletes [ListModel]s that hasn't been updated for the given [RemoveExpiredListsPayload.expirationDuration].
@@ -380,6 +392,14 @@ class ListStore @Inject constructor(
             this.error = error
         }
     }
+
+    /**
+     * This is the payload for [ListAction.LIST_REQUIRES_REFRESH].
+     *
+     * @property type [ListDescriptorTypeIdentifier] which will tell [ListStore] and the clients which
+     * [ListDescriptor]s requires a refresh.
+     */
+    class OnListRequiresRefresh(val type: ListDescriptorTypeIdentifier): Store.OnChanged<ListError>()
 
     /**
      * This is the payload for [ListAction.LIST_ITEMS_CHANGED].

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -399,7 +399,7 @@ class ListStore @Inject constructor(
      * @property type [ListDescriptorTypeIdentifier] which will tell [ListStore] and the clients which
      * [ListDescriptor]s requires a refresh.
      */
-    class OnListRequiresRefresh(val type: ListDescriptorTypeIdentifier): Store.OnChanged<ListError>()
+    class OnListRequiresRefresh(val type: ListDescriptorTypeIdentifier) : Store.OnChanged<ListError>()
 
     /**
      * This is the payload for [ListAction.LIST_ITEMS_CHANGED].

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.PageStore.UploadRequestResult.ERROR_NON
 import org.wordpress.android.fluxc.store.PageStore.UploadRequestResult.SUCCESS
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType.DELETE
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNKNOWN_POST
@@ -154,7 +155,13 @@ class PageStore @Inject constructor(
             val payload = RemotePostPayload(post, page.site)
             dispatcher.dispatch(PostActionBuilder.newDeletePostAction(payload))
         } else {
-            val event = OnPostChanged(CauseOfOnPostChanged.DeletePost(page.pageId, page.remoteId), 0)
+            val event = OnPostChanged(
+                    CauseOfOnPostChanged.DeletePost(
+                            localPostId = page.pageId,
+                            remotePostId = page.remoteId,
+                            postDeleteActionType = DELETE
+                    ), 0
+            )
             event.error = PostError(PostErrorType.UNKNOWN_POST)
             cont.resume(event)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -595,10 +595,10 @@ public class PostStore extends Store {
         PostDeleteActionType postDeleteActionType = PostStatus.fromPost(payload.post) == PostStatus.TRASHED
                 ? PostDeleteActionType.DELETE : PostDeleteActionType.TRASH;
         if (payload.site.isUsingWpComRestApi()) {
-            mPostRestClient.deletePost(payload.site, payload.post, postDeleteActionType);
+            mPostRestClient.deletePost(payload.post, payload.site, postDeleteActionType);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
-            mPostXMLRPCClient.deletePost(payload.site, payload.post, postDeleteActionType);
+            mPostXMLRPCClient.deletePost(payload.post, payload.site, postDeleteActionType);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -853,8 +853,8 @@ public class PostStore extends Store {
         OnPostChanged onPostChanged = new OnPostChanged(causeOfChange, rowsAffected);
         emitChange(onPostChanged);
 
-        mDispatcher.dispatch(ListActionBuilder.newListItemsChangedAction(
-                new ListItemsChangedPayload(PostListDescriptor.calculateTypeIdentifier(postModel.getLocalSiteId()))));
+        mDispatcher.dispatch(ListActionBuilder
+                .newListRequiresRefreshAction(PostListDescriptor.calculateTypeIdentifier(postModel.getLocalSiteId())));
     }
 
     public void setLocalRevision(RevisionModel model, SiteModel site, PostModel post) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -165,6 +165,33 @@ public class PostStore extends Store {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
+    public static class DeletedPostPayload extends Payload<PostError> {
+        @NonNull public PostModel postToBeDeleted;
+        @NonNull public SiteModel site;
+        @NonNull public PostDeleteActionType postDeleteActionType;
+        @Nullable public PostModel deletedPostResponse;
+
+        public DeletedPostPayload(@NonNull PostModel postToBeDeleted, @NonNull SiteModel site,
+                                  @NonNull PostDeleteActionType postDeleteActionType,
+                                  @Nullable PostModel deletedPostResponse) {
+            this.postToBeDeleted = postToBeDeleted;
+            this.site = site;
+            this.postDeleteActionType = postDeleteActionType;
+            this.deletedPostResponse = deletedPostResponse;
+        }
+
+        public DeletedPostPayload(@NonNull PostModel postToBeDeleted, @NonNull SiteModel site,
+                                  @NonNull PostDeleteActionType postDeleteActionType,
+                                  @NonNull PostError deletePostError) {
+            this.postToBeDeleted = postToBeDeleted;
+            this.site = site;
+            this.postDeleteActionType = postDeleteActionType;
+            this.deletedPostResponse = null;
+            this.error = deletePostError;
+        }
+    }
+
     public static class FetchRevisionsPayload extends Payload<BaseNetworkError> {
         public PostModel post;
         public SiteModel site;
@@ -257,6 +284,11 @@ public class PostStore extends Store {
             this.post = post;
             this.revisionsModel = revisionsModel;
         }
+    }
+
+    public enum PostDeleteActionType {
+        TRASH,
+        DELETE
     }
 
     public enum PostErrorType {
@@ -536,7 +568,7 @@ public class PostStore extends Store {
                 deletePost((RemotePostPayload) action.getPayload());
                 break;
             case DELETED_POST:
-                handleDeletePostCompleted((RemotePostPayload) action.getPayload());
+                handleDeletePostCompleted((DeletedPostPayload) action.getPayload());
                 break;
             case RESTORE_POST:
                 handleRestorePost((RemotePostPayload) action.getPayload());
@@ -560,11 +592,13 @@ public class PostStore extends Store {
     }
 
     private void deletePost(RemotePostPayload payload) {
+        PostDeleteActionType postDeleteActionType = PostStatus.fromPost(payload.post) == PostStatus.TRASHED
+                ? PostDeleteActionType.DELETE : PostDeleteActionType.TRASH;
         if (payload.site.isUsingWpComRestApi()) {
-            mPostRestClient.deletePost(payload.post, payload.site);
+            mPostRestClient.deletePost(payload.site, payload.post, postDeleteActionType);
         } else {
             // TODO: check for WP-REST-API plugin and use it here
-            mPostXMLRPCClient.deletePost(payload.post, payload.site);
+            mPostXMLRPCClient.deletePost(payload.site, payload.post, postDeleteActionType);
         }
     }
 
@@ -675,28 +709,47 @@ public class PostStore extends Store {
         emitChange(onRevisionsFetched);
     }
 
-    private void handleDeletePostCompleted(RemotePostPayload payload) {
-        OnPostChanged event = new OnPostChanged(
-                new CauseOfOnPostChanged.DeletePost(payload.post.getId(), payload.post.getRemotePostId()), 0);
-
+    private void handleDeletePostCompleted(DeletedPostPayload payload) {
+        CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.DeletePost(payload.postToBeDeleted.getId(),
+                payload.postToBeDeleted.getRemotePostId(), payload.postDeleteActionType);
+        OnPostChanged event = new OnPostChanged(causeOfChange, 0);
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            mDispatcher.dispatch(ListActionBuilder.newListRequiresRefreshAction(
-                    PostListDescriptor.calculateTypeIdentifier(payload.post.getLocalSiteId())));
-            PostModel postToSave = payload.post;
-            if (!payload.site.isUsingWpComRestApi()) {
-                /*
-                 * XML-RPC delete request doesn't return the updated post, so we need to manually change the status
-                 * and then fetch the post from remote to ensure post is properly synced.
-                 */
-                postToSave.setStatus(PostStatus.TRASHED.toString());
-                mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
+            if (payload.postDeleteActionType == PostDeleteActionType.TRASH) {
+                handlePostSuccessfullyTrashed(payload);
+            } else {
+                // If the post is completely removed from the server, remove it from the local DB as well
+                mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(payload.postToBeDeleted));
             }
-            PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postToSave);
         }
-
         emitChange(event);
+    }
+
+    /**
+     * Saves the changes for the trashed post in the DB, lets ListStore know about updated lists.
+     *
+     * If the trashed post is for an XML-RPC site, it'll also fetch the updated post from remote since XML-RPC delete
+     * call doesn't return the updated post.
+     */
+    private void handlePostSuccessfullyTrashed(DeletedPostPayload payload) {
+        mDispatcher.dispatch(ListActionBuilder.newListRequiresRefreshAction(
+                PostListDescriptor.calculateTypeIdentifier(payload.postToBeDeleted.getLocalSiteId())));
+
+        PostModel postToSave;
+        if (payload.deletedPostResponse != null) {
+            postToSave = payload.deletedPostResponse;
+        } else {
+            /*
+             * XML-RPC delete request doesn't return the updated post, so we need to manually change the status
+             * and then fetch the post from remote to ensure post is properly synced.
+             */
+            postToSave = payload.postToBeDeleted;
+            postToSave.setStatus(PostStatus.TRASHED.toString());
+            mDispatcher.dispatch(
+                    PostActionBuilder.newFetchPostAction(new RemotePostPayload(postToSave, payload.site)));
+        }
+        PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postToSave);
     }
 
     private void handleFetchPostsCompleted(FetchPostsResponsePayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -682,11 +682,8 @@ public class PostStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            // TODO: Let ListStore know that the list needs to be refreshed
-//            ListItemsRemovedPayload listActionPayload = new ListItemsRemovedPayload(
-//                    PostListDescriptor.calculateTypeIdentifier(payload.post.getLocalSiteId()),
-//                    Collections.singletonList(payload.post.getRemotePostId()));
-//            mDispatcher.dispatch(ListActionBuilder.newListItemsRemovedAction(listActionPayload));
+            mDispatcher.dispatch(ListActionBuilder.newListRequiresRefreshAction(
+                    PostListDescriptor.calculateTypeIdentifier(payload.post.getLocalSiteId())));
             PostModel postToSave = payload.post;
             if (!payload.site.isUsingWpComRestApi()) {
                 /*

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -741,9 +741,6 @@ public class PostStore extends Store {
             }
             emitChange(onPostUploaded);
             return;
-        } else if (payload.origin == PostAction.DELETE_POST) {
-            handleDeletePostCompleted(payload);
-            return;
         } else if (payload.origin == PostAction.RESTORE_POST) {
             handleRestorePostCompleted(payload, true);
             return;


### PR DESCRIPTION
Fixes #1008. This PR changes how the delete post action is implemented in the `PostStore`. Since both blog posts and site pages have support for trashed posts, we should not delete the trashed post from the DB and instead just update its status.

Since we use the `DELETE_POST` action to both trash and delete posts (a post will be deleted if it's already trashed), a new payload of `DeletedPostPayload` is implemented to separate the two actions. This action type is exposed in the `CauseOfOnPostChanged.DeletePost` with an enum `PostDeleteActionType` so the UI can handle trash and delete actions separately.

Furthermore, when a post is trashed we'll need to refresh the post lists for that site. This is implemented with a new `ListStore` action called `OnListRequiresRefresh`.

Finally the restore post action was not saving the result from the REST API call in the DB which was fixed by making sure the updated post is added to the `RESTORED_POST` payload.

**To test:**
The best way to test these changes would be to test trash, delete and restore actions in WPAndroid's `issue/trash-restore-delete-post-list-actions` branch.

@0nko I don't think any of these changes will affect the `PagesStore` but just for my peace of mind, could you please take a look at the changes and see if that's the case? The only changes I've made about `PagesStore` is reflect the addition of `PostDeleteActionType` in `CauseOfOnPostChanged.DeletePost` which I am not 100% sure about, but since it's for an error case, I don't think the change will matter. 🤞 