### PR TITLE
CircleCI: More helpful Slack notifications for connected tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ jobs:
           steps:
             - run:
                 name: Setup Slack messages
+                when: always
                 command: |
                   FIREBASE_URL="https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.fbe4c2866a46a076"
                   echo "export SLACK_FAILURE_MESSAGE=':red_circle: FluxC Connected tests have failed!\nSee $FIREBASE_URL'" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   android: wordpress-mobile/android@0.0.23
-  slack: circleci/slack@2.0.0
+  slack: circleci/slack@2.5.0
 
 commands:
   copy-gradle-properties:
@@ -115,7 +115,22 @@ jobs:
       - when:
           condition: << parameters.post-slack-status >>
           steps:
-            - slack/status
+            - run:
+                name: Setup Slack messages
+                command: |
+                  FIREBASE_URL="https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.fbe4c2866a46a076"
+                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: FluxC Connected tests have failed!\nSee $FIREBASE_URL'" >> $BASH_ENV
+                  echo "export SLACK_SUCCESS_MESSAGE=':tada: FluxC Connected tests have succeeded!\nSee $FIREBASE_URL'" >> $BASH_ENV
+            - slack/status:
+                fail_only: 'true'
+                failure_message: '${SLACK_FAILURE_MESSAGE}'
+                success_message: '${SLACK_SUCCESS_MESSAGE}'
+                webhook: '${SLACK_FAILURE_WEBHOOK}'
+            - slack/status:
+                fail_only: 'false'
+                failure_message: '${SLACK_FAILURE_MESSAGE}'
+                success_message: '${SLACK_SUCCESS_MESSAGE}'
+                webhook: '${SLACK_STATUS_WEBHOOK}'
 
 workflows:
   fluxc:


### PR DESCRIPTION
Slack notifications for connected tests now work as follows.
- On success:
     - Post to `$SLACK_STATUS_WEBHOOK` with this message: `🎉 FluxC Connected tests have succeeded!\nSee https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.fbe4c2866a46a076`.
- On failure:
    - Post to `$SLACK_STATUS_WEBHOOK` with this message: `🔴 FluxC Connected tests have failed!\nSee https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.fbe4c2866a46a076`.
    - Post to `$SLACK_FAILURE_WEBHOOK` with the same message as above.

`$SLACK_FAILURE_WEBHOOK` and `$SLACK_STATUS_WEBHOOK` are currently the same, but we can update them to use different channels once merged.