### PR TITLE
Woo: order tracking shipment providers

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
@@ -444,6 +445,28 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
                     "https://tools.usps.com/go/TrackConfirmAction_input?qtc_tLabels1=11122233344466666")
             assertEquals(trackingNumber, "11122233344466666")
             assertEquals(dateShipped, "2019-02-19")
+        }
+    }
+
+    @Test
+    fun testOrderShipmentProvidersFetchSuccess() {
+        val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
+        interceptor.respondWith("wc-order-shipment-providers-success.json")
+        orderRestClient.fetchOrderShipmentProviders(siteModel, orderModel)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_ORDER_SHIPMENT_PROVIDERS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchOrderShipmentProvidersResponsePayload
+        assertNull(payload.error)
+        assertEquals(54, payload.providers.size)
+
+        with(payload.providers[0]) {
+            assertEquals(localSiteId, siteModel.id)
+            assertEquals("Australia", country)
+            assertEquals("Australia Post", carrierName)
+            assertEquals("http://auspost.com.au/track/track.html?id=%1\$s", carrierLink)
         }
     }
 

--- a/example/src/androidTest/resources/wc-order-shipment-providers-success.json
+++ b/example/src/androidTest/resources/wc-order-shipment-providers-success.json
@@ -1,0 +1,96 @@
+{
+  "data": {
+    "Australia": {
+      "Australia Post": "http:\/\/auspost.com.au\/track\/track.html?id=%1$s",
+      "Fastway Couriers": "http:\/\/www.fastway.com.au\/courier-services\/track-your-parcel?l=%1$s"
+    },
+    "Austria": {
+      "post.at": "http:\/\/www.post.at\/sendungsverfolgung.php?pnum1=%1$s",
+      "dhl.at": "http:\/\/www.dhl.at\/content\/at\/de\/express\/sendungsverfolgung.html?brand=DHL&AWB=%1$s",
+      "DPD.at": "https:\/\/tracking.dpd.de\/parcelstatus?locale=de_AT&query=%1$s"
+    },
+    "Brazil": {
+      "Correios": "http:\/\/websro.correios.com.br\/sro_bin\/txect01$.QueryList?P_LINGUA=001&P_TIPO=001&P_COD_UNI=%1$s"
+    },
+    "Belgium": {
+      "bpost": "https:\/\/track.bpost.be\/btr\/web\/#\/search?itemCode=%1$s"
+    },
+    "Canada": {
+      "Canada Post": "http:\/\/www.canadapost.ca\/cpotools\/apps\/track\/personal\/findByTrackNumber?trackingNumber=%1$s"
+    },
+    "Czech Republic": {
+      "PPL.cz": "http:\/\/www.ppl.cz\/main2.aspx?cls=Package&idSearch=%1$s",
+      "\u010cesk\u00e1 po\u0161ta": "https:\/\/www.postaonline.cz\/trackandtrace\/-\/zasilka\/cislo?parcelNumbers=%1$s",
+      "DHL.cz": "http:\/\/www.dhl.cz\/cs\/express\/sledovani_zasilek.html?AWB=%1$s",
+      "DPD.cz": "https:\/\/tracking.dpd.de\/parcelstatus?locale=cs_CZ&query=%1$s"
+    },
+    "Finland": {
+      "Itella": "http:\/\/www.posti.fi\/itemtracking\/posti\/search_by_shipment_id?lang=en&ShipmentId=%1$s"
+    },
+    "France": {
+      "Colissimo": "http:\/\/www.colissimo.fr\/portail_colissimo\/suivre.do?language=fr_FR&colispart=%1$s"
+    },
+    "Germany": {
+      "DHL Intraship (DE)": "http:\/\/nolp.dhl.de\/nextt-online-public\/set_identcodes.do?lang=de&idc=%1$s&rfn=&extendedSearch=true",
+      "Hermes": "https:\/\/tracking.hermesworld.com\/?TrackID=%1$s",
+      "Deutsche Post DHL": "http:\/\/nolp.dhl.de\/nextt-online-public\/set_identcodes.do?lang=de&idc=%1$s",
+      "UPS Germany": "http:\/\/wwwapps.ups.com\/WebTracking\/processInputRequest?sort_by=status&tracknums_displayed=1&TypeOfInquiryNumber=T&loc=de_DE&InquiryNumber1=%1$s",
+      "DPD.de": "https:\/\/tracking.dpd.de\/parcelstatus?query=%1$s&locale=en_DE"
+    },
+    "Ireland": {
+      "DPD.ie": "http:\/\/www2.dpd.ie\/Services\/QuickTrack\/tabid\/222\/ConsignmentID\/%1$s\/Default.aspx",
+      "An Post": "https:\/\/track.anpost.ie\/TrackingResults.aspx?rtt=1&items=%1$s"
+    },
+    "Italy": {
+      "BRT (Bartolini)": "http:\/\/as777.brt.it\/vas\/sped_det_show.hsm?referer=sped_numspe_par.htm&Nspediz=%1$s",
+      "DHL Express": "http:\/\/www.dhl.it\/it\/express\/ricerca.html?AWB=%1$s&brand=DHL"
+    },
+    "India": {
+      "DTDC": "http:\/\/www.dtdc.in\/tracking\/tracking_results.asp?Ttype=awb_no&strCnno=%1$s&TrkType2=awb_no"
+    },
+    "Netherlands": {
+      "PostNL": "https:\/\/mijnpakket.postnl.nl\/Claim?Barcode=%1$s&Postalcode=%2$s&Foreign=False&ShowAnonymousLayover=False&CustomerServiceClaim=False",
+      "DPD.NL": "http:\/\/track.dpdnl.nl\/?parcelnumber=%1$s",
+      "UPS Netherlands": "http:\/\/wwwapps.ups.com\/WebTracking\/processInputRequest?sort_by=status&tracknums_displayed=1&TypeOfInquiryNumber=T&loc=nl_NL&InquiryNumber1=%1$s"
+    },
+    "New Zealand": {
+      "Courier Post": "http:\/\/trackandtrace.courierpost.co.nz\/Search\/%1$s",
+      "NZ Post": "http:\/\/www.nzpost.co.nz\/tools\/tracking?trackid=%1$s",
+      "Fastways": "http:\/\/www.fastway.co.nz\/courier-services\/track-your-parcel?l=%1$s",
+      "PBT Couriers": "http:\/\/www.pbt.com\/nick\/results.cfm?ticketNo=%1$s"
+    },
+    "Romania": {
+      "Fan Courier": "https:\/\/www.fancourier.ro\/awb-tracking\/?xawb=%1$s",
+      "DPD Romania": "https:\/\/tracking.dpd.de\/parcelstatus?query=%1$s&locale=ro_RO",
+      "Urgent Cargus": "https:\/\/app.urgentcargus.ro\/Private\/Tracking.aspx?CodBara=%1$s"
+    },
+    "South African": {
+      "SAPO": "http:\/\/sms.postoffice.co.za\/TrackingParcels\/Parcel.aspx?id=%1$s"
+    },
+    "Sweden": {
+      "PostNord Sverige AB": "http:\/\/www.postnord.se\/sv\/verktyg\/sok\/Sidor\/spara-brev-paket-och-pall.aspx?search=%1$s",
+      "DHL.se": "http:\/\/www.dhl.se\/content\/se\/sv\/express\/godssoekning.shtml?brand=DHL&AWB=%1$s",
+      "Bring.se": "http:\/\/tracking.bring.se\/tracking.html?q=%1$s",
+      "UPS.se": "http:\/\/wwwapps.ups.com\/WebTracking\/track?track=yes&loc=sv_SE&trackNums=%1$s",
+      "DB Schenker": "http:\/\/privpakportal.schenker.nu\/TrackAndTrace\/packagesearch.aspx?packageId=%1$s"
+    },
+    "United Kingdom": {
+      "DHL": "http:\/\/www.dhl.com\/content\/g0\/en\/express\/tracking.shtml?brand=DHL&AWB=%1$s",
+      "DPD.co.uk": "http:\/\/www.dpd.co.uk\/tracking\/trackingSearch.do?search.searchType=0&search.parcelNumber=%1$s",
+      "InterLink": "http:\/\/www.interlinkexpress.com\/apps\/tracking\/?reference=%1$s&postcode=%2$s#results",
+      "ParcelForce": "http:\/\/www.parcelforce.com\/portal\/pw\/track?trackNumber=%1$s",
+      "Royal Mail": "https:\/\/www.royalmail.com\/track-your-item\/?trackNumber=%1$s",
+      "TNT Express (consignment)": "http:\/\/www.tnt.com\/webtracker\/tracking.do?requestType=GEN&searchType=CON&respLang=en&respCountry=GENERIC&sourceID=1&sourceCountry=ww&cons=%1$s&navigation=1&g\nenericSiteIdent=",
+      "TNT Express (reference)": "http:\/\/www.tnt.com\/webtracker\/tracking.do?requestType=GEN&searchType=REF&respLang=en&respCountry=GENERIC&sourceID=1&sourceCountry=ww&cons=%1$s&navigation=1&genericSiteIdent=",
+      "UK Mail": "https:\/\/www.ukmail.com\/manage-my-delivery\/manage-my-delivery?ConsignmentNumber=%1$s"
+    },
+    "United States": {
+      "Fedex": "http:\/\/www.fedex.com\/Tracking?action=track&tracknumbers=%1$s",
+      "FedEx Sameday": "https:\/\/www.fedexsameday.com\/fdx_dotracking_ua.aspx?tracknum=%1$s",
+      "OnTrac": "http:\/\/www.ontrac.com\/trackingdetail.asp?tracking=%1$s",
+      "UPS": "http:\/\/wwwapps.ups.com\/WebTracking\/track?track=yes&trackNums=%1$s",
+      "USPS": "https:\/\/tools.usps.com\/go\/TrackConfirmAction_input?qtc_tLabels1=%1$s",
+      "DHL US": "https:\/\/www.logistics.dhl\/us-en\/home\/tracking\/tracking-ecommerce.html?tracking-id=%1$s"
+    }
+  }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -423,7 +423,7 @@ class WooCommerceFragment : Fragment(), CustomStatsDialog.Listener {
                     prependToLog("Fetching a list of providers from the API")
 
                     val payload = FetchOrderShipmentProvidersPayload(site, order)
-                    dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingProvidersAction(payload))
+                    dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentProvidersAction(payload))
                 } ?: prependToLog("No orders found in db to use as seed. Fetch orders first.")
             }
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WooCommerceFragment.kt
@@ -40,12 +40,14 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRe
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderShipmentProvidersChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderStatusOptionsChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrdersSearched
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
@@ -412,6 +414,19 @@ class WooCommerceFragment : Fragment(), CustomStatsDialog.Listener {
                 }
             } ?: showNoWCSitesToast()
         }
+
+        fetch_shipment_providers.setOnClickListener {
+            getFirstWCSite()?.let { site ->
+                // Just use the first order, the shipment trackings api oddly requires an order_id for fetching
+                // a list of providers, even though the providers are not order specific.
+                getFirstWCOrder()?.let { order ->
+                    prependToLog("Fetching a list of providers from the API")
+
+                    val payload = FetchOrderShipmentProvidersPayload(site, order)
+                    dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingProvidersAction(payload))
+                } ?: prependToLog("No orders found in db to use as seed. Fetch orders first.")
+            }
+        }
     }
 
     override fun onStart() {
@@ -467,6 +482,21 @@ class WooCommerceFragment : Fragment(), CustomStatsDialog.Listener {
                             "weight unit = ${settings.weightUnit}, dimension unit = ${settings.dimensionUnit}"
             )
         } ?: prependToLog("Error getting product settings from db")
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onOrderShipmentProviderChanged(event: OnOrderShipmentProvidersChanged) {
+        if (event.isError) {
+            prependToLog("Error fetching shipment providers - error: " + event.error.type)
+        } else {
+            getFirstWCSite()?.let { site ->
+                wcOrderStore.getShipmentProvidersForSite(site).forEach { provider ->
+                    prependToLog(" - ${provider.carrierName}")
+                }
+                prependToLog("[${event.rowsAffected}] shipment providers fetched successfully!")
+            }
+        }
     }
 
     @Suppress("unused")

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -101,6 +101,12 @@
             android:text="Fetch Order Shipment Trackings"/>
 
         <Button
+            android:id="@+id/fetch_shipment_providers"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fetch Order Shipment Providers"/>
+
+        <Button
             android:id="@+id/update_latest_order_status"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.wc.order
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonParser
-import com.google.gson.JsonPrimitive
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -1,15 +1,20 @@
 package org.wordpress.android.fluxc.wc.order
 
 import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.JsonParser
+import com.google.gson.JsonPrimitive
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderNoteApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderShipmentTrackingApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatusApiResponse
+import kotlin.collections.MutableMap.MutableEntry
 
 object OrderTestUtils {
     fun generateSampleOrder(
@@ -94,6 +99,34 @@ object OrderTestUtils {
             trackingProvider = "USPS"
             trackingLink = ""
             dateShipped = "2019-01-01"
+        }
+    }
+
+    fun getOrderShipmentProvidersFromJson(json: String, siteId: Int): List<WCOrderShipmentProviderModel> {
+        val providers = mutableListOf<WCOrderShipmentProviderModel>()
+        val jsonElement = JsonParser().parse(json)
+        jsonElement.asJsonObject.entrySet().forEach { countryEntry: MutableEntry<String, JsonElement> ->
+            countryEntry.value.asJsonObject.entrySet().map { carrierEntry ->
+                carrierEntry?.let { carrier ->
+                    val provider = WCOrderShipmentProviderModel().apply {
+                        localSiteId = siteId
+                        this.country = countryEntry.key ?: ""
+                        this.carrierName = carrier.key
+                        this.carrierLink = carrier.value.asString
+                    }
+                    providers.add(provider)
+                }
+            }
+        }
+        return providers
+    }
+
+    fun generateOrderShipmentProvider(siteId: Int): WCOrderShipmentProviderModel {
+        return WCOrderShipmentProviderModel().apply {
+            localSiteId = siteId
+            country = "Australia"
+            carrierName = "Amanda Test"
+            carrierLink = "http://google.com"
         }
     }
 }

--- a/example/src/test/resources/wc/order-shipment-providers.json
+++ b/example/src/test/resources/wc/order-shipment-providers.json
@@ -1,0 +1,94 @@
+{
+  "Australia": {
+    "Australia Post": "http:\/\/auspost.com.au\/track\/track.html?id=%1$s",
+    "Fastway Couriers": "http:\/\/www.fastway.com.au\/courier-services\/track-your-parcel?l=%1$s"
+  },
+  "Austria": {
+    "post.at": "http:\/\/www.post.at\/sendungsverfolgung.php?pnum1=%1$s",
+    "dhl.at": "http:\/\/www.dhl.at\/content\/at\/de\/express\/sendungsverfolgung.html?brand=DHL&AWB=%1$s",
+    "DPD.at": "https:\/\/tracking.dpd.de\/parcelstatus?locale=de_AT&query=%1$s"
+  },
+  "Brazil": {
+    "Correios": "http:\/\/websro.correios.com.br\/sro_bin\/txect01$.QueryList?P_LINGUA=001&P_TIPO=001&P_COD_UNI=%1$s"
+  },
+  "Belgium": {
+    "bpost": "https:\/\/track.bpost.be\/btr\/web\/#\/search?itemCode=%1$s"
+  },
+  "Canada": {
+    "Canada Post": "http:\/\/www.canadapost.ca\/cpotools\/apps\/track\/personal\/findByTrackNumber?trackingNumber=%1$s"
+  },
+  "Czech Republic": {
+    "PPL.cz": "http:\/\/www.ppl.cz\/main2.aspx?cls=Package&idSearch=%1$s",
+    "\u010cesk\u00e1 po\u0161ta": "https:\/\/www.postaonline.cz\/trackandtrace\/-\/zasilka\/cislo?parcelNumbers=%1$s",
+    "DHL.cz": "http:\/\/www.dhl.cz\/cs\/express\/sledovani_zasilek.html?AWB=%1$s",
+    "DPD.cz": "https:\/\/tracking.dpd.de\/parcelstatus?locale=cs_CZ&query=%1$s"
+  },
+  "Finland": {
+    "Itella": "http:\/\/www.posti.fi\/itemtracking\/posti\/search_by_shipment_id?lang=en&ShipmentId=%1$s"
+  },
+  "France": {
+    "Colissimo": "http:\/\/www.colissimo.fr\/portail_colissimo\/suivre.do?language=fr_FR&colispart=%1$s"
+  },
+  "Germany": {
+    "DHL Intraship (DE)": "http:\/\/nolp.dhl.de\/nextt-online-public\/set_identcodes.do?lang=de&idc=%1$s&rfn=&extendedSearch=true",
+    "Hermes": "https:\/\/tracking.hermesworld.com\/?TrackID=%1$s",
+    "Deutsche Post DHL": "http:\/\/nolp.dhl.de\/nextt-online-public\/set_identcodes.do?lang=de&idc=%1$s",
+    "UPS Germany": "http:\/\/wwwapps.ups.com\/WebTracking\/processInputRequest?sort_by=status&tracknums_displayed=1&TypeOfInquiryNumber=T&loc=de_DE&InquiryNumber1=%1$s",
+    "DPD.de": "https:\/\/tracking.dpd.de\/parcelstatus?query=%1$s&locale=en_DE"
+  },
+  "Ireland": {
+    "DPD.ie": "http:\/\/www2.dpd.ie\/Services\/QuickTrack\/tabid\/222\/ConsignmentID\/%1$s\/Default.aspx",
+    "An Post": "https:\/\/track.anpost.ie\/TrackingResults.aspx?rtt=1&items=%1$s"
+  },
+  "Italy": {
+    "BRT (Bartolini)": "http:\/\/as777.brt.it\/vas\/sped_det_show.hsm?referer=sped_numspe_par.htm&Nspediz=%1$s",
+    "DHL Express": "http:\/\/www.dhl.it\/it\/express\/ricerca.html?AWB=%1$s&brand=DHL"
+  },
+  "India": {
+    "DTDC": "http:\/\/www.dtdc.in\/tracking\/tracking_results.asp?Ttype=awb_no&strCnno=%1$s&TrkType2=awb_no"
+  },
+  "Netherlands": {
+    "PostNL": "https:\/\/mijnpakket.postnl.nl\/Claim?Barcode=%1$s&Postalcode=%2$s&Foreign=False&ShowAnonymousLayover=False&CustomerServiceClaim=False",
+    "DPD.NL": "http:\/\/track.dpdnl.nl\/?parcelnumber=%1$s",
+    "UPS Netherlands": "http:\/\/wwwapps.ups.com\/WebTracking\/processInputRequest?sort_by=status&tracknums_displayed=1&TypeOfInquiryNumber=T&loc=nl_NL&InquiryNumber1=%1$s"
+  },
+  "New Zealand": {
+    "Courier Post": "http:\/\/trackandtrace.courierpost.co.nz\/Search\/%1$s",
+    "NZ Post": "http:\/\/www.nzpost.co.nz\/tools\/tracking?trackid=%1$s",
+    "Fastways": "http:\/\/www.fastway.co.nz\/courier-services\/track-your-parcel?l=%1$s",
+    "PBT Couriers": "http:\/\/www.pbt.com\/nick\/results.cfm?ticketNo=%1$s"
+  },
+  "Romania": {
+    "Fan Courier": "https:\/\/www.fancourier.ro\/awb-tracking\/?xawb=%1$s",
+    "DPD Romania": "https:\/\/tracking.dpd.de\/parcelstatus?query=%1$s&locale=ro_RO",
+    "Urgent Cargus": "https:\/\/app.urgentcargus.ro\/Private\/Tracking.aspx?CodBara=%1$s"
+  },
+  "South African": {
+    "SAPO": "http:\/\/sms.postoffice.co.za\/TrackingParcels\/Parcel.aspx?id=%1$s"
+  },
+  "Sweden": {
+    "PostNord Sverige AB": "http:\/\/www.postnord.se\/sv\/verktyg\/sok\/Sidor\/spara-brev-paket-och-pall.aspx?search=%1$s",
+    "DHL.se": "http:\/\/www.dhl.se\/content\/se\/sv\/express\/godssoekning.shtml?brand=DHL&AWB=%1$s",
+    "Bring.se": "http:\/\/tracking.bring.se\/tracking.html?q=%1$s",
+    "UPS.se": "http:\/\/wwwapps.ups.com\/WebTracking\/track?track=yes&loc=sv_SE&trackNums=%1$s",
+    "DB Schenker": "http:\/\/privpakportal.schenker.nu\/TrackAndTrace\/packagesearch.aspx?packageId=%1$s"
+  },
+  "United Kingdom": {
+    "DHL": "http:\/\/www.dhl.com\/content\/g0\/en\/express\/tracking.shtml?brand=DHL&AWB=%1$s",
+    "DPD.co.uk": "http:\/\/www.dpd.co.uk\/tracking\/trackingSearch.do?search.searchType=0&search.parcelNumber=%1$s",
+    "InterLink": "http:\/\/www.interlinkexpress.com\/apps\/tracking\/?reference=%1$s&postcode=%2$s#results",
+    "ParcelForce": "http:\/\/www.parcelforce.com\/portal\/pw\/track?trackNumber=%1$s",
+    "Royal Mail": "https:\/\/www.royalmail.com\/track-your-item\/?trackNumber=%1$s",
+    "TNT Express (consignment)": "http:\/\/www.tnt.com\/webtracker\/tracking.do?requestType=GEN&searchType=CON&respLang=en&respCountry=GENERIC&sourceID=1&sourceCountry=ww&cons=%1$s&navigation=1&g\nenericSiteIdent=",
+    "TNT Express (reference)": "http:\/\/www.tnt.com\/webtracker\/tracking.do?requestType=GEN&searchType=REF&respLang=en&respCountry=GENERIC&sourceID=1&sourceCountry=ww&cons=%1$s&navigation=1&genericSiteIdent=",
+    "UK Mail": "https:\/\/www.ukmail.com\/manage-my-delivery\/manage-my-delivery?ConsignmentNumber=%1$s"
+  },
+  "United States": {
+    "Fedex": "http:\/\/www.fedex.com\/Tracking?action=track&tracknumbers=%1$s",
+    "FedEx Sameday": "https:\/\/www.fedexsameday.com\/fdx_dotracking_ua.aspx?tracknum=%1$s",
+    "OnTrac": "http:\/\/www.ontrac.com\/trackingdetail.asp?tracking=%1$s",
+    "UPS": "http:\/\/wwwapps.ups.com\/WebTracking\/track?track=yes&trackNums=%1$s",
+    "USPS": "https:\/\/tools.usps.com\/go\/TrackConfirmAction_input?qtc_tLabels1=%1$s",
+    "DHL US": "https:\/\/www.logistics.dhl\/us-en\/home\/tracking\/tracking-ecommerce.html?tracking-id=%1$s"
+  }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 65;
+        return 66;
     }
 
     @Override
@@ -502,6 +502,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
                 oldVersion++;
+            case 65:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -739,6 +743,15 @@ public class WellSqlConfig extends DefaultWellConfig {
                                + "TRACKING_PROVIDER TEXT NOT NULL,"
                                + "TRACKING_LINK TEXT NOT NULL,"
                                + "DATE_SHIPPED TEXT NOT NULL)");
+                    break;
+                case 65:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("CREATE TABLE WCOrderShipmentProviderModel ("
+                               + "LOCAL_SITE_ID INTEGER,"
+                               + "COUNTRY TEXT NOT NULL,"
+                               + "CARRIER_NAME TEXT NOT NULL,"
+                               + "CARRIER_LINK TEXT NOT NULL,"
+                               + "_id INTEGER PRIMARY KEY AUTOINCREMENT)");
                     break;
             }
         }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -49,7 +49,7 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = FetchOrderShipmentTrackingsPayload.class)
     FETCH_ORDER_SHIPMENT_TRACKINGS,
     @Action(payloadType = FetchOrderShipmentProvidersPayload.class)
-    FETCH_ORDER_SHIPMENT_TRACKING_PROVIDERS,
+    FETCH_ORDER_SHIPMENT_PROVIDERS,
 
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
@@ -73,5 +73,5 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = FetchOrderShipmentTrackingsResponsePayload.class)
     FETCHED_ORDER_SHIPMENT_TRACKINGS,
     @Action(payloadType = FetchOrderShipmentProvidersResponsePayload.class)
-    FETCHED_ORDER_SHIPMENT_TRACKING_PROVIDERS
+    FETCHED_ORDER_SHIPMENT_PROVIDERS
 }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -7,8 +7,8 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingProvidersPayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingProvidersResponsePayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload;
@@ -48,7 +48,7 @@ public enum WCOrderAction implements IAction {
     FETCH_ORDER_STATUS_OPTIONS,
     @Action(payloadType = FetchOrderShipmentTrackingsPayload.class)
     FETCH_ORDER_SHIPMENT_TRACKINGS,
-    @Action(payloadType = FetchOrderShipmentTrackingProvidersPayload.class)
+    @Action(payloadType = FetchOrderShipmentProvidersPayload.class)
     FETCH_ORDER_SHIPMENT_TRACKING_PROVIDERS,
 
     // Remote responses
@@ -72,6 +72,6 @@ public enum WCOrderAction implements IAction {
     FETCHED_ORDER_STATUS_OPTIONS,
     @Action(payloadType = FetchOrderShipmentTrackingsResponsePayload.class)
     FETCHED_ORDER_SHIPMENT_TRACKINGS,
-    @Action(payloadType = FetchOrderShipmentTrackingProvidersResponsePayload.class)
+    @Action(payloadType = FetchOrderShipmentProvidersResponsePayload.class)
     FETCHED_ORDER_SHIPMENT_TRACKING_PROVIDERS
 }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -7,6 +7,8 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingProvidersPayload;
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingProvidersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload;
@@ -46,6 +48,8 @@ public enum WCOrderAction implements IAction {
     FETCH_ORDER_STATUS_OPTIONS,
     @Action(payloadType = FetchOrderShipmentTrackingsPayload.class)
     FETCH_ORDER_SHIPMENT_TRACKINGS,
+    @Action(payloadType = FetchOrderShipmentTrackingProvidersPayload.class)
+    FETCH_ORDER_SHIPMENT_TRACKING_PROVIDERS,
 
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
@@ -67,5 +71,7 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = FetchOrderStatusOptionsResponsePayload.class)
     FETCHED_ORDER_STATUS_OPTIONS,
     @Action(payloadType = FetchOrderShipmentTrackingsResponsePayload.class)
-    FETCHED_ORDER_SHIPMENT_TRACKINGS
+    FETCHED_ORDER_SHIPMENT_TRACKINGS,
+    @Action(payloadType = FetchOrderShipmentTrackingProvidersResponsePayload.class)
+    FETCHED_ORDER_SHIPMENT_TRACKING_PROVIDERS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderShipmentProviderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderShipmentProviderModel.kt
@@ -7,7 +7,7 @@ import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
-data class WCOrderShipmentTrackingProviderModel(@PrimaryKey @Column private var id: Int = 0) :Identifiable {
+data class WCOrderShipmentProviderModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var localSiteId = 0
     @Column var country = ""
     @Column var carrierName = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderShipmentTrackingProviderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderShipmentTrackingProviderModel.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+data class WCOrderShipmentTrackingProviderModel(@PrimaryKey @Column private var id: Int = 0) :Identifiable {
+    @Column var localSiteId = 0
+    @Column var country = ""
+    @Column var carrierName = ""
+    @Column var carrierLink = ""
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    override fun getId() = this.id
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -411,8 +411,7 @@ class OrderRestClient(
                     response?.let {
                         val providers = jsonResponseToShipmentProviderList(site, it)
                         val payload = FetchOrderShipmentProvidersResponsePayload(site, order, providers)
-                        dispatcher.dispatch(
-                                WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
+                        dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
                     }
                 },
                 WPComErrorListener { networkError ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -411,7 +411,8 @@ class OrderRestClient(
                     response?.let {
                         val providers = jsonResponseToShipmentProviderList(site, it)
                         val payload = FetchOrderShipmentProvidersResponsePayload(site, order, providers)
-                        dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
+                        dispatcher.dispatch(
+                                WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
                     }
                 },
                 WPComErrorListener { networkError ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import android.content.Context
 import com.android.volley.RequestQueue
+import com.google.gson.JsonElement
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction
@@ -11,6 +12,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
+import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
@@ -22,6 +24,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
@@ -32,6 +35,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload
 import javax.inject.Singleton
+import kotlin.collections.MutableMap.MutableEntry
 
 @Singleton
 class OrderRestClient(
@@ -390,6 +394,35 @@ class OrderRestClient(
         add(request)
     }
 
+    /**
+     * Fetches a list of shipment providers from the WooCommerce Shipment Tracking plugin.
+     *
+     * Makes a GET call to `/wc/v2/orders/<order_id>/shipment-trackings/providers/` via the Jetpack tunnel
+     * (see [JetpackTunnelGsonRequest]), retrieving a list of shipment tracking provider objects. The `<order_id>`
+     * argument is only needed because it is a requirement of the plugins API even though this data is not directly
+     * related to shipment providers.
+     */
+    fun fetchOrderShipmentProviders(site: SiteModel, order: WCOrderModel) {
+        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).shipment_trackings.providers.pathV2
+
+        val params = emptyMap<String, String>()
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, JsonElement::class.java,
+                { response: JsonElement? ->
+                    response?.let {
+                        val providers = jsonResponseToShipmentProviderList(site, it)
+                        val payload = FetchOrderShipmentProvidersResponsePayload(site, order, providers)
+                        dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
+                    }
+                },
+                WPComErrorListener { networkError ->
+                    val providersError = networkErrorToOrderError(networkError)
+                    val payload = FetchOrderShipmentProvidersResponsePayload(providersError, site, order)
+                    dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
+                },
+                { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
     private fun orderResponseToOrderModel(response: OrderApiResponse): WCOrderModel {
         return WCOrderModel().apply {
             remoteOrderId = response.id ?: 0
@@ -486,5 +519,26 @@ class OrderRestClient(
             trackingLink = response.tracking_link ?: ""
             dateShipped = response.date_shipped ?: ""
         }
+    }
+
+    private fun jsonResponseToShipmentProviderList(
+        site: SiteModel,
+        response: JsonElement
+    ): List<WCOrderShipmentProviderModel> {
+        val providers = mutableListOf<WCOrderShipmentProviderModel>()
+        response.asJsonObject.entrySet().forEach { countryEntry: MutableEntry<String, JsonElement> ->
+            countryEntry.value.asJsonObject.entrySet().map { carrierEntry ->
+                carrierEntry?.let { carrier ->
+                    val provider = WCOrderShipmentProviderModel().apply {
+                        localSiteId = site.id
+                        this.country = countryEntry.key ?: ""
+                        this.carrierName = carrier.key
+                        this.carrierLink = carrier.value.asString
+                    }
+                    providers.add(provider)
+                }
+            }
+        }
+        return providers
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -411,13 +411,13 @@ class OrderRestClient(
                     response?.let {
                         val providers = jsonResponseToShipmentProviderList(site, it)
                         val payload = FetchOrderShipmentProvidersResponsePayload(site, order, providers)
-                        dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
+                        dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentProvidersAction(payload))
                     }
                 },
                 WPComErrorListener { networkError ->
                     val providersError = networkErrorToOrderError(networkError)
                     val payload = FetchOrderShipmentProvidersResponsePayload(providersError, site, order)
-                    dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
+                    dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentProvidersAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })
         add(request)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import android.content.Context
 import com.android.volley.RequestQueue
-import com.google.gson.JsonElement
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction
@@ -12,7 +11,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
-import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
@@ -24,7 +22,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
@@ -35,7 +32,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload
 import javax.inject.Singleton
-import kotlin.collections.MutableMap.MutableEntry
 
 @Singleton
 class OrderRestClient(
@@ -394,35 +390,6 @@ class OrderRestClient(
         add(request)
     }
 
-    /**
-     * Fetches a list of shipment providers from the WooCommerce Shipment Tracking plugin.
-     *
-     * Makes a GET call to `/wc/v2/orders/<order_id>/shipment-trackings/providers/` via the Jetpack tunnel
-     * (see [JetpackTunnelGsonRequest]), retrieving a list of shipment tracking provider objects. The `<order_id>`
-     * argument is only needed because it is a requirement of the plugins API even though this data is not directly
-     * related to shipment providers.
-     */
-    fun fetchOrderShipmentProviders(site: SiteModel, order: WCOrderModel) {
-        val url = WOOCOMMERCE.orders.id(order.remoteOrderId).shipment_trackings.providers.pathV2
-
-        val params = emptyMap<String, String>()
-        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, JsonElement::class.java,
-                { response: JsonElement? ->
-                    response?.let {
-                        val providers = jsonResponseToShipmentProviderList(site, it)
-                        val payload = FetchOrderShipmentProvidersResponsePayload(site, order, providers)
-                        dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
-                    }
-                },
-                WPComErrorListener { networkError ->
-                    val providersError = networkErrorToOrderError(networkError)
-                    val payload = FetchOrderShipmentProvidersResponsePayload(providersError, site, order)
-                    dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderShipmentTrackingProvidersAction(payload))
-                },
-                { request: WPComGsonRequest<*> -> add(request) })
-        add(request)
-    }
-
     private fun orderResponseToOrderModel(response: OrderApiResponse): WCOrderModel {
         return WCOrderModel().apply {
             remoteOrderId = response.id ?: 0
@@ -519,26 +486,5 @@ class OrderRestClient(
             trackingLink = response.tracking_link ?: ""
             dateShipped = response.date_shipped ?: ""
         }
-    }
-
-    private fun jsonResponseToShipmentProviderList(
-        site: SiteModel,
-        response: JsonElement
-    ): List<WCOrderShipmentProviderModel> {
-        val providers = mutableListOf<WCOrderShipmentProviderModel>()
-        response.asJsonObject.entrySet().forEach { countryEntry: MutableEntry<String, JsonElement> ->
-            countryEntry.value.asJsonObject.entrySet().map { carrierEntry ->
-                carrierEntry?.let { carrier ->
-                    val provider = WCOrderShipmentProviderModel().apply {
-                        localSiteId = site.id
-                        this.country = countryEntry.key ?: ""
-                        this.carrierName = carrier.key
-                        this.carrierLink = carrier.value.asString
-                    }
-                    providers.add(provider)
-                }
-            }
-        }
-        return providers
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
+import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingProviderModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
@@ -166,6 +167,19 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         constructor(error: OrderError, site: SiteModel, order: WCOrderModel) : this(site, order) { this.error = error }
     }
 
+    class FetchOrderShipmentTrackingProvidersPayload(
+        val site: SiteModel,
+        val order: WCOrderModel
+    ) : Payload<BaseNetworkError>()
+
+    class FetchOrderShipmentTrackingProvidersResponsePayload(
+        val site: SiteModel,
+        val order: WCOrderModel,
+        val providers: List<WCOrderShipmentTrackingProviderModel> = emptyList()
+    ) : Payload<OrderError>() {
+        constructor(error: OrderError, site: SiteModel, order: WCOrderModel) : this(site, order) { this.error = error }
+    }
+
     class OrderError(val type: OrderErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
 
     enum class OrderErrorType {
@@ -198,6 +212,10 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     ) : OnChanged<OrderError>()
 
     class OnOrderStatusOptionsChanged(
+        var rowsAffected: Int
+    ) : OnChanged<OrderError>()
+
+    class OnOrderShipmentTrackingProvidersChanged(
         var rowsAffected: Int
     ) : OnChanged<OrderError>()
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -281,7 +281,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
                 fetchOrderStatusOptions(action.payload as FetchOrderStatusOptionsPayload)
             WCOrderAction.FETCH_ORDER_SHIPMENT_TRACKINGS ->
                 fetchOrderShipmentTrackings(action.payload as FetchOrderShipmentTrackingsPayload)
-            WCOrderAction.FETCH_ORDER_SHIPMENT_TRACKING_PROVIDERS ->
+            WCOrderAction.FETCH_ORDER_SHIPMENT_PROVIDERS ->
                 fetchOrderShipmentProviders(action.payload as FetchOrderShipmentProvidersPayload)
 
             // remote responses
@@ -300,7 +300,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
                 handleFetchOrderStatusOptionsCompleted(action.payload as FetchOrderStatusOptionsResponsePayload)
             WCOrderAction.FETCHED_ORDER_SHIPMENT_TRACKINGS ->
                 handleFetchOrderShipmentTrackingsCompleted(action.payload as FetchOrderShipmentTrackingsResponsePayload)
-            WCOrderAction.FETCHED_ORDER_SHIPMENT_TRACKING_PROVIDERS ->
+            WCOrderAction.FETCHED_ORDER_SHIPMENT_PROVIDERS ->
                 handleFetchOrderShipmentProvidersCompleted(
                         action.payload as FetchOrderShipmentProvidersResponsePayload)
         }

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -2,6 +2,7 @@
 /orders/<id>/
 /orders/<id>/notes/
 /orders/<id>/shipment-trackings/
+/orders/<id>/shipment-trackings/providers/
 
 /products/<id>/
 /products/<id>/variations/


### PR DESCRIPTION
Fixes #1208 by adding the ability to fetch shipment providers from the installed WooCommerce Shipment Tracking plugin. 

<img src="https://user-images.githubusercontent.com/5810477/56170672-05ebe180-5fa8-11e9-8918-75bac96ed8cc.png" width="300"/>

Notes:
- The plugin currently requires an order Id be used to fetch the list of providers even though providers are not directly attached to order_ids. This is why all this code lives in `WCOrderStore` and related classes.
- Mocked, Release, and unit tests have all been added
- The shipment providers api response is in non-standard JSON. For this reason the entire document has to be manually parsed instead of using model objects to automagically parse. 