### PR TITLE
Fix intermittent Jetpack plugin test failures

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -257,9 +257,9 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         List<ImmutablePluginModel> plugins = mPluginStore.getPluginDirectory(site, PluginDirectoryType.SITE);
         assertTrue(plugins.size() > 0);
 
-        mDispatcher.dispatch(PluginActionBuilder.newRemoveSitePluginsAction(site));
         mNextEvent = TestEvents.REMOVED_SITE_PLUGINS;
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(PluginActionBuilder.newRemoveSitePluginsAction(site));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Assert site plugins are removed
@@ -530,10 +530,10 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
                                   TestEvents testEvent) throws InterruptedException {
         Assert.assertTrue(!TextUtils.isEmpty(plugin.getName()));
         Assert.assertTrue(!TextUtils.isEmpty(plugin.getSlug()));
-        mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(
-                new DeleteSitePluginPayload(site, plugin.getName(), plugin.getSlug())));
         mNextEvent = testEvent;
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(
+                new DeleteSitePluginPayload(site, plugin.getName(), plugin.getSlug())));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -543,10 +543,10 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
     private void installSitePlugin(SiteModel site, String pluginSlug,
                                    TestEvents testEvent) throws InterruptedException {
-        mDispatcher.dispatch(PluginActionBuilder.newInstallSitePluginAction(
-                new InstallSitePluginPayload(site, pluginSlug)));
         mNextEvent = testEvent;
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(PluginActionBuilder.newInstallSitePluginAction(
+                new InstallSitePluginPayload(site, pluginSlug)));
         // Since after install we dispatch an event to activate the plugin, we are giving twice the normal time to
         // ensure there is enough time to complete both events
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS));

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PluginTestJetpack.java
@@ -4,8 +4,6 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
-import junit.framework.Assert;
-
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
@@ -54,6 +52,7 @@ import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -167,7 +166,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
         List<ImmutablePluginModel> updatedPlugins = mPluginStore.getPluginDirectory(site, PluginDirectoryType.SITE);
         for (ImmutablePluginModel immutablePlugin : updatedPlugins) {
-            assertFalse(pluginSlugToInstall.equals(immutablePlugin.getSlug()));
+            assertNotEquals(pluginSlugToInstall, immutablePlugin.getSlug());
         }
 
         signOutWPCom();
@@ -200,7 +199,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
             }
         }
 
-        Assert.assertNotNull(activePluginToTest);
+        assertNotNull(activePluginToTest);
 
         // Trying to delete an active plugin should result in DELETE_SITE_PLUGIN_ERROR
         deleteSitePlugin(site, activePluginToTest, TestEvents.DELETE_SITE_PLUGIN_ERROR);
@@ -263,7 +262,7 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Assert site plugins are removed
-        assertTrue(mPluginStore.getPluginDirectory(site, PluginDirectoryType.SITE).size() == 0);
+        assertEquals(0, mPluginStore.getPluginDirectory(site, PluginDirectoryType.SITE).size());
 
         signOutWPCom();
     }
@@ -368,8 +367,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
         } else {
             assertEquals(mNextEvent, TestEvents.SITE_PLUGINS_FETCHED);
             assertEquals(event.type, PluginDirectoryType.SITE);
-            assertEquals(event.loadMore, false); // pagination is not enabled for site plugins
-            assertEquals(event.canLoadMore, false); // pagination is not enabled for site plugins
+            assertFalse(event.loadMore); // pagination is not enabled for site plugins
+            assertFalse(event.canLoadMore); // pagination is not enabled for site plugins
         }
         mCountDownLatch.countDown();
     }
