### PR TITLE
Introduce changesConfirmedAt and remoteStatus into post model

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -336,6 +336,32 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     @Test
+    public void testRemotePostStatusIsBeingSet() throws InterruptedException {
+        mNextEvent = TestEvents.POSTS_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(sSite, false)));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        mNextEvent = TestEvents.POSTS_FETCHED;
+        mCountDownLatch = new CountDownLatch(1);
+
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostsAction(new FetchPostsPayload(sSite, true)));
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        boolean statusMatches = true;
+        for (PostModel post : mPostStore.getPostsForSite(sSite)) {
+            if (!post.getStatus().equals(post.getRemoteStatus())) {
+                statusMatches = false;
+                break;
+            }
+        }
+        assertTrue(statusMatches);
+    }
+
+    @Test
     public void testFullFeaturedPostUpload() throws InterruptedException {
         createNewPost();
 

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreDbIntegrationTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreDbIntegrationTest.java
@@ -97,6 +97,20 @@ public class PostStoreDbIntegrationTest {
     }
 
     @Test
+    public void testUpdatePublishedConfirmedAt() {
+        // Arrange
+        String dummyDate = "1955-11-05T14:15:00Z";
+        PostModel postModel = new PostModel();
+        postModel.setPublishConfirmedAt(dummyDate);
+
+        // Act
+        mPostSqlUtils.insertPostForResult(postModel);
+
+        // Assert
+        assertEquals(dummyDate, PostTestUtils.getPosts().get(0).getPublishConfirmedAt());
+    }
+
+    @Test
     public void testPushAndFetchCollision() throws InterruptedException {
         // Test uploading a post, fetching remote posts and updating the db from the fetch first
 

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreDbIntegrationTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreDbIntegrationTest.java
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.model.revisions.Diff;
 import org.wordpress.android.fluxc.model.revisions.DiffOperations;
 import org.wordpress.android.fluxc.model.revisions.LocalDiffModel;
@@ -97,17 +98,31 @@ public class PostStoreDbIntegrationTest {
     }
 
     @Test
-    public void testUpdatePublishedConfirmedAt() {
+    public void testUpdateChangesConfirmedAt() {
         // Arrange
         String dummyDate = "1955-11-05T14:15:00Z";
         PostModel postModel = new PostModel();
-        postModel.setPublishConfirmedAt(dummyDate);
+        postModel.setChangesConfirmedAt(dummyDate);
 
         // Act
         mPostSqlUtils.insertPostForResult(postModel);
 
         // Assert
-        assertEquals(dummyDate, PostTestUtils.getPosts().get(0).getPublishConfirmedAt());
+        assertEquals(dummyDate, PostTestUtils.getPosts().get(0).getChangesConfirmedAt());
+    }
+
+    @Test
+    public void testUpdateRemotePostStatus() {
+        // Arrange
+        String dummyStatus = PostStatus.PENDING.toString();
+        PostModel postModel = new PostModel();
+        postModel.setRemoteStatus(dummyStatus);
+
+        // Act
+        mPostSqlUtils.insertPostForResult(postModel);
+
+        // Assert
+        assertEquals(dummyStatus, PostTestUtils.getPosts().get(0).getRemoteStatus());
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -45,6 +45,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private String mExcerpt;
     @Column private String mTagNames;
     @Column private String mStatus;
+    @Column private String mRemoteStatus;
     @Column private String mPassword;
     @Column private long mFeaturedImageId;
     @Column private String mPostFormat;
@@ -52,7 +53,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private double mLatitude = PostLocation.INVALID_LATITUDE;
     @Column private double mLongitude = PostLocation.INVALID_LONGITUDE;
 
-    @Column private String mPublishConfirmedAt; // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    @Column private String mChangesConfirmedAt; // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
 
     // Page specific
     @Column private boolean mIsPage;
@@ -214,6 +215,18 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         mStatus = status;
     }
 
+    public @NonNull String getRemoteStatus() {
+        return StringUtils.notNullStr(mRemoteStatus);
+    }
+
+    /**
+     * This method shouldn't be called outside of FluxC. We should set it's modifier to internal when this class
+     * is converted to Kotlin.
+     */
+    public void setRemoteStatus(String status) {
+        mRemoteStatus = status;
+    }
+
     public @NonNull String getPassword() {
         return StringUtils.notNullStr(mPassword);
     }
@@ -280,12 +293,12 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         mLongitude = longitude;
     }
 
-    public String getPublishConfirmedAt() {
-        return mPublishConfirmedAt;
+    public String getChangesConfirmedAt() {
+        return mChangesConfirmedAt;
     }
 
-    public void setPublishConfirmedAt(String publishConfirmedAt) {
-        mPublishConfirmedAt = publishConfirmedAt;
+    public void setChangesConfirmedAt(String changesConfirmedAt) {
+        mChangesConfirmedAt = changesConfirmedAt;
     }
 
     public boolean isPage() {
@@ -397,12 +410,13 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
                 && StringUtils.equals(getExcerpt(), otherPost.getExcerpt())
                 && StringUtils.equals(getTagNames(), otherPost.getTagNames())
                 && StringUtils.equals(getStatus(), otherPost.getStatus())
+                && StringUtils.equals(getRemoteStatus(), otherPost.getRemoteStatus())
                 && StringUtils.equals(getPassword(), otherPost.getPassword())
                 && StringUtils.equals(getPostFormat(), otherPost.getPostFormat())
                 && StringUtils.equals(getSlug(), otherPost.getSlug())
                 && StringUtils.equals(getParentTitle(), otherPost.getParentTitle())
                 && StringUtils.equals(getDateLocallyChanged(), otherPost.getDateLocallyChanged())
-                && StringUtils.equals(getPublishConfirmedAt(), ((PostModel) other).getPublishConfirmedAt());
+                && StringUtils.equals(getChangesConfirmedAt(), ((PostModel) other).getChangesConfirmedAt());
     }
 
     public @Nullable JSONArray getJSONCustomFields() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -52,6 +52,8 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private double mLatitude = PostLocation.INVALID_LATITUDE;
     @Column private double mLongitude = PostLocation.INVALID_LONGITUDE;
 
+    @Column private String mPublishConfirmedAt; // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+
     // Page specific
     @Column private boolean mIsPage;
     @Column private long mParentId;
@@ -278,6 +280,14 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         mLongitude = longitude;
     }
 
+    public String getPublishConfirmedAt() {
+        return mPublishConfirmedAt;
+    }
+
+    public void setPublishConfirmedAt(String publishConfirmedAt) {
+        mPublishConfirmedAt = publishConfirmedAt;
+    }
+
     public boolean isPage() {
         return mIsPage;
     }
@@ -391,7 +401,8 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
                 && StringUtils.equals(getPostFormat(), otherPost.getPostFormat())
                 && StringUtils.equals(getSlug(), otherPost.getSlug())
                 && StringUtils.equals(getParentTitle(), otherPost.getParentTitle())
-                && StringUtils.equals(getDateLocallyChanged(), otherPost.getDateLocallyChanged());
+                && StringUtils.equals(getDateLocallyChanged(), otherPost.getDateLocallyChanged())
+                && StringUtils.equals(getPublishConfirmedAt(), ((PostModel) other).getPublishConfirmedAt());
     }
 
     public @Nullable JSONArray getJSONCustomFields() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -339,6 +339,7 @@ public class PostRestClient extends BaseWPComRestClient {
         post.setExcerpt(from.getExcerpt());
         post.setSlug(from.getSlug());
         post.setStatus(from.getStatus());
+        post.setRemoteStatus(from.getStatus());
         post.setPassword(from.getPassword());
         post.setIsPage(from.getType().equals("page"));
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -449,6 +449,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         post.setPassword(MapUtils.getMapStr(postMap, "post_password"));
         post.setStatus(MapUtils.getMapStr(postMap, "post_status"));
+        post.setRemoteStatus(MapUtils.getMapStr(postMap, "post_status"));
 
         if ("page".equals(MapUtils.getMapStr(postMap, "post_type"))) {
             post.setIsPage(true);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 75;
+        return 76;
     }
 
     @Override
@@ -557,6 +557,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add WEB_EDITOR TEXT;");
                 db.execSQL("alter table SiteModel add MOBILE_EDITOR TEXT;");
+                oldVersion++;
+            case 75:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table PostModel add PUBLISHED_CONFIRMED_AT TEXT;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -8,6 +8,7 @@ import android.preference.PreferenceManager;
 
 import androidx.annotation.StringDef;
 
+import com.wellsql.generated.PostModelTable;
 import com.yarolegovich.wellsql.DefaultWellConfig;
 import com.yarolegovich.wellsql.WellSql;
 import com.yarolegovich.wellsql.WellTableManager;
@@ -560,7 +561,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 75:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("alter table PostModel add PUBLISHED_CONFIRMED_AT TEXT;");
+                db.execSQL("alter table PostModel add CHANGES_CONFIRMED_AT TEXT;");
+                db.execSQL("alter table PostModel add REMOTE_STATUS TEXT;");
+                // when a post is locally changed we don't know it's original/remote status anymore
+                db.execSQL("update PostModel SET REMOTE_STATUS = " + PostModelTable.STATUS + " WHERE "
+                        + PostModelTable.IS_LOCALLY_CHANGED + " = 0;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
First task from https://github.com/wordpress-mobile/WordPress-Android/issues/10174

Introduces
- `changesConfirmedAt` - local field which will help us determine which locally modified posts can be safely auto-uploaded
- `remoteStatus` - remote status of the post which should never modified locally as oppose to `status` which holds the local status of the post.

To test:
The basic behavior is tested in the integration tests.

You might want to consider testing the migration with the example app + stetho, but we can leave that for WPAndroid.

