### PR TITLE
Add foreign key relationship between SiteModel and NotificationModel

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.example.ThreeEditTextDialog.Listener;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated;
@@ -101,6 +102,16 @@ public class SitesFragment extends Fragment {
                 SiteModel site = mSiteStore.getSites().get(0);
                 // Delete site
                 mDispatcher.dispatch(SiteActionBuilder.newDeleteSiteAction(site));
+            }
+        });
+
+        view.findViewById(R.id.delete_first_site_db).setOnClickListener(new OnClickListener() {
+            @Override public void onClick(View v) {
+                SiteModel site = mSiteStore.getSites().get(0);
+                // Delete site from db
+                SiteSqlUtils.deleteSite(site);
+
+                prependToLog("Site " + site.getName() + "has been deleted from the db");
             }
         });
 

--- a/example/src/main/res/layout/fragment_sites.xml
+++ b/example/src/main/res/layout/fragment_sites.xml
@@ -48,6 +48,12 @@
         android:text="⚠️️ Delete First Site ⚠️️" />
 
     <Button
+        android:id="@+id/delete_first_site_db"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Delete First Site (DB Only)"/>
+
+    <Button
         android:id="@+id/fetch_plans"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -26,6 +26,13 @@ import kotlin.test.assertNull
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
 class NotificationSqlUtilsTest {
+    // All notifications require a matching [SiteModel] in the database in order to save
+    // to the database due to a foreign key constraint
+    private val site = SiteModel().apply {
+        name = "Unit Test Site"
+        url = "https://www.mytestsite.com"
+    }
+
     @Before
     fun setUp() {
         val appContext = RuntimeEnvironment.application.applicationContext
@@ -35,21 +42,17 @@ class NotificationSqlUtilsTest {
                 "")
         WellSql.init(config)
         config.reset()
+
+        // Save the test [SiteModel] to the db
+        saveSiteToDb(site)
     }
 
     @Test
     fun testInsertOrUpdateNotifications() {
-        val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
-        } ?: emptyList()
-
         // Test inserting notifications
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
+        val notesList = notificationSqlUtils.getNotifications()
 
         // Test updating notifications
         val newNote = notesList[0].copy(noteId = -1, remoteNoteId = 333)
@@ -65,14 +68,7 @@ class NotificationSqlUtilsTest {
     fun testGetNotifications() {
         // Insert notifications
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
 
         // Get notifications
         val notifications = notificationSqlUtils.getNotifications(SelectQuery.ORDER_DESCENDING)
@@ -83,20 +79,11 @@ class NotificationSqlUtilsTest {
     fun testGetNotificationsForSite() {
         // Insert notifications
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
-        val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
 
         // Get notifications
         val notifications = notificationSqlUtils.getNotificationsForSite(site, SelectQuery.ORDER_DESCENDING)
-        assertEquals(3, notifications.size)
+        assertEquals(6, notifications.size)
     }
 
     @Test
@@ -106,7 +93,6 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/store-order-notification.json")
         val apiResponse = NotificationTestUtils.parseNotificationApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 141286411 }
         val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse, site.id))
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(1, inserted)
@@ -119,7 +105,7 @@ class NotificationSqlUtilsTest {
         val note = notifications[0]
         assertEquals(note.title, "New Order")
         assertEquals(note.noteHash, 2064099309)
-        assertEquals(note.localSiteId, 141286411)
+        assertEquals(note.localSiteId, site.id)
         assertEquals(note.remoteNoteId, 3604874081)
         assertEquals(note.type, NotificationModel.Kind.STORE_ORDER)
         assertEquals(note.read, true)
@@ -186,7 +172,6 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/store-review-notification.json")
         val apiResponse = NotificationTestUtils.parseNotificationApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
         val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse, site.id))
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(1, inserted)
@@ -201,7 +186,7 @@ class NotificationSqlUtilsTest {
         val note = notifications[0]
         assertEquals(note.noteHash, 1543255567)
         assertEquals(note.title, "Product Review")
-        assertEquals(note.localSiteId, 153482281)
+        assertEquals(note.localSiteId, site.id)
         assertEquals(note.remoteNoteId, 3617558725)
         assertEquals(note.type, NotificationModel.Kind.COMMENT)
         assertEquals(note.read, true)
@@ -220,14 +205,7 @@ class NotificationSqlUtilsTest {
     fun testGetNotifications_filterBy() {
         // Insert notifications
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
 
         // Get notifications of type "store_order"
         val newOrderNotifications = notificationSqlUtils.getNotifications(
@@ -248,40 +226,43 @@ class NotificationSqlUtilsTest {
 
     @Test
     fun testGetNotificationsForSite_filterBy() {
-        // Insert notifications
+        // Insert notifications for main test site
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
-        val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
+
+        // Insert notifications for additional test site
+        val site2 = SiteModel().apply {
+            name = "Test Site 2"
+            url = "https://someothertestsite.com"
+        }
+        saveSiteToDb(site2)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site2)
+
+        // Verify we have 12 total notifications in the db
+        val allNotifs = notificationSqlUtils.getNotifications()
+        assertEquals(12, allNotifs.size)
 
         // Get notifications of type "store_order".
         //
-        // Note: TWO store_order notifications were inserted into the db, but they belong to two
-        // different sites so only 1 should be returned.
+        // Note: FOUR store_order notifications were inserted into the db, but they belong to two
+        // different sites so only 2 should be returned.
         val newOrderNotifications = notificationSqlUtils.getNotificationsForSite(
-                site,
+                site2,
                 filterByType = listOf(NotificationModel.Kind.STORE_ORDER.toString()))
-        assertEquals(1, newOrderNotifications.size)
+        assertEquals(2, newOrderNotifications.size)
 
         // Get notifications of subtype "store_review"
         val storeReviewNotifications = notificationSqlUtils.getNotificationsForSite(
-                site,
+                site2,
                 filterBySubtype = listOf(NotificationModel.Subkind.STORE_REVIEW.toString()))
         assertEquals(2, storeReviewNotifications.size)
 
         // Get notifications of type "store_order" or subtype "store_review"
         val combinedNotifications = notificationSqlUtils.getNotificationsForSite(
-                site,
+                site2,
                 filterByType = listOf(NotificationModel.Kind.STORE_ORDER.toString()),
                 filterBySubtype = listOf(NotificationModel.Subkind.STORE_REVIEW.toString()))
-        assertEquals(3, combinedNotifications.size)
+        assertEquals(4, combinedNotifications.size)
     }
 
     @Test
@@ -290,25 +271,16 @@ class NotificationSqlUtilsTest {
 
         // Insert notifications
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
-        val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
 
         // Fetch a single notification using the noteIdSet
         val idSet = NoteIdSet(-1, noteId, site.id)
         val notification = notificationSqlUtils.getNotificationByIdSet(idSet)
         assertNotNull(notification)
 
-        notification?.let {
-            assertEquals(it.remoteNoteId, noteId)
-            assertEquals(it.localSiteId, site.id)
+        with(notification) {
+            assertEquals(remoteNoteId, noteId)
+            assertEquals(localSiteId, site.id)
         }
     }
 
@@ -318,24 +290,15 @@ class NotificationSqlUtilsTest {
 
         // Insert notifications
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
-        val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
 
         // Fetch a single notification using the remoteNoteId
         val notification = notificationSqlUtils.getNotificationByRemoteId(noteId)
         assertNotNull(notification)
 
-        notification?.let {
-            assertEquals(it.remoteNoteId, noteId)
-            assertEquals(it.localSiteId, site.id)
+        with(notification) {
+            assertEquals(remoteNoteId, noteId)
+            assertEquals(localSiteId, site.id)
         }
     }
 
@@ -343,14 +306,7 @@ class NotificationSqlUtilsTest {
     fun testGetNotificationCount() {
         // Insert notifications
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
 
         // Get notifications
         val count = notificationSqlUtils.getNotificationsCount()
@@ -360,16 +316,8 @@ class NotificationSqlUtilsTest {
     @Test
     fun testHasUnreadNotifications() {
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
 
-        val site = SiteModel().apply { id = 0 }
         val hasUnread = notificationSqlUtils.hasUnreadNotificationsForSite(site)
         assertEquals(hasUnread, true)
     }
@@ -380,16 +328,7 @@ class NotificationSqlUtilsTest {
 
         // Insert notifications
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
-        val jsonString = UnitTestUtils
-                .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
-        val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
-        val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
-        } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
-        assertEquals(6, inserted)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
 
         // Fetch a single notification
         val notification = notificationSqlUtils.getNotificationByRemoteId(noteId)
@@ -406,35 +345,48 @@ class NotificationSqlUtilsTest {
     @Test
     fun testDeleteSiteCascadesToNotificationTable() {
         // Assemble:
-        // - Insert a [SiteModel] record into the database
-        // - Insert notification records with [local_site_id] matching above [SiteModel] into the database
-        val site = SiteModel().apply {
-            name = "Unit Test Site"
-            url = "https://www.mytestsite.com"
-        }
-        val siteRowsAffected = SiteSqlUtils.insertOrUpdateSite(site)
-        assertEquals(1, siteRowsAffected)
-        val savedSite = SiteSqlUtils.getSitesByNameOrUrlMatching(site.name).firstOrNull()
-        assertNotNull(savedSite)
-        assertEquals(site.name, savedSite.name)
-
+        // - Insert notifications for main test site
+        // - Insert notifications for additional test site
+        // - Verify we have 12 total notifications in the db
         val notificationSqlUtils = NotificationSqlUtils(FormattableContentMapper(Gson()))
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site)
+
+        val site2 = SiteModel().apply {
+            name = "Test Site 2"
+            url = "https://someothertestsite.com"
+        }
+        saveSiteToDb(site2)
+        generateAndSaveTestNotificationsToDb(notificationSqlUtils, site2)
+
+        val allNotifs = notificationSqlUtils.getNotifications()
+        assertEquals(12, allNotifs.size)
+
+        // Act:
+        // - Delete the site from the database
+        SiteSqlUtils.deleteSite(site2)
+
+        // Assert:
+        // - Verify all the notifications for site2 have also been deleted from the database
+        val savedNotifs = notificationSqlUtils.getNotifications()
+        assertEquals(6, savedNotifs.size)
+    }
+
+    private fun generateAndSaveTestNotificationsToDb(sqlUtils: NotificationSqlUtils, siteModel: SiteModel) {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, savedSite.id)
+            NotificationApiResponse.notificationResponseToNotificationModel(it, siteModel.id)
         } ?: emptyList()
-        val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
+        val inserted = notesList.sumBy { sqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
+    }
 
-        // Act:
-        // - Delete the site from the database
-        SiteSqlUtils.deleteSite(savedSite)
-
-        // Assert:
-        // - Verify all the notifications have also been deleted from the database
-        val savedNotifs = notificationSqlUtils.getNotifications()
-        assertEquals(0, savedNotifs.size)
+    private fun saveSiteToDb(siteModel: SiteModel) {
+        val siteRowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel)
+        assertEquals(1, siteRowsAffected)
+        val savedSite = SiteSqlUtils.getSitesByNameOrUrlMatching(siteModel.name).firstOrNull()
+        assertNotNull(savedSite)
+        assertEquals(siteModel.name, savedSite.name)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -8,6 +8,7 @@ import com.yarolegovich.wellsql.WellSql
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.notification.NoteIdSet
@@ -207,6 +208,10 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
     }
 
     @Table(name = "NotificationModel")
+    @RawConstraints(
+            "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+            "UNIQUE (REMOTE_NOTE_ID, LOCAL_SITE_ID) ON CONFLICT REPLACE"
+    )
     data class NotificationModelBuilder(
         @PrimaryKey @Column private var mId: Int = -1,
         @Column var remoteNoteId: Long,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 68;
+        return 69;
     }
 
     @Override
@@ -515,6 +515,15 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 67:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
+            case 68:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS NotificationModel");
+                db.execSQL("CREATE TABLE NotificationModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                           + "REMOTE_NOTE_ID INTEGER,LOCAL_SITE_ID INTEGER,NOTE_HASH INTEGER,TYPE TEXT,"
+                           + "SUBTYPE TEXT,READ INTEGER,ICON TEXT,NOTICON TEXT,TIMESTAMP TEXT,URL TEXT,"
+                           + "TITLE TEXT,FORMATTABLE_BODY TEXT,FORMATTABLE_SUBJECT TEXT,FORMATTABLE_META TEXT, "
+                           + "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
Fixes #1284 by adding a foreign key for `local_site_id` that depends on `SiteModel`. If the matching site is deleted, the records matching that `local_site_id` in `NotificationModel` will deleted automatically. 

This PR includes:
- Update to `NotificationModelBuilder` to add the foreign key
- Update to `WellSqlConfig` to drop `NotificationModel` on upgrade and recreate the table with the foreign key
- Updated tests to account for the new `SiteModel` db dependency as well as a test to verify that the `on delete cascade` works
- New `DELETE FIRST SITE (DB ONLY)` button in the Sites section of the example app. This allows for testing by:
1.  Log in with a Woo account
2. In the Notifications page, fetch all notifications from the API
3. In the Sites page, delete the first site from the db
4. Verify the `NotificationModel` table using Stethos.

<img src="https://user-images.githubusercontent.com/5810477/59648191-6aa7f180-913b-11e9-80a9-1cae1c2da3a6.png" width="300"/>
