### PR TITLE
Post scheduling reminder store

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -64,4 +64,5 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_PostListTestXMLRPC test);
     void inject(ReleaseStack_TransactionsTest test);
     void inject(ReleaseStack_WCOrderListTest test);
+    void inject(ReleaseStack_PostSchedulingTestJetpack test);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostSchedulingTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostSchedulingTestJetpack.kt
@@ -1,0 +1,163 @@
+package org.wordpress.android.fluxc.release
+
+import org.greenrobot.eventbus.Subscribe
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.action.ActivityLogAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.example.BuildConfig
+import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.ONE_HOUR
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+/**
+ * Tests with real credentials on real servers using the full release stack (no mock)
+ */
+class ReleaseStack_PostSchedulingTestJetpack : ReleaseStack_Base() {
+    private val incomingActions: MutableList<Action<*>> = mutableListOf()
+    @Inject lateinit var postSchedulingNotificationStore: PostSchedulingNotificationStore
+    @Inject internal lateinit var siteStore: SiteStore
+    @Inject internal lateinit var accountStore: AccountStore
+
+    private var nextEvent: TestEvents? = null
+
+    internal enum class TestEvents {
+        NONE,
+        SITE_CHANGED,
+        SITE_REMOVED,
+        ERROR_DUPLICATE_SITE
+    }
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mReleaseStackAppComponent.inject(this)
+        // Register
+        init()
+        // Reset expected test event
+        nextEvent = TestEvents.NONE
+        this.incomingActions.clear()
+    }
+
+    @Test
+    fun testPostSchedulingNotification() {
+        authenticate()
+
+        val postId = 1
+
+        val startPeriod = postSchedulingNotificationStore.getSchedulingReminderPeriod(postId)
+
+        assertEquals(startPeriod, Period.OFF)
+
+        val period = ONE_HOUR
+
+        val scheduledNotificationId = postSchedulingNotificationStore.schedule(postId, period)
+
+        assertNotNull(scheduledNotificationId)
+
+        val scheduledNotification = postSchedulingNotificationStore.getSchedulingReminder(scheduledNotificationId!!)
+
+        assertEquals(scheduledNotification!!.notificationId, scheduledNotificationId)
+        assertEquals(scheduledNotification.postId, postId)
+        assertEquals(scheduledNotification.scheduledTime, period)
+
+        postSchedulingNotificationStore.deleteSchedulingReminders(postId)
+
+        val deletedPeriod = postSchedulingNotificationStore.getSchedulingReminderPeriod(postId)
+
+        assertEquals(startPeriod, Period.OFF)
+    }
+
+
+    private fun authenticate(): SiteModel {
+        authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
+                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY)
+
+        return siteStore.sites[0]
+    }
+
+    @Subscribe
+    fun onAuthenticationChanged(event: OnAuthenticationChanged) {
+        if (event.isError) {
+            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
+        }
+        mCountDownLatch.countDown()
+    }
+
+    @Subscribe
+    fun onAccountChanged(event: OnAccountChanged) {
+        AppLog.d(T.TESTS, "Received OnAccountChanged event")
+        if (event.isError) {
+            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
+        }
+        mCountDownLatch.countDown()
+    }
+
+    @Subscribe
+    fun onSiteChanged(event: OnSiteChanged) {
+        AppLog.i(T.TESTS, "site count " + siteStore.sitesCount)
+        if (event.isError) {
+            if (nextEvent == TestEvents.ERROR_DUPLICATE_SITE) {
+                assertEquals(SiteErrorType.DUPLICATE_SITE, event.error.type)
+                mCountDownLatch.countDown()
+                return
+            }
+            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
+        }
+        assertTrue(siteStore.hasSite())
+        assertEquals(TestEvents.SITE_CHANGED, nextEvent)
+        mCountDownLatch.countDown()
+    }
+
+    @Subscribe
+    fun onAction(action: Action<*>) {
+        if (action.type is ActivityLogAction) {
+            incomingActions.add(action)
+            mCountDownLatch?.countDown()
+        }
+    }
+
+    @Throws(InterruptedException::class)
+    private fun authenticateWPComAndFetchSites(username: String, password: String) {
+        // Authenticate a test user (actual credentials declared in gradle.properties)
+        val payload = AuthenticatePayload(username, password)
+        mCountDownLatch = CountDownLatch(1)
+
+        // Correct user we should get an OnAuthenticationChanged message
+        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload))
+        // Wait for a network response / onChanged event
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        // Fetch account from REST API, and wait for OnAccountChanged event
+        mCountDownLatch = CountDownLatch(1)
+        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        // Fetch sites from REST API, and wait for onSiteChanged event
+        mCountDownLatch = CountDownLatch(1)
+        nextEvent = TestEvents.SITE_CHANGED
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(siteStore.sitesCount > 0)
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostSchedulingTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostSchedulingTestJetpack.kt
@@ -87,7 +87,6 @@ class ReleaseStack_PostSchedulingTestJetpack : ReleaseStack_Base() {
         assertEquals(deletedPeriod, Period.OFF)
     }
 
-
     private fun authenticate(): SiteModel {
         authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
                 BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostSchedulingTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostSchedulingTestJetpack.kt
@@ -84,7 +84,7 @@ class ReleaseStack_PostSchedulingTestJetpack : ReleaseStack_Base() {
 
         val deletedPeriod = postSchedulingNotificationStore.getSchedulingReminderPeriod(postId)
 
-        assertEquals(startPeriod, Period.OFF)
+        assertEquals(deletedPeriod, Period.OFF)
     }
 
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStoreTest.kt
@@ -34,8 +34,8 @@ class PostSchedulingNotificationStoreTest {
 
     @Test
     fun `schedule deletes previous notification and inserts update when set`() {
-        periodMappings.entries.forEach { (domainModel, dbModel) ->
-            store.schedule(postId, domainModel)
+        periodMappings.entries.forEach { (schedulingReminderModel, dbModel) ->
+            store.schedule(postId, schedulingReminderModel)
 
             inOrder(sqlUtils).apply {
                 this.verify(sqlUtils).deleteSchedulingReminders(postId)
@@ -61,7 +61,7 @@ class PostSchedulingNotificationStoreTest {
 
     @Test
     fun `returns notification from database`() {
-        periodMappings.entries.forEach { (domainModel, dbModel) ->
+        periodMappings.entries.forEach { (schedulingReminderModel, dbModel) ->
             whenever(sqlUtils.getSchedulingReminder(notificationId)).thenReturn(
                     SchedulingReminderDbModel(
                             notificationId,
@@ -69,21 +69,21 @@ class PostSchedulingNotificationStoreTest {
                             dbModel
                     )
             )
-            val schedulingReminderModel = store.getSchedulingReminder(notificationId)
+            val schedulingReminder = store.getSchedulingReminder(notificationId)
 
-            assertThat(schedulingReminderModel!!.notificationId).isEqualTo(notificationId)
-            assertThat(schedulingReminderModel.postId).isEqualTo(postId)
-            assertThat(schedulingReminderModel.scheduledTime).isEqualTo(domainModel)
+            assertThat(schedulingReminder!!.notificationId).isEqualTo(notificationId)
+            assertThat(schedulingReminder.postId).isEqualTo(postId)
+            assertThat(schedulingReminder.scheduledTime).isEqualTo(schedulingReminderModel)
         }
     }
 
     @Test
     fun `returns scheduling reminder period from database`() {
-        periodMappings.entries.forEach { (domainModel, dbModel) ->
+        periodMappings.entries.forEach { (schedulingReminderModel, dbModel) ->
             whenever(sqlUtils.getSchedulingReminderPeriodDbModel(postId)).thenReturn(dbModel)
             val schedulingReminderPeriod = store.getSchedulingReminderPeriod(postId)
 
-            assertThat(schedulingReminderPeriod).isEqualTo(domainModel)
+            assertThat(schedulingReminderPeriod).isEqualTo(schedulingReminderModel)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStoreTest.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.fluxc.store
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.persistence.PostSchedulingNotificationSqlUtils
+import org.wordpress.android.fluxc.persistence.PostSchedulingNotificationSqlUtils.SchedulingReminderDbModel
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel
+
+@RunWith(MockitoJUnitRunner::class)
+class PostSchedulingNotificationStoreTest {
+    @Mock lateinit var sqlUtils: PostSchedulingNotificationSqlUtils
+    private lateinit var store: PostSchedulingNotificationStore
+    private val postId = 1
+    private val notificationId = 2
+    private val periodMappings = mapOf(
+            SchedulingReminderModel.Period.ONE_HOUR to SchedulingReminderDbModel.Period.ONE_HOUR,
+            SchedulingReminderModel.Period.TEN_MINUTES to SchedulingReminderDbModel.Period.TEN_MINUTES,
+            SchedulingReminderModel.Period.WHEN_PUBLISHED to SchedulingReminderDbModel.Period.WHEN_PUBLISHED
+    )
+
+    @Before
+    fun setUp() {
+        store = PostSchedulingNotificationStore(sqlUtils)
+    }
+
+    @Test
+    fun `schedule deletes previous notification and inserts update when set`() {
+        periodMappings.entries.forEach { (domainModel, dbModel) ->
+            store.schedule(postId, domainModel)
+
+            inOrder(sqlUtils).apply {
+                this.verify(sqlUtils).deletePostSchedulingNotifications(postId)
+                this.verify(sqlUtils).insert(postId, dbModel)
+            }
+        }
+    }
+
+    @Test
+    fun `schedule deletes previous notification when OFF`() {
+        store.schedule(postId, SchedulingReminderModel.Period.OFF)
+
+        verify(sqlUtils).deletePostSchedulingNotifications(postId)
+        verify(sqlUtils, never()).insert(any(), any())
+    }
+
+    @Test
+    fun `deletes notification per post`() {
+        store.deletePostSchedulingNotifications(postId)
+
+        verify(sqlUtils).deletePostSchedulingNotifications(postId)
+    }
+
+    @Test
+    fun `returns notification from database`() {
+        periodMappings.entries.forEach { (domainModel, dbModel) ->
+            whenever(sqlUtils.getNotification(notificationId)).thenReturn(
+                    SchedulingReminderDbModel(
+                            notificationId,
+                            postId,
+                            dbModel
+                    )
+            )
+            val schedulingReminderModel = store.getNotification(notificationId)
+
+            assertThat(schedulingReminderModel!!.notificationId).isEqualTo(notificationId)
+            assertThat(schedulingReminderModel.postId).isEqualTo(postId)
+            assertThat(schedulingReminderModel.scheduledTime).isEqualTo(domainModel)
+        }
+    }
+
+    @Test
+    fun `returns scheduling reminder period from database`() {
+        periodMappings.entries.forEach { (domainModel, dbModel) ->
+            whenever(sqlUtils.getSchedulingReminderPeriodDbModel(postId)).thenReturn(dbModel)
+            val schedulingReminderPeriod = store.getSchedulingReminderPeriod(postId)
+
+            assertThat(schedulingReminderPeriod).isEqualTo(domainModel)
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStoreTest.kt
@@ -38,7 +38,7 @@ class PostSchedulingNotificationStoreTest {
             store.schedule(postId, domainModel)
 
             inOrder(sqlUtils).apply {
-                this.verify(sqlUtils).deletePostSchedulingNotifications(postId)
+                this.verify(sqlUtils).deleteSchedulingReminders(postId)
                 this.verify(sqlUtils).insert(postId, dbModel)
             }
         }
@@ -48,28 +48,28 @@ class PostSchedulingNotificationStoreTest {
     fun `schedule deletes previous notification when OFF`() {
         store.schedule(postId, SchedulingReminderModel.Period.OFF)
 
-        verify(sqlUtils).deletePostSchedulingNotifications(postId)
+        verify(sqlUtils).deleteSchedulingReminders(postId)
         verify(sqlUtils, never()).insert(any(), any())
     }
 
     @Test
     fun `deletes notification per post`() {
-        store.deletePostSchedulingNotifications(postId)
+        store.deleteSchedulingReminders(postId)
 
-        verify(sqlUtils).deletePostSchedulingNotifications(postId)
+        verify(sqlUtils).deleteSchedulingReminders(postId)
     }
 
     @Test
     fun `returns notification from database`() {
         periodMappings.entries.forEach { (domainModel, dbModel) ->
-            whenever(sqlUtils.getNotification(notificationId)).thenReturn(
+            whenever(sqlUtils.getSchedulingReminder(notificationId)).thenReturn(
                     SchedulingReminderDbModel(
                             notificationId,
                             postId,
                             dbModel
                     )
             )
-            val schedulingReminderModel = store.getNotification(notificationId)
+            val schedulingReminderModel = store.getSchedulingReminder(notificationId)
 
             assertThat(schedulingReminderModel!!.notificationId).isEqualTo(notificationId)
             assertThat(schedulingReminderModel.postId).isEqualTo(postId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -204,7 +204,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
         )
     }
 
-    @Table(name = "NotificationModel")
+    @Table(name = "SchedulingReminderModel")
     data class NotificationModelBuilder(
         @PrimaryKey @Column private var mId: Int = -1,
         @Column var remoteNoteId: Long,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -204,7 +204,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
         )
     }
 
-    @Table(name = "SchedulingReminderModel")
+    @Table(name = "NotificationModel")
     data class NotificationModelBuilder(
         @PrimaryKey @Column private var mId: Int = -1,
         @Column var remoteNoteId: Long,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
@@ -53,7 +53,13 @@ class PostSchedulingNotificationSqlUtils
                 .where()
                 .equals(PostSchedulingReminderTable.ID, notificationId)
                 .endWhere().asModel.firstOrNull()
-                ?.let { SchedulingReminderDbModel(it.id, it.postId, SchedulingReminderDbModel.Period.valueOf(it.scheduledTime)) }
+                ?.let {
+                    SchedulingReminderDbModel(
+                            it.id,
+                            it.postId,
+                            SchedulingReminderDbModel.Period.valueOf(it.scheduledTime)
+                    )
+                }
     }
 
     data class SchedulingReminderDbModel(val notificationId: Int, val postId: Int, val period: Period) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
@@ -6,6 +6,7 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.NotificationModel
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.ScheduledTime
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.ScheduledTime.OFF
 import javax.inject.Inject
@@ -15,7 +16,7 @@ import javax.inject.Singleton
 class PostSchedulingNotificationSqlUtils
 @Inject constructor() {
     fun insert(
-        postId: Long,
+        postId: Int,
         scheduledTime: ScheduledTime
     ): Int? {
         deletePostSchedulingNotifications(postId)
@@ -32,7 +33,7 @@ class PostSchedulingNotificationSqlUtils
                 .endWhere().asModel.firstOrNull()?.id
     }
 
-    fun deletePostSchedulingNotifications(postId: Long) {
+    fun deletePostSchedulingNotifications(postId: Int) {
         WellSql.delete(PostSchedulingNotificationBuilder::class.java)
                 .where()
                 .equals(PostSchedulingNotificationTable.POST_ID, postId)
@@ -41,7 +42,7 @@ class PostSchedulingNotificationSqlUtils
     }
 
     fun getScheduledTime(
-        postId: Long
+        postId: Int
     ): ScheduledTime {
         return WellSql.select(PostSchedulingNotificationBuilder::class.java)
                 .where()
@@ -49,19 +50,20 @@ class PostSchedulingNotificationSqlUtils
                 .endWhere().asModel.firstOrNull()?.scheduledTime?.let { ScheduledTime.valueOf(it) } ?: OFF
     }
 
-    fun isScheduled(
+    fun getNotification(
         notificationId: Int
-    ): Boolean {
+    ): NotificationModel? {
         return WellSql.select(PostSchedulingNotificationBuilder::class.java)
                 .where()
                 .equals(PostSchedulingNotificationTable.ID, notificationId)
-                .endWhere().asModel.firstOrNull() != null
+                .endWhere().asModel.firstOrNull()
+                ?.let { NotificationModel(it.id, it.postId, ScheduledTime.valueOf(it.scheduledTime)) }
     }
 
     @Table(name = "PostSchedulingNotification")
     data class PostSchedulingNotificationBuilder(
         @PrimaryKey @Column private var mId: Int = -1,
-        @Column var postId: Long,
+        @Column var postId: Int,
         @Column var scheduledTime: String
     ) : Identifiable {
         constructor() : this(-1, -1, "")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.persistence
 
-import com.wellsql.generated.PostSchedulingNotificationTable
+import com.wellsql.generated.PostSchedulingReminderTable
 import com.yarolegovich.wellsql.WellSql
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
@@ -25,15 +25,15 @@ class PostSchedulingNotificationSqlUtils
         ).execute()
         return WellSql.select(PostSchedulingReminderBuilder::class.java)
                 .where()
-                .equals(PostSchedulingNotificationTable.POST_ID, postId)
-                .equals(PostSchedulingNotificationTable.SCHEDULED_TIME, scheduledTime.name)
+                .equals(PostSchedulingReminderTable.POST_ID, postId)
+                .equals(PostSchedulingReminderTable.SCHEDULED_TIME, scheduledTime.name)
                 .endWhere().asModel.firstOrNull()?.id
     }
 
     fun deletePostSchedulingNotifications(postId: Int) {
         WellSql.delete(PostSchedulingReminderBuilder::class.java)
                 .where()
-                .equals(PostSchedulingNotificationTable.POST_ID, postId)
+                .equals(PostSchedulingReminderTable.POST_ID, postId)
                 .endWhere()
                 .execute()
     }
@@ -43,7 +43,7 @@ class PostSchedulingNotificationSqlUtils
     ): SchedulingReminderDbModel.Period? {
         return WellSql.select(PostSchedulingReminderBuilder::class.java)
                 .where()
-                .equals(PostSchedulingNotificationTable.POST_ID, postId)
+                .equals(PostSchedulingReminderTable.POST_ID, postId)
                 .endWhere().asModel.firstOrNull()?.scheduledTime?.let { SchedulingReminderDbModel.Period.valueOf(it) }
     }
 
@@ -52,7 +52,7 @@ class PostSchedulingNotificationSqlUtils
     ): SchedulingReminderDbModel? {
         return WellSql.select(PostSchedulingReminderBuilder::class.java)
                 .where()
-                .equals(PostSchedulingNotificationTable.ID, notificationId)
+                .equals(PostSchedulingReminderTable.ID, notificationId)
                 .endWhere().asModel.firstOrNull()
                 ?.let { SchedulingReminderDbModel(it.id, it.postId, SchedulingReminderDbModel.Period.valueOf(it.scheduledTime)) }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
@@ -8,7 +8,6 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.NotificationModel
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.ScheduledTime
-import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.ScheduledTime.OFF
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -43,11 +42,11 @@ class PostSchedulingNotificationSqlUtils
 
     fun getScheduledTime(
         postId: Int
-    ): ScheduledTime {
+    ): ScheduledTime? {
         return WellSql.select(PostSchedulingNotificationBuilder::class.java)
                 .where()
                 .equals(PostSchedulingNotificationTable.POST_ID, postId)
-                .endWhere().asModel.firstOrNull()?.scheduledTime?.let { ScheduledTime.valueOf(it) } ?: OFF
+                .endWhere().asModel.firstOrNull()?.scheduledTime?.let { ScheduledTime.valueOf(it) }
     }
 
     fun getNotification(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
@@ -16,7 +16,6 @@ class PostSchedulingNotificationSqlUtils
         postId: Int,
         scheduledTime: SchedulingReminderDbModel.Period
     ): Int? {
-        deletePostSchedulingNotifications(postId)
         WellSql.insert(
                 PostSchedulingReminderBuilder(
                         postId = postId,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSchedulingNotificationSqlUtils.kt
@@ -29,7 +29,7 @@ class PostSchedulingNotificationSqlUtils
                 .endWhere().asModel.firstOrNull()?.id
     }
 
-    fun deletePostSchedulingNotifications(postId: Int) {
+    fun deleteSchedulingReminders(postId: Int) {
         WellSql.delete(PostSchedulingReminderBuilder::class.java)
                 .where()
                 .equals(PostSchedulingReminderTable.POST_ID, postId)
@@ -46,7 +46,7 @@ class PostSchedulingNotificationSqlUtils
                 .endWhere().asModel.firstOrNull()?.scheduledTime?.let { SchedulingReminderDbModel.Period.valueOf(it) }
     }
 
-    fun getNotification(
+    fun getSchedulingReminder(
         notificationId: Int
     ): SchedulingReminderDbModel? {
         return WellSql.select(PostSchedulingReminderBuilder::class.java)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 75;
+        return 76;
     }
 
     @Override
@@ -557,6 +557,12 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table SiteModel add WEB_EDITOR TEXT;");
                 db.execSQL("alter table SiteModel add MOBILE_EDITOR TEXT;");
+                oldVersion++;
+            case 75:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL(
+                        "CREATE TABLE PostSchedulingNotification (_id INTEGER PRIMARY KEY AUTOINCREMENT,POST_ID "
+                        + "INTEGER,SCHEDULED_TIME TEXT NOT NULL)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -561,8 +561,8 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 75:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL(
-                        "CREATE TABLE PostSchedulingNotification (_id INTEGER PRIMARY KEY AUTOINCREMENT,POST_ID "
-                        + "INTEGER,SCHEDULED_TIME TEXT NOT NULL)");
+                        "CREATE TABLE PostSchedulingReminder (_id INTEGER PRIMARY KEY AUTOINCREMENT,POST_ID INTEGER,"
+                        + "SCHEDULED_TIME TEXT NOT NULL)");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.persistence.PostSchedulingNotificationSqlUtils
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PostSchedulingNotificationStore
+@Inject constructor(private val sqlUtils: PostSchedulingNotificationSqlUtils) {
+    fun schedule(postId: Long, scheduledTime: ScheduledTime): Int? {
+        return sqlUtils.insert(postId, scheduledTime)
+    }
+    fun deletePostSchedulingNotifications(postId: Long){
+        sqlUtils.deletePostSchedulingNotifications(postId)
+    }
+
+    fun isScheduled(notificationId: Int): Boolean {
+        return sqlUtils.isScheduled(notificationId)
+    }
+
+    fun getScheduledTime(postId: Long): ScheduledTime {
+        return sqlUtils.getScheduledTime(postId)
+    }
+
+    enum class ScheduledTime {
+        ONE_HOUR, TEN_MINUTES, WHEN_PUBLISHED, OFF
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
@@ -25,7 +25,7 @@ class PostSchedulingNotificationStore
 
     fun getSchedulingReminder(notificationId: Int): SchedulingReminderModel? {
         val dmModel = sqlUtils.getSchedulingReminder(notificationId)
-        return dmModel?.let { SchedulingReminderModel(it.notificationId, it.postId, it.period.toDomainModel()) }
+        return dmModel?.let { SchedulingReminderModel(it.notificationId, it.postId, it.period.toSchedulingReminderPeriod()) }
     }
 
     fun getSchedulingReminderPeriod(postId: Int): Period {
@@ -37,7 +37,7 @@ class PostSchedulingNotificationStore
         }
     }
 
-    private fun SchedulingReminderDbModel.Period?.toDomainModel(): Period {
+    private fun SchedulingReminderDbModel.Period?.toSchedulingReminderPeriod(): Period {
         return when (this) {
             SchedulingReminderDbModel.Period.ONE_HOUR -> ONE_HOUR
             SchedulingReminderDbModel.Period.TEN_MINUTES -> TEN_MINUTES

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
@@ -15,16 +15,16 @@ class PostSchedulingNotificationStore
 @Inject constructor(private val sqlUtils: PostSchedulingNotificationSqlUtils) {
     fun schedule(postId: Int, schedulingReminderPeriod: Period): Int? {
         val dbModel = schedulingReminderPeriod.toDbModel()
-        sqlUtils.deletePostSchedulingNotifications(postId)
+        sqlUtils.deleteSchedulingReminders(postId)
         return dbModel?.let { sqlUtils.insert(postId, dbModel) }
     }
 
-    fun deletePostSchedulingNotifications(postId: Int) {
-        sqlUtils.deletePostSchedulingNotifications(postId)
+    fun deleteSchedulingReminders(postId: Int) {
+        sqlUtils.deleteSchedulingReminders(postId)
     }
 
-    fun getNotification(notificationId: Int): SchedulingReminderModel? {
-        val dmModel = sqlUtils.getNotification(notificationId)
+    fun getSchedulingReminder(notificationId: Int): SchedulingReminderModel? {
+        val dmModel = sqlUtils.getSchedulingReminder(notificationId)
         return dmModel?.let { SchedulingReminderModel(it.notificationId, it.postId, it.period.toDomainModel()) }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
@@ -18,12 +18,12 @@ class PostSchedulingNotificationStore
         return sqlUtils.getNotification(notificationId)
     }
 
-    fun getScheduledTime(postId: Int): ScheduledTime {
+    fun getScheduledTime(postId: Int): ScheduledTime? {
         return sqlUtils.getScheduledTime(postId)
     }
 
     enum class ScheduledTime {
-        ONE_HOUR, TEN_MINUTES, WHEN_PUBLISHED, OFF
+        ONE_HOUR, TEN_MINUTES, WHEN_PUBLISHED
     }
 
     data class NotificationModel(val notificationId: Int, val postId: Int, val scheduledTime: ScheduledTime)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
@@ -1,30 +1,71 @@
 package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.persistence.PostSchedulingNotificationSqlUtils
+import org.wordpress.android.fluxc.persistence.PostSchedulingNotificationSqlUtils.SchedulingReminderDbModel
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.OFF
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.ONE_HOUR
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.TEN_MINUTES
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.WHEN_PUBLISHED
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class PostSchedulingNotificationStore
 @Inject constructor(private val sqlUtils: PostSchedulingNotificationSqlUtils) {
-    fun schedule(postId: Int, scheduledTime: ScheduledTime): Int? {
-        return sqlUtils.insert(postId, scheduledTime)
+    fun schedule(postId: Int, schedulingReminderPeriod: Period): Int? {
+        val dbModel = schedulingReminderPeriod.toDbModel()
+        return if (dbModel == null) {
+            sqlUtils.deletePostSchedulingNotifications(postId)
+            null
+        } else {
+            sqlUtils.insert(postId, dbModel)
+        }
     }
-    fun deletePostSchedulingNotifications(postId: Int){
+
+    fun deletePostSchedulingNotifications(postId: Int) {
         sqlUtils.deletePostSchedulingNotifications(postId)
     }
 
-    fun getNotification(notificationId: Int): NotificationModel? {
-        return sqlUtils.getNotification(notificationId)
+    fun getNotification(notificationId: Int): SchedulingReminderModel? {
+        val dmModel = sqlUtils.getNotification(notificationId)
+        return dmModel?.let { SchedulingReminderModel(it.notificationId, it.postId, it.period.toDomainModel()) }
     }
 
-    fun getScheduledTime(postId: Int): ScheduledTime? {
-        return sqlUtils.getScheduledTime(postId)
+    fun getSchedulingReminderPeriod(postId: Int): Period {
+        return when (sqlUtils.getSchedulingReminderPeriodDbModel(postId)) {
+            SchedulingReminderDbModel.Period.ONE_HOUR -> ONE_HOUR
+            SchedulingReminderDbModel.Period.TEN_MINUTES -> TEN_MINUTES
+            SchedulingReminderDbModel.Period.WHEN_PUBLISHED -> WHEN_PUBLISHED
+            null -> OFF
+        }
     }
 
-    enum class ScheduledTime {
-        ONE_HOUR, TEN_MINUTES, WHEN_PUBLISHED
+    private fun SchedulingReminderDbModel.Period?.toDomainModel(): Period {
+        return when (this) {
+            SchedulingReminderDbModel.Period.ONE_HOUR -> ONE_HOUR
+            SchedulingReminderDbModel.Period.TEN_MINUTES -> TEN_MINUTES
+            SchedulingReminderDbModel.Period.WHEN_PUBLISHED -> WHEN_PUBLISHED
+            null -> OFF
+        }
     }
 
-    data class NotificationModel(val notificationId: Int, val postId: Int, val scheduledTime: ScheduledTime)
+    private fun Period.toDbModel(): SchedulingReminderDbModel.Period? {
+        return when (this) {
+            ONE_HOUR -> SchedulingReminderDbModel.Period.ONE_HOUR
+            TEN_MINUTES -> SchedulingReminderDbModel.Period.TEN_MINUTES
+            WHEN_PUBLISHED -> SchedulingReminderDbModel.Period.WHEN_PUBLISHED
+            OFF -> null
+        }
+    }
+
+    data class SchedulingReminderModel(
+        val notificationId: Int,
+        val postId: Int,
+        val scheduledTime: Period
+    ) {
+        enum class Period {
+            OFF, ONE_HOUR, TEN_MINUTES, WHEN_PUBLISHED
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
@@ -25,7 +25,13 @@ class PostSchedulingNotificationStore
 
     fun getSchedulingReminder(notificationId: Int): SchedulingReminderModel? {
         val dmModel = sqlUtils.getSchedulingReminder(notificationId)
-        return dmModel?.let { SchedulingReminderModel(it.notificationId, it.postId, it.period.toSchedulingReminderPeriod()) }
+        return dmModel?.let {
+            SchedulingReminderModel(
+                    it.notificationId,
+                    it.postId,
+                    it.period.toSchedulingReminderPeriod()
+            )
+        }
     }
 
     fun getSchedulingReminderPeriod(postId: Int): Period {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
@@ -15,12 +15,8 @@ class PostSchedulingNotificationStore
 @Inject constructor(private val sqlUtils: PostSchedulingNotificationSqlUtils) {
     fun schedule(postId: Int, schedulingReminderPeriod: Period): Int? {
         val dbModel = schedulingReminderPeriod.toDbModel()
-        return if (dbModel == null) {
-            sqlUtils.deletePostSchedulingNotifications(postId)
-            null
-        } else {
-            sqlUtils.insert(postId, dbModel)
-        }
+        sqlUtils.deletePostSchedulingNotifications(postId)
+        return dbModel?.let { sqlUtils.insert(postId, dbModel) }
     }
 
     fun deletePostSchedulingNotifications(postId: Int) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostSchedulingNotificationStore.kt
@@ -7,22 +7,24 @@ import javax.inject.Singleton
 @Singleton
 class PostSchedulingNotificationStore
 @Inject constructor(private val sqlUtils: PostSchedulingNotificationSqlUtils) {
-    fun schedule(postId: Long, scheduledTime: ScheduledTime): Int? {
+    fun schedule(postId: Int, scheduledTime: ScheduledTime): Int? {
         return sqlUtils.insert(postId, scheduledTime)
     }
-    fun deletePostSchedulingNotifications(postId: Long){
+    fun deletePostSchedulingNotifications(postId: Int){
         sqlUtils.deletePostSchedulingNotifications(postId)
     }
 
-    fun isScheduled(notificationId: Int): Boolean {
-        return sqlUtils.isScheduled(notificationId)
+    fun getNotification(notificationId: Int): NotificationModel? {
+        return sqlUtils.getNotification(notificationId)
     }
 
-    fun getScheduledTime(postId: Long): ScheduledTime {
+    fun getScheduledTime(postId: Int): ScheduledTime {
         return sqlUtils.getScheduledTime(postId)
     }
 
     enum class ScheduledTime {
         ONE_HOUR, TEN_MINUTES, WHEN_PUBLISHED, OFF
     }
+
+    data class NotificationModel(val notificationId: Int, val postId: Int, val scheduledTime: ScheduledTime)
 }


### PR DESCRIPTION
This PR adds a store that keeps the information about the scheduling reminders set from Edit post settings. It lets you schedule a notification, delete all scheduled notifications and get all notifications from the DB. 

It should be tested with the related WPAndroid PR.