### PR TITLE
Add PostStore.getLocalDrafts

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalDraftTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalDraftTest.kt
@@ -1,0 +1,82 @@
+package org.wordpress.android.fluxc.page
+
+import com.nhaarman.mockitokotlin2.mock
+import com.yarolegovich.wellsql.WellSql
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.persistence.PostSqlUtils
+import org.wordpress.android.fluxc.store.PageStore
+import org.wordpress.android.fluxc.test
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class PageStoreLocalDraftTest {
+    private val pageStore = PageStore(postStore = mock(), dispatcher = mock(), coroutineContext = Dispatchers.Default)
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val modelsToTest = listOf(PostModel::class.java)
+        val config = SingleStoreWellSqlConfigForTests(appContext, modelsToTest, "")
+        WellSql.init(config)
+        config.reset()
+    }
+
+    @After
+    fun tearDown() {
+        WellSql.closeDb()
+    }
+
+    @Test
+    fun `getLocalDraftPages returns local draft pages only`() = test {
+        // Arrange
+        val site = SiteModel().apply { id = 3_000 }
+
+        val baseTitle = "Voluptatem harum repellendus"
+        val expectedPages = List(3) {
+            createLocalDraft(localSiteId = site.id, baseTitle = baseTitle).apply {
+                setIsPage(true)
+            }
+        }
+
+        val unexpectedPosts = listOf(
+                // local draft post
+                createLocalDraft(localSiteId = site.id).apply { setIsPage(false) },
+                // other site page
+                createLocalDraft(localSiteId = 4_000),
+                // uploaded page
+                PostModel().apply {
+                    title = "Title"
+                    localSiteId = site.id
+                    setIsLocalDraft(false)
+                }
+        )
+
+        expectedPages.plus(unexpectedPosts).forEach { PostSqlUtils.insertPostForResult(it) }
+
+        // Act
+        val localDraftPages = pageStore.getLocalDraftPages(site)
+
+        // Assert
+        assertThat(localDraftPages).hasSize(3)
+        assertThat(localDraftPages).allMatch { it.title.startsWith(baseTitle) }
+        assertThat(localDraftPages.map { it.pageId }).isEqualTo(expectedPages.map { it.id })
+    }
+
+    private fun createLocalDraft(localSiteId: Int, baseTitle: String = "Title") = PostModel().apply {
+        this.localSiteId = localSiteId
+        title = "$baseTitle:${UUID.randomUUID()}"
+        setIsLocalDraft(true)
+        status = PostStatus.DRAFT.toString()
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -467,7 +467,7 @@ public class PostStoreUnitTest {
 
     /**
      * Tests that getPostsByLocalOrRemotePostIds works correctly in various situations.
-     *
+     * <p>
      * Normally it's not a good idea to combine multiple tests like this, however due to Java's verbosity the tests
      * are combined to avoid having too much boilerplate code.
      */

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -437,7 +437,7 @@ public class PostStoreUnitTest {
     }
 
     @Test
-    public void testGetLocalDraftsMethodOnlyReturnsLocalDrafts() {
+    public void testGetLocalDraftPostsMethodOnlyReturnsLocalDrafts() {
         // Arrange
         final String baseTitle = "Alexandrine Thiel";
         for (int i = 0; i < 3; i++) {
@@ -446,6 +446,10 @@ public class PostStoreUnitTest {
             PostSqlUtils.insertPostForResult(post);
         }
 
+        final PostModel localDraftPage = PostTestUtils.generateSampleLocalDraftPost();
+        localDraftPage.setIsPage(true);
+        PostSqlUtils.insertPostForResult(localDraftPage);
+
         final PostModel uploadedPost = PostTestUtils.generateSampleUploadedPost();
         PostSqlUtils.insertPostForResult(uploadedPost);
 
@@ -453,15 +457,16 @@ public class PostStoreUnitTest {
         site.setId(PostTestUtils.DEFAULT_LOCAL_SITE_ID);
 
         // Act
-        final List<PostModel> localDrafts = PostSqlUtils.getLocalDrafts(site.getId());
+        final List<PostModel> localDraftPosts = mPostStore.getLocalDraftPosts(site);
 
         // Assert
-        assertEquals(3, localDrafts.size());
-        for (PostModel localDraft : localDrafts) {
-            assertTrue(localDraft.isLocalDraft());
-            assertTrue(localDraft.getTitle().startsWith(baseTitle));
+        assertEquals(3, localDraftPosts.size());
+        for (PostModel localDraftPost : localDraftPosts) {
+            assertTrue(localDraftPost.isLocalDraft());
+            assertTrue(localDraftPost.getTitle().startsWith(baseTitle));
 
-            assertNotEquals(uploadedPost.getId(), localDraft.getId());
+            assertNotEquals(uploadedPost.getId(), localDraftPost.getId());
+            assertNotEquals(localDraftPage.getId(), localDraftPost.getId());
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -33,6 +33,7 @@ import org.wordpress.android.util.DateTimeUtils;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
@@ -433,6 +434,35 @@ public class PostStoreUnitTest {
 
         mPostStore.deleteLocalRevisionOfAPostOrPage(postModel);
         assertNull(mPostStore.getLocalRevision(site, postModel));
+    }
+
+    @Test
+    public void testGetLocalDraftsMethodOnlyReturnsLocalDrafts() {
+        // Arrange
+        final String baseTitle = "Alexandrine Thiel";
+        for (int i = 0; i < 3; i++) {
+            final String compoundTitle = baseTitle.concat(":").concat(UUID.randomUUID().toString());
+            final PostModel post = PostTestUtils.generateSampleLocalDraftPost(compoundTitle);
+            PostSqlUtils.insertPostForResult(post);
+        }
+
+        final PostModel uploadedPost = PostTestUtils.generateSampleUploadedPost();
+        PostSqlUtils.insertPostForResult(uploadedPost);
+
+        final SiteModel site = new SiteModel();
+        site.setId(PostTestUtils.DEFAULT_LOCAL_SITE_ID);
+
+        // Act
+        final List<PostModel> localDrafts = PostSqlUtils.getLocalDrafts(site.getId());
+
+        // Assert
+        assertEquals(3, localDrafts.size());
+        for (PostModel localDraft : localDrafts) {
+            assertTrue(localDraft.isLocalDraft());
+            assertTrue(localDraft.getTitle().startsWith(baseTitle));
+
+            assertNotEquals(uploadedPost.getId(), localDraft.getId());
+        }
     }
 
     /**

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.post;
 
+import android.support.annotation.NonNull;
+
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.PostModel;
@@ -29,9 +31,13 @@ public class PostTestUtils {
     }
 
     public static PostModel generateSampleLocalDraftPost() {
+        return generateSampleLocalDraftPost("A test post");
+    }
+
+    static PostModel generateSampleLocalDraftPost(@NonNull String title) {
         PostModel example = new PostModel();
         example.setLocalSiteId(6);
-        example.setTitle("A test post");
+        example.setTitle(title);
         example.setContent("Bunch of content here");
         example.setIsLocalDraft(true);
         return example;

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
@@ -16,13 +16,15 @@ public class PostTestUtils {
     public static final double EXAMPLE_LATITUDE = 44.8378;
     public static final double EXAMPLE_LONGITUDE = -0.5792;
 
+    static final int DEFAULT_LOCAL_SITE_ID = 6;
+
     public static PostModel generateSampleUploadedPost() {
         return generateSampleUploadedPost("text");
     }
 
     public static PostModel generateSampleUploadedPost(String postFormat) {
         PostModel example = new PostModel();
-        example.setLocalSiteId(6);
+        example.setLocalSiteId(DEFAULT_LOCAL_SITE_ID);
         example.setRemotePostId(5);
         example.setTitle("A test post");
         example.setContent("Bunch of content here");
@@ -36,7 +38,7 @@ public class PostTestUtils {
 
     static PostModel generateSampleLocalDraftPost(@NonNull String title) {
         PostModel example = new PostModel();
-        example.setLocalSiteId(6);
+        example.setLocalSiteId(DEFAULT_LOCAL_SITE_ID);
         example.setTitle(title);
         example.setContent("Bunch of content here");
         example.setIsLocalDraft(true);
@@ -45,7 +47,7 @@ public class PostTestUtils {
 
     public static PostModel generateSampleLocallyChangedPost() {
         PostModel example = new PostModel();
-        example.setLocalSiteId(6);
+        example.setLocalSiteId(DEFAULT_LOCAL_SITE_ID);
         example.setRemotePostId(7);
         example.setTitle("A test post");
         example.setContent("Bunch of content here");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -125,6 +125,17 @@ public class PostSqlUtils {
                 .getAsModel();
     }
 
+    public static List<PostModel> getLocalDrafts(@NonNull Integer localSiteId) {
+        return WellSql.select(PostModel.class)
+                      .where()
+                      .beginGroup()
+                      .equals(PostModelTable.LOCAL_SITE_ID, localSiteId)
+                      .equals(PostModelTable.IS_LOCAL_DRAFT, true)
+                      .endGroup()
+                      .endWhere()
+                      .getAsModel();
+    }
+
     public static List<PostModel> getPostsByRemoteIds(@Nullable List<Long> remoteIds, int localSiteId) {
         if (remoteIds != null && remoteIds.size() > 0) {
             return WellSql.select(PostModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -125,12 +125,13 @@ public class PostSqlUtils {
                 .getAsModel();
     }
 
-    public static List<PostModel> getLocalDrafts(@NonNull Integer localSiteId) {
+    public static List<PostModel> getLocalDrafts(@NonNull Integer localSiteId, boolean isPage) {
         return WellSql.select(PostModel.class)
                       .where()
                       .beginGroup()
                       .equals(PostModelTable.LOCAL_SITE_ID, localSiteId)
                       .equals(PostModelTable.IS_LOCAL_DRAFT, true)
+                      .equals(PostModelTable.IS_PAGE, isPage)
                       .endGroup()
                       .endWhere()
                       .getAsModel();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
@@ -182,6 +182,12 @@ class PageStore @Inject constructor(
         fetchPages(site, false)
     }
 
+    suspend fun getLocalDraftPages(site: SiteModel): List<PageModel> = withContext(coroutineContext) {
+        return@withContext PostSqlUtils.getLocalDrafts(site.id, true).map {
+            PageModel(post = it, site = site)
+        }
+    }
+
     private fun fetchPages(site: SiteModel, loadMore: Boolean) {
         val payload = FetchPostsPayload(site, loadMore, PAGE_TYPES)
         dispatcher.dispatch(PostActionBuilder.newFetchPagesAction(payload))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -422,6 +422,9 @@ public class PostStore extends Store {
         return getUploadedPagesForSite(site).size();
     }
 
+    /**
+     * Returns all posts and pages that are local drafts for the given site.
+     */
     public List<PostModel> getLocalDrafts(@NonNull SiteModel site) {
         return PostSqlUtils.getLocalDrafts(site.getId());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -425,8 +425,8 @@ public class PostStore extends Store {
     /**
      * Returns all posts and pages that are local drafts for the given site.
      */
-    public List<PostModel> getLocalDrafts(@NonNull SiteModel site) {
-        return PostSqlUtils.getLocalDrafts(site.getId());
+    public List<PostModel> getLocalDraftPosts(@NonNull SiteModel site) {
+        return PostSqlUtils.getLocalDrafts(site.getId(), false);
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -422,6 +422,10 @@ public class PostStore extends Store {
         return getUploadedPagesForSite(site).size();
     }
 
+    public List<PostModel> getLocalDrafts(@NonNull SiteModel site) {
+        return PostSqlUtils.getLocalDrafts(site.getId());
+    }
+
     /**
      * Given a local ID for a post, returns that post as a {@link PostModel}.
      */


### PR DESCRIPTION
This adds a `PostStore.getLocalDrafts` method. This is a companion PR to wordpress-mobile/WordPress-Android#9774.