### PR TITLE
Don't clean up PostUploadModel when a media is associated

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -327,14 +327,14 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         // Wait for the event to be processed by the UploadStore
         TestUtils.waitFor(50);
 
-        // The cancelled post should be cleared since we've now modified it
-        // There's no pending post either, because we haven't re-registered one yet
-        assertEquals(0, mUploadStore.getCancelledPosts().size());
+        // The cancelled post should not be cleared after a new media has been associated
         assertEquals(0, mUploadStore.getFailedPosts().size());
         assertEquals(0, mUploadStore.getPendingPosts().size());
-        assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
+        assertEquals(1, mUploadStore.getCancelledPosts().size());
+        assertEquals(1, mUploadStore.getAllRegisteredPosts().size());
 
-        assertNull(getPostUploadModelForPostModel(mPost));
+        PostUploadModel postUploadModel = getPostUploadModelForPostModel(mPost);
+        assertEquals(postUploadModel.getUploadState(), PostUploadModel.CANCELLED);
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -255,18 +255,6 @@ public class UploadStore extends Store {
             mediaUploadModel.setMediaError(new MediaError(MediaErrorType.MALFORMED_MEDIA_ARG, errorMessage));
         }
         UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel);
-
-        // If we have a FAILED or CANCELLED post associated with this media, we've already started making changes to
-        // this post and don't need a reference to the old PostUploadModel anymore
-        int localPostId = payload.media.getLocalPostId();
-        if (localPostId > 0) {
-            PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(localPostId);
-            if (postUploadModel != null
-                    && (postUploadModel.getUploadState() == PostUploadModel.CANCELLED
-                    || postUploadModel.getUploadState() == PostUploadModel.FAILED)) {
-                UploadSqlUtils.deletePostUploadModelWithLocalId(localPostId);
-            }
-        }
     }
 
     private void handleMediaUploaded(@NonNull ProgressPayload payload) {


### PR DESCRIPTION
Original code modified in this PR comes from this commit: https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/2c640725647e79851bd056f6a84252f5f9d9de32

Before this patch: the idea was to delete the `PostUploadModel` in case it's cancelled or failed when a new media is added to that post (when `UploadStore.handleUploadMedia()` is called). It makes sense since when a new media is associated, we want to start post uploads from a fresh state.

The problem:

1. We rely on the `PostUploadModel` via `UploadStore` getters in the wpandroid `UploadService`places for different purposes [1]. One being to test if there is a failing media upload associated to that post.
2. `UploadStore.handleUploadMedia()` gets called even when we retry a failed upload (it's not only called when a new media is associated). This is usually not a big deal because on retry, a `PostUploadModel` will be recreated if one doesn't exist yet.
3. but 1. and 2. happens in different threads, and `PostUploadModel` could be deleted right before another thread is checking for it, and it won't be recreated at that time. This can results in post uploaded with media not uploaded. It affects wpandroid: https://github.com/wordpress-mobile/WordPress-Android/issues/10076

Proposed solution in this PR:

- Don't clean up `PostUploadModel` when a new media is associated to a post. This is not a problem because [we'll reuse it and **reset its state**](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/8954d4098e20b1fc8ecff0a2fb76a0ffb0b62676/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java#L152) if there was an issue previously.

[1] We use different `UploadStore` getters notably `isRegisteredPostModel()` to check if a media is associated to a post, or even count failed and successful uploads.