### PR TITLE
Issue/1223 manage stock mocked tests

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -48,31 +48,6 @@
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
       <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     </JetCodeStyleSettings>
-    <Objective-C-extensions>
-      <file>
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
-      </file>
-      <class>
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
-      </class>
-      <extensions>
-        <pair source="cpp" header="h" fileNamingConvention="NONE" />
-        <pair source="c" header="h" fileNamingConvention="NONE" />
-      </extensions>
-    </Objective-C-extensions>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.mocked
 
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -97,6 +98,36 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RemoteProductPayload
         assertNotNull(payload.error)
     }
+
+    @Test
+    fun testFetchSingleProductManageStock() {
+        // check that a product's manage stock field is correctly set to true
+        interceptor.respondWith("wc-fetch-product-response-manage-stock-true.json")
+        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        val payloadTrue = lastAction!!.payload as RemoteProductPayload
+        assertTrue(payloadTrue.product.manageStock)
+
+        // check that a product's manage stock field is correctly set to false
+        interceptor.respondWith("wc-fetch-product-response-manage-stock-false.json")
+        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        val payloadFalse = lastAction!!.payload as RemoteProductPayload
+        assertFalse(payloadFalse.product.manageStock)
+
+        // check that a product's manage stock field is correctly set to true when response contains
+        // "parent" rather than true/false (this is for product variations who inherit the parent's
+        // manage stock)
+        interceptor.respondWith("wc-fetch-product-response-manage-stock-parent.json")
+        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        val payloadParent = lastAction!!.payload as RemoteProductPayload
+        assertTrue(payloadParent.product.manageStock)
+    }
+
 
     @Test
     fun testFetchProductVariationsSuccess() {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -128,7 +128,6 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertTrue(payloadParent.product.manageStock)
     }
 
-
     @Test
     fun testFetchProductVariationsSuccess() {
         interceptor.respondWith("wc-fetch-product-variations-response-success.json")

--- a/example/src/androidTest/resources/wc-fetch-product-response-manage-stock-false.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-manage-stock-false.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "id": 1537,
+    "manage_stock": false
+  }
+}

--- a/example/src/androidTest/resources/wc-fetch-product-response-manage-stock-parent.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-manage-stock-parent.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "id": 1537,
+    "manage_stock": "parent"
+  }
+}

--- a/example/src/androidTest/resources/wc-fetch-product-response-manage-stock-true.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-manage-stock-true.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "id": 1537,
+    "manage_stock": true
+  }
+}


### PR DESCRIPTION
Adds the mocked tests to that were missing from #1224. We check three cases:

* That the product's `manageStock` is set to true when the response contains true
* That the product's `manageStock` is set to false when the response contains false
* That the product's `manageStock` is set to true when the response contains `"parent"` 