### PR TITLE
Temporarily disable post list tests as they keep failing

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestWpCom.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestWpCom.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,6 +45,7 @@ internal class RestPostListTestCase(
     val testMode: ListStoreConnectedTestMode = SinglePage(false)
 )
 
+@Ignore("Temporarily disabled: These tests keep failing due to a race condition.")
 @RunWith(Parameterized::class)
 internal class ReleaseStack_PostListTestWpCom(
     private val testCase: RestPostListTestCase

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestXMLRPC.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestXMLRPC.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,6 +34,7 @@ internal class XmlRpcPostListTestCase(
     val testMode: ListStoreConnectedTestMode = SinglePage(false)
 )
 
+@Ignore("Temporarily disabled: These tests keep failing due to a race condition.")
 @RunWith(Parameterized::class)
 internal class ReleaseStack_PostListTestXMLRPC(
     private val testCase: XmlRpcPostListTestCase


### PR DESCRIPTION
Temporarily disables PostList tests as they keep failing due to a race condition.

It seems they don't take into account following constraints
- there is no guarantee event bus events will be consumed in the same order as they where emitted when they are consumed on a background thread
- LiveData don't propagate all the events to their observables if more changes happen within a short timeframe (which is desired in the UI, but our tests don't take it into account - we wait for all the events, but some of them just never arrive)

These changes https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/do-not-merge/fix-post-list-tests?expand=1 fix the issues, but it's not something we can merge into develop. I pushed them just to gather ideas how to fix it properly.