### PR TITLE
Remove size from test since they will now be variable

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -71,7 +71,6 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
 
         val trackings = orderStore.getShipmentTrackingsForOrder(orderModel)
         assertTrue(trackings.isNotEmpty())
-        assertEquals(2, trackings.size)
     }
 
     /**


### PR DESCRIPTION
Small fix for one of the current Order Shipment Tracking tests. An existing PR (#1226 ) made some changes that changed the number of records were on the test server. This was causing the test to fail. Now that tests can add and delete shipment tracking records, it's better just to make sure that there ARE tracking records and not worry about exactly how many.