### PR TITLE
Feature/setting mobile editor preference for a site

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -51,7 +51,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -64,6 +64,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         SITE_CHANGED,
         POST_FORMATS_CHANGED,
         USER_ROLES_CHANGED,
+        SITE_EDITORS_CHANGED,
         PLANS_FETCHED,
         PLANS_UNKNOWN_BLOG_ERROR,
         SITE_REMOVED,
@@ -127,6 +128,25 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         // Test fetched Post Formats
         List<PostFormatModel> postFormats = mSiteStore.getPostFormats(firstSite);
         assertNotSame(0, postFormats.size());
+    }
+
+    @Test
+    public void testFetchSiteEditors() throws InterruptedException {
+        authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
+                BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
+
+        // Get the first site
+        SiteModel firstSite = mSiteStore.getSites().get(0);
+
+        // Fetch user roles
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSiteEditorsAction(firstSite));
+        mNextEvent = TestEvents.SITE_EDITORS_CHANGED;
+        mCountDownLatch = new CountDownLatch(1);
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Default editors for a wpcom site
+        assertEquals(firstSite.getMobileEditor(), "aztec");
+        assertEquals(firstSite.getWebEditor(), "gutenberg");
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -145,9 +146,9 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        // Default editors for a wpcom site
-        assertEquals(firstSite.getMobileEditor(), "aztec");
-        assertEquals(firstSite.getWebEditor(), "classic");
+        String siteEditor = firstSite.getMobileEditor();
+        // Test mobile editors for a wpcom site
+        assertTrue(siteEditor.equals("aztec") || siteEditor.equals("gutenberg"));
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnDomainSupportedStatesFetche
 import org.wordpress.android.fluxc.store.SiteStore.OnPlansFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteEditorsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains;
 import org.wordpress.android.fluxc.store.SiteStore.OnUserRolesChanged;
@@ -146,7 +147,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
         // Default editors for a wpcom site
         assertEquals(firstSite.getMobileEditor(), "aztec");
-        assertEquals(firstSite.getWebEditor(), "gutenberg");
+        assertEquals(firstSite.getWebEditor(), "classic");
     }
 
     @Test
@@ -453,6 +454,16 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         assertEquals(TestEvents.USER_ROLES_CHANGED, mNextEvent);
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onSiteEditorsChanged(OnSiteEditorsChanged event) {
+        if (event.isError()) {
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
+        }
+        assertEquals(TestEvents.SITE_EDITORS_CHANGED, mNextEvent);
         mCountDownLatch.countDown();
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -129,8 +129,16 @@ public class SitesFragment extends Fragment {
             public void onClick(View v) {
                 SiteModel site = mSiteStore.getSites().get(0);
                 // Fetch site plans
+                mDispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site));
+            }
+        });
+
+        view.findViewById(R.id.fetch_editors).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SiteModel site = mSiteStore.getSites().get(0);
+                // Fetch site editors
                 mDispatcher.dispatch(SiteActionBuilder.newFetchSiteEditorsAction(site));
-                //mDispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site));
             }
         });
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -129,7 +129,8 @@ public class SitesFragment extends Fragment {
             public void onClick(View v) {
                 SiteModel site = mSiteStore.getSites().get(0);
                 // Fetch site plans
-                mDispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site));
+                mDispatcher.dispatch(SiteActionBuilder.newFetchSiteEditorsAction(site));
+                //mDispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site));
             }
         });
 

--- a/example/src/main/res/layout/fragment_sites.xml
+++ b/example/src/main/res/layout/fragment_sites.xml
@@ -58,4 +58,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Fetch First Site Plans" />
+
+    <Button
+        android:id="@+id/fetch_editors"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fetch First Site Editors" />
 </LinearLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -38,8 +38,6 @@ public enum SiteAction implements IAction {
     FETCH_PROFILE_XML_RPC,
     @Action(payloadType = SiteModel.class)
     FETCH_SITE,
-    @Action(payloadType = SiteModel.class)
-    FETCH_SITE_EDITORS,
     @Action
     FETCH_SITES,
     @Action(payloadType = RefreshSitesXMLRPCPayload.class)
@@ -48,6 +46,8 @@ public enum SiteAction implements IAction {
     CREATE_NEW_SITE,
     @Action(payloadType = SiteModel.class)
     FETCH_POST_FORMATS,
+    @Action(payloadType = SiteModel.class)
+    FETCH_SITE_EDITORS,
     @Action(payloadType = SiteModel.class)
     FETCH_USER_ROLES,
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityR
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferStatusResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartPayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
+import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatedPrimaryDomainPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityResponsePayload;
@@ -48,6 +49,8 @@ public enum SiteAction implements IAction {
     FETCH_POST_FORMATS,
     @Action(payloadType = SiteModel.class)
     FETCH_SITE_EDITORS,
+    @Action(payloadType = DesignateMobileEditorPayload.class)
+    DESIGNATE_MOBILE_EDITOR,
     @Action(payloadType = SiteModel.class)
     FETCH_USER_ROLES,
     @Action(payloadType = SiteModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DesignatedPrimaryDomainPayloa
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchedEditorsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
@@ -37,6 +38,8 @@ public enum SiteAction implements IAction {
     FETCH_PROFILE_XML_RPC,
     @Action(payloadType = SiteModel.class)
     FETCH_SITE,
+    @Action(payloadType = SiteModel.class)
+    FETCH_SITE_EDITORS,
     @Action
     FETCH_SITES,
     @Action(payloadType = RefreshSitesXMLRPCPayload.class)
@@ -89,6 +92,8 @@ public enum SiteAction implements IAction {
     CREATED_NEW_SITE,
     @Action(payloadType = FetchedPostFormatsPayload.class)
     FETCHED_POST_FORMATS,
+    @Action(payloadType = FetchedEditorsPayload.class)
+    FETCHED_SITE_EDITORS,
     @Action(payloadType = FetchedUserRolesPayload.class)
     FETCHED_USER_ROLES,
     @Action(payloadType = DeleteSiteResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -83,6 +83,8 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private String mIconUrl;
     @Column private boolean mHasFreePlan;
     @Column private String mUnmappedUrl;
+    @Column private String mWebEditor;
+    @Column private String mMobileEditor;
 
     // WPCom capabilities
     @Column private boolean mHasCapabilityEditPages;
@@ -511,6 +513,22 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setUnmappedUrl(String unMappedUrl) {
         mUnmappedUrl = unMappedUrl;
+    }
+
+    public String getWebEditor() {
+        return mWebEditor;
+    }
+
+    public void setWebEditor(String webEditor) {
+        mWebEditor = webEditor;
+    }
+
+    public String getMobileEditor() {
+        return mMobileEditor;
+    }
+
+    public void setMobileEditor(String mobileEditor) {
+        mMobileEditor = mobileEditor;
     }
 
     public boolean isJetpackInstalled() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteEditorsResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteEditorsResponse.java
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import org.wordpress.android.fluxc.network.Response;
+
+public class SiteEditorsResponse implements Response {
+    public String editor_mobile;
+    public String editor_web;
+    public String opt_in;
+    public String opt_out;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteEditorsResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteEditorsResponse.java
@@ -5,6 +5,4 @@ import org.wordpress.android.fluxc.network.Response;
 public class SiteEditorsResponse implements Response {
     public String editor_mobile;
     public String editor_web;
-    public String opt_in;
-    public String opt_out;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.SiteAction;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2;
 import org.wordpress.android.fluxc.model.PlanModel;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.RoleModel;
@@ -55,6 +56,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedCountriesRespo
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesError;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchedEditorsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedUserRolesPayload;
@@ -67,6 +69,8 @@ import org.wordpress.android.fluxc.store.SiteStore.PostFormatsErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.QuickStartCompletedResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.QuickStartError;
 import org.wordpress.android.fluxc.store.SiteStore.QuickStartErrorType;
+import org.wordpress.android.fluxc.store.SiteStore.SiteEditorsError;
+import org.wordpress.android.fluxc.store.SiteStore.SiteEditorsErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteError;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
@@ -261,6 +265,38 @@ public class SiteRestClient extends BaseWPComRestClient {
 
         // Disable retries and increase timeout for site creation (it can sometimes take a long time to complete)
         request.setRetryPolicy(new DefaultRetryPolicy(NEW_SITE_TIMEOUT_MS, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
+        add(request);
+    }
+
+    public void fetchSiteEditor(final SiteModel site) {
+        Map<String, String> params = new HashMap<>();
+        String url = WPCOMV2.sites.site(site.getSiteId()).gutenberg.getUrl();
+        final WPComGsonRequest<SiteEditorsResponse> request = WPComGsonRequest.buildGetRequest(url, params,
+                SiteEditorsResponse.class,
+                new Listener<SiteEditorsResponse>() {
+                    @Override
+                    public void onResponse(SiteEditorsResponse response) {
+                        if (response != null) {
+                            FetchedEditorsPayload payload;
+                            payload = new FetchedEditorsPayload(site, response.editor_web, response.editor_mobile);
+                            mDispatcher.dispatch(SiteActionBuilder.newFetchedSiteEditorsAction(payload));
+                        } else {
+                            AppLog.e(T.API, "Received empty response to /sites/$site/gutenberg for " + site.getUrl());
+                            FetchedEditorsPayload payload = new FetchedEditorsPayload(site, "", "");
+                            payload.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
+                            mDispatcher.dispatch(SiteActionBuilder.newFetchedSiteEditorsAction(payload));
+                        }
+                    }
+                },
+                new WPComErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                        FetchedEditorsPayload payload = new FetchedEditorsPayload(site, "", "");
+                        payload.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchedSiteEditorsAction(payload));
+                    }
+                }
+                );
         add(request);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -300,6 +300,32 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
+    public void designateMobileEditor(final SiteModel site, final String mobileEditorName) {
+        Map<String, Object> params = new HashMap<>();
+        String url = WPCOMV2.sites.site(site.getSiteId()).gutenberg.getUrl();
+        params.put("editor", mobileEditorName);
+        params.put("platform", "mobile");
+        final WPComGsonRequest<SiteEditorsResponse> request = WPComGsonRequest
+                .buildPostRequest(url, params, SiteEditorsResponse.class,
+                        new Listener<SiteEditorsResponse>() {
+                            @Override
+                            public void onResponse(SiteEditorsResponse response) {
+                                FetchedEditorsPayload payload;
+                                payload = new FetchedEditorsPayload(site, response.editor_web, response.editor_mobile);
+                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSiteEditorsAction(payload));
+                            }
+                        },
+                        new WPComErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                                FetchedEditorsPayload payload = new FetchedEditorsPayload(site, "", "");
+                                payload.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
+                                mDispatcher.dispatch(SiteActionBuilder.newFetchedSiteEditorsAction(payload));
+                            }
+                        });
+        add(request);
+    }
+
     public void fetchPostFormats(@NonNull final SiteModel site) {
         String url = WPCOMREST.sites.site(site.getSiteId()).post_formats.getUrlV1_1();
         final WPComGsonRequest<PostFormatsResponse> request = WPComGsonRequest.buildGetRequest(url, null,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -268,7 +268,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void fetchSiteEditor(final SiteModel site) {
+    public void fetchSiteEditors(final SiteModel site) {
         Map<String, String> params = new HashMap<>();
         String url = WPCOMV2.sites.site(site.getSiteId()).gutenberg.getUrl();
         final WPComGsonRequest<SiteEditorsResponse> request = WPComGsonRequest.buildGetRequest(url, params,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -558,7 +558,6 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("alter table SiteModel add WEB_EDITOR TEXT;");
                 db.execSQL("alter table SiteModel add MOBILE_EDITOR TEXT;");
                 oldVersion++;
-
         }
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 74;
+        return 75;
     }
 
     @Override
@@ -553,6 +553,12 @@ public class WellSqlConfig extends DefaultWellConfig {
                            + "SUBTYPE TEXT,READ INTEGER,ICON TEXT,NOTICON TEXT,TIMESTAMP TEXT,URL TEXT,"
                            + "TITLE TEXT,FORMATTABLE_BODY TEXT,FORMATTABLE_SUBJECT TEXT,FORMATTABLE_META TEXT)");
                 oldVersion++;
+            case 74:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table SiteModel add WEB_EDITOR TEXT;");
+                db.execSQL("alter table SiteModel add MOBILE_EDITOR TEXT;");
+                oldVersion++;
+
         }
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -112,6 +112,16 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class DesignateMobileEditorPayload extends Payload<SiteEditorsError> {
+        public SiteModel site;
+        public String editor;
+
+        public DesignateMobileEditorPayload(@NonNull SiteModel site, @NonNull String editorName) {
+            this.site = site;
+            this.editor = editorName;
+        }
+    }
+
     public static class FetchedEditorsPayload extends Payload<SiteEditorsError> {
         public SiteModel site;
         public String webEditor;
@@ -1381,7 +1391,10 @@ public class SiteStore extends Store {
                 updatePostFormats((FetchedPostFormatsPayload) action.getPayload());
                 break;
             case FETCH_SITE_EDITORS:
-                fetchSiteEditor((SiteModel) action.getPayload());
+                fetchSiteEditors((SiteModel) action.getPayload());
+                break;
+            case DESIGNATE_MOBILE_EDITOR:
+                designateMobileEditor((DesignateMobileEditorPayload) action.getPayload());
                 break;
             case FETCHED_SITE_EDITORS:
                 updateSiteEditors((FetchedEditorsPayload) action.getPayload());
@@ -1660,9 +1673,15 @@ public class SiteStore extends Store {
         emitChange(event);
     }
 
-    private void fetchSiteEditor(SiteModel site) {
+    private void fetchSiteEditors(SiteModel site) {
         if (site.isUsingWpComRestApi()) {
             mSiteRestClient.fetchSiteEditors(site);
+        }
+    }
+
+    private void designateMobileEditor(DesignateMobileEditorPayload payload) {
+        if (payload.site.isUsingWpComRestApi()) {
+            mSiteRestClient.designateMobileEditor(payload.site, payload.editor);
         }
     }
 
@@ -1672,6 +1691,8 @@ public class SiteStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
+            site.setMobileEditor(payload.mobileEditor);
+            site.setWebEditor(payload.webEditor);
             try {
                 event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(site);
             } catch (Exception e) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1662,7 +1662,7 @@ public class SiteStore extends Store {
 
     private void fetchSiteEditor(SiteModel site) {
         if (site.isUsingWpComRestApi()) {
-            mSiteRestClient.fetchSiteEditor(site);
+            mSiteRestClient.fetchSiteEditors(site);
         }
     }
 

--- a/fluxc/src/main/tools/wp-com-v2-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-v2-endpoints.txt
@@ -5,6 +5,8 @@
 /sites/$site/activity
 /sites/$site/rewind
 
+/sites/$site/gutenberg
+
 /sites/$site/stats/orders/
 /sites/$site/stats/top-earners
 


### PR DESCRIPTION
This PR adds the ability of reading and setting the default mobile editor to the Site Store.
See #1084

- The remote REST endpoint is only available for wpcom/JP sites
- The default values are "aztec" for mobile, and "gutenberg" for web
- The remote REST endpoint is available on the wpcom dev remote console for testing
GET `wpcom/v2/sites/SiteID_OR_ADDRESS/gutenberg?platform=mobile` 
POST `wpcom/v2/sites/SiteID_OR_ADDRESS/gutenberg?platform=mobile&editor=gutenberg` (*)
- On the app side (wp-android) we just need in this first phase to switch a local toggle and update the remote site accordingly. No need to read, even though this PR does also have this part of the code in place
- To test the fetching of the editor preferences, just log in to the app, and go to Site screen and tap on the last button at the very bottom of the screen

`wp-android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10209

Related master issue: https://github.com/wordpress-mobile/WordPress-Android/issues/10192

(*) Apparently there is a problem on the API where setting a mobile editor does't really change the value on the backend. For more info or context please ping one of us on the mobile-gb channel on Slack). 
