### PR TITLE
Bind PagedListWrapper.isEmpty to its data

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
@@ -47,7 +47,6 @@ class PagedListWrapperTest {
     private val mockListDescriptor = mock<ListDescriptor>()
     private val mockRefresh = mock<() -> Unit>()
     private val mockInvalidate = mock<() -> Unit>()
-    private val mockIsListEmpty = mock<() -> Boolean>()
 
     private fun createPagedListWrapper(lifecycle: Lifecycle = mock()) = PagedListWrapper(
             data = MutableLiveData<PagedList<String>>(),
@@ -56,7 +55,6 @@ class PagedListWrapperTest {
             lifecycle = lifecycle,
             refresh = mockRefresh,
             invalidate = mockInvalidate,
-            isListEmpty = mockIsListEmpty,
             parentCoroutineContext = TEST_SCOPE.coroutineContext
     )
 
@@ -68,13 +66,6 @@ class PagedListWrapperTest {
 
         verify(mockDispatcher, onlyOnce()).register(pagedListWrapper)
         verify(mockLifecycle, onlyOnce()).addObserver(pagedListWrapper)
-    }
-
-    @Test
-    fun `isListEmpty is updated in init`() {
-        createPagedListWrapper()
-
-        verify(mockIsListEmpty, onlyOnce()).invoke()
     }
 
     @Test
@@ -142,23 +133,9 @@ class PagedListWrapperTest {
     }
 
     @Test
-    fun `onListChanged invokes updates isEmpty`() {
-        triggerOnListChanged()
-        // PagedListWrapper.init will trigger `isEmpty` once
-        verify(mockIsListEmpty, times(2)).invoke()
-    }
-
-    @Test
     fun `onListItemsChanged invokes invalidate property`() {
         triggerOnListItemsChanged()
         verify(mockInvalidate, onlyOnce()).invoke()
-    }
-
-    @Test
-    fun `onListItemsChanged invokes updates isEmpty`() {
-        triggerOnListItemsChanged()
-        // PagedListWrapper.init will trigger `isEmpty` once
-        verify(mockIsListEmpty, times(2)).invoke()
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
@@ -8,7 +8,6 @@ import android.arch.lifecycle.Observer
 import android.arch.paging.PagedList
 import com.nhaarman.mockitokotlin2.firstValue
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -33,9 +32,6 @@ import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChan
 import org.wordpress.android.fluxc.store.ListStore.OnListItemsChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
-
-// TODO: It turns out Mockito internally uses `times(1)` when that parameter is missing. Remove this in a subsequent PR
-private fun onlyOnce() = times(1)
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -64,8 +60,8 @@ class PagedListWrapperTest {
 
         val pagedListWrapper = createPagedListWrapper(mockLifecycle)
 
-        verify(mockDispatcher, onlyOnce()).register(pagedListWrapper)
-        verify(mockLifecycle, onlyOnce()).addObserver(pagedListWrapper)
+        verify(mockDispatcher).register(pagedListWrapper)
+        verify(mockLifecycle).addObserver(pagedListWrapper)
     }
 
     @Test
@@ -78,8 +74,8 @@ class PagedListWrapperTest {
         assertThat(lifecycle.observerCount).isEqualTo(1)
         lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
-        verify(mockDispatcher, onlyOnce()).register(pagedListWrapper)
-        verify(mockDispatcher, onlyOnce()).unregister(pagedListWrapper)
+        verify(mockDispatcher).register(pagedListWrapper)
+        verify(mockDispatcher).unregister(pagedListWrapper)
         assertThat(lifecycle.observerCount).isEqualTo(0)
     }
 
@@ -89,7 +85,7 @@ class PagedListWrapperTest {
 
         pagedListWrapper.fetchFirstPage()
 
-        verify(mockRefresh, onlyOnce()).invoke()
+        verify(mockRefresh).invoke()
     }
 
     @Test
@@ -98,7 +94,7 @@ class PagedListWrapperTest {
 
         pagedListWrapper.invalidateData()
 
-        verify(mockInvalidate, onlyOnce()).invoke()
+        verify(mockInvalidate).invoke()
     }
 
     @Test
@@ -129,13 +125,13 @@ class PagedListWrapperTest {
     @Test
     fun `onListChanged invokes invalidate property`() {
         triggerOnListChanged()
-        verify(mockInvalidate, onlyOnce()).invoke()
+        verify(mockInvalidate).invoke()
     }
 
     @Test
     fun `onListItemsChanged invokes invalidate property`() {
         triggerOnListItemsChanged()
-        verify(mockInvalidate, onlyOnce()).invoke()
+        verify(mockInvalidate).invoke()
     }
 
     @Test
@@ -163,7 +159,7 @@ class PagedListWrapperTest {
 
     private inline fun <reified T> captureAndVerifySingleValue(observer: Observer<T>, result: T) {
         val captor = ArgumentCaptor.forClass(T::class.java)
-        verify(observer, onlyOnce()).onChanged(captor.capture())
+        verify(observer).onChanged(captor.capture())
         assertThat(captor.firstValue).isEqualTo(result)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -107,9 +107,6 @@ class ListStore @Inject constructor(
                     }
                 },
                 invalidate = factory::invalidate,
-                isListEmpty = {
-                    getListItemsCount(listDescriptor) == 0L
-                },
                 parentCoroutineContext = coroutineContext
         )
     }
@@ -171,14 +168,6 @@ class ListStore @Inject constructor(
         return if (listModel != null) {
             listItemSqlUtils.getListItems(listModel.id).map { it.remoteItemId }
         } else emptyList()
-    }
-
-    /**
-     * A helper function that returns the number of records a list has for the given [ListDescriptor].
-     */
-    private fun getListItemsCount(listDescriptor: ListDescriptor): Long {
-        val listModel = listSqlUtils.getList(listDescriptor)
-        return if (listModel != null) listItemSqlUtils.getListItemsCount(listModel.id) else 0L
     }
 
     /**


### PR DESCRIPTION
In the previous iteration of `PagedListWrapper` I binded the `isEmpty` to `ListStore` because the list size couldn't be changed from outside and that made the value of `isEmpty` immediately available. It was addressing an issue I had in WPAndroid where the post list initially showed the empty view instead of loading. Neither of these cases are true anymore, so this PR binds the `isEmpty` property to the actual data.

It also removes the `onlyOnce` property with its `TODO`. This is unrelated, but I thought it was a good chance to get it out of the way.

**To test:**
I tested this in WPAndroid's `feature/master-post-filters` branch and the local drafts showed up as expected (even if there are no remote drafts) and the empty view worked as expected as well. It'd be great to double test this.

Also the connected tests for post list can be ran. I found that the WPCom tests sometimes failed for me. I think this is due to tests running one after another too quickly. It'll need to be addressed, but it's unrelated to these changes.