@@ -528,8 +527,8 @@ public class ReleaseStack_PluginTestJetpack extends ReleaseStack_Base {
 
     private void deleteSitePlugin(SiteModel site, @NonNull ImmutablePluginModel plugin,
                                   TestEvents testEvent) throws InterruptedException {
-        Assert.assertTrue(!TextUtils.isEmpty(plugin.getName()));
-        Assert.assertTrue(!TextUtils.isEmpty(plugin.getSlug()));
+        assertTrue(!TextUtils.isEmpty(plugin.getName()));
+        assertTrue(!TextUtils.isEmpty(plugin.getSlug()));
         mNextEvent = testEvent;
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(


### PR DESCRIPTION
The `testPluginActionNotAvailable` test has been failing intermittently on CI:

```
06-08 00:13:13.706: I/TestRunner(7983): started: testPluginActionNotAvailable(org.wordpress.android.fluxc.release.ReleaseStack_PluginTestJetpack)
06-08 00:13:13.707: I/MonitoringInstr(7983): Activities that are still in CREATED to STOPPED: 0
06-08 00:13:13.768: D/WordPress-API(7983): SiteStore onRegister
06-08 00:13:13.771: D/WordPress-API(7983): AccountStore onRegister
06-08 00:13:13.774: D/WordPress-API(7983): PluginStore onRegister
06-08 00:13:13.774: D/WordPress-API(7983): Dispatching action: PluginAction-CONFIGURE_SITE_PLUGIN
06-08 00:13:13.775: D/WordPress-API(7983): Dispatching action: PluginAction-CONFIGURED_SITE_PLUGIN
06-08 00:13:13.775: I/WordPress-API(7983): Received onSitePluginConfigured
06-08 00:13:13.775: D/WordPress-API(7983): Dispatching action: PluginAction-CONFIGURE_SITE_PLUGIN
06-08 00:13:13.776: D/WordPress-API(7983): Dispatching action: PluginAction-CONFIGURED_SITE_PLUGIN
06-08 00:13:13.776: I/WordPress-API(7983): Received onSitePluginConfigured
06-08 00:13:13.776: D/WordPress-API(7983): Dispatching action: PluginAction-DELETE_SITE_PLUGIN
06-08 00:13:13.776: D/WordPress-API(7983): Dispatching action: PluginAction-DELETED_SITE_PLUGIN
06-08 00:13:13.776: I/WordPress-API(7983): Received onSitePluginDeleted
...
06-08 00:13:43.777: E/TestRunner(7983): failed: testPluginActionNotAvailable(org.wordpress.android.fluxc.release.ReleaseStack_PluginTestJetpack)
06-08 00:13:43.777: E/TestRunner(7983): ----- begin exception -----
06-08 00:13:43.782: E/TestRunner(7983): java.lang.AssertionError
06-08 00:13:43.782: E/TestRunner(7983): 	at org.junit.Assert.fail(Assert.java:86)
06-08 00:13:43.782: E/TestRunner(7983): 	at org.junit.Assert.assertTrue(Assert.java:41)
06-08 00:13:43.782: E/TestRunner(7983): 	at org.junit.Assert.assertTrue(Assert.java:52)
06-08 00:13:43.782: E/TestRunner(7983): 	at org.wordpress.android.fluxc.release.ReleaseStack_PluginTestJetpack.deleteSitePlugin(ReleaseStack_PluginTestJetpack.java:537)
06-08 00:13:43.782: E/TestRunner(7983): 	at org.wordpress.android.fluxc.release.ReleaseStack_PluginTestJetpack.testPluginActionNotAvailable(ReleaseStack_PluginTestJetpack.java:299)
...
```

 I haven't been able to reproduce it but I believe I have a guess as to what caused it, and it's probably the ordering in `deleteSitePlugin()`:

```kotlin
private void deleteSitePlugin(...) throws InterruptedException {
        ...
	mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(
			new DeleteSitePluginPayload(site, plugin.getName(), plugin.getSlug())));
	mNextEvent = testEvent;
	mCountDownLatch = new CountDownLatch(1);
	assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
}
```

1. `mCountDownLatch`: count 0
2. `DELETE_SITE_PLUGIN` action is dispatched
3. Action is completed (it's handled locally so very fast)
4. `DELETED_SITE_PLUGIN` action is dispatched
5. `onSitePluginDeleted()` is called, before the `mCountDownLatch = new CountDownLatch(1);` line in the function above
6. `mCountDownLatch.countDown()` is called - count is already 0, nothing happens (execution proceeds)
7. The rest of the `deleteSitePlugin` method is called, `mCountDownLatch`: count 1
8. `assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));` is called after the `countDown()` was already called in step 6, and it just ends up timing out and failing the test

We tend to init the `CountDownLatch` before dispatching because this sort of thing can happen - I reordered things in this function and elsewhere in this class to hopefully address the issue.

### To test
You could try reproducing the failure (and then confirm that this fixes it), I didn't have much luck. 

But otherwise it's enough to confirm that my guess at the problem makes sense and that this would solve it, and the tests pass.