### PR TITLE
Remove connected cart redemption test

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
@@ -130,10 +130,12 @@ class ReleaseStack_TransactionsTest : ReleaseStack_WPComBase() {
 
         assertNotNull(event.cartDetails!!.products)
         assertTrue(event.cartDetails!!.products!!.isNotEmpty())
-        assertEquals(event.cartDetails!!.products!!.size, 2)
 
-        assertEquals(event.cartDetails!!.products!![0].product_id, TEST_DOMAIN_PRODUCT_ID)
-        assertEquals(event.cartDetails!!.products!![0].meta, TEST_DOMAIN_NAME)
+        val domainProductInCart = event.cartDetails!!.products!!.find {
+            it.product_id == TEST_DOMAIN_PRODUCT_ID &&
+                    it.meta == TEST_DOMAIN_NAME
+        }
+        assertNotNull(domainProductInCart)
 
         if (nextEvent == ERROR_REDEEMING_SHOPPING_CART_WRONG_COUNTRY_CODE) {
             val contactModelWithWrongCountryCode = TEST_DOMAIN_CONTACT_MODEL.copy(countryCode = "USB")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
@@ -35,7 +35,7 @@ class ReleaseStack_TransactionsTest : ReleaseStack_WPComBase() {
     companion object {
         private const val TEST_DOMAIN_NAME = "superrandomdomain192849347.blog"
         private const val TEST_DOMAIN_PRODUCT_ID = "76"
-        private var TEST_DOMAIN_CONTACT_MODEL = DomainContactModel(
+        private val TEST_DOMAIN_CONTACT_MODEL = DomainContactModel(
                 "Wapu",
                 "Wordpress",
                 "WordPress",


### PR DESCRIPTION
This PR removes connected test that redeems domain credit.

Test made the assumption that there will be no domain credit at the remote test site, which is not correct and could change anytime.

