### PR TITLE
Fix a couple of unescaped display names that might need to be HTML unescaped

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model.stats.time
 
 import com.google.gson.Gson
+import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.AuthorsModel.Post
 import org.wordpress.android.fluxc.model.stats.time.ClicksModel.Click
@@ -214,7 +215,8 @@ class TimeStatsMapper
                 if (author.name == null || author.views == null || author.avatarUrl == null) {
                     AppLog.e(STATS, "AuthorsResponse: Missing fields on an author")
                 }
-                AuthorsModel.Author(author.name ?: "", author.views ?: 0, author.avatarUrl, posts ?: listOf())
+                AuthorsModel.Author(StringEscapeUtils.unescapeHtml4(author.name) ?: "",
+                        author.views ?: 0, author.avatarUrl, posts ?: listOf())
             }
         }
         val hasMore = if (first != null && authors != null) first.authors.size > authors.size else false

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -305,7 +305,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                         for (UserRoleWPComRestResponse roleResponse : response.roles) {
                             RoleModel roleModel = new RoleModel();
                             roleModel.setName(roleResponse.name);
-                            roleModel.setDisplayName(roleResponse.display_name);
+                            roleModel.setDisplayName(StringEscapeUtils.unescapeHtml4(roleResponse.display_name));
                             roleArray.add(roleModel);
                         }
                         mDispatcher.dispatch(SiteActionBuilder.newFetchedUserRolesAction(new


### PR DESCRIPTION
Related to this issue: https://github.com/wordpress-mobile/WordPress-Android/issues/9747

Note: I checked that `StringEscapeUtils.unescapeHtml4(null)` returns `null`.