### PR TITLE
Fixes trash remote post connected tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -617,7 +617,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
     }
 
     @Test
-    public void testDeleteRemotePost() throws InterruptedException {
+    public void testTrashRemotePost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
 
@@ -628,10 +628,9 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         deletePost(uploadedPost);
 
-        // The post should be removed from the db (regardless of whether it was deleted or just trashed on the server)
-        assertNull(mPostStore.getPostByLocalPostId(uploadedPost.getId()));
-        assertEquals(0, WellSqlUtils.getTotalPostsCount());
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
+        // The post status should be trashed
+        PostModel trashedPost = mPostStore.getPostByLocalPostId(uploadedPost.getId());
+        assertEquals(PostStatus.TRASHED.toString(), trashedPost.getStatus());
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -630,7 +629,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         // The post status should be trashed
         PostModel trashedPost = mPostStore.getPostByLocalPostId(uploadedPost.getId());
-        assertEquals(PostStatus.TRASHED.toString(), trashedPost.getStatus());
+        assertNotNull(trashedPost);
+        assertEquals(PostStatus.TRASHED, PostStatus.fromPost(trashedPost));
     }
 
     @Test
@@ -645,17 +645,8 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         deletePost(uploadedPost);
 
-        // Make sure the post is actually removed
-        assertNull(mPostStore.getPostByLocalPostId(uploadedPost.getId()));
-        assertEquals(0, WellSqlUtils.getTotalPostsCount());
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
-
-        // fetch trashed post from server
-        fetchPost(uploadedPost);
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
-
-        // Get the current copy of the trashed post from the PostStore
-        PostModel trashedPost = mPostStore.getPostByRemotePostId(uploadedPost.getRemotePostId(), sSite);
+        // The post status should be trashed
+        PostModel trashedPost = mPostStore.getPostByLocalPostId(uploadedPost.getId());
         assertNotNull(trashedPost);
         assertEquals(PostStatus.TRASHED, PostStatus.fromPost(trashedPost));
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
+import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
@@ -1020,7 +1021,12 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
             if (mNextEvent.equals(TestEvents.POST_DELETED)) {
                 assertNotEquals(0, ((DeletePost) event.causeOfChange).getLocalPostId());
                 assertNotEquals(0, ((DeletePost) event.causeOfChange).getRemotePostId());
-                mCountDownLatch.countDown();
+                if (((DeletePost) event.causeOfChange).getPostDeleteActionType() == PostDeleteActionType.TRASH) {
+                    // When a post is trashed, we fetch the updated post from remote and we need to wait for its result
+                    mNextEvent = TestEvents.POST_UPDATED;
+                } else {
+                    mCountDownLatch.countDown();
+                }
             }
         } else if (event.causeOfChange instanceof CauseOfOnPostChanged.RemoveAllPosts) {
             if (mNextEvent.equals(TestEvents.ALL_POST_REMOVED)) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -601,7 +601,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     @Test
-    public void testDeleteRemotePost() throws InterruptedException {
+    public void testTrashRemotePost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();
 
@@ -612,10 +612,9 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         deletePost(uploadedPost);
 
-        // The post should be removed from the db (regardless of whether it was deleted or just trashed on the server)
-        assertNull(mPostStore.getPostByLocalPostId(uploadedPost.getId()));
-        assertEquals(0, WellSqlUtils.getTotalPostsCount());
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
+        // The post status should be trashed
+        PostModel trashedPost = mPostStore.getPostByLocalPostId(uploadedPost.getId());
+        assertEquals(PostStatus.TRASHED.toString(), trashedPost.getStatus());
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -614,7 +613,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // The post status should be trashed
         PostModel trashedPost = mPostStore.getPostByLocalPostId(uploadedPost.getId());
-        assertEquals(PostStatus.TRASHED.toString(), trashedPost.getStatus());
+        assertNotNull(trashedPost);
+        assertEquals(PostStatus.TRASHED, PostStatus.fromPost(trashedPost));
     }
 
     @Test
@@ -629,17 +629,8 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         deletePost(uploadedPost);
 
-        // Make sure the post is actually removed
-        assertNull(mPostStore.getPostByLocalPostId(uploadedPost.getId()));
-        assertEquals(0, WellSqlUtils.getTotalPostsCount());
-        assertEquals(0, mPostStore.getPostsCountForSite(sSite));
-
-        // fetch trashed post from server
-        fetchPost(uploadedPost);
-        assertEquals(1, mPostStore.getPostsCountForSite(sSite));
-
-        // Get the current copy of the trashed post from the PostStore
-        PostModel trashedPost = mPostStore.getPostByRemotePostId(uploadedPost.getRemotePostId(), sSite);
+        // The post status should be trashed
+        PostModel trashedPost = mPostStore.getPostByLocalPostId(uploadedPost.getId());
         assertNotNull(trashedPost);
         assertEquals(PostStatus.TRASHED, PostStatus.fromPost(trashedPost));
 


### PR DESCRIPTION
This PR fixes the connected tests for deleting a remote post. We recently implemented post filters and as part of it, we are now keeping trashed posts in the DB so we can show them in the UI as opposed to just removing them from the DB completely as we did before. That means the previous tests that asserted the post not being in the DB is no longer valid. Instead, we are just verifying that the status of the post is now `TRASHED`.

In [this report](https://circleci.com/gh/wordpress-mobile/WordPress-FluxC-Android/1644) it looks like the `ReleaseStack_PostTestXMLRPC.testRestoreInvalidRemotePost` test is failing as well, but we have not made any changes related to it and locally it passes for me. I don't know if that was a glitch or something else, if it still fails after this PR, we can tackle that separately.

Thanks for reporting this @aforcier and sorry for missing it in the first place 😞 

**To test**
* Run the changed connected tests

_P.S: One reviewer is enough for this PR._