### PR TITLE
Update target SDK of FluxC to 28

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -28,7 +28,7 @@ android {
         versionCode 4
         versionName "0.1"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 28
     }
     buildTypes {
         release {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -25,7 +25,7 @@ android {
         versionCode 1
         versionName "0.1"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 28
     }
     buildTypes {
         release {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -25,7 +25,7 @@ android {
         versionCode 1
         versionName "0.1"
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 26
     }
     buildTypes {
         release {


### PR DESCRIPTION
This PR updates target SDK for FluxC to 28. Let's merge it once the related WPAndroid PR is finished. Let me know if I should add something else but it seems pretty straightforward.