### PR TITLE
Save mobile editor preference for self hosted sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -182,8 +182,13 @@ public class SiteRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(SiteWPComRestResponse response) {
                         if (response != null) {
-                            SiteModel site = siteResponseToSiteModel(response);
-                            mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(site));
+                            SiteModel newSite = siteResponseToSiteModel(response);
+                            // The REST API doesn't return info about the editor(s). Make sure to copy old values
+                            // otherwise the apps will receive an update site without editor prefs set.
+                            // The apps will dispatch the action to update editor(s) when necessary.
+                            newSite.setMobileEditor(site.getMobileEditor());
+                            newSite.setWebEditor(site.getWebEditor());
+                            mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(newSite));
                         } else {
                             AppLog.e(T.API, "Received empty response to /sites/$site/ for " + site.getUrl());
                             SiteModel payload = new SiteModel();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1682,6 +1682,17 @@ public class SiteStore extends Store {
     private void designateMobileEditor(DesignateMobileEditorPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mSiteRestClient.designateMobileEditor(payload.site, payload.editor);
+        } else {
+            // Just update the editor pref on the DB
+            SiteModel site = payload.site;
+            site.setMobileEditor(payload.editor);
+            OnSiteEditorsChanged event = new OnSiteEditorsChanged(site);
+            try {
+                event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(site);
+            } catch (Exception e) {
+                event.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
+            }
+            emitChange(event);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1683,7 +1683,7 @@ public class SiteStore extends Store {
         if (payload.site.isUsingWpComRestApi()) {
             mSiteRestClient.designateMobileEditor(payload.site, payload.editor);
         } else {
-            // Just update the editor pref on the DB
+            // .ORG sites: Just update the editor pref on the DB and emit the change
             SiteModel site = payload.site;
             site.setMobileEditor(payload.editor);
             OnSiteEditorsChanged event = new OnSiteEditorsChanged(site);


### PR DESCRIPTION
This PR does implement saving of mobile editor choice to DB when the action `DESIGNATE_MOBILE_EDITOR` is dispatched from host apps on a .ORG site.

.ORG sites don't have an endpoint yet to save and retrieve the editor setting, we just need to save it locally on the DB.

This PR is on top of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1314 (Well, not strictly on top of that but, i've branched from that PR).

Testing via: https://github.com/wordpress-mobile/WordPress-Android/pull/10254