### PR TITLE
Fix featured image upload on self-hosted sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -208,6 +208,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                                 responseMedia.setId(media.getId());
                                 responseMedia.setLocalSiteId(site.getId());
                                 responseMedia.setLocalPostId(media.getLocalPostId());
+                                responseMedia.setMarkedLocallyAsFeatured(media.getMarkedLocallyAsFeatured());
 
                                 notifyMediaUploaded(responseMedia, null);
                             }
@@ -319,6 +320,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                             responseMedia.setId(media.getId());
                             responseMedia.setLocalSiteId(site.getId());
                             responseMedia.setLocalPostId(media.getLocalPostId());
+                            responseMedia.setMarkedLocallyAsFeatured(media.getMarkedLocallyAsFeatured());
 
                             if (isFreshUpload) {
                                 notifyMediaUploaded(responseMedia, null);


### PR DESCRIPTION
Fixes featured image upload on self-hosted sites in WPAndroid.

You can test this in WPAndroid on branch `issue/10263-featured-image-self-hosted-site`.

Testing steps can be found [here](https://github.com/wordpress-mobile/WordPress-Android/issues/10263).
