### PR TITLE
Implements invalidate list ListStore action

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.store.ListStore.ListErrorType.PERMISSION_ERRO
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChange
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChange.FIRST_PAGE_FETCHED
+import org.wordpress.android.fluxc.store.ListStore.OnListDataInvalidated
 import org.wordpress.android.fluxc.store.ListStore.OnListItemsChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
@@ -140,6 +141,12 @@ class PagedListWrapperTest {
         verify(mockRefresh).invoke()
     }
 
+    @Test
+    fun `onListDataInvalidated invokes invalidate property`() {
+        triggerOnListDataInvalidated()
+        verify(mockInvalidate).invoke()
+    }
+
     private fun testListStateIsPropagatedCorrectly(listState: ListState, listError: ListError? = null) {
         val pagedListWrapper = createPagedListWrapper()
         val isFetchingFirstPageObserver = mock<Observer<Boolean>>()
@@ -193,5 +200,12 @@ class PagedListWrapperTest {
         whenever(mockListDescriptor.typeIdentifier).thenReturn(ListDescriptorTypeIdentifier(0))
         val event = OnListRequiresRefresh(type = mockListDescriptor.typeIdentifier)
         pagedListWrapper.onListRequiresRefresh(event)
+    }
+
+    private fun triggerOnListDataInvalidated() {
+        val pagedListWrapper = createPagedListWrapper()
+        whenever(mockListDescriptor.typeIdentifier).thenReturn(ListDescriptorTypeIdentifier(0))
+        val event = OnListDataInvalidated(type = mockListDescriptor.typeIdentifier)
+        pagedListWrapper.onListDataInvalidated(event)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -19,6 +19,8 @@ enum class ListAction : IAction {
     LIST_ITEMS_REMOVED,
     @Action(payloadType = ListDescriptorTypeIdentifier::class)
     LIST_REQUIRES_REFRESH,
+    @Action(payloadType = ListDescriptorTypeIdentifier::class)
+    LIST_DATA_INVALIDATED,
     @Action(payloadType = RemoveExpiredListsPayload::class)
     REMOVE_EXPIRED_LISTS,
     @Action

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
@@ -15,6 +15,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged
+import org.wordpress.android.fluxc.store.ListStore.OnListDataInvalidated
 import org.wordpress.android.fluxc.store.ListStore.OnListItemsChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
@@ -149,6 +150,18 @@ class PagedListWrapper<T>(
     fun onListRequiresRefresh(event: OnListRequiresRefresh) {
         if (listDescriptor.typeIdentifier == event.type) {
             fetchFirstPage()
+        }
+    }
+
+    /**
+     * Handles the [OnListDataInvalidated] `ListStore` event. It'll invalidate the list if the type of this list matches
+     * the type of list that is invalidated.
+     */
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    @Suppress("unused")
+    fun onListDataInvalidated(event: OnListDataInvalidated) {
+        if (listDescriptor.typeIdentifier == event.type) {
+            invalidateData()
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.ListAction
 import org.wordpress.android.fluxc.action.ListAction.FETCHED_LIST_ITEMS
+import org.wordpress.android.fluxc.action.ListAction.LIST_DATA_INVALIDATED
 import org.wordpress.android.fluxc.action.ListAction.LIST_ITEMS_CHANGED
 import org.wordpress.android.fluxc.action.ListAction.LIST_ITEMS_REMOVED
 import org.wordpress.android.fluxc.action.ListAction.LIST_REQUIRES_REFRESH
@@ -65,6 +66,7 @@ class ListStore @Inject constructor(
             LIST_ITEMS_CHANGED -> handleListItemsChanged(action.payload as ListItemsChangedPayload)
             LIST_ITEMS_REMOVED -> handleListItemsRemoved(action.payload as ListItemsRemovedPayload)
             LIST_REQUIRES_REFRESH -> handleListRequiresRefresh(action.payload as ListDescriptorTypeIdentifier)
+            LIST_DATA_INVALIDATED -> handleListDataInvalidated(action.payload as ListDescriptorTypeIdentifier)
             REMOVE_EXPIRED_LISTS -> handleRemoveExpiredLists(action.payload as RemoveExpiredListsPayload)
             REMOVE_ALL_LISTS -> handleRemoveAllLists()
         }
@@ -284,6 +286,16 @@ class ListStore @Inject constructor(
     }
 
     /**
+     * Handles the [ListAction.LIST_DATA_INVALIDATED] action.
+     *
+     * Whenever the data of a list is invalidated, [OnListDataInvalidated] event will be emitted so the listening
+     * lists can invalidate their data.
+     */
+    private fun handleListDataInvalidated(typeIdentifier: ListDescriptorTypeIdentifier) {
+        emitChange(OnListDataInvalidated(type = typeIdentifier))
+    }
+
+    /**
      * Handles the [ListAction.REMOVE_EXPIRED_LISTS] action.
      *
      * It deletes [ListModel]s that hasn't been updated for the given [RemoveExpiredListsPayload.expirationDuration].
@@ -383,12 +395,14 @@ class ListStore @Inject constructor(
     }
 
     /**
-     * This is the payload for [ListAction.LIST_REQUIRES_REFRESH].
-     *
-     * @property type [ListDescriptorTypeIdentifier] which will tell [ListStore] and the clients which
-     * [ListDescriptor]s requires a refresh.
+     * The event to be emitted when a list needs to be refresh for a specific [ListDescriptorTypeIdentifier].
      */
     class OnListRequiresRefresh(val type: ListDescriptorTypeIdentifier) : Store.OnChanged<ListError>()
+
+    /**
+     * The event to be emitted when a list's data is invalidated for a specific [ListDescriptorTypeIdentifier].
+     */
+    class OnListDataInvalidated(val type: ListDescriptorTypeIdentifier) : Store.OnChanged<ListError>()
 
     /**
      * This is the payload for [ListAction.LIST_ITEMS_CHANGED].


### PR DESCRIPTION
This PR adds `LIST_DATA_INVALIDATED` action to `ListStore` and listens for it in the `PagedListWrapper`. This was added so that we can invalidate lists without having a reference to the list we want to invalidate in the clients.

It also fixes the comment for `OnListRequiresRefresh`.

**To review/merge:**
1. Review and merge #1212 
2. Change the base branch to `feature/master-post-filters`
3. Mark the PR ready to review