### PR TITLE
Remove unused /is-available/domain/ feature

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
@@ -18,7 +18,6 @@ import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -30,7 +29,6 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
     private enum TestEvents {
         NONE,
         IS_AVAILABLE_BLOG,
-        IS_AVAILABLE_DOMAIN,
         IS_AVAILABLE_EMAIL,
         IS_AVAILABLE_USERNAME,
         ERROR_INVALID
@@ -80,42 +78,6 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         assertEquals("notavalidname#", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
-    }
-
-    @Test
-    public void testIsAvailableDomain() throws InterruptedException {
-        mNextEvent = TestEvents.IS_AVAILABLE_DOMAIN;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AccountActionBuilder.newIsAvailableDomainAction("docbrown.com"));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        assertEquals("docbrown.com", mLastEvent.value);
-        assertFalse(mLastEvent.isAvailable);
-        assertTrue(mLastEvent.suggestions.size() > 0);
-
-        String unavailableDomain = "docbrown" + RandomStringUtils.randomAlphanumeric(8).toLowerCase() + ".com";
-        mNextEvent = TestEvents.IS_AVAILABLE_DOMAIN;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AccountActionBuilder.newIsAvailableDomainAction(unavailableDomain));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        assertEquals(unavailableDomain, mLastEvent.value);
-        assertTrue(mLastEvent.isAvailable);
-        assertNull(mLastEvent.suggestions);
-    }
-
-    @Test
-    public void testIsAvailableDomainInvalid() throws InterruptedException {
-        mNextEvent = TestEvents.ERROR_INVALID;
-        mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(AccountActionBuilder.newIsAvailableDomainAction("notavaliddomain#"));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        assertEquals("notavaliddomain#", mLastEvent.value);
         assertFalse(mLastEvent.isAvailable);
     }
 
@@ -203,10 +165,6 @@ public class ReleaseStack_AccountAvailabilityTest extends ReleaseStack_Base {
         switch (event.type) {
             case BLOG:
                 assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_BLOG);
-                mCountDownLatch.countDown();
-                break;
-            case DOMAIN:
-                assertEquals(mNextEvent, TestEvents.IS_AVAILABLE_DOMAIN);
                 mCountDownLatch.countDown();
                 break;
             case EMAIL:

--- a/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPComEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPComEndpointTest.java
@@ -64,7 +64,6 @@ public class WPComEndpointTest {
         assertEquals("/is-available/email/", WPCOMREST.is_available.email.getEndpoint());
         assertEquals("/is-available/username/", WPCOMREST.is_available.username.getEndpoint());
         assertEquals("/is-available/blog/", WPCOMREST.is_available.blog.getEndpoint());
-        assertEquals("/is-available/domain/", WPCOMREST.is_available.domain.getEndpoint());
 
         // Magic link email sender
         assertEquals("/auth/send-login-email/", WPCOMREST.auth.send_login_email.getEndpoint());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AccountAction.java
@@ -56,8 +56,6 @@ public enum AccountAction implements IAction {
     @Action(payloadType = String.class)
     IS_AVAILABLE_BLOG,
     @Action(payloadType = String.class)
-    IS_AVAILABLE_DOMAIN,
-    @Action(payloadType = String.class)
     IS_AVAILABLE_EMAIL,
     @Action(payloadType = String.class)
     IS_AVAILABLE_USERNAME,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -188,14 +188,12 @@ public class AccountRestClient extends BaseWPComRestClient {
         public IsAvailable type;
         public String value;
         public boolean isAvailable;
-        public List<String> suggestions;
     }
 
     public enum IsAvailable {
         EMAIL,
         USERNAME,
-        BLOG,
-        DOMAIN
+        BLOG
     }
 
     public AccountRestClient(Context appContext, Dispatcher dispatcher, RequestQueue requestQueue,
@@ -967,9 +965,6 @@ public class AccountRestClient extends BaseWPComRestClient {
             case BLOG:
                 url = WPCOMREST.is_available.blog.getUrlV0();
                 break;
-            case DOMAIN:
-                url = WPCOMREST.is_available.domain.getUrlV0();
-                break;
             case EMAIL:
                 url = WPCOMREST.is_available.email.getUrlV0();
                 break;
@@ -998,7 +993,6 @@ public class AccountRestClient extends BaseWPComRestClient {
                             if (response.error.equals("taken")) {
                                 // We consider "taken" not to be an error, and we report that the item is unavailable
                                 payload.isAvailable = false;
-                                payload.suggestions = response.suggestions; // These are only supplied by /domain/
                             } else if (response.error.equals("invalid") && type.equals(IsAvailable.BLOG)
                                     && response.message.contains("reserved")) {
                                 // Special case for /is-available/blog, which returns 'invalid' instead of 'taken'

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/IsAvailableResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/IsAvailableResponse.java
@@ -2,11 +2,8 @@ package org.wordpress.android.fluxc.network.rest.wpcom.account;
 
 import org.wordpress.android.fluxc.network.rest.JsonObjectOrFalse;
 
-import java.util.List;
-
 public class IsAvailableResponse extends JsonObjectOrFalse {
     public String error;
     public String message;
     public String status;
-    public List<String> suggestions; // /is-available/domain only
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -410,7 +410,6 @@ public class AccountStore extends Store {
         public IsAvailable type;
         public String value;
         public boolean isAvailable;
-        public List<String> suggestions;
 
         public OnAvailabilityChecked(IsAvailable type, String value, boolean isAvailable) {
             this.type = type;
@@ -847,9 +846,6 @@ public class AccountStore extends Store {
             case IS_AVAILABLE_BLOG:
                 mAccountRestClient.isAvailable((String) payload, IsAvailable.BLOG);
                 break;
-            case IS_AVAILABLE_DOMAIN:
-                mAccountRestClient.isAvailable((String) payload, IsAvailable.DOMAIN);
-                break;
             case IS_AVAILABLE_EMAIL:
                 mAccountRestClient.isAvailable((String) payload, IsAvailable.EMAIL);
                 break;
@@ -1055,7 +1051,6 @@ public class AccountStore extends Store {
 
     private void handleCheckedIsAvailable(IsAvailableResponsePayload payload) {
         OnAvailabilityChecked event = new OnAvailabilityChecked(payload.type, payload.value, payload.isAvailable);
-        event.suggestions = payload.suggestions;
 
         if (payload.isError()) {
             event.error = payload.error;

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -7,7 +7,6 @@
 /devices/$deviceId#String/delete/
 
 /is-available/blog/
-/is-available/domain/
 /is-available/email/
 /is-available/username/
 


### PR DESCRIPTION
This endpoint now returns a 500 error and is breaking the `ReleaseStack_AccountAvailabilityTest#testIsAvailableDomain` test.

We've never used this endpoint and in fact we've since added support for /domains/$domainName/is-available/ when handling the `SiteAction.CHECK_DOMAIN_AVAILABILITY` action.

### To test
1. Run the rest of the tests in `ReleaseStack_AccountAvailabilityTest`
2. Satisfy yourself that this feature is unused in our apps