### PR TITLE
issue/wcproductstore-singleton

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -17,7 +17,9 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Locale
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcProductRestClient: ProductRestClient) :
         Store(dispatcher) {
     class FetchSingleProductPayload(


### PR DESCRIPTION
This PR adds the `@Singleton` annotation to the WCProducStore. I neglected to do this, which was causing multiple `OnProductChanged()` events to fire in WCAndroid for each request to fetch a product.