### PR TITLE
Add methods for getting locally changed Posts and Pages

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalChangesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalChangesTest.kt
@@ -79,7 +79,7 @@ class PageStoreLocalChangesTest {
     }
 
     @Test
-    fun `getLocallyChangedPages returns local draft and locally changed pages only`() = test {
+    fun `getPagesWithLocalChanges returns local draft and locally changed pages only`() = test {
         // Arrange
         val site = SiteModel().apply { id = 3_000 }
 
@@ -121,7 +121,7 @@ class PageStoreLocalChangesTest {
         expectedPages.plus(unexpectedPosts).forEach { postSqlUtils.insertPostForResult(it) }
 
         // Act
-        val locallyChangedPages = pageStore.getLocallyChangedPages(site)
+        val locallyChangedPages = pageStore.getPagesWithLocalChanges(site)
 
         // Assert
         assertThat(locallyChangedPages).hasSize(expectedPages.size)

--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalChangesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalChangesTest.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.test
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
-class PageStoreLocalDraftTest {
+class PageStoreLocalChangesTest {
     private val postSqlUtils = PostSqlUtils()
     private val pageStore = PageStore(
             postStore = mock(),

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreDbIntegrationTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreDbIntegrationTest.java
@@ -475,7 +475,7 @@ public class PostStoreDbIntegrationTest {
     }
 
     @Test
-    public void testGetLocallyChangedPostsReturnsLocalDraftsAndChangedPostsOnly() {
+    public void testGetPostsWithLocalChangesReturnsLocalDraftsAndChangedPostsOnly() {
         // Arrange
         final SiteModel site = new SiteModel();
         site.setId(PostTestUtils.DEFAULT_LOCAL_SITE_ID);
@@ -527,7 +527,7 @@ public class PostStoreDbIntegrationTest {
                 unchangedPublishedPost.getId());
 
         // Act
-        final List<PostModel> locallyChangedPosts = mPostStore.getLocallyChangedPosts(site);
+        final List<PostModel> locallyChangedPosts = mPostStore.getPostsWithLocalChanges(site);
 
         // Assert
         assertEquals(expectedPostIds.size(), locallyChangedPosts.size());

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostTestUtils.java
@@ -45,11 +45,15 @@ public class PostTestUtils {
         return example;
     }
 
-    public static PostModel generateSampleLocallyChangedPost() {
+    static PostModel generateSampleLocallyChangedPost() {
+        return generateSampleLocallyChangedPost("A test post");
+    }
+
+    static PostModel generateSampleLocallyChangedPost(@NonNull String title) {
         PostModel example = new PostModel();
         example.setLocalSiteId(DEFAULT_LOCAL_SITE_ID);
         example.setRemotePostId(7);
-        example.setTitle("A test post");
+        example.setTitle(title);
         example.setContent("Bunch of content here");
         example.setIsLocallyChanged(true);
         return example;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -147,6 +147,18 @@ public class PostSqlUtils {
                       .getAsModel();
     }
 
+    public List<PostModel> getLocallyChangedPosts(@NonNull Integer localSiteId, boolean isPage) {
+        return WellSql.select(PostModel.class)
+                      .where()
+                      .equals(PostModelTable.IS_PAGE, isPage)
+                      .equals(PostModelTable.LOCAL_SITE_ID, localSiteId)
+                      .beginGroup()
+                      .equals(PostModelTable.IS_LOCAL_DRAFT, true).or().equals(PostModelTable.IS_LOCALLY_CHANGED, true)
+                      .endGroup()
+                      .endWhere()
+                      .getAsModel();
+    }
+
     public List<PostModel> getPostsByRemoteIds(@Nullable List<Long> remoteIds, int localSiteId) {
         if (remoteIds != null && remoteIds.size() > 0) {
             return WellSql.select(PostModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -147,7 +147,7 @@ public class PostSqlUtils {
                       .getAsModel();
     }
 
-    public List<PostModel> getLocallyChangedPosts(@NonNull Integer localSiteId, boolean isPage) {
+    public List<PostModel> getPostsWithLocalChanges(@NonNull Integer localSiteId, boolean isPage) {
         return WellSql.select(PostModel.class)
                       .where()
                       .equals(PostModelTable.IS_PAGE, isPage)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
@@ -184,13 +184,23 @@ class PageStore @Inject constructor(
     }
 
     /**
-     * Get pages that have not been uploaded to the server yet.
+     * Get local draft pages that have not been uploaded to the server yet.
      *
      * This returns [PostModel] instead of [PageModel] to accommodate the `UploadService` in WPAndroid which relies
      * heavily on [PostModel]. When `UploadService` gets refactored, we should change this back to using [PageModel].
      */
     suspend fun getLocalDraftPages(site: SiteModel): List<PostModel> = withContext(coroutineContext) {
         return@withContext postSqlUtils.getLocalDrafts(site.id, true)
+    }
+
+    /**
+     * Get pages that have not been uploaded to the server yet.
+     *
+     * This returns [PostModel] instead of [PageModel] to accommodate the `UploadService` in WPAndroid which relies
+     * heavily on [PostModel]. When `UploadService` gets refactored, we should change this back to using [PageModel].
+     */
+    suspend fun getLocallyChangedPages(site: SiteModel): List<PostModel> = withContext(coroutineContext) {
+        return@withContext postSqlUtils.getLocallyChangedPosts(site.id, true)
     }
 
     private fun fetchPages(site: SiteModel, loadMore: Boolean) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
@@ -199,8 +199,8 @@ class PageStore @Inject constructor(
      * This returns [PostModel] instead of [PageModel] to accommodate the `UploadService` in WPAndroid which relies
      * heavily on [PostModel]. When `UploadService` gets refactored, we should change this back to using [PageModel].
      */
-    suspend fun getLocallyChangedPages(site: SiteModel): List<PostModel> = withContext(coroutineContext) {
-        return@withContext postSqlUtils.getLocallyChangedPosts(site.id, true)
+    suspend fun getPagesWithLocalChanges(site: SiteModel): List<PostModel> = withContext(coroutineContext) {
+        return@withContext postSqlUtils.getPostsWithLocalChanges(site.id, true)
     }
 
     private fun fetchPages(site: SiteModel, loadMore: Boolean) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -436,8 +436,8 @@ public class PostStore extends Store {
     /**
      * Returns all posts that are local drafts or has been locally changed.
      */
-    public List<PostModel> getLocallyChangedPosts(@NonNull SiteModel site) {
-        return mPostSqlUtils.getLocallyChangedPosts(site.getId(), false);
+    public List<PostModel> getPostsWithLocalChanges(@NonNull SiteModel site) {
+        return mPostSqlUtils.getPostsWithLocalChanges(site.getId(), false);
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -427,10 +427,17 @@ public class PostStore extends Store {
     }
 
     /**
-     * Returns all posts and pages that are local drafts for the given site.
+     * Returns all posts that are local drafts for the given site.
      */
     public List<PostModel> getLocalDraftPosts(@NonNull SiteModel site) {
         return mPostSqlUtils.getLocalDrafts(site.getId(), false);
+    }
+
+    /**
+     * Returns all posts that are local drafts or has been locally changed.
+     */
+    public List<PostModel> getLocallyChangedPosts(@NonNull SiteModel site) {
+        return mPostSqlUtils.getLocallyChangedPosts(site.getId(), false);
     }
 
     /**
@@ -739,7 +746,7 @@ public class PostStore extends Store {
 
     /**
      * Saves the changes for the trashed post in the DB, lets ListStore know about updated lists.
-     *
+     * <p>
      * If the trashed post is for an XML-RPC site, it'll also fetch the updated post from remote since XML-RPC delete
      * call doesn't return the updated post.
      */


### PR DESCRIPTION
This is a dependency of https://github.com/wordpress-mobile/WordPress-Android/issues/10177. 

This adds the methods `PostStore.getLocallyChangedPosts` and `PageStore.getLocallyChangedPages`. 

## Testing 

- Please validate the unit and integration tests.
- Probably better to test this along with https://github.com/wordpress-mobile/WordPress-Android/issues/10177 too. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 
