### PR TITLE
Retain old values of editor prefs on site details update

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -182,8 +182,13 @@ public class SiteRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(SiteWPComRestResponse response) {
                         if (response != null) {
-                            SiteModel site = siteResponseToSiteModel(response);
-                            mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(site));
+                            SiteModel newSite = siteResponseToSiteModel(response);
+                            // The REST API doesn't return info about the editor(s). Make sure to copy old values
+                            // otherwise the apps will receive an update site without editor prefs set.
+                            // The apps will dispatch the action to update editor(s) when necessary.
+                            newSite.setMobileEditor(site.getMobileEditor());
+                            newSite.setWebEditor(site.getWebEditor());
+                            mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(newSite));
                         } else {
                             AppLog.e(T.API, "Received empty response to /sites/$site/ for " + site.getUrl());
                             SiteModel payload = new SiteModel();


### PR DESCRIPTION
This PR does fix a problem where the details of mobile editors are cleared on site update, and the host apps receiving a version of SiteModel with empty editor props.
This is because the REST API call made to retrieve editors are not the same of site details, resulting in site details returning and clearing the old model. 

This PR does make sure to copy old values for the editor prefs to the new response, and it only affects wpcom sites, since the .org sites already keep the "old" model and just refresh it.

Host apps will dispatch the action to update editor details on their own.