### PR TITLE
Distinguish 2FA auth errors when fetching account settings

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -71,8 +71,8 @@ public class AccountRestClient extends BaseWPComRestClient {
 
     private final AppSecrets mAppSecrets;
 
-    public static class AccountRestPayload extends Payload<BaseNetworkError> {
-        public AccountRestPayload(AccountModel account, BaseNetworkError error) {
+    public static class AccountRestPayload extends Payload<WPComGsonNetworkError> {
+        public AccountRestPayload(AccountModel account, WPComGsonNetworkError error) {
             this.account = account;
             this.error = error;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -959,6 +959,11 @@ public class AccountStore extends Store {
 
             AccountErrorType errorType;
             if (payload.error.apiError.equals("reauthorization_required")) {
+                // This error will always occur for 2FA accounts when using a non-production WordPress.com OAuth client.
+                // Essentially, some APIs around account management are disabled in those cases for security reasons.
+                // The error is a bit generic from the server-side - it essentially means the user isn't privileged to
+                // do the action and needs to reauthorize. For bearer token-based login, there is no escalation of
+                // privileges possible, so the request just fails at that point.
                 errorType = AccountErrorType.SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR;
             } else {
                 errorType = AccountErrorType.SETTINGS_FETCH_GENERIC_ERROR;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -954,19 +954,15 @@ public class AccountStore extends Store {
             mAccount.copyAccountSettingsAttributes(payload.account);
             updateDefaultAccount(mAccount, AccountAction.FETCH_SETTINGS);
         } else {
-            if (payload.error != null) {
-                OnAccountChanged accountChanged = new OnAccountChanged();
-                AccountErrorType errorType;
-                if (payload.error.apiError.equals("reauthorization_required")) {
-                    errorType = AccountErrorType.SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR;
-                } else {
-                    errorType = AccountErrorType.SETTINGS_FETCH_GENERIC_ERROR;
-                }
-                accountChanged.error = new AccountError(errorType, payload.error.message);
-                emitChange(accountChanged);
+            OnAccountChanged accountChanged = new OnAccountChanged();
+            AccountErrorType errorType;
+            if (payload.error.apiError.equals("reauthorization_required")) {
+                errorType = AccountErrorType.SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR;
             } else {
-                emitAccountChangeError(AccountErrorType.SETTINGS_FETCH_GENERIC_ERROR);
+                errorType = AccountErrorType.SETTINGS_FETCH_GENERIC_ERROR;
             }
+            accountChanged.error = new AccountError(errorType, payload.error.message);
+            emitChange(accountChanged);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -955,6 +955,8 @@ public class AccountStore extends Store {
             updateDefaultAccount(mAccount, AccountAction.FETCH_SETTINGS);
         } else {
             OnAccountChanged accountChanged = new OnAccountChanged();
+            accountChanged.causeOfChange = AccountAction.FETCH_SETTINGS;
+
             AccountErrorType errorType;
             if (payload.error.apiError.equals("reauthorization_required")) {
                 errorType = AccountErrorType.SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR;
@@ -962,6 +964,7 @@ public class AccountStore extends Store {
                 errorType = AccountErrorType.SETTINGS_FETCH_GENERIC_ERROR;
             }
             accountChanged.error = new AccountError(errorType, payload.error.message);
+
             emitChange(accountChanged);
         }
     }


### PR DESCRIPTION
Adds a distinct error type for the `reauthorization_required` API error, so we can identify it from the host app.

Part of the fix for https://github.com/wordpress-mobile/WordPress-Android/issues/8754. There will be a counterpart WPAndroid issue making use of the change.

We get this error for 2FA accounts when using a non-production WordPress.com OAuth client. Essentially, some APIs around account management are disabled in those cases for security reasons.

The error is a bit generic from the server-side - it essentially means the user isn't privileged to do the action (in this case, calling the `/me/settings/` endpoint) and needs to reauthorize. For bearer token-based login, there is no escalation of privileges possible, so the request just fails at that point. If using production credentials, this error should never be seen. This is pretty deeply embedded and I don't think it's worth changing server-side for a development-only issue.

### To test
Verify the connected account tests are still passing. There isn't otherwise a great way to test this in an automated way due to 2FA being required, but you can test this from the example app:
1. Generate an OAuth client id and secret for an account that has 2fa enabled ([instructions](https://github.com/wordpress-mobile/WordPress-Android/#oauth2-authentication)).
2. Update `wp.OAUTH.APP.ID` and `wp.OAUTH.APP.SECRET` in `example/gradle.properties` to those values.
3. Run the example app, and log into the account the credentials belong to.
4. Confirm that you see a `SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR` in the log, but otherwise things are working.

(These steps are similar to the WPAndroid ones I'll be sharing in the counterpart PR.)