### PR TITLE
Add support for email_login_not_allowed

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -259,6 +259,7 @@ class MainFragment : Fragment() {
                 AuthenticationErrorType.INVALID_OTP -> { }
                 AuthenticationErrorType.INVALID_REQUEST,
                 AuthenticationErrorType.UNSUPPORTED_RESPONSE_TYPE,
+                AuthenticationErrorType.EMAIL_LOGIN_NOT_ALLOWED,
                 AuthenticationErrorType.GENERIC_ERROR,
                 null -> {
                     // Show Toast "Network Error"?

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -460,6 +460,7 @@ public class AccountStore extends Store {
         UNSUPPORTED_GRANT_TYPE,
         UNSUPPORTED_RESPONSE_TYPE,
         UNKNOWN_TOKEN,
+        EMAIL_LOGIN_NOT_ALLOWED,
 
         // From response's "message" field - sadly... (be careful with i18n)
         INCORRECT_USERNAME_OR_PASSWORD,


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/WordPress-Android/issues/7922

Following a corresponding fix on the WordPress.com side (so the error type is sent properly), this PR adds support for the `email_login_not_allowed` error type. Without this change, the error will be reported as `GENERIC_ERROR`.

WPAndroid side PR: https://github.com/wordpress-mobile/WordPress-Android/pull/9601

To test:

No test steps available.

👋 @aforcier , I'm adding you as a reviewer so we to make sure the Woo app is fine with the change too.