### PR TITLE
Notifications: Remove localSiteId and replace with remoteSiteId 

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -153,7 +153,7 @@ class MockedStack_NotificationTest : MockedStack_Base() {
     @Test
     fun testFetchNotificationsSuccess() {
         interceptor.respondWith("fetch-notifications-response-success.json")
-        notificationRestClient.fetchNotifications(siteStore)
+        notificationRestClient.fetchNotifications()
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -202,7 +202,7 @@ class MockedStack_NotificationTest : MockedStack_Base() {
         assertNotNull(payload.notification)
         with(payload) {
             assertEquals(notification!!.remoteNoteId, remoteNoteId)
-            assertEquals(notification!!.getRemoteSiteId(), remoteSiteId)
+            assertEquals(notification!!.remoteSiteId, remoteSiteId)
         }
     }
 
@@ -223,13 +223,13 @@ class MockedStack_NotificationTest : MockedStack_Base() {
 
     @Test
     fun testMarkSingleNotificationReadSuccess() {
-        val testNoteIdSet = NoteIdSet(0, 22L, 2)
+        val testNoteIdSet = NoteIdSet(0, 22L, 2L)
 
         interceptor.respondWith("mark-notification-read-response-success.json")
         notificationRestClient.markNotificationRead(
                 listOf(NotificationModel(
                         remoteNoteId = testNoteIdSet.remoteNoteId,
-                        localSiteId = testNoteIdSet.localSiteId)))
+                        remoteSiteId = testNoteIdSet.remoteSiteId)))
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -248,21 +248,21 @@ class MockedStack_NotificationTest : MockedStack_Base() {
 
     @Test
     fun testMarkMultipleNotificationsReadSuccess() {
-        val testNoteIdSet1 = NoteIdSet(0, 22L, 2)
-        val testNoteIdSet2 = NoteIdSet(0, 33L, 3)
-        val testNoteIdSet3 = NoteIdSet(0, 44L, 4)
+        val testNoteIdSet1 = NoteIdSet(0, 22L, 2L)
+        val testNoteIdSet2 = NoteIdSet(0, 33L, 3L)
+        val testNoteIdSet3 = NoteIdSet(0, 44L, 4L)
 
         interceptor.respondWith("mark-notification-read-response-success.json")
         notificationRestClient.markNotificationRead(listOf(
                 NotificationModel(
                         remoteNoteId = testNoteIdSet1.remoteNoteId,
-                        localSiteId = testNoteIdSet1.localSiteId),
+                        remoteSiteId = testNoteIdSet1.remoteSiteId),
                 NotificationModel(
                         remoteNoteId = testNoteIdSet2.remoteNoteId,
-                        localSiteId = testNoteIdSet2.localSiteId),
+                        remoteSiteId = testNoteIdSet2.remoteSiteId),
                 NotificationModel(
                         remoteNoteId = testNoteIdSet3.remoteNoteId,
-                        localSiteId = testNoteIdSet3.localSiteId)))
+                        remoteSiteId = testNoteIdSet3.remoteSiteId)))
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -276,15 +276,15 @@ class MockedStack_NotificationTest : MockedStack_Base() {
         assertEquals(3, payload.notifications!!.size)
         with(payload.notifications!![0]) {
             assertEquals(remoteNoteId, testNoteIdSet1.remoteNoteId)
-            assertEquals(localSiteId, testNoteIdSet1.localSiteId)
+            assertEquals(remoteSiteId, testNoteIdSet1.remoteSiteId)
         }
         with(payload.notifications!![1]) {
             assertEquals(remoteNoteId, testNoteIdSet2.remoteNoteId)
-            assertEquals(localSiteId, testNoteIdSet2.localSiteId)
+            assertEquals(remoteSiteId, testNoteIdSet2.remoteSiteId)
         }
         with(payload.notifications!![2]) {
             assertEquals(remoteNoteId, testNoteIdSet3.remoteNoteId)
-            assertEquals(localSiteId, testNoteIdSet3.localSiteId)
+            assertEquals(remoteSiteId, testNoteIdSet3.remoteSiteId)
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -82,7 +82,7 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
+        val site = SiteModel().apply { siteId = 153482281 }
         val notesList = apiResponse.notes?.map {
             NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
@@ -101,7 +101,7 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/store-order-notification.json")
         val apiResponse = NotificationTestUtils.parseNotificationApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 141286411 }
+        val site = SiteModel().apply { siteId = 141286411 }
         val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse))
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(1, inserted)
@@ -181,7 +181,7 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/store-review-notification.json")
         val apiResponse = NotificationTestUtils.parseNotificationApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
+        val site = SiteModel().apply { siteId = 153482281 }
         val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse))
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(1, inserted)
@@ -248,7 +248,7 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
+        val site = SiteModel().apply { siteId = 153482281 }
         val notesList = apiResponse.notes?.map {
             NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
@@ -287,7 +287,7 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
+        val site = SiteModel().apply { siteId = 153482281 }
         val notesList = apiResponse.notes?.map {
             NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
@@ -312,7 +312,7 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
+        val site = SiteModel().apply { siteId = 153482281 }
         val notesList = apiResponse.notes?.map {
             NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
@@ -357,7 +357,7 @@ class NotificationSqlUtilsTest {
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
 
-        val site = SiteModel().apply { id = 0 }
+        val site = SiteModel().apply { siteId = 153482281 }
         val hasUnread = notificationSqlUtils.hasUnreadNotificationsForSite(site)
         assertEquals(hasUnread, true)
     }
@@ -371,7 +371,6 @@ class NotificationSqlUtilsTest {
         val jsonString = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
-        val site = SiteModel().apply { id = 153482281 }
         val notesList = apiResponse.notes?.map {
             NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()

--- a/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/notifications/NotificationSqlUtilsTest.kt
@@ -40,7 +40,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
 
         // Test inserting notifications
@@ -65,7 +65,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
@@ -84,8 +84,7 @@ class NotificationSqlUtilsTest {
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
         val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
@@ -103,7 +102,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/store-order-notification.json")
         val apiResponse = NotificationTestUtils.parseNotificationApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 141286411 }
-        val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse, site.id))
+        val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse))
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(1, inserted)
 
@@ -115,7 +114,7 @@ class NotificationSqlUtilsTest {
         val note = notifications[0]
         assertEquals(note.title, "New Order")
         assertEquals(note.noteHash, 2064099309)
-        assertEquals(note.localSiteId, 141286411)
+        assertEquals(note.remoteSiteId, 141286411)
         assertEquals(note.remoteNoteId, 3604874081)
         assertEquals(note.type, NotificationModel.Kind.STORE_ORDER)
         assertEquals(note.read, true)
@@ -183,7 +182,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/store-review-notification.json")
         val apiResponse = NotificationTestUtils.parseNotificationApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
-        val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse, site.id))
+        val notesList = listOf(NotificationApiResponse.notificationResponseToNotificationModel(apiResponse))
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(1, inserted)
 
@@ -197,7 +196,7 @@ class NotificationSqlUtilsTest {
         val note = notifications[0]
         assertEquals(note.noteHash, 1543255567)
         assertEquals(note.title, "Product Review")
-        assertEquals(note.localSiteId, 153482281)
+        assertEquals(note.remoteSiteId, 153482281)
         assertEquals(note.remoteNoteId, 3617558725)
         assertEquals(note.type, NotificationModel.Kind.COMMENT)
         assertEquals(note.read, true)
@@ -220,7 +219,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
@@ -251,8 +250,7 @@ class NotificationSqlUtilsTest {
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
         val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
@@ -291,19 +289,18 @@ class NotificationSqlUtilsTest {
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
         val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
 
         // Fetch a single notification using the noteIdSet
-        val idSet = NoteIdSet(-1, noteId, site.id)
+        val idSet = NoteIdSet(-1, noteId, site.siteId)
         val notification = notificationSqlUtils.getNotificationByIdSet(idSet)
         assertNotNull(notification)
 
         assertEquals(notification.remoteNoteId, noteId)
-        assertEquals(notification.localSiteId, site.id)
+        assertEquals(notification.remoteSiteId, site.siteId)
     }
 
     @Test
@@ -317,8 +314,7 @@ class NotificationSqlUtilsTest {
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
         val notesList = apiResponse.notes?.map {
-            val siteId = NotificationApiResponse.getRemoteSiteId(it)
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId!!.toInt())
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
@@ -328,7 +324,7 @@ class NotificationSqlUtilsTest {
         assertNotNull(notification)
 
         assertEquals(notification.remoteNoteId, noteId)
-        assertEquals(notification.localSiteId, site.id)
+        assertEquals(notification.remoteSiteId, site.siteId)
     }
 
     @Test
@@ -339,7 +335,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
@@ -356,7 +352,7 @@ class NotificationSqlUtilsTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/notifications-api-response.json")
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val notesList = apiResponse.notes?.map {
-            NotificationApiResponse.notificationResponseToNotificationModel(it, 0)
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)
@@ -377,8 +373,7 @@ class NotificationSqlUtilsTest {
         val apiResponse = NotificationTestUtils.parseNotificationsApiResponseFromJsonString(jsonString)
         val site = SiteModel().apply { id = 153482281 }
         val notesList = apiResponse.notes?.map {
-            val siteId = site.id
-            NotificationApiResponse.notificationResponseToNotificationModel(it, siteId)
+            NotificationApiResponse.notificationResponseToNotificationModel(it)
         } ?: emptyList()
         val inserted = notesList.sumBy { notificationSqlUtils.insertOrUpdateNotification(it) }
         assertEquals(6, inserted)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NoteIdSet.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NoteIdSet.kt
@@ -1,3 +1,3 @@
 package org.wordpress.android.fluxc.model.notification
 
-data class NoteIdSet(val id: Int, val remoteNoteId: Long, val localSiteId: Int)
+data class NoteIdSet(val id: Int, val remoteNoteId: Long, val remoteSiteId: Long)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 data class NotificationModel(
     val noteId: Int = 0,
     val remoteNoteId: Long = 0L,
-    var localSiteId: Int = 0,
+    var remoteSiteId: Long = 0L,
     var noteHash: Long = 0L,
     val type: Kind = Kind.UNKNOWN,
     val subtype: Subkind? = Subkind.NONE,
@@ -61,10 +61,8 @@ data class NotificationModel(
         }
     }
 
-    fun getRemoteSiteId(): Long? = meta?.ids?.site
-
     fun toLogString(): String {
         return "[id=$noteId, remoteNoteId=$remoteNoteId, read=$read, " +
-                "localSiteId=$localSiteId, type=${type.name}, subtype=${subtype?.name}, title=$title]"
+                "siteId=$remoteSiteId, type=${type.name}, subtype=${subtype?.name}, title=$title]"
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -9,8 +9,8 @@ data class NotificationModel(
     val remoteNoteId: Long = 0L,
     var localSiteId: Int = 0,
     var noteHash: Long = 0L,
-    val type: Kind = NotificationModel.Kind.UNKNOWN,
-    val subtype: Subkind? = NotificationModel.Subkind.NONE,
+    val type: Kind = Kind.UNKNOWN,
+    val subtype: Subkind? = Subkind.NONE,
     var read: Boolean = false,
     val icon: String? = null,
     val noticon: String? = null,
@@ -36,7 +36,7 @@ data class NotificationModel(
         UNKNOWN;
 
         companion object {
-            private val reverseMap = Kind.values().associateBy(
+            private val reverseMap = values().associateBy(
                     Kind::name)
             fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: UNKNOWN
         }
@@ -49,7 +49,7 @@ data class NotificationModel(
         NONE;
 
         companion object {
-            private val reverseMap = Subkind.values().associateBy(
+            private val reverseMap = values().associateBy(
                     Subkind::name)
             fun fromString(type: String): Subkind {
                 return if (type.isEmpty()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -7,7 +7,10 @@ import java.util.Locale
 data class NotificationModel(
     val noteId: Int = 0,
     val remoteNoteId: Long = 0L,
+
+    // Note: this could be 0 in the db if the notification is not for one of the users sites
     var remoteSiteId: Long = 0L,
+
     var noteHash: Long = 0L,
     val type: Kind = Kind.UNKNOWN,
     val subtype: Subkind? = Subkind.NONE,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationApiResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationApiResponse.kt
@@ -22,8 +22,7 @@ class NotificationApiResponse : Response {
 
     companion object {
         fun notificationResponseToNotificationModel(
-            response: NotificationApiResponse,
-            siteId: Int = 0
+            response: NotificationApiResponse
         ): NotificationModel {
             val noteType = response.type?.let {
                 NotificationModel.Kind.fromString(response.type)
@@ -36,7 +35,7 @@ class NotificationApiResponse : Response {
             return NotificationModel(
                     noteId = 0,
                     remoteNoteId = response.id ?: 0,
-                    localSiteId = siteId,
+                    remoteSiteId = response.meta?.ids?.site ?: 0L,
                     noteHash = response.note_hash ?: 0L,
                     type = noteType,
                     subtype = noteSubType,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.store.NotificationStore.NotificationError
 import org.wordpress.android.fluxc.store.NotificationStore.NotificationErrorType
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.UnregisterDeviceResponsePayload
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.DeviceUtils
@@ -153,11 +152,9 @@ class NotificationRestClient constructor(
      *
      * https://developer.wordpress.com/docs/api/1/get/notifications/
      *
-     * @param siteStore A reference to [SiteStore] used for finding and populating the localSiteId property of
-     * [NotificationModel]
      * @param remoteNoteIds Optional. A list of remote notification ids to be fetched from the remote api
      */
-    fun fetchNotifications(siteStore: SiteStore, remoteNoteIds: List<Long>? = null) {
+    fun fetchNotifications(remoteNoteIds: List<Long>? = null) {
         val url = WPCOMREST.notifications.urlV1_1
         val params = mutableMapOf(
                 "number" to NOTIFICATION_DEFAULT_NUMBER.toString(),
@@ -189,7 +186,7 @@ class NotificationRestClient constructor(
     }
 
     /**
-     * Fetch a single notification by it's remote note_id.
+     * Fetch a single notification by its remote note_id.
      *
      * https://developer.wordpress.com/docs/api/1/get/notifications/%s
      */

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -172,9 +172,7 @@ class NotificationRestClient constructor(
                         Date(it)
                     }
                     val notifications = response?.notes?.map { it ->
-                        val remoteSiteId = NotificationApiResponse.getRemoteSiteId(it) ?: 0
-                        val localSiteId = siteStore.getLocalIdForRemoteSiteId(remoteSiteId)
-                        NotificationApiResponse.notificationResponseToNotificationModel(it, localSiteId)
+                        NotificationApiResponse.notificationResponseToNotificationModel(it)
                     } ?: listOf()
                     val payload = FetchNotificationsResponsePayload(notifications, lastSeenTime)
                     dispatcher.dispatch(NotificationActionBuilder.newFetchedNotificationsAction(payload))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -27,7 +27,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
                 .equals(NotificationModelTable.ID, notification.noteId)
                 .or()
                 .beginGroup()
-                .equals(NotificationModelTable.LOCAL_SITE_ID, notification.localSiteId)
+                .equals(NotificationModelTable.REMOTE_SITE_ID, notification.remoteSiteId)
                 .equals(NotificationModelTable.REMOTE_NOTE_ID, notification.remoteNoteId)
                 .endGroup()
                 .endGroup().endWhere()
@@ -94,7 +94,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
     ): List<NotificationModel> {
         val conditionClauseBuilder = WellSql.select(NotificationModelBuilder::class.java)
                 .where()
-                .equals(NotificationModelTable.LOCAL_SITE_ID, site.id)
+                .equals(NotificationModelTable.REMOTE_SITE_ID, site.siteId)
 
         if (filterByType != null || filterBySubtype != null) {
             conditionClauseBuilder.beginGroup()
@@ -127,7 +127,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
     ): Boolean {
         val conditionClauseBuilder = WellSql.select(NotificationModelBuilder::class.java)
                 .where()
-                .equals(NotificationModelTable.LOCAL_SITE_ID, site.id)
+                .equals(NotificationModelTable.REMOTE_SITE_ID, site.siteId)
                 .equals(NotificationModelTable.READ, 0)
 
         if (filterByType != null || filterBySubtype != null) {
@@ -152,13 +152,13 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
     }
 
     fun getNotificationByIdSet(idSet: NoteIdSet): NotificationModel? {
-        val (id, remoteNoteId, localSiteId) = idSet
+        val (id, remoteNoteId, remoteSiteId) = idSet
         return WellSql.select(NotificationModelBuilder::class.java)
                 .where().beginGroup()
                 .equals(NotificationModelTable.ID, id)
                 .or()
                 .beginGroup()
-                .equals(NotificationModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(NotificationModelTable.REMOTE_SITE_ID, remoteSiteId)
                 .equals(NotificationModelTable.REMOTE_NOTE_ID, remoteNoteId)
                 .endGroup()
                 .endGroup().endWhere()
@@ -190,7 +190,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
         return NotificationModelBuilder(
                 mId = this.noteId,
                 remoteNoteId = this.remoteNoteId,
-                localSiteId = this.localSiteId,
+                remoteSiteId = this.remoteSiteId,
                 noteHash = this.noteHash,
                 type = this.type.toString(),
                 subtype = this.subtype.toString(),
@@ -210,7 +210,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
     data class NotificationModelBuilder(
         @PrimaryKey @Column private var mId: Int = -1,
         @Column var remoteNoteId: Long,
-        @Column var localSiteId: Int,
+        @Column var remoteSiteId: Long,
         @Column var noteHash: Long,
         @Column var type: String,
         @Column var subtype: String? = null,
@@ -246,7 +246,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
             return NotificationModel(
                     mId,
                     remoteNoteId,
-                    localSiteId,
+                    remoteSiteId,
                     noteHash,
                     Kind.fromString(type),
                     subkind,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -175,9 +175,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
                 .firstOrNull()?.build(formattableContentMapper)
     }
 
-    fun deleteAllNotifications(): Int {
-        return WellSql.delete(NotificationModelBuilder::class.java).execute()
-    }
+    fun deleteAllNotifications() = WellSql.delete(NotificationModelBuilder::class.java).execute()
 
     fun deleteNotificationByRemoteId(remoteNoteId: Long): Int {
         return WellSql.delete(NotificationModelBuilder::class.java)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 71;
+        return 72;
     }
 
     @Override
@@ -534,6 +534,14 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("DROP TABLE IF EXISTS NotificationModel");
                 db.execSQL("CREATE TABLE NotificationModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
                            + "REMOTE_NOTE_ID INTEGER,LOCAL_SITE_ID INTEGER,NOTE_HASH INTEGER,TYPE TEXT,"
+                           + "SUBTYPE TEXT,READ INTEGER,ICON TEXT,NOTICON TEXT,TIMESTAMP TEXT,URL TEXT,"
+                           + "TITLE TEXT,FORMATTABLE_BODY TEXT,FORMATTABLE_SUBJECT TEXT,FORMATTABLE_META TEXT)");
+                oldVersion++;
+            case 71:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("DROP TABLE IF EXISTS NotificationModel");
+                db.execSQL("CREATE TABLE NotificationModel (_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                           + "REMOTE_NOTE_ID INTEGER,REMOTE_SITE_ID INTEGER,NOTE_HASH INTEGER,TYPE TEXT,"
                            + "SUBTYPE TEXT,READ INTEGER,ICON TEXT,NOTICON TEXT,TIMESTAMP TEXT,URL TEXT,"
                            + "TITLE TEXT,FORMATTABLE_BODY TEXT,FORMATTABLE_SUBJECT TEXT,FORMATTABLE_META TEXT)");
                 oldVersion++;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -423,8 +423,6 @@ constructor(
         } else {
             // Update the localSiteId and save to the db
             val rows = payload.notification?.let {
-                val remoteSiteId = it.getRemoteSiteId() ?: 0
-                it.localSiteId = siteStore.getLocalIdForRemoteSiteId(remoteSiteId)
                 notificationSqlUtils.insertOrUpdateNotification(it)
             } ?: 0
             // Fetch inserted/updated local notification id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -8,11 +8,6 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.NotificationAction
-import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATION
-import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATIONS
-import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_SEEN
-import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_READ
-import org.wordpress.android.fluxc.action.NotificationAction.UPDATE_NOTIFICATION
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -77,7 +72,7 @@ constructor(
         GENERIC_ERROR;
 
         companion object {
-            private val reverseMap = DeviceRegistrationErrorType.values().associateBy(DeviceRegistrationErrorType::name)
+            private val reverseMap = values().associateBy(DeviceRegistrationErrorType::name)
             fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: GENERIC_ERROR
         }
     }
@@ -91,6 +86,7 @@ constructor(
 
     class FetchNotificationsPayload : Payload<BaseNetworkError>()
 
+    @Suppress("unused")
     class FetchNotificationsResponsePayload(
         val notifs: List<NotificationModel> = emptyList(),
         val lastSeen: Date? = null
@@ -105,12 +101,14 @@ constructor(
     class FetchNotificationResponsePayload(
         val notification: NotificationModel? = null
     ) : Payload<NotificationError>() {
+        @Suppress("unused")
         constructor(error: NotificationError) : this() { this.error = error }
     }
 
     class FetchNotificationHashesResponsePayload(
         val hashesMap: Map<Long, Long> = emptyMap()
     ) : Payload<NotificationError>() {
+        @Suppress("unused")
         constructor(error: NotificationError) : this() { this.error = error }
     }
 
@@ -122,6 +120,7 @@ constructor(
         val success: Boolean = false,
         val lastSeenTime: Long? = null
     ) : Payload<NotificationError>() {
+        @Suppress("unused")
         constructor(error: NotificationError) : this() { this.error = error }
     }
 
@@ -133,6 +132,7 @@ constructor(
         val notifications: List<NotificationModel>? = null,
         val success: Boolean = false
     ) : Payload<NotificationError>() {
+        @Suppress("unused")
         constructor(error: NotificationError) : this() { this.error = error }
     }
 
@@ -145,12 +145,13 @@ constructor(
         GENERIC_ERROR;
 
         companion object {
-            private val reverseMap = NotificationErrorType.values().associateBy(NotificationErrorType::name)
+            private val reverseMap = values().associateBy(NotificationErrorType::name)
             fun fromString(type: String) = reverseMap[type.toUpperCase(Locale.US)] ?: GENERIC_ERROR
         }
     }
 
     // OnChanged events
+    @Suppress("unused")
     class OnDeviceRegistered(val deviceId: String?) : OnChanged<DeviceRegistrationError>()
 
     class OnDeviceUnregistered : OnChanged<DeviceUnregistrationError>()
@@ -254,11 +255,13 @@ constructor(
      *
      * @param idSet A [NoteIdSet] containing the localSiteId, remoteNoteId, and localNoteId
      */
+    @Suppress("unused")
     fun getNotificationByIdSet(idSet: NoteIdSet) = notificationSqlUtils.getNotificationByIdSet(idSet)
 
     /**
      * Fetch a notification from the database by the remote notification ID.
      */
+    @Suppress("unused")
     fun getNotificationByRemoteId(remoteNoteId: Long) =
             notificationSqlUtils.getNotificationByRemoteId(remoteNoteId)
 
@@ -363,7 +366,7 @@ constructor(
             // Unable to synchronize notifications with remote. Emit error event.
             val onNotificationChanged = OnNotificationChanged(0).also {
                 it.error = payload.error
-                it.causeOfChange = FETCH_NOTIFICATIONS
+                it.causeOfChange = NotificationAction.FETCH_NOTIFICATIONS
             }
             emitChange(onNotificationChanged)
             return
@@ -404,7 +407,7 @@ constructor(
 
             OnNotificationChanged(rowsAffected)
         }.apply {
-            causeOfChange = FETCH_NOTIFICATIONS
+            causeOfChange = NotificationAction.FETCH_NOTIFICATIONS
         }
 
         emitChange(onNotificationChanged)
@@ -432,7 +435,7 @@ constructor(
                 dbNotification?.let { changedNotificationLocalIds.add(it.noteId) }
             }
         }.apply {
-            causeOfChange = FETCH_NOTIFICATION
+            causeOfChange = NotificationAction.FETCH_NOTIFICATION
         }
         emitChange(onNotificationChanged)
     }
@@ -454,7 +457,7 @@ constructor(
                 lastSeenTime = payload.lastSeenTime
             }
         }.apply {
-            causeOfChange = MARK_NOTIFICATIONS_SEEN
+            causeOfChange = NotificationAction.MARK_NOTIFICATIONS_SEEN
         }
         emitChange(onNotificationChanged)
     }
@@ -487,7 +490,7 @@ constructor(
             payload.notifications?.forEach {
                 changedNotificationLocalIds.add(it.noteId)
             }
-            causeOfChange = MARK_NOTIFICATIONS_READ
+            causeOfChange = NotificationAction.MARK_NOTIFICATIONS_READ
         }
         emitChange(onNotificationChanged)
     }
@@ -497,7 +500,7 @@ constructor(
         val rowsAffected = notificationSqlUtils.insertOrUpdateNotification(payload)
         val onNotificationChanged = OnNotificationChanged(rowsAffected).apply {
             changedNotificationLocalIds.add(payload.noteId)
-            causeOfChange = UPDATE_NOTIFICATION
+            causeOfChange = NotificationAction.UPDATE_NOTIFICATION
         }
         emitChange(onNotificationChanged)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -30,8 +30,7 @@ constructor(
     dispatcher: Dispatcher,
     private val context: Context,
     private val notificationRestClient: NotificationRestClient,
-    private val notificationSqlUtils: NotificationSqlUtils,
-    private val siteStore: SiteStore
+    private val notificationSqlUtils: NotificationSqlUtils
 ) : Store(dispatcher) {
     companion object {
         const val WPCOM_PUSH_DEVICE_UUID = "NOTIFICATIONS_UUID_PREF_KEY"
@@ -353,7 +352,7 @@ constructor(
             notificationRestClient.fetchNotificationHashes()
         } else {
             // Fetch all notifications from the remote
-            notificationRestClient.fetchNotifications(siteStore)
+            notificationRestClient.fetchNotifications()
         }
     }
 
@@ -394,7 +393,7 @@ constructor(
         }
 
         // Fetch new and updated notifications from the remote api
-        notificationRestClient.fetchNotifications(siteStore, notifsToFetch.keys.toList())
+        notificationRestClient.fetchNotifications(notifsToFetch.keys.toList())
     }
 
     private fun handleFetchNotificationsCompleted(payload: FetchNotificationsResponsePayload) {


### PR DESCRIPTION
Fixes #1293 by removing `localSiteId` from the various notification-related models and replacing it with `remoteSiteId` where applicable. All tests have also been updated. 

**Note:** PR #1292 must be approved and merged before this one can be reviewed.

## To Test
- Please make sure to test upgrading from the version in develop (be sure to pull notifications) and then upgrade to this version and pull notifications. 
- Run all the automated tests
- Run all the notifications tests in the example app