### PR TITLE
Add new field into MediaModel

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -235,6 +235,7 @@ public class MediaSqlUtilsTest {
         boolean testVerticalAlign = false;
         boolean testFeatured = false;
         boolean testFeaturedInPost = false;
+        boolean testMarkedLocallyAsFeatured = false;
         MediaModel testModel = new MediaModel();
         testModel.setMediaId(testId);
         testModel.setPostId(testPostId);
@@ -262,6 +263,7 @@ public class MediaSqlUtilsTest {
         testModel.setVerticalAlignment(testVerticalAlign);
         testModel.setFeatured(testFeatured);
         testModel.setFeaturedInPost(testFeaturedInPost);
+        testModel.setMarkedLocallyAsFeatured(testMarkedLocallyAsFeatured);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testModel));
         testModel.setPostId(testPostId + 1);
         testModel.setAuthorId(testAuthorId + 1);
@@ -287,6 +289,7 @@ public class MediaSqlUtilsTest {
         testModel.setVerticalAlignment(!testVerticalAlign);
         testModel.setFeatured(!testFeatured);
         testModel.setFeaturedInPost(!testFeaturedInPost);
+        testModel.setMarkedLocallyAsFeatured(!testMarkedLocallyAsFeatured);
         Assert.assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(testModel));
         List<MediaModel> media = MediaSqlUtils.getAllSiteMedia(getTestSiteWithLocalId(testLocalSiteId));
         Assert.assertEquals(1, media.size());
@@ -316,6 +319,7 @@ public class MediaSqlUtilsTest {
         Assert.assertEquals(!testVerticalAlign, testMedia.getVerticalAlignment());
         Assert.assertEquals(!testFeatured, testMedia.getFeatured());
         Assert.assertEquals(!testFeaturedInPost, testMedia.getFeaturedInPost());
+        Assert.assertEquals(!testMarkedLocallyAsFeatured, testMedia.getMarkedLocallyAsFeatured());
     }
 
     // Inserts many items with matching titles, deletes all media with the title, verifies

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -72,6 +72,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
 
     // Local only
     @Column private String mUploadState;
+    @Column private boolean mMarkedLocallyAsFeatured;
 
     // Other Sizes. Only available for images on self-hosted (xmlrpc layer) sites
     @Column private String mFileUrlMediumSize;
@@ -106,6 +107,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
                 && getVideoPressProcessingDone() == otherMedia.getVideoPressProcessingDone()
                 && getFeatured() == otherMedia.getFeatured()
                 && getFeaturedInPost() == otherMedia.getFeaturedInPost()
+                && getMarkedLocallyAsFeatured() == otherMedia.getMarkedLocallyAsFeatured()
                 && StringUtils.equals(getGuid(), otherMedia.getGuid())
                 && StringUtils.equals(getUploadDate(), otherMedia.getUploadDate())
                 && StringUtils.equals(getUrl(), otherMedia.getUrl())
@@ -357,6 +359,14 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
 
     public void setFeaturedInPost(boolean featuredInPost) {
         mFeaturedInPost = featuredInPost;
+    }
+
+    public boolean getMarkedLocallyAsFeatured() {
+        return mMarkedLocallyAsFeatured;
+    }
+
+    public void setMarkedLocallyAsFeatured(boolean markedLocallyAsFeatured) {
+        mMarkedLocallyAsFeatured = markedLocallyAsFeatured;
     }
 
     public boolean getFeaturedInPost() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -217,6 +217,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         MediaModel uploadedMedia = responseMedia.get(0);
                         uploadedMedia.setId(media.getId());
                         uploadedMedia.setLocalPostId(media.getLocalPostId());
+                        uploadedMedia.setMarkedLocallyAsFeatured(media.getMarkedLocallyAsFeatured());
 
                         notifyMediaUploaded(uploadedMedia, null);
                     } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 70;
+        return 71;
     }
 
     @Override
@@ -528,6 +528,10 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 69:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
+            case 70:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("ALTER TABLE MediaModel ADD MARKED_LOCALLY_AS_FEATURED INTEGER");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
Corresponding WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/10079


This PR adds a new field into the MediaModel so we can differentiate regular media uploads from featured image uploads.
