### PR TITLE
Issue/fixing transaction client parameter type

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
@@ -34,7 +34,7 @@ class ReleaseStack_TransactionsTest : ReleaseStack_WPComBase() {
 
     companion object {
         private const val TEST_DOMAIN_NAME = "superrandomdomain192849347.blog"
-        private const val TEST_DOMAIN_PRODUCT_ID = "76"
+        private const val TEST_DOMAIN_PRODUCT_ID = 76
         private val TEST_DOMAIN_CONTACT_MODEL = DomainContactModel(
                 "Wapu",
                 "Wordpress",
@@ -132,8 +132,7 @@ class ReleaseStack_TransactionsTest : ReleaseStack_WPComBase() {
         assertTrue(event.cartDetails!!.products!!.isNotEmpty())
 
         val domainProductInCart = event.cartDetails!!.products!!.find {
-            it.product_id == TEST_DOMAIN_PRODUCT_ID &&
-                    it.meta == TEST_DOMAIN_NAME
+            it.product_id == TEST_DOMAIN_PRODUCT_ID && it.meta == TEST_DOMAIN_NAME && it.extra.privacy
         }
         assertNotNull(domainProductInCart)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsFixtures.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.transactions
 
 import org.wordpress.android.fluxc.model.DomainContactModel
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Extra
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Product
 
 val SUPPORTED_COUNTRIES_MODEL = arrayOf(
@@ -12,8 +13,8 @@ val CREATE_SHOPPING_CART_RESPONSE = CreateShoppingCartResponse(
         76,
         22.toString(),
         listOf(
-                Product("76", "superraredomainname156726.blog"),
-                Product("1001", "other product")
+                Product(76, "superraredomainname156726.blog", Extra(true)),
+                Product(1001, "other product", Extra(true))
         )
 )
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
@@ -34,7 +34,7 @@ class TransactionsStoreTest {
 
     companion object {
         private const val TEST_DOMAIN_NAME = "superraredomainname156726.blog"
-        private const val TEST_DOMAIN_PRODUCT_ID = "76"
+        private const val TEST_DOMAIN_PRODUCT_ID = 76
     }
 
     @ExperimentalCoroutinesApi

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainSuggestionResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainSuggestionResponse.java
@@ -8,7 +8,7 @@ public class DomainSuggestionResponse implements Response {
     public boolean is_free;
     public boolean supports_privacy;
 
-    public String product_id;
+    public int product_id;
     public String product_slug;
     public String vendor;
     public float relevance;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
@@ -68,7 +68,7 @@ constructor(
         )
 
         val params = mapOf(
-                "temporary" to "true",
+                "temporary" to true,
                 "products" to arrayOf(domainProduct)
         )
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
@@ -133,8 +133,11 @@ constructor(
         val products: List<Product>?
     ) : Response {
         data class Product(
-            val product_id: String?,
-            val meta: String?
+            val product_id: Int,
+            val meta: String?,
+            val extra: Extra
         )
+
+        data class Extra(val privacy: Boolean)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
@@ -55,7 +55,7 @@ constructor(
 
     suspend fun createShoppingCart(
         site: SiteModel,
-        productId: String,
+        productId: Int,
         domainName: String,
         isPrivacyProtectionEnabled: Boolean
     ): CreatedShoppingCartPayload {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
@@ -133,7 +133,7 @@ class TransactionsStore @Inject constructor(
 
     class CreateShoppingCartPayload(
         val site: SiteModel,
-        val productId: String,
+        val productId: Int,
         val domainName: String,
         val isPrivacyEnabled: Boolean
     ) : Payload<BaseRequest.BaseNetworkError>()


### PR DESCRIPTION
Anyone is free to review this PR.

Changed types of some parameters we pass to/receive from the Transactions back end and added a new parameter to `CreateShoppingCartResponse`.