### PR TITLE
Make PageStore.getLocalDraftPages return PostModel

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalDraftTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalDraftTest.kt
@@ -70,7 +70,7 @@ class PageStoreLocalDraftTest {
         // Assert
         assertThat(localDraftPages).hasSize(3)
         assertThat(localDraftPages).allMatch { it.title.startsWith(baseTitle) }
-        assertThat(localDraftPages.map { it.pageId }).isEqualTo(expectedPages.map { it.id })
+        assertThat(localDraftPages.map { it.id }).isEqualTo(expectedPages.map { it.id })
     }
 
     private fun createLocalDraft(localSiteId: Int, baseTitle: String = "Title") = PostModel().apply {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
@@ -182,10 +182,14 @@ class PageStore @Inject constructor(
         fetchPages(site, false)
     }
 
-    suspend fun getLocalDraftPages(site: SiteModel): List<PageModel> = withContext(coroutineContext) {
-        return@withContext PostSqlUtils.getLocalDrafts(site.id, true).map {
-            PageModel(post = it, site = site)
-        }
+    /**
+     * Get pages that have not been uploaded to the server yet.
+     *
+     * This returns [PostModel] instead of [PageModel] to accommodate the `UploadService` in WPAndroid which relies
+     * heavily on [PostModel]. When `UploadService` gets refactored, we should change this back to using [PageModel].
+     */
+    suspend fun getLocalDraftPages(site: SiteModel): List<PostModel> = withContext(coroutineContext) {
+        return@withContext PostSqlUtils.getLocalDrafts(site.id, true)
     }
 
     private fun fetchPages(site: SiteModel, loadMore: Boolean) {


### PR DESCRIPTION
This is part of https://github.com/wordpress-mobile/WordPress-Android/pull/9902. 

## Findings

In https://github.com/wordpress-mobile/WordPress-Android/pull/9902, I added support for uploading local draft pages to `LocalDraftUploadStarter`. I found that `UploadService` is heavily reliant on the `PostModel` class but the `PageStore. getLocalDraftPages()` I previously created in #1243 returns `PageModel`. 

I initially looked at using the `List<PageModel>` returned from `getLocalDraftPages()` to query the corresponding `PostModel` for them. This requires 2 queries for `LocalDraftUploadStarter`. I'd rather not have that if we can avoid it. 

I also thought of including the `PostModel` as a read-only property in `PageModel` but it felt odd and defeats the purpose of the `class`. Of course, I don't really know the goals of the `PageModel` class so please let me know if this is okay to do. 

## Solution

In this PR, I opted to return `PostModel` instead of `PageModel` in `getLocalDraftPages()`. 

Please let me know if the `PageModel` solution would be better. I'd be happy to change it. 

## Testing 

Please run the `PageStoreLocalDraftTest`. 