### PR TITLE
Add test for page remote-auto-save

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -662,9 +662,26 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
     @Test
     public void testAutoSavePost() throws InterruptedException {
+        boolean testPage = false;
+        //noinspection ConstantConditions
+        testAutoSavePostOrPage(testPage);
+    }
+
+    @Test
+    public void testAutoSavePage() throws InterruptedException {
+        boolean testPage = true;
+        //noinspection ConstantConditions
+        testAutoSavePostOrPage(testPage);
+    }
+
+    private void testAutoSavePostOrPage(boolean testPage) throws InterruptedException {
         // Arrange
         PostModel post = createNewPost();
         setupPostAttributes(post);
+
+        if (testPage) {
+            post.setIsPage(true);
+        }
 
         post.setStatus(PostStatus.PUBLISHED.toString());
 
@@ -673,7 +690,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(post.getId());
 
         // Act
-        uploadedPost.setContent("post content edited");
+        uploadedPost.setContent("content edited");
         remoteAutoSavePost(uploadedPost);
 
         // Assert

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -662,15 +662,13 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
     @Test
     public void testAutoSavePost() throws InterruptedException {
-        boolean testPage = false;
-        //noinspection ConstantConditions
+        final boolean testPage = false;
         testAutoSavePostOrPage(testPage);
     }
 
     @Test
     public void testAutoSavePage() throws InterruptedException {
-        boolean testPage = true;
-        //noinspection ConstantConditions
+        final boolean testPage = true;
         testAutoSavePostOrPage(testPage);
     }
 
@@ -679,9 +677,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         PostModel post = createNewPost();
         setupPostAttributes(post);
 
-        if (testPage) {
-            post.setIsPage(true);
-        }
+        post.setIsPage(testPage);
 
         post.setStatus(PostStatus.PUBLISHED.toString());
 


### PR DESCRIPTION
I wanted to add support for "Page remote-auto-save" into PageStore. However, after looking at the code and it's usage I don't think it makes sense. All code related to uploading/fetching Page content/title etc is located in the PostStore so it makes sense to have there even the code for remote-auto-save. 
The Remote-Auto-Save action already works with Pages so I just added an integration test to make sure the API handles it correctly. 

To test
1. Run `testAutoSavePost` and `testAutoSavePage`