### PR TITLE
Make PostSqlUtils mockable

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertTrue;
 
 public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
     @Inject PostStore mPostStore;
+    @Inject PostSqlUtils mPostSqlUtils;
 
     private static final String POST_DEFAULT_TITLE = "PostTestWPCom base post";
     private static final String POST_DEFAULT_DESCRIPTION = "Hi there, I'm a post from FluxC!";
@@ -93,7 +94,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(mPost));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        assertEquals(0, PostSqlUtils.getPostsForSite(sSite, false).size());
+        assertEquals(0, mPostSqlUtils.getPostsForSite(sSite, false).size());
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalDraftTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalDraftTest.kt
@@ -21,7 +21,13 @@ import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class PageStoreLocalDraftTest {
-    private val pageStore = PageStore(postStore = mock(), dispatcher = mock(), coroutineContext = Dispatchers.Default)
+    private val postSqlUtils = PostSqlUtils()
+    private val pageStore = PageStore(
+            postStore = mock(),
+            dispatcher = mock(),
+            coroutineContext = Dispatchers.Default,
+            postSqlUtils = postSqlUtils
+    )
 
     @Before
     fun setUp() {
@@ -62,7 +68,7 @@ class PageStoreLocalDraftTest {
                 }
         )
 
-        expectedPages.plus(unexpectedPosts).forEach { PostSqlUtils.insertPostForResult(it) }
+        expectedPages.plus(unexpectedPosts).forEach { postSqlUtils.insertPostForResult(it) }
 
         // Act
         val localDraftPages = pageStore.getLocalDraftPages(site)

--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.model.page.PageStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.page.PageStatus.SCHEDULED
 import org.wordpress.android.fluxc.model.page.PageStatus.TRASHED
 import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.persistence.PostSqlUtils
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
@@ -81,7 +82,7 @@ class PageStoreTest {
         actionCaptor = argumentCaptor()
         val pages = listOf(pageWithoutQuery, pageWithQuery, pageWithoutTitle)
         whenever(postStore.getPagesForSite(site)).thenReturn(pages)
-        store = PageStore(postStore, dispatcher, Dispatchers.Unconfined)
+        store = PageStore(postStore, PostSqlUtils(), dispatcher, Dispatchers.Unconfined)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreUnitTest.java
@@ -44,8 +44,9 @@ import static org.junit.Assert.assertNotEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class PostStoreUnitTest {
+    private PostSqlUtils mPostSqlUtils = new PostSqlUtils();
     private PostStore mPostStore = new PostStore(new Dispatcher(), Mockito.mock(PostRestClient.class),
-            Mockito.mock(PostXMLRPCClient.class));
+            Mockito.mock(PostXMLRPCClient.class), mPostSqlUtils);
 
     @Before
     public void setUp() {
@@ -63,7 +64,7 @@ public class PostStoreUnitTest {
 
     @Test
     public void testInsertNullPost() {
-        assertEquals(0, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(null));
+        assertEquals(0, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(null));
 
         assertEquals(0, PostTestUtils.getPostsCount());
     }
@@ -72,7 +73,7 @@ public class PostStoreUnitTest {
     public void testSimpleInsertionAndRetrieval() {
         PostModel postModel = new PostModel();
         postModel.setRemotePostId(42);
-        PostModel result = PostSqlUtils.insertPostForResult(postModel);
+        PostModel result = mPostSqlUtils.insertPostForResult(postModel);
 
         assertEquals(1, PostTestUtils.getPostsCount());
         assertEquals(42, PostTestUtils.getPosts().get(0).getRemotePostId());
@@ -83,15 +84,15 @@ public class PostStoreUnitTest {
     public void testInsertWithLocalChanges() {
         PostModel postModel = PostTestUtils.generateSampleUploadedPost();
         postModel.setIsLocallyChanged(true);
-        PostSqlUtils.insertPostForResult(postModel);
+        mPostSqlUtils.insertPostForResult(postModel);
 
         String newTitle = "A different title";
         postModel.setTitle(newTitle);
 
-        assertEquals(0, PostSqlUtils.insertOrUpdatePostKeepingLocalChanges(postModel));
+        assertEquals(0, mPostSqlUtils.insertOrUpdatePostKeepingLocalChanges(postModel));
         assertEquals("A test post", PostTestUtils.getPosts().get(0).getTitle());
 
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel));
+        assertEquals(1, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel));
         assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
     }
 
@@ -100,7 +101,7 @@ public class PostStoreUnitTest {
         // Test uploading a post, fetching remote posts and updating the db from the fetch first
 
         PostModel postModel = PostTestUtils.generateSampleLocalDraftPost();
-        PostSqlUtils.insertPostForResult(postModel);
+        mPostSqlUtils.insertPostForResult(postModel);
 
         // The post after uploading, updated with the remote post ID, about to be saved locally
         PostModel postFromUploadResponse = PostTestUtils.getPosts().get(0);
@@ -111,8 +112,8 @@ public class PostStoreUnitTest {
         final PostModel postFromPostListFetch = postFromUploadResponse.clone();
         postFromPostListFetch.setId(0);
 
-        PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromPostListFetch);
-        PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromUploadResponse);
+        mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromPostListFetch);
+        mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postFromUploadResponse);
 
         assertEquals(1, PostTestUtils.getPosts().size());
 
@@ -124,29 +125,29 @@ public class PostStoreUnitTest {
     @Test
     public void testInsertWithoutLocalChanges() {
         PostModel postModel = PostTestUtils.generateSampleUploadedPost();
-        PostSqlUtils.insertPostForResult(postModel);
+        mPostSqlUtils.insertPostForResult(postModel);
 
         String newTitle = "A different title";
         postModel.setTitle(newTitle);
 
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostKeepingLocalChanges(postModel));
+        assertEquals(1, mPostSqlUtils.insertOrUpdatePostKeepingLocalChanges(postModel));
         assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
 
         newTitle = "Another different title";
         postModel.setTitle(newTitle);
 
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel));
+        assertEquals(1, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel));
         assertEquals(newTitle, PostTestUtils.getPosts().get(0).getTitle());
     }
 
     @Test
     public void testGetPostsForSite() {
         PostModel uploadedPost1 = PostTestUtils.generateSampleUploadedPost();
-        PostSqlUtils.insertPostForResult(uploadedPost1);
+        mPostSqlUtils.insertPostForResult(uploadedPost1);
 
         PostModel uploadedPost2 = PostTestUtils.generateSampleUploadedPost();
         uploadedPost2.setLocalSiteId(8);
-        PostSqlUtils.insertPostForResult(uploadedPost2);
+        mPostSqlUtils.insertPostForResult(uploadedPost2);
 
         SiteModel site1 = new SiteModel();
         site1.setId(uploadedPost1.getLocalSiteId());
@@ -165,9 +166,9 @@ public class PostStoreUnitTest {
         PostModel textPost = PostTestUtils.generateSampleUploadedPost();
         PostModel imagePost = PostTestUtils.generateSampleUploadedPost("image");
         PostModel videoPost = PostTestUtils.generateSampleUploadedPost("video");
-        PostSqlUtils.insertPostForResult(textPost);
-        PostSqlUtils.insertPostForResult(imagePost);
-        PostSqlUtils.insertPostForResult(videoPost);
+        mPostSqlUtils.insertPostForResult(textPost);
+        mPostSqlUtils.insertPostForResult(imagePost);
+        mPostSqlUtils.insertPostForResult(videoPost);
 
         SiteModel site = new SiteModel();
         site.setId(textPost.getLocalSiteId());
@@ -189,10 +190,10 @@ public class PostStoreUnitTest {
         site.setId(6);
 
         PostModel uploadedPost = PostTestUtils.generateSampleUploadedPost();
-        PostSqlUtils.insertPostForResult(uploadedPost);
+        mPostSqlUtils.insertPostForResult(uploadedPost);
 
         PostModel localDraft = PostTestUtils.generateSampleLocalDraftPost();
-        PostSqlUtils.insertPostForResult(localDraft);
+        mPostSqlUtils.insertPostForResult(localDraft);
 
         assertEquals(2, PostTestUtils.getPostsCount());
         assertEquals(2, mPostStore.getPostsCountForSite(site));
@@ -203,7 +204,7 @@ public class PostStoreUnitTest {
     @Test
     public void testGetPostByLocalId() {
         PostModel post = PostTestUtils.generateSampleLocalDraftPost();
-        PostSqlUtils.insertPostForResult(post);
+        mPostSqlUtils.insertPostForResult(post);
 
         assertEquals(post, mPostStore.getPostByLocalPostId(post.getId()));
     }
@@ -211,7 +212,7 @@ public class PostStoreUnitTest {
     @Test
     public void testGetPostByRemoteId() {
         PostModel post = PostTestUtils.generateSampleUploadedPost();
-        PostSqlUtils.insertPostForResult(post);
+        mPostSqlUtils.insertPostForResult(post);
 
         SiteModel site = new SiteModel();
         site.setId(6);
@@ -225,21 +226,21 @@ public class PostStoreUnitTest {
         site.setId(6);
 
         PostModel uploadedPost1 = PostTestUtils.generateSampleUploadedPost();
-        PostSqlUtils.insertPostForResult(uploadedPost1);
+        mPostSqlUtils.insertPostForResult(uploadedPost1);
 
         PostModel uploadedPost2 = PostTestUtils.generateSampleUploadedPost();
         uploadedPost2.setRemotePostId(9);
-        PostSqlUtils.insertPostForResult(uploadedPost2);
+        mPostSqlUtils.insertPostForResult(uploadedPost2);
 
         PostModel localDraft = PostTestUtils.generateSampleLocalDraftPost();
-        PostSqlUtils.insertPostForResult(localDraft);
+        mPostSqlUtils.insertPostForResult(localDraft);
 
         PostModel locallyChangedPost = PostTestUtils.generateSampleLocallyChangedPost();
-        PostSqlUtils.insertPostForResult(locallyChangedPost);
+        mPostSqlUtils.insertPostForResult(locallyChangedPost);
 
         assertEquals(4, mPostStore.getPostsCountForSite(site));
 
-        PostSqlUtils.deleteUploadedPostsForSite(site, false);
+        mPostSqlUtils.deleteUploadedPostsForSite(site, false);
 
         assertEquals(2, mPostStore.getPostsCountForSite(site));
     }
@@ -250,32 +251,32 @@ public class PostStoreUnitTest {
         site.setId(6);
 
         PostModel uploadedPost1 = PostTestUtils.generateSampleUploadedPost();
-        PostSqlUtils.insertPostForResult(uploadedPost1);
+        mPostSqlUtils.insertPostForResult(uploadedPost1);
 
         PostModel uploadedPost2 = PostTestUtils.generateSampleUploadedPost();
         uploadedPost2.setRemotePostId(9);
-        PostSqlUtils.insertPostForResult(uploadedPost2);
+        mPostSqlUtils.insertPostForResult(uploadedPost2);
 
         PostModel localDraft = PostTestUtils.generateSampleLocalDraftPost();
-        PostSqlUtils.insertPostForResult(localDraft);
+        mPostSqlUtils.insertPostForResult(localDraft);
 
         PostModel locallyChangedPost = PostTestUtils.generateSampleLocallyChangedPost();
-        PostSqlUtils.insertPostForResult(locallyChangedPost);
+        mPostSqlUtils.insertPostForResult(locallyChangedPost);
 
         assertEquals(4, mPostStore.getPostsCountForSite(site));
 
-        PostSqlUtils.deletePost(uploadedPost1);
+        mPostSqlUtils.deletePost(uploadedPost1);
 
         assertEquals(null, mPostStore.getPostByLocalPostId(uploadedPost1.getId()));
         assertEquals(3, mPostStore.getPostsCountForSite(site));
 
-        PostSqlUtils.deletePost(uploadedPost2);
-        PostSqlUtils.deletePost(localDraft);
+        mPostSqlUtils.deletePost(uploadedPost2);
+        mPostSqlUtils.deletePost(localDraft);
 
         assertNotEquals(null, mPostStore.getPostByLocalPostId(locallyChangedPost.getId()));
         assertEquals(1, mPostStore.getPostsCountForSite(site));
 
-        PostSqlUtils.deletePost(locallyChangedPost);
+        mPostSqlUtils.deletePost(locallyChangedPost);
 
         assertEquals(null, mPostStore.getPostByLocalPostId(locallyChangedPost.getId()));
         assertEquals(0, mPostStore.getPostsCountForSite(site));
@@ -290,13 +291,13 @@ public class PostStoreUnitTest {
         PostModel post = new PostModel();
         post.setLocalSiteId(6);
         post.setRemotePostId(42);
-        PostSqlUtils.insertPostForResult(post);
+        mPostSqlUtils.insertPostForResult(post);
 
         PostModel page = new PostModel();
         page.setIsPage(true);
         page.setLocalSiteId(6);
         page.setRemotePostId(43);
-        PostSqlUtils.insertPostForResult(page);
+        mPostSqlUtils.insertPostForResult(page);
 
         assertEquals(2, PostTestUtils.getPostsCount());
 
@@ -319,21 +320,21 @@ public class PostStoreUnitTest {
         post.setLocalSiteId(6);
         post.setRemotePostId(42);
         post.setDateCreated(DateTimeUtils.iso8601UTCFromDate(new Date()));
-        PostSqlUtils.insertPostForResult(post);
+        mPostSqlUtils.insertPostForResult(post);
 
         PostModel localDraft = new PostModel();
         localDraft.setLocalSiteId(6);
         localDraft.setIsLocalDraft(true);
         localDraft.setDateCreated("2016-01-01T07:00:00+00:00");
-        PostSqlUtils.insertPostForResult(localDraft);
+        mPostSqlUtils.insertPostForResult(localDraft);
 
         PostModel scheduledPost = new PostModel();
         scheduledPost.setLocalSiteId(6);
         scheduledPost.setRemotePostId(23);
         scheduledPost.setDateCreated("2056-01-01T07:00:00+00:00");
-        PostSqlUtils.insertPostForResult(scheduledPost);
+        mPostSqlUtils.insertPostForResult(scheduledPost);
 
-        List<PostModel> posts = PostSqlUtils.getPostsForSite(site, false);
+        List<PostModel> posts = mPostSqlUtils.getPostsForSite(site, false);
 
         // Expect order draft > scheduled > published
         assertTrue(posts.get(0).isLocalDraft());
@@ -344,15 +345,15 @@ public class PostStoreUnitTest {
     @Test
     public void testRemoveAllPosts() {
         PostModel uploadedPost1 = PostTestUtils.generateSampleUploadedPost();
-        PostSqlUtils.insertPostForResult(uploadedPost1);
+        mPostSqlUtils.insertPostForResult(uploadedPost1);
 
         PostModel uploadedPost2 = PostTestUtils.generateSampleUploadedPost();
         uploadedPost2.setLocalSiteId(8);
-        PostSqlUtils.insertPostForResult(uploadedPost2);
+        mPostSqlUtils.insertPostForResult(uploadedPost2);
 
         assertEquals(2, PostTestUtils.getPostsCount());
 
-        PostSqlUtils.deleteAllPosts();
+        mPostSqlUtils.deleteAllPosts();
 
         assertEquals(0, PostTestUtils.getPostsCount());
     }
@@ -360,17 +361,17 @@ public class PostStoreUnitTest {
     @Test
     public void testNumLocalChanges() {
         // first make sure there aren't any local changes
-        assertEquals(PostStore.getNumLocalChanges(), 0);
+        assertEquals(mPostStore.getNumLocalChanges(), 0);
 
         // then add a post with local changes and ensure we get the correct count
         PostModel testPost = PostTestUtils.generateSampleLocalDraftPost();
         testPost.setIsLocallyChanged(true);
-        PostSqlUtils.insertOrUpdatePost(testPost, true);
-        assertEquals(PostStore.getNumLocalChanges(), 1);
+        mPostSqlUtils.insertOrUpdatePost(testPost, true);
+        assertEquals(mPostStore.getNumLocalChanges(), 1);
 
         // delete the post and again check the count
-        PostSqlUtils.deletePost(testPost);
-        assertEquals(PostStore.getNumLocalChanges(), 0);
+        mPostSqlUtils.deletePost(testPost);
+        assertEquals(mPostStore.getNumLocalChanges(), 0);
     }
 
     @Test
@@ -443,15 +444,15 @@ public class PostStoreUnitTest {
         for (int i = 0; i < 3; i++) {
             final String compoundTitle = baseTitle.concat(":").concat(UUID.randomUUID().toString());
             final PostModel post = PostTestUtils.generateSampleLocalDraftPost(compoundTitle);
-            PostSqlUtils.insertPostForResult(post);
+            mPostSqlUtils.insertPostForResult(post);
         }
 
         final PostModel localDraftPage = PostTestUtils.generateSampleLocalDraftPost();
         localDraftPage.setIsPage(true);
-        PostSqlUtils.insertPostForResult(localDraftPage);
+        mPostSqlUtils.insertPostForResult(localDraftPage);
 
         final PostModel uploadedPost = PostTestUtils.generateSampleUploadedPost();
-        PostSqlUtils.insertPostForResult(uploadedPost);
+        mPostSqlUtils.insertPostForResult(uploadedPost);
 
         final SiteModel site = new SiteModel();
         site.setId(PostTestUtils.DEFAULT_LOCAL_SITE_ID);
@@ -524,14 +525,14 @@ public class PostStoreUnitTest {
         for (int i = 1; i <= localIds.size(); i++) {
             PostModel post = PostTestUtils.generateSampleLocalDraftPost();
             post.setLocalSiteId(localSiteId);
-            PostSqlUtils.insertOrUpdatePost(post, false);
+            mPostSqlUtils.insertOrUpdatePost(post, false);
         }
 
         for (RemoteId remoteId : remoteIds) {
             PostModel post = PostTestUtils.generateSampleUploadedPost();
             post.setLocalSiteId(localSiteId);
             post.setRemotePostId(remoteId.getValue());
-            PostSqlUtils.insertOrUpdatePost(post, false);
+            mPostSqlUtils.insertOrUpdatePost(post, false);
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
+import org.wordpress.android.fluxc.persistence.PostSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
@@ -45,7 +46,8 @@ import static org.wordpress.android.fluxc.site.SiteUtils.generateWPComSite;
 
 @RunWith(RobolectricTestRunner.class)
 public class SiteStoreUnitTest {
-    private SiteStore mSiteStore = new SiteStore(new Dispatcher(), Mockito.mock(SiteRestClient.class),
+    private PostSqlUtils mPostSqlUtils = new PostSqlUtils();
+    private SiteStore mSiteStore = new SiteStore(new Dispatcher(), mPostSqlUtils, Mockito.mock(SiteRestClient.class),
             Mockito.mock(SiteXMLRPCClient.class));
 
     @Before
@@ -811,7 +813,7 @@ public class SiteStoreUnitTest {
         sitesToKeep.addAll(allSites.subList(0, 6));
 
         // remove six sites (2/3 * (15 - 6))
-        SiteSqlUtils.removeWPComRestSitesAbsentFromList(sitesToKeep);
+        SiteSqlUtils.removeWPComRestSitesAbsentFromList(mPostSqlUtils, sitesToKeep);
 
         assertTrue(mSiteStore.getSitesCount() == 9);
 

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/UploadSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/UploadSqlUtilsTest.java
@@ -33,6 +33,7 @@ import static junit.framework.Assert.assertTrue;
 @RunWith(RobolectricTestRunner.class)
 public class UploadSqlUtilsTest {
     private Random mRandom = new Random(System.currentTimeMillis());
+    private PostSqlUtils mPostSqlUtils = new PostSqlUtils();
 
     @Before
     public void setUp() {
@@ -173,7 +174,7 @@ public class UploadSqlUtilsTest {
     @Test
     public void testInsertPost() {
         PostModel testPost = UploadTestUtils.getTestPost();
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost));
+        assertEquals(1, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost));
         List<PostModel> postList = PostTestUtils.getPosts();
         assertEquals(1, postList.size());
         assertNotNull(postList.get(0));
@@ -189,7 +190,7 @@ public class UploadSqlUtilsTest {
         assertEquals(PostUploadModel.PENDING, postUploadModel.getUploadState());
 
         // Deleting the PostModel should cause the corresponding PostUploadModel to be deleted also
-        PostSqlUtils.deletePost(testPost);
+        mPostSqlUtils.deletePost(testPost);
 
         postList = PostTestUtils.getPosts();
         assertTrue(postList.isEmpty());
@@ -202,10 +203,10 @@ public class UploadSqlUtilsTest {
     public void testGetPostModelsByState() {
         PostModel testPost1 = UploadTestUtils.getTestPost();
         testPost1.setIsLocalDraft(true);
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost1));
+        assertEquals(1, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost1));
         PostModel testPost2 = UploadTestUtils.getTestPost();
         testPost2.setIsLocalDraft(true);
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost2));
+        assertEquals(1, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost2));
         List<PostModel> postList = PostTestUtils.getPosts();
         assertEquals(2, postList.size());
 
@@ -255,8 +256,8 @@ public class UploadSqlUtilsTest {
         testPost1.setIsLocalDraft(true);
         PostModel testPost2 = UploadTestUtils.getTestPost();
         testPost2.setIsLocalDraft(true);
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost1));
-        assertEquals(1, PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost2));
+        assertEquals(1, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost1));
+        assertEquals(1, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost2));
         List<PostModel> postModels = PostTestUtils.getPosts();
         assertEquals(2, postModels.size());
 

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/UploadStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/UploadStoreUnitTest.java
@@ -41,8 +41,9 @@ import static org.junit.Assert.assertTrue;
 public class UploadStoreUnitTest {
     private Dispatcher mDispatcher = new Dispatcher();
     private UploadStore mUploadStore = new UploadStore(mDispatcher);
+    private PostSqlUtils mPostSqlUtils = new PostSqlUtils();
     private PostStore mPostStore = new PostStore(mDispatcher, Mockito.mock(PostRestClient.class),
-            Mockito.mock(PostXMLRPCClient.class));
+            Mockito.mock(PostXMLRPCClient.class), mPostSqlUtils);
 
     @Before
     public void setUp() {
@@ -78,7 +79,7 @@ public class UploadStoreUnitTest {
         // Create a PostModel and add it to the PostStore
         PostModel postModel = UploadTestUtils.getTestPost();
         postModel.setId(55);
-        PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel);
+        mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel);
         postModel = mPostStore.getPostByLocalPostId(postModel.getId());
         assertNotNull(postModel);
 
@@ -126,7 +127,7 @@ public class UploadStoreUnitTest {
         // Create a PostModel and add it to the PostStore
         PostModel postModel = UploadTestUtils.getTestPost();
         postModel.setId(55);
-        PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel);
+        mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(postModel);
         postModel = mPostStore.getPostByLocalPostId(postModel.getId());
         assertNotNull(postModel);
 
@@ -187,7 +188,7 @@ public class UploadStoreUnitTest {
         // Create another PostModel and add it to the PostStore - this time, without registering it with the UploadStore
         PostModel unregisteredPostModel = UploadTestUtils.getTestPost();
         unregisteredPostModel.setId(55);
-        PostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(unregisteredPostModel);
+        mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(unregisteredPostModel);
 
         // Create a MediaModel attached to the above post
         MediaModel mediaLinkedToPost = UploadTestUtils.getLocalTestMedia();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -24,8 +24,17 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Inject;
+
+import dagger.Reusable;
+
+@Reusable
 public class PostSqlUtils {
-    public static int insertOrUpdatePost(PostModel post, boolean overwriteLocalChanges) {
+    @Inject
+    public PostSqlUtils() {
+    }
+
+    public int insertOrUpdatePost(PostModel post, boolean overwriteLocalChanges) {
         if (post == null) {
             return 0;
         }
@@ -70,15 +79,15 @@ public class PostSqlUtils {
         return 0;
     }
 
-    public static int insertOrUpdatePostKeepingLocalChanges(PostModel post) {
+    public int insertOrUpdatePostKeepingLocalChanges(PostModel post) {
         return insertOrUpdatePost(post, false);
     }
 
-    public static int insertOrUpdatePostOverwritingLocalChanges(PostModel post) {
+    public int insertOrUpdatePostOverwritingLocalChanges(PostModel post) {
         return insertOrUpdatePost(post, true);
     }
 
-    public static List<PostModel> getPostsForSite(SiteModel site, boolean getPages) {
+    public List<PostModel> getPostsForSite(SiteModel site, boolean getPages) {
         if (site == null) {
             return Collections.emptyList();
         }
@@ -93,7 +102,7 @@ public class PostSqlUtils {
                 .getAsModel();
     }
 
-    public static List<PostModel> getPostsForSiteWithFormat(SiteModel site, List<String> postFormat, boolean getPages) {
+    public List<PostModel> getPostsForSiteWithFormat(SiteModel site, List<String> postFormat, boolean getPages) {
         if (site == null) {
             return Collections.emptyList();
         }
@@ -109,7 +118,7 @@ public class PostSqlUtils {
                 .getAsModel();
     }
 
-    public static List<PostModel> getUploadedPostsForSite(SiteModel site, boolean getPages) {
+    public List<PostModel> getUploadedPostsForSite(SiteModel site, boolean getPages) {
         if (site == null) {
             return Collections.emptyList();
         }
@@ -125,7 +134,7 @@ public class PostSqlUtils {
                 .getAsModel();
     }
 
-    public static List<PostModel> getLocalDrafts(@NonNull Integer localSiteId, boolean isPage) {
+    public List<PostModel> getLocalDrafts(@NonNull Integer localSiteId, boolean isPage) {
         return WellSql.select(PostModel.class)
                       .where()
                       .beginGroup()
@@ -137,7 +146,7 @@ public class PostSqlUtils {
                       .getAsModel();
     }
 
-    public static List<PostModel> getPostsByRemoteIds(@Nullable List<Long> remoteIds, int localSiteId) {
+    public List<PostModel> getPostsByRemoteIds(@Nullable List<Long> remoteIds, int localSiteId) {
         if (remoteIds != null && remoteIds.size() > 0) {
             return WellSql.select(PostModel.class)
                           .where().isIn(PostModelTable.REMOTE_POST_ID, remoteIds)
@@ -147,7 +156,7 @@ public class PostSqlUtils {
         return Collections.emptyList();
     }
 
-    public static List<PostModel> getPostsByLocalOrRemotePostIds(
+    public List<PostModel> getPostsByLocalOrRemotePostIds(
             @NonNull List<? extends LocalOrRemoteId> localOrRemoteIds, int localSiteId) {
         if (localOrRemoteIds.isEmpty()) {
             return Collections.emptyList();
@@ -177,13 +186,13 @@ public class PostSqlUtils {
         return whereQuery.endGroup().endWhere().getAsModel();
     }
 
-    public static PostModel insertPostForResult(PostModel post) {
+    public PostModel insertPostForResult(PostModel post) {
         WellSql.insert(post).asSingleTransaction(true).execute();
 
         return post;
     }
 
-    public static int deletePost(PostModel post) {
+    public int deletePost(PostModel post) {
         if (post == null) {
             return 0;
         }
@@ -197,7 +206,7 @@ public class PostSqlUtils {
                 .execute();
     }
 
-    public static int deleteUploadedPostsForSite(SiteModel site, boolean pages) {
+    public int deleteUploadedPostsForSite(SiteModel site, boolean pages) {
         if (site == null) {
             return 0;
         }
@@ -213,11 +222,11 @@ public class PostSqlUtils {
                 .execute();
     }
 
-    public static int deleteAllPosts() {
+    public int deleteAllPosts() {
         return WellSql.delete(PostModel.class).execute();
     }
 
-    public static boolean getSiteHasLocalChanges(SiteModel site) {
+    public boolean getSiteHasLocalChanges(SiteModel site) {
         return site != null && WellSql.select(PostModel.class)
                 .where().beginGroup()
                 .equals(PostModelTable.LOCAL_SITE_ID, site.getId())
@@ -228,7 +237,7 @@ public class PostSqlUtils {
                 .endGroup().endGroup().endWhere().getAsCursor().getCount() > 0;
     }
 
-    public static int getNumLocalChanges() {
+    public int getNumLocalChanges() {
         return WellSql.select(PostModel.class)
                 .where().beginGroup()
                 .equals(PostModelTable.IS_LOCAL_DRAFT, true)
@@ -238,7 +247,7 @@ public class PostSqlUtils {
                 .getAsCursor().getCount();
     }
 
-    public static void insertOrUpdateLocalRevision(LocalRevisionModel revision, List<LocalDiffModel> diffs) {
+    public void insertOrUpdateLocalRevision(LocalRevisionModel revision, List<LocalDiffModel> diffs) {
         int localRevisionModels =
                 WellSql.select(LocalRevisionModel.class)
                         .where().beginGroup()
@@ -271,7 +280,7 @@ public class PostSqlUtils {
         }
     }
 
-    public static List<LocalRevisionModel> getLocalRevisions(SiteModel site, PostModel post) {
+    public List<LocalRevisionModel> getLocalRevisions(SiteModel site, PostModel post) {
         return WellSql.select(LocalRevisionModel.class)
                 .where().beginGroup()
                 .equals(LocalRevisionModelTable.POST_ID, post.getRemotePostId())
@@ -279,7 +288,7 @@ public class PostSqlUtils {
                 .endGroup().endWhere().getAsModel();
     }
 
-    public static List<LocalDiffModel> getLocalRevisionDiffs(LocalRevisionModel revision) {
+    public List<LocalDiffModel> getLocalRevisionDiffs(LocalRevisionModel revision) {
         return WellSql.select(LocalDiffModel.class)
                 .where().beginGroup()
                 .equals(LocalDiffModelTable.POST_ID, revision.getPostId())
@@ -288,7 +297,7 @@ public class PostSqlUtils {
                 .endGroup().endWhere().getAsModel();
     }
 
-    public static void deleteLocalRevisionAndDiffs(LocalRevisionModel revision) {
+    public void deleteLocalRevisionAndDiffs(LocalRevisionModel revision) {
         WellSql.delete(LocalRevisionModel.class)
                 .where().beginGroup()
                 .equals(LocalRevisionModelTable.REVISION_ID, revision.getRevisionId())
@@ -304,7 +313,7 @@ public class PostSqlUtils {
                 .endGroup().endWhere().execute();
     }
 
-    public static void deleteLocalRevisionAndDiffsOfAPostOrPage(PostModel post) {
+    public void deleteLocalRevisionAndDiffsOfAPostOrPage(PostModel post) {
         WellSql.delete(LocalRevisionModel.class)
                 .where().beginGroup()
                 .equals(LocalRevisionModelTable.POST_ID, post.getRemotePostId())
@@ -318,7 +327,7 @@ public class PostSqlUtils {
                 .endGroup().endWhere().execute();
     }
 
-    public static List<LocalId> getLocalPostIdsForFilter(SiteModel site, boolean isPage, String searchQuery,
+    public List<LocalId> getLocalPostIdsForFilter(SiteModel site, boolean isPage, String searchQuery,
                                                          String orderBy, @Order int order) {
         ConditionClauseBuilder<SelectQuery<PostModel>> clauseBuilder =
                 WellSql.select(PostModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -285,7 +285,7 @@ public class SiteSqlUtils {
      * @param sites
      *  list of sites to keep in local database
      */
-    public static int removeWPComRestSitesAbsentFromList(@NonNull List<SiteModel> sites) {
+    public static int removeWPComRestSitesAbsentFromList(PostSqlUtils postSqlUtils, @NonNull List<SiteModel> sites) {
         // get all local WP.com+Jetpack sites
         List<SiteModel> localSites = WellSql.select(SiteModel.class)
                 .where()
@@ -299,7 +299,7 @@ public class SiteSqlUtils {
                 SiteModel localSite = localIterator.next();
 
                 // don't remove sites with local changes
-                if (PostSqlUtils.getSiteHasLocalChanges(localSite)) {
+                if (postSqlUtils.getSiteHasLocalChanges(localSite)) {
                     localIterator.remove();
                 } else {
                     // don't remove local site if the remote ID matches a given site's ID

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
@@ -31,6 +31,7 @@ import kotlin.coroutines.suspendCoroutine
 @Singleton
 class PageStore @Inject constructor(
     private val postStore: PostStore,
+    private val postSqlUtils: PostSqlUtils,
     private val dispatcher: Dispatcher,
     private val coroutineContext: CoroutineContext
 ) {
@@ -170,7 +171,7 @@ class PageStore @Inject constructor(
     suspend fun deletePageFromDb(page: PageModel): Boolean = withContext(coroutineContext) {
         val post = postStore.getPostByLocalPostId(page.pageId)
         return@withContext if (post != null) {
-            PostSqlUtils.deletePost(post) > 0
+            postSqlUtils.deletePost(post) > 0
         } else {
             false
         }
@@ -183,7 +184,7 @@ class PageStore @Inject constructor(
     }
 
     suspend fun getLocalDraftPages(site: SiteModel): List<PageModel> = withContext(coroutineContext) {
-        return@withContext PostSqlUtils.getLocalDrafts(site.id, true).map {
+        return@withContext postSqlUtils.getLocalDrafts(site.id, true).map {
             PageModel(post = it, site = site)
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSit
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedCountryResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
+import org.wordpress.android.fluxc.persistence.PostSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
 import org.wordpress.android.fluxc.utils.SiteErrorUtils;
@@ -896,12 +897,15 @@ public class SiteStore extends Store {
 
     private SiteRestClient mSiteRestClient;
     private SiteXMLRPCClient mSiteXMLRPCClient;
+    private PostSqlUtils mPostSqlUtils;
 
     @Inject
-    public SiteStore(Dispatcher dispatcher, SiteRestClient siteRestClient, SiteXMLRPCClient siteXMLRPCClient) {
+    public SiteStore(Dispatcher dispatcher, PostSqlUtils postSqlUtils, SiteRestClient siteRestClient,
+                     SiteXMLRPCClient siteXMLRPCClient) {
         super(dispatcher);
         mSiteRestClient = siteRestClient;
         mSiteXMLRPCClient = siteXMLRPCClient;
+        mPostSqlUtils = postSqlUtils;
     }
 
     @Override
@@ -1412,7 +1416,7 @@ public class SiteStore extends Store {
             if (res.duplicateSiteFound) {
                 event.error = new SiteError(SiteErrorType.DUPLICATE_SITE);
             }
-            SiteSqlUtils.removeWPComRestSitesAbsentFromList(fetchedSites.getSites());
+            SiteSqlUtils.removeWPComRestSitesAbsentFromList(mPostSqlUtils, fetchedSites.getSites());
         }
         emitChange(event);
     }


### PR DESCRIPTION
Replaces static access to PostSqlUtils with instance access so we can mock PostSqlUtils in unit tests.

To Test:
1. Run the modified integration tests 
2. Quickly test the WPAndroid app

Merge instructions
- review this PR
- review [corresponding WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/9911)
- merge this PR
- merge WPAndroid PR (ideally, update fluxc's hash in WPAndroid after this PR is merged) 