### PR TITLE
Add author into PostModel

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -53,8 +53,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private double mLongitude = PostLocation.INVALID_LONGITUDE;
 
     @Column private long mAuthorId;
-    @Column private String mAuthorFirstName;
-    @Column private String mAuthorLastName;
+    @Column private String mAuthorDisplayName;
 
     // Page specific
     @Column private boolean mIsPage;
@@ -290,20 +289,12 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         this.mAuthorId = authorId;
     }
 
-    public String getAuthorFirstName() {
-        return mAuthorFirstName;
+    public String getAuthorDisplayName() {
+        return mAuthorDisplayName;
     }
 
-    public void setAuthorFirstName(String authorFirstName) {
-        this.mAuthorFirstName = authorFirstName;
-    }
-
-    public String getAuthorLastName() {
-        return mAuthorLastName;
-    }
-
-    public void setAuthorLastName(String authorLastName) {
-        this.mAuthorLastName = authorLastName;
+    public void setAuthorDisplayName(String authorDisplayName) {
+        mAuthorDisplayName = authorDisplayName;
     }
 
     public boolean isPage() {
@@ -420,8 +411,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
                 && StringUtils.equals(getPostFormat(), otherPost.getPostFormat())
                 && StringUtils.equals(getSlug(), otherPost.getSlug())
                 && StringUtils.equals(getParentTitle(), otherPost.getParentTitle())
-                && StringUtils.equals(getAuthorFirstName(), otherPost.getAuthorFirstName())
-                && StringUtils.equals(getAuthorLastName(), otherPost.getAuthorLastName())
+                && StringUtils.equals(getAuthorDisplayName(), otherPost.getAuthorDisplayName())
                 && StringUtils.equals(getDateLocallyChanged(), otherPost.getDateLocallyChanged());
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -52,6 +52,10 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private double mLatitude = PostLocation.INVALID_LATITUDE;
     @Column private double mLongitude = PostLocation.INVALID_LONGITUDE;
 
+    @Column private long mAuthorId;
+    @Column private String mAuthorFirstName;
+    @Column private String mAuthorLastName;
+
     // Page specific
     @Column private boolean mIsPage;
     @Column private long mParentId;
@@ -278,6 +282,30 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         mLongitude = longitude;
     }
 
+    public long getAuthorId() {
+        return mAuthorId;
+    }
+
+    public void setAuthorId(long authorId) {
+        this.mAuthorId = authorId;
+    }
+
+    public String getAuthorFirstName() {
+        return mAuthorFirstName;
+    }
+
+    public void setAuthorFirstName(String authorFirstName) {
+        this.mAuthorFirstName = authorFirstName;
+    }
+
+    public String getAuthorLastName() {
+        return mAuthorLastName;
+    }
+
+    public void setAuthorLastName(String authorLastName) {
+        this.mAuthorLastName = authorLastName;
+    }
+
     public boolean isPage() {
         return mIsPage;
     }
@@ -370,6 +398,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         return getId() == otherPost.getId() && getLocalSiteId() == otherPost.getLocalSiteId()
                 && getRemoteSiteId() == otherPost.getRemoteSiteId() && getRemotePostId() == otherPost.getRemotePostId()
                 && getFeaturedImageId() == otherPost.getFeaturedImageId()
+                && getAuthorId() == otherPost.getAuthorId()
                 && Double.compare(otherPost.getLatitude(), getLatitude()) == 0
                 && Double.compare(otherPost.getLongitude(), getLongitude()) == 0
                 && isPage() == otherPost.isPage()
@@ -391,6 +420,8 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
                 && StringUtils.equals(getPostFormat(), otherPost.getPostFormat())
                 && StringUtils.equals(getSlug(), otherPost.getSlug())
                 && StringUtils.equals(getParentTitle(), otherPost.getParentTitle())
+                && StringUtils.equals(getAuthorFirstName(), otherPost.getAuthorFirstName())
+                && StringUtils.equals(getAuthorLastName(), otherPost.getAuthorLastName())
                 && StringUtils.equals(getDateLocallyChanged(), otherPost.getDateLocallyChanged());
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -344,8 +344,7 @@ public class PostRestClient extends BaseWPComRestClient {
 
         if (from.getAuthor() != null) {
             post.setAuthorId(from.getAuthor().getId());
-            post.setAuthorFirstName(from.getAuthor().getFirstName());
-            post.setAuthorLastName(from.getAuthor().getLastName());
+            post.setAuthorDisplayName(from.getAuthor().getName());
         }
 
         if (from.getPostThumbnail() != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -342,6 +342,12 @@ public class PostRestClient extends BaseWPComRestClient {
         post.setPassword(from.getPassword());
         post.setIsPage(from.getType().equals("page"));
 
+        if (from.getAuthor() != null) {
+            post.setAuthorId(from.getAuthor().getId());
+            post.setAuthorFirstName(from.getAuthor().getFirstName());
+            post.setAuthorLastName(from.getAuthor().getLastName());
+        }
+
         if (from.getPostThumbnail() != null) {
             post.setFeaturedImageId(from.getPostThumbnail().getId());
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -26,7 +26,8 @@ data class PostWPComRestResponse(
     @SerializedName("geo") val geo: GeoLocation? = null,
     @SerializedName("tags") val tags: Map<String, TermWPComRestResponse>? = null,
     @SerializedName("categories") val categories: Map<String, TermWPComRestResponse>? = null,
-    @SerializedName("capabilities") val capabilities: Capabilities? = null
+    @SerializedName("capabilities") val capabilities: Capabilities? = null,
+    @SerializedName("author") val author: Author? = null
 ) {
     data class PostsResponse(
         @SerializedName("posts") val posts: List<PostWPComRestResponse>
@@ -45,5 +46,10 @@ data class PostWPComRestResponse(
         @SerializedName("publish_post") val publishPost: Boolean = false,
         @SerializedName("edit_post") val editPost: Boolean = false,
         @SerializedName("delete_post") val deletePost: Boolean = false
+    )
+    data class Author(
+        @SerializedName("ID") val id: Long = 0,
+        @SerializedName("first_name") val firstName: String?,
+        @SerializedName("last_name") val lastName: String?
     )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -49,7 +49,6 @@ data class PostWPComRestResponse(
     )
     data class Author(
         @SerializedName("ID") val id: Long = 0,
-        @SerializedName("first_name") val firstName: String?,
-        @SerializedName("last_name") val lastName: String?
+        @SerializedName("name") val name: String?
     )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 77;
+        return 78;
     }
 
     @Override
@@ -566,6 +566,12 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL(
                         "CREATE TABLE PostSchedulingReminder (_id INTEGER PRIMARY KEY AUTOINCREMENT,POST_ID INTEGER,"
                         + "SCHEDULED_TIME TEXT NOT NULL)");
+                oldVersion++;
+            case 77:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("alter table PostModel add AUTHOR_ID INTEGER;");
+                db.execSQL("alter table PostModel add AUTHOR_FIRST_NAME TEXT;");
+                db.execSQL("alter table PostModel add AUTHOR_LAST_NAME TEXT;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -570,8 +570,7 @@ public class WellSqlConfig extends DefaultWellConfig {
             case 77:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table PostModel add AUTHOR_ID INTEGER;");
-                db.execSQL("alter table PostModel add AUTHOR_FIRST_NAME TEXT;");
-                db.execSQL("alter table PostModel add AUTHOR_LAST_NAME TEXT;");
+                db.execSQL("alter table PostModel add AUTHOR_DISPLAY_NAME TEXT;");
                 oldVersion++;
         }
         db.setTransactionSuccessful();


### PR DESCRIPTION
Fixes #1316

This PR adds 3 new fields into the PostModel
- ~authorFirstName~
- ~authorLastName~
- authorDisplayName
- authorId

Notes:
- I considered removing all posts without localChanges (locallyChanged, localDrafts) in order to make sure we fetch the new empty fields. However, I decided it's not worth users' data and the risk of (not)removing something important (I wasn't sure if I need to clear some other dependant tables or not). So the fields will be filled only on new posts or posts which were recently modified. Let me know what you think about it.
- We fetch author fields only for WPCom sites. The core endpoint contains only authorId and fetching the additional fields from another endpoint isn't worth it.


To test:
https://github.com/wordpress-mobile/WordPress-Android/pull/10276

