### PR TITLE
Check null response object for device register api & order stats fetc…

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -110,7 +110,7 @@ class MockedStack_NotificationTest : MockedStack_Base() {
     @Test
     fun testRegistrationResponseNull() {
         val errorJson = JsonObject().apply {
-            addProperty("error", DeviceRegistrationErrorType.RESPONSE_NULL.name)
+            addProperty("error", DeviceRegistrationErrorType.INVALID_RESPONSE.name)
             addProperty("message", "Response object is null")
         }
 
@@ -129,7 +129,7 @@ class MockedStack_NotificationTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RegisterDeviceResponsePayload
         assertNotNull(payload.error)
         assertNull(payload.deviceId)
-        assertEquals(DeviceRegistrationErrorType.RESPONSE_NULL, payload.error.type)
+        assertEquals(DeviceRegistrationErrorType.INVALID_RESPONSE, payload.error.type)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -5,6 +5,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
@@ -16,11 +17,12 @@ import org.wordpress.android.fluxc.model.notification.NoteIdSet
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
+import org.wordpress.android.fluxc.store.NotificationStore.DeviceRegistrationErrorType
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationHashesResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload
-import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload
+import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.NotificationAppKey
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
 import org.wordpress.android.fluxc.store.SiteStore
@@ -103,6 +105,31 @@ class MockedStack_NotificationTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RegisterDeviceResponsePayload
 
         assertEquals(responseJson.get("ID").asString, payload.deviceId)
+    }
+
+    @Test
+    fun testRegistrationResponseNull() {
+        val errorJson = JsonObject().apply {
+            addProperty("error", DeviceRegistrationErrorType.RESPONSE_NULL.name)
+            addProperty("message", "Response object is null")
+        }
+
+        interceptor.respondWithError(errorJson)
+
+        val gcmToken = "sample-token"
+        val uuid = "sample-uuid"
+        val site = SiteModel().apply { siteId = 123456 }
+        notificationRestClient.registerDeviceForPushNotifications(gcmToken, NotificationAppKey.WOOCOMMERCE, uuid, site)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(NotificationAction.REGISTERED_DEVICE, lastAction!!.type)
+
+        val payload = lastAction!!.payload as RegisterDeviceResponsePayload
+        assertNotNull(payload.error)
+        assertNull(payload.deviceId)
+        assertEquals(DeviceRegistrationErrorType.RESPONSE_NULL, payload.error.type)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePay
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchVisitorStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.RESPONSE_NULL
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -169,6 +170,28 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
         assertEquals(OrderStatsApiUnit.DAY, payload.apiUnit)
         assertNull(payload.stats)
         assertEquals(OrderStatsErrorType.INVALID_PARAM, payload.error.type)
+    }
+
+    @Test
+    fun testStatsFetchResponseNullError() {
+        val errorJson = JsonObject().apply {
+            addProperty("error", OrderStatsErrorType.RESPONSE_NULL.name)
+            addProperty("message", "Response object is null")
+        }
+
+        interceptor.respondWithError(errorJson)
+        orderStatsRestClient.fetchStats(siteModel, OrderStatsApiUnit.DAY, "2019-02-01", 7)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCStatsAction.FETCHED_ORDER_STATS, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchOrderStatsResponsePayload
+        assertNotNull(payload.error)
+        assertEquals(siteModel, payload.site)
+        assertEquals(OrderStatsApiUnit.DAY, payload.apiUnit)
+        assertNull(payload.stats)
+        assertEquals(OrderStatsErrorType.RESPONSE_NULL, payload.error.type)
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -74,21 +74,24 @@ class NotificationRestClient constructor(
         val url = WPCOMREST.devices.new_.urlV1
         val request = WPComGsonRequest.buildPostRequest(
                 url, params, RegisterDeviceRestResponse::class.java,
-                { response ->
-                    response?.let { response.id?.takeIf { it.isNotEmpty() }?.let {
-                        val payload = RegisterDeviceResponsePayload(it)
-                        dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
+                { response: RegisterDeviceRestResponse? ->
+                    response?.let {
+                        if (!it.id.isNullOrEmpty()) {
+                            val payload = RegisterDeviceResponsePayload(it.id)
+                            dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
+                        } else {
+                            val registrationError =
+                                    DeviceRegistrationError(DeviceRegistrationErrorType.MISSING_DEVICE_ID)
+                            val payload = RegisterDeviceResponsePayload(registrationError)
+                            dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
+                        }
                     } ?: run {
-                        val registrationError = DeviceRegistrationError(DeviceRegistrationErrorType.MISSING_DEVICE_ID)
-                        val payload = RegisterDeviceResponsePayload(registrationError)
-                        dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
-                    } } ?: run {
                         AppLog.e(T.API, "Response for url $url with param $params is null: $response")
-                        val registrationError = DeviceRegistrationError(DeviceRegistrationErrorType.INVALID_RESPONSE,
-                                "Response object is null")
+                        val registrationError = DeviceRegistrationError(DeviceRegistrationErrorType.INVALID_RESPONSE)
                         val payload = RegisterDeviceResponsePayload(registrationError)
                         dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
-                    } },
+                    }
+                },
                 { wpComError ->
                     val registrationError = networkErrorToRegistrationError(wpComError)
                     val payload = RegisterDeviceResponsePayload(registrationError)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -84,7 +84,7 @@ class NotificationRestClient constructor(
                         dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
                     } } ?: run {
                         AppLog.e(T.API, "Response for url $url with param $params is null: $response")
-                        val registrationError = DeviceRegistrationError(DeviceRegistrationErrorType.RESPONSE_NULL,
+                        val registrationError = DeviceRegistrationError(DeviceRegistrationErrorType.INVALID_RESPONSE,
                                 "Response object is null")
                         val payload = RegisterDeviceResponsePayload(registrationError)
                         dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -28,6 +28,8 @@ import org.wordpress.android.fluxc.store.NotificationStore.NotificationErrorType
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.UnregisterDeviceResponsePayload
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.DeviceUtils
 import org.wordpress.android.util.PackageUtils
 import java.util.Date
@@ -73,15 +75,20 @@ class NotificationRestClient constructor(
         val request = WPComGsonRequest.buildPostRequest(
                 url, params, RegisterDeviceRestResponse::class.java,
                 { response ->
-                    response.id?.takeIf { it.isNotEmpty() }?.let {
+                    response?.let { response.id?.takeIf { it.isNotEmpty() }?.let {
                         val payload = RegisterDeviceResponsePayload(it)
                         dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
                     } ?: run {
                         val registrationError = DeviceRegistrationError(DeviceRegistrationErrorType.MISSING_DEVICE_ID)
                         val payload = RegisterDeviceResponsePayload(registrationError)
                         dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
-                    }
-                },
+                    } } ?: run {
+                        AppLog.e(T.API, "Response for url $url with param $params is null: $response")
+                        val registrationError = DeviceRegistrationError(DeviceRegistrationErrorType.RESPONSE_NULL,
+                                "Response object is null")
+                        val payload = RegisterDeviceResponsePayload(registrationError)
+                        dispatcher.dispatch(NotificationActionBuilder.newRegisteredDeviceAction(payload))
+                    } },
                 { wpComError ->
                     val registrationError = networkErrorToRegistrationError(wpComError)
                     val payload = RegisterDeviceResponsePayload(registrationError)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -291,6 +291,8 @@ constructor(
                         AppLog.e(T.NOTIFS, "Server response missing device_id - registration skipped!")
                     DeviceRegistrationErrorType.GENERIC_ERROR ->
                         AppLog.e(T.NOTIFS, "Error trying to register device: ${error.type} - ${error.message}")
+                    DeviceRegistrationErrorType.RESPONSE_NULL ->
+                        AppLog.e(T.NOTIFS, "Server response missing response object: ${error.type} - ${error.message}")
                 }
                 onDeviceRegistered.error = payload.error
             } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -72,7 +72,7 @@ constructor(
     ) : OnChangedError
 
     enum class DeviceRegistrationErrorType {
-        RESPONSE_NULL,
+        INVALID_RESPONSE,
         MISSING_DEVICE_ID,
         GENERIC_ERROR;
 
@@ -291,7 +291,7 @@ constructor(
                         AppLog.e(T.NOTIFS, "Server response missing device_id - registration skipped!")
                     DeviceRegistrationErrorType.GENERIC_ERROR ->
                         AppLog.e(T.NOTIFS, "Error trying to register device: ${error.type} - ${error.message}")
-                    DeviceRegistrationErrorType.RESPONSE_NULL ->
+                    DeviceRegistrationErrorType.INVALID_RESPONSE ->
                         AppLog.e(T.NOTIFS, "Server response missing response object: ${error.type} - ${error.message}")
                 }
                 onDeviceRegistered.error = payload.error

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -72,6 +72,7 @@ constructor(
     ) : OnChangedError
 
     enum class DeviceRegistrationErrorType {
+        RESPONSE_NULL,
         MISSING_DEVICE_ID,
         GENERIC_ERROR;
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -135,6 +135,7 @@ class WCStatsStore @Inject constructor(
     class OrderStatsError(val type: OrderStatsErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
 
     enum class OrderStatsErrorType {
+        RESPONSE_NULL,
         INVALID_PARAM,
         GENERIC_ERROR;
 


### PR DESCRIPTION
Crash fix for woocommerce/woocommerce-android#917 in WooCommerce.

There have been 3 reports of crashes in Woo app because of the response object being `null`. This PR catches that null response and returns an error response to the client and lets the client handle it by showing an error message to the user.

There are only 2 places in the app where the crashes have occurred so added the fix to only 2 methods:
1. **when fetching order stats** - used only by Woo and ~might~ does not need an additional PR to handle this error response since Woo is handling all error responses in a generic manner while also logging the error response.
2. **When registering fcm token** - this is called by both Woo and WP and might need subsequent PRs in WP to handle this error response.

### Tests
1. Run `testStatsFetchResponseNullError` in `MockedStack_WCStatsTest` class
2. Run `testRegistrationResponseNull` in `MockedStack_NotificationTest` class.