### PR TITLE
Adds message when authentication fails when running WPCom tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -134,7 +134,8 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
     @SuppressWarnings("unused")
     @Subscribe
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
-        assertFalse(event.isError());
+        assertFalse("!!!!! Authentication failed - verify tests.properties contains valid credentials !!!!! ",
+                event.isError());
         assertEquals(TestEvents.AUTHENTICATED, mNextEvent);
         mCountDownLatch.countDown();
     }
@@ -142,8 +143,7 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
     @SuppressWarnings("unused")
     @Subscribe
     public void onAccountChanged(OnAccountChanged event) {
-        assertFalse("!!!!! Authentication failed - verify tests.properties contains valid credentials !!!!! ",
-                event.isError());
+        assertFalse(event.isError());
         assertEquals(TestEvents.ACCOUNT_FETCHED, mNextEvent);
         mCountDownLatch.countDown();
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPComBase.java
@@ -142,7 +142,8 @@ public class ReleaseStack_WPComBase extends ReleaseStack_Base {
     @SuppressWarnings("unused")
     @Subscribe
     public void onAccountChanged(OnAccountChanged event) {
-        assertFalse(event.isError());
+        assertFalse("!!!!! Authentication failed - verify tests.properties contains valid credentials !!!!! ",
+                event.isError());
         assertEquals(TestEvents.ACCOUNT_FETCHED, mNextEvent);
         mCountDownLatch.countDown();
     }


### PR DESCRIPTION
Adds explicit message to facilitate debugging when WPCom tests fail due to invalid credentials in tests.properties.