### PR TITLE
Add Kotlin support to Singleton checkstyle rules

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -87,9 +87,15 @@
         <property name="message" value="Stores must be annotated with @Singleton"/>
     </module>
 
-    <!-- Specific to FluxC -->
+    <!-- Specific to FluxC - Java -->
     <module name="RegexpMultiline">
         <property name="format" value="(?&lt;!^@Singleton)\n.*extends Base[\w]*Client[\s{]"/>
+        <property name="message" value="Network clients must be annotated with @Singleton"/>
+    </module>
+
+    <!-- Specific to FluxC - Kotlin -->
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;!@Singleton)\n.*class(.+\n)*.*:[\n\s]*Base[\w]*Client\("/>
         <property name="message" value="Network clients must be annotated with @Singleton"/>
     </module>
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -83,7 +83,7 @@
 
     <!-- Specific to FluxC -->
     <module name="RegexpMultiline">
-        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Store[\s{]"/>
+        <property name="format" value="(?&lt;!@Singleton)\n.*class \S*Store [^{]"/>
         <property name="message" value="Stores must be annotated with @Singleton"/>
     </module>
 


### PR DESCRIPTION
Fixes #1220, updating the Checkstyle rules which verify that stores and network clients are annotated with `@Singleton` to now support Kotlin.

### To test
Remove the `@Singleton` annotation from various stores and network clients (in particular, ones written in Kotlin), run `./gradlew checkstyle`, and confirm that they each cause an error.