### PR TITLE
Fix failing insights test

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ManageInsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ManageInsightsTestJetpack.kt
@@ -64,7 +64,7 @@ class ReleaseStack_ManageInsightsTestJetpack : ReleaseStack_Base() {
 
         val emptyStats = runBlocking { statsStore.getAddedInsights(site) }
 
-        // Starts with 4 default blocks
+        // Starts with 5 default blocks
         assertEquals(emptyStats.size, 5)
         if (!emptyStats.contains(InsightType.FOLLOWERS)) {
             runBlocking { statsStore.addType(site, InsightType.FOLLOWERS) }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ManageInsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ManageInsightsTestJetpack.kt
@@ -65,20 +65,20 @@ class ReleaseStack_ManageInsightsTestJetpack : ReleaseStack_Base() {
         val emptyStats = runBlocking { statsStore.getAddedInsights(site) }
 
         // Starts with 4 default blocks
-        assertEquals(emptyStats.size, 4)
+        assertEquals(emptyStats.size, 5)
         if (!emptyStats.contains(InsightType.FOLLOWERS)) {
             runBlocking { statsStore.addType(site, InsightType.FOLLOWERS) }
         }
 
         val statsWithFollowers = runBlocking { statsStore.getAddedInsights(site) }
 
-        assertEquals(statsWithFollowers.size, 5)
+        assertEquals(statsWithFollowers.size, 6)
 
         runBlocking { statsStore.removeType(site, FOLLOWERS) }
 
         val statsWithoutFollowers = runBlocking { statsStore.getAddedInsights(site) }
 
-        assertEquals(statsWithoutFollowers.size, 4)
+        assertEquals(statsWithoutFollowers.size, 5)
     }
 
     @Test


### PR DESCRIPTION
`testAddAndRemoveInsights` started failing because now we have 5 default Insights blocks, not 4. This PR is increasing the size to fix the test. 