### PR TITLE
issue/reset-tables

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -537,6 +537,22 @@ public class WellSqlConfig extends DefaultWellConfig {
         }
     }
 
+    /**
+     * Recreates all the tables in this database - similar to the above but can be used from onDowngrade where we can't
+     * call giveMeWritableDb (attempting to do so results in "IllegalStateException: getDatabase called recursively")
+     */
+    @SuppressWarnings("unused")
+    private void reset(WellTableManager helper) {
+        AppLog.d(T.DB, "resetting tables");
+        for (Class<? extends Identifiable> table : mTables) {
+            AppLog.d(T.DB, "dropping table " + table.getSimpleName());
+            helper.dropTable(table);
+            AppLog.d(T.DB, "creating table " + table.getSimpleName());
+            helper.createTable(table);
+        }
+    }
+
+
     private void migrateAddOn(@AddOn String addOnName, SQLiteDatabase db, int oldDbVersion) {
         if (mActiveAddOns.contains(addOnName)) {
             switch (oldDbVersion) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -542,7 +542,7 @@ public class WellSqlConfig extends DefaultWellConfig {
      * call giveMeWritableDb (attempting to do so results in "IllegalStateException: getDatabase called recursively")
      */
     @SuppressWarnings("unused")
-    private void reset(WellTableManager helper) {
+    public void reset(WellTableManager helper) {
         AppLog.d(T.DB, "resetting tables");
         for (Class<? extends Identifiable> table : mTables) {
             AppLog.d(T.DB, "dropping table " + table.getSimpleName());


### PR DESCRIPTION
Adds an alternate method for resetting the database. This will be used by both WCAndroid and WPAndroid to recreate the database when a version downgrade is detected and `BuildConfig.DEBUG` is true. The existing `reset()` method can't be used in this situation (it results in an `IllegalAccessException`).

To test, change `getDbVersion()` to return an older version then add this code:

```
@Override 
public void onDowngrade(SQLiteDatabase db, WellTableManager helper, int oldVersion, int newVersion) {
    reset(helper);
}
```