### PR TITLE
issue/1223-wc-manage-stock 

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -37,7 +37,7 @@ class ProductApiResponse : Response {
     var tax_status: String? = null
     var tax_class: String? = null
 
-    var manage_stock = false
+    var manage_stock: String? = null
     var stock_quantity = 0
     var stock_status: String? = null
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -135,7 +135,11 @@ class ProductRestClient(
             taxStatus = response.tax_status ?: ""
             taxClass = response.tax_class ?: ""
 
-            manageStock = response.manage_stock
+            // variations may have "parent" here if inventory is enabled for the parent but not the variation
+            manageStock = response.manage_stock?.let {
+                it == "true" || it == "parent"
+            } ?: false
+
             stockQuantity = response.stock_quantity
             stockStatus = response.stock_status ?: ""
 


### PR DESCRIPTION
Fixes #1223 by handling `manage_stock` when it's set to `parent` for a product variation. To test:

* Enable stock management at the parent level but not the variation, fetch that variation and confirm the product model has `manageStock=true`
* Disable stock management at the parent level but enable it for the variation, fetch that variation and confirm the product model has `manageStock=true` 
* Disable stock management for both the parent and the variation, fetch that variation and confirm the product model has `manageStock=false` 


