### PR TITLE
Add remote autosave support for scheduled posts

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -662,26 +662,38 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
     }
 
     @Test
-    public void testAutoSavePost() throws InterruptedException {
-        final boolean testPage = false;
-        testAutoSavePostOrPage(testPage);
+    public void testAutoSavePublishedPost() throws InterruptedException {
+        // Arrange
+        PostModel post = createNewPost();
+        post.setStatus(PostStatus.PUBLISHED.toString());
+
+        testAutoSavePostOrPage(post, false);
     }
 
     @Test
-    public void testAutoSavePage() throws InterruptedException {
-        final boolean testPage = true;
-        testAutoSavePostOrPage(testPage);
-    }
-
-    private void testAutoSavePostOrPage(boolean testPage) throws InterruptedException {
+    public void testAutoSaveScheduledPost() throws InterruptedException {
         // Arrange
         PostModel post = createNewPost();
-        setupPostAttributes(post);
+        post.setStatus(PostStatus.SCHEDULED.toString());
+        post.setDateCreated("2075-10-14T10:51:11+00:00");
 
-        post.setIsPage(testPage);
+        testAutoSavePostOrPage(post, false);
+    }
 
+    @Test
+    public void testAutoSavePublishedPage() throws InterruptedException {
+        // Arrange
+        PostModel post = createNewPost();
         post.setStatus(PostStatus.PUBLISHED.toString());
 
+        testAutoSavePostOrPage(post, true);
+    }
+
+    private void testAutoSavePostOrPage(PostModel post, boolean isPage) throws InterruptedException {
+        // Arrange
+        setupPostAttributes(post);
+
+        post.setIsPage(isPage);
         uploadPost(post);
 
         PostModel uploadedPost = mPostStore.getPostByLocalPostId(post.getId());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -240,11 +240,11 @@ public class PostRestClient extends BaseWPComRestClient {
     }
 
     public void remoteAutoSavePost(final @NonNull PostModel post, final @NonNull SiteModel site) {
-        if (PostStatus.fromPost(post) != PostStatus.PUBLISHED) {
+        if (PostStatus.fromPost(post) != PostStatus.PUBLISHED && PostStatus.fromPost(post) != PostStatus.SCHEDULED) {
             // We could use /rest/v1.2 for other post statuses as Calypso does, but we decided to use pushPost(..)
             // instead as the RemoteAutoSave /rest/v1.2 doesn't create a new revision.
             PostError postError = new PostError(PostErrorType.UNSUPPORTED_ACTION,
-                            "RemoteAutoSave is supported only for Published posts.");
+                            "RemoteAutoSave is supported only for Published/Scheduled posts.");
             RemoteAutoSavePostPayload payload = new RemoteAutoSavePostPayload(post.getId(), postError);
             mDispatcher.dispatch(PostActionBuilder.newRemoteAutoSavedPostAction(payload));
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -552,7 +552,6 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_REMOTE_MODIFIED TEXT");
                 db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_PREVIEW_URL TEXT");
                 oldVersion++;
-
         }
         db.setTransactionSuccessful();
         db.endTransaction();


### PR DESCRIPTION
Fixes #1297 

Enables remote auto-save for Scheduled posts/pages.

To test:
- Run `ReleaseStack_PostTestWPCom`