### PR TITLE
New feature to count post upload errors and cancellations

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -337,6 +337,52 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         assertEquals(postUploadModel.getUploadState(), PostUploadModel.CANCELLED);
     }
 
+
+    @Test
+    public void testPostErrorAndCancellationCounter() throws InterruptedException {
+        SiteModel site = getTestSite();
+
+        // Instantiate new post
+        createNewPost(site);
+        setupPostAttributes();
+
+        // Start uploading a media
+        MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
+        testMedia.setLocalPostId(mPost.getId());
+
+        // Register the post with the UploadStore and verify that it exists and has the right state
+        List<MediaModel> mediaModelList = new ArrayList<>();
+        mediaModelList.add(testMedia);
+        mUploadStore.registerPostModel(mPost, mediaModelList);
+        assertTrue(mUploadStore.isRegisteredPostModel(mPost));
+
+        // Check there is no error before starting the media upload
+        assertEquals(0, mUploadStore.getNumberOfPostUploadErrorsOrCancellations(mPost));
+
+        startFailingMediaUpload(testMedia, site);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Check the post has been cancelled and the counter is now 1
+        assertTrue(mUploadStore.isCancelledPost(mPost));
+        assertEquals(1, mUploadStore.getNumberOfPostUploadErrorsOrCancellations(mPost));
+
+        startFailingMediaUpload(testMedia, site);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Check the counter is still 1 since we didn't re-register the post
+        assertTrue(mUploadStore.isCancelledPost(mPost));
+        assertEquals(1, mUploadStore.getNumberOfPostUploadErrorsOrCancellations(mPost));
+
+        // Re-register the post (it should reset the state) and retry to upload a media (with failure)
+        mUploadStore.registerPostModel(mPost, mediaModelList);
+        startFailingMediaUpload(testMedia, site);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // The post should be cancelled and counter incremented
+        assertTrue(mUploadStore.isCancelledPost(mPost));
+        assertEquals(2, mUploadStore.getNumberOfPostUploadErrorsOrCancellations(mPost));
+    }
+
     @Test
     public void testUpdateMediaModelState() throws InterruptedException {
         SiteModel site = getTestSite();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostUploadModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostUploadModel.java
@@ -48,6 +48,7 @@ public class PostUploadModel extends Payload<BaseNetworkError> implements Identi
     // Serialization of a PostError
     @Column private String mErrorType;
     @Column private String mErrorMessage;
+    @Column private int mNumberOfUploadErrorsOrCancellations;
 
     public PostUploadModel() {}
 
@@ -156,5 +157,17 @@ public class PostUploadModel extends Payload<BaseNetworkError> implements Identi
         List<Integer> idList = new ArrayList<>(ids);
         Collections.sort(idList);
         return TextUtils.join(",", idList);
+    }
+
+    public int getNumberOfUploadErrorsOrCancellations() {
+        return mNumberOfUploadErrorsOrCancellations;
+    }
+
+    public void incNumberOfUploadErrorsOrCancellations() {
+        mNumberOfUploadErrorsOrCancellations += 1;
+    }
+
+    public void setNumberOfUploadErrorsOrCancellations(int numberOfUploadErrorsOrCancellations) {
+        mNumberOfUploadErrorsOrCancellations = numberOfUploadErrorsOrCancellations;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 71;
+        return 72;
     }
 
     @Override
@@ -536,6 +536,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                            + "REMOTE_NOTE_ID INTEGER,LOCAL_SITE_ID INTEGER,NOTE_HASH INTEGER,TYPE TEXT,"
                            + "SUBTYPE TEXT,READ INTEGER,ICON TEXT,NOTICON TEXT,TIMESTAMP TEXT,URL TEXT,"
                            + "TITLE TEXT,FORMATTABLE_BODY TEXT,FORMATTABLE_SUBJECT TEXT,FORMATTABLE_META TEXT)");
+                oldVersion++;
+            case 71:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("ALTER TABLE PostUploadModel ADD NUMBER_OF_UPLOAD_ERRORS_OR_CANCELLATIONS INTEGER");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
This will be used to fix https://github.com/wordpress-mobile/WordPress-Android/issues/10059

I really don't like the field name: `mNumberOfUploadErrorsOrCancellations`. I was thinking splitting this into 2 fields (to count error and cancellations separately) but it seems pretty useless.

<s>Note: this is a draft PR, waiting for https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1295 to be merged first (I'll have update the base branch then).</s>