### PR TITLE
Add support for tlds filter when requesting domain suggestions

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -71,6 +71,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         FETCHED_CONNECT_SITE_INFO,
         FETCHED_WPCOM_SITE_BY_URL,
         FETCHED_DOMAIN_SUGGESTIONS,
+        FETCHED_TLDS_FILTERED_DOMAINS,
         DOMAIN_SUGGESTION_ERROR_INVALID_QUERY,
         ERROR_INVALID_SITE,
         ERROR_UNKNOWN_SITE,
@@ -80,7 +81,6 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         CHECK_BLACKLISTED_DOMAIN_AVAILABILITY,
         FETCHED_DOMAIN_SUPPORTED_STATES,
         FETCHED_DOMAIN_SUPPORTED_COUNTRIES,
-        FETCHED_TLDS_FILTERED_DOMAINS,
     }
 
     private TestEvents mNextEvent;
@@ -272,11 +272,10 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @Test
     public void testTldsFilteredSuggestions() throws InterruptedException {
-        String keywords = "awesomesubdomain";
-
+        String keyword = "awesomesubdomain";
         List<String> requestedTlds = Arrays.asList("blog", "net");
 
-        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, 20, requestedTlds);
+        SuggestDomainsPayload payload = new SuggestDomainsPayload(keyword, 20, requestedTlds);
         testSuggestDomains(payload, TestEvents.FETCHED_TLDS_FILTERED_DOMAINS);
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -51,7 +51,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -40,7 +40,6 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -273,9 +272,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     @Test
     public void testTldsFilteredSuggestions() throws InterruptedException {
         String keyword = "awesomedomain";
-        List<String> requestedTlds = Arrays.asList("blog", "net");
 
-        SuggestDomainsPayload payload = new SuggestDomainsPayload(keyword, 20, requestedTlds);
+        SuggestDomainsPayload payload = new SuggestDomainsPayload(keyword, 20, "blog");
         testSuggestDomains(payload, TestEvents.FETCHED_TLDS_FILTERED_DOMAINS);
     }
 
@@ -516,8 +514,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         } else if (mNextEvent == TestEvents.FETCHED_TLDS_FILTERED_DOMAINS) {
             for (DomainSuggestionResponse suggestionResponse : event.suggestions) {
                 String domain = suggestionResponse.domain_name;
-                assertTrue("Was expecting the domain to end in " + dotNetSuffix + " or " + dotBlogSuffix,
-                        domain.endsWith(dotBlogSuffix) || domain.endsWith(dotNetSuffix));
+                assertTrue("Was expecting the domain to end in " + dotNetSuffix, domain.endsWith(dotBlogSuffix));
             }
         } else {
             throw new AssertionError("Unexpected event type: " + mNextEvent);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -80,7 +80,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         AUTOMATED_TRANSFER_NOT_FOUND,
         CHECK_BLACKLISTED_DOMAIN_AVAILABILITY,
         FETCHED_DOMAIN_SUPPORTED_STATES,
-        FETCHED_DOMAIN_SUPPORTED_COUNTRIES,
+        FETCHED_DOMAIN_SUPPORTED_COUNTRIES
     }
 
     private TestEvents mNextEvent;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -272,7 +273,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @Test
     public void testTldsFilteredSuggestions() throws InterruptedException {
-        String keyword = "awesomesubdomain";
+        String keyword = "awesomedomain";
         List<String> requestedTlds = Arrays.asList("blog", "net");
 
         SuggestDomainsPayload payload = new SuggestDomainsPayload(keyword, 20, requestedTlds);
@@ -517,7 +518,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
             for (DomainSuggestionResponse suggestionResponse : event.suggestions) {
                 String domain = suggestionResponse.domain_name;
                 assertTrue("Was expecting the domain to end in " + dotNetSuffix + " or " + dotBlogSuffix,
-                        domain.endsWith(wpcomSuffix) || domain.endsWith(dotNetSuffix));
+                        domain.endsWith(dotBlogSuffix) || domain.endsWith(dotNetSuffix));
             }
         } else {
             throw new AssertionError("Unexpected event type: " + mNextEvent);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -403,7 +403,8 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void suggestDomains(@NonNull final String query, final Boolean onlyWordpressCom,
                                final Boolean includeWordpressCom, final Boolean includeDotBlogSubdomain,
-                               final Long segmentId, final int quantity, final boolean includeVendorDot) {
+                               final Long segmentId, final int quantity, final boolean includeVendorDot,
+                               List<String> tlds) {
         String url = WPCOMREST.domains.suggestions.getUrlV1_1();
         Map<String, String> params = new HashMap<>(4);
         params.put("query", query);
@@ -419,13 +420,19 @@ public class SiteRestClient extends BaseWPComRestClient {
         if (segmentId != null) {
             params.put("segment_id", String.valueOf(segmentId));
         }
+        if (tlds != null) {
+            for (String supportedTlds : tlds) {
+                params.put("tlds", supportedTlds);
+            }
+        }
         params.put("quantity", String.valueOf(quantity));
         if (includeVendorDot) {
             params.put("vendor", "dot");
         }
         final WPComGsonRequest<ArrayList<DomainSuggestionResponse>> request =
                 WPComGsonRequest.buildGetRequest(url, params,
-                        new TypeToken<ArrayList<DomainSuggestionResponse>>(){}.getType(),
+                        new TypeToken<ArrayList<DomainSuggestionResponse>>() {
+                        }.getType(),
                         new Listener<ArrayList<DomainSuggestionResponse>>() {
                             @Override
                             public void onResponse(ArrayList<DomainSuggestionResponse> response) {
@@ -451,7 +458,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 }
                             }
                         }
-                );
+                                                );
         add(request);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -404,7 +404,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     public void suggestDomains(@NonNull final String query, final Boolean onlyWordpressCom,
                                final Boolean includeWordpressCom, final Boolean includeDotBlogSubdomain,
                                final Long segmentId, final int quantity, final boolean includeVendorDot,
-                               List<String> tlds) {
+                               final String tlds) {
         String url = WPCOMREST.domains.suggestions.getUrlV1_1();
         Map<String, String> params = new HashMap<>(4);
         params.put("query", query);
@@ -421,9 +421,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             params.put("segment_id", String.valueOf(segmentId));
         }
         if (tlds != null) {
-            for (String supportedTlds : tlds) {
-                params.put("tlds", supportedTlds);
-            }
+            params.put("tlds", tlds);
         }
         params.put("quantity", String.valueOf(quantity));
         if (includeVendorDot) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -142,6 +142,7 @@ public class SiteStore extends Store {
         @Nullable public Boolean onlyWordpressCom;
         @Nullable public Boolean includeWordpressCom;
         @Nullable public Boolean includeDotBlogSubdomain;
+        @Nullable public List<String> tlds;
         @Nullable public Long segmentId;
         public int quantity;
         public boolean includeVendorDot;
@@ -152,6 +153,7 @@ public class SiteStore extends Store {
             this.onlyWordpressCom = onlyWordpressCom;
             this.includeWordpressCom = includeWordpressCom;
             this.includeDotBlogSubdomain = includeDotBlogSubdomain;
+            this.tlds = tlds;
             this.quantity = quantity;
             this.includeVendorDot = includeVendorDot;
         }
@@ -161,6 +163,12 @@ public class SiteStore extends Store {
             this.segmentId = segmentId;
             this.quantity = quantity;
             this.includeVendorDot = includeVendorDot;
+        }
+
+         public SuggestDomainsPayload(@NonNull String query, int quantity, List<String> tlds) {
+            this.query = query;
+            this.quantity = quantity;
+            this.tlds = tlds;
         }
     }
 
@@ -1668,7 +1676,8 @@ public class SiteStore extends Store {
 
     private void suggestDomains(SuggestDomainsPayload payload) {
         mSiteRestClient.suggestDomains(payload.query, payload.onlyWordpressCom, payload.includeWordpressCom,
-                payload.includeDotBlogSubdomain, payload.segmentId, payload.quantity, payload.includeVendorDot);
+                payload.includeDotBlogSubdomain, payload.segmentId, payload.quantity, payload.includeVendorDot,
+                payload.tlds);
     }
 
     private void handleSuggestedDomains(SuggestDomainsResponsePayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -142,7 +142,7 @@ public class SiteStore extends Store {
         @Nullable public Boolean onlyWordpressCom;
         @Nullable public Boolean includeWordpressCom;
         @Nullable public Boolean includeDotBlogSubdomain;
-        @Nullable public List<String> tlds;
+        @Nullable public String tlds;
         @Nullable public Long segmentId;
         public int quantity;
         public boolean includeVendorDot;
@@ -165,7 +165,7 @@ public class SiteStore extends Store {
             this.includeVendorDot = includeVendorDot;
         }
 
-         public SuggestDomainsPayload(@NonNull String query, int quantity, List<String> tlds) {
+         public SuggestDomainsPayload(@NonNull String query, int quantity, String tlds) {
             this.query = query;
             this.quantity = quantity;
             this.tlds = tlds;


### PR DESCRIPTION
This PR adds functionality to specify TLDs when requestion domain suggestions.

Could be tested with [this](https://github.com/wordpress-mobile/WordPress-Android/pull/10178) wpandroid PR.