### PR TITLE
Add clean operations to stats sql utils

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
@@ -24,6 +25,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
+import org.wordpress.android.fluxc.store.StatsStore
 import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
 import org.wordpress.android.fluxc.store.stats.insights.CommentsStore
 import org.wordpress.android.fluxc.store.stats.insights.FollowersStore
@@ -54,6 +56,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     @Inject lateinit var todayStore: TodayInsightsStore
     @Inject lateinit var postingActivityStore: PostingActivityStore
     @Inject internal lateinit var siteStore: SiteStore
+    @Inject internal lateinit var statsStore: StatsStore
     @Inject internal lateinit var accountStore: AccountStore
 
     private var nextEvent: TestEvents? = null
@@ -77,7 +80,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
     }
 
     @Test
-    fun testFetchAllTimeInsights() {
+    fun testFetchAllTimeInsightsAndDeletesAfterwards() {
         val site = authenticate()
 
         val fetchedInsights = runBlocking { allTimeStore.fetchAllTimeInsights(site) }
@@ -88,10 +91,14 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         val insightsFromDb = allTimeStore.getAllTimeInsights(site)
 
         assertEquals(fetchedInsights.model, insightsFromDb)
+
+        runBlocking { statsStore.deleteAllData() }
+
+        assertNull(allTimeStore.getAllTimeInsights(site))
     }
 
     @Test
-    fun testFetchLatestPostInsights() {
+    fun testFetchLatestPostInsightsAndDeletesBySiteAfter() {
         val site = authenticate()
 
         val fetchedInsights = runBlocking { latestPostStore.fetchLatestPostInsights(site) }
@@ -102,6 +109,10 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
         val insightsFromDb = latestPostStore.getLatestPostInsights(site)
 
         assertEquals(fetchedInsights.model, insightsFromDb)
+
+        runBlocking { statsStore.deleteSiteData(site) }
+
+        assertNull(latestPostStore.getLatestPostInsights(site))
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InsightsTestJetpack.kt
@@ -92,7 +92,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
 
         assertEquals(fetchedInsights.model, insightsFromDb)
 
-        runBlocking { statsStore.deleteAllData() }
+        statsStore.deleteAllData()
 
         assertNull(allTimeStore.getAllTimeInsights(site))
     }
@@ -110,7 +110,7 @@ class ReleaseStack_InsightsTestJetpack : ReleaseStack_Base() {
 
         assertEquals(fetchedInsights.model, insightsFromDb)
 
-        runBlocking { statsStore.deleteSiteData(site) }
+        statsStore.deleteSiteData(site)
 
         assertNull(latestPostStore.getLatestPostInsights(site))
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
@@ -17,6 +17,7 @@ import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.persistence.InsightTypeSqlUtils
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.COMMENTS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWERS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.LATEST_POST_SUMMARY
@@ -32,6 +33,7 @@ class StatsStoreTest {
     @Mock lateinit var preferenceUtilsWrapper: PreferenceUtilsWrapper
     @Mock lateinit var sharedPreferences: SharedPreferences
     @Mock lateinit var sharedPreferencesEditor: SharedPreferences.Editor
+    @Mock lateinit var statsSqlUtils: StatsSqlUtils
     private lateinit var store: StatsStore
 
     @ExperimentalCoroutinesApi
@@ -40,7 +42,8 @@ class StatsStoreTest {
         store = StatsStore(
                 Unconfined,
                 insightTypesSqlUtils,
-                preferenceUtilsWrapper
+                preferenceUtilsWrapper,
+                statsSqlUtils
         )
         whenever(preferenceUtilsWrapper.getFluxCPreferences()).thenReturn(sharedPreferences)
         whenever(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)
@@ -207,5 +210,21 @@ class StatsStoreTest {
         val insightsManagementNewsCardShowing = store.isInsightsManagementNewsCardShowing()
 
         assertThat(insightsManagementNewsCardShowing).isEqualTo(prefsValue)
+    }
+
+    @Test
+    fun `deletes all stats`() = test {
+        store.deleteAllData()
+
+        verify(statsSqlUtils).deleteAllStats()
+    }
+
+    @Test
+    fun `deletes all stats for a site`() = test {
+        val site = SiteModel()
+
+        store.deleteSiteData(site)
+
+        verify(statsSqlUtils).deleteSiteStats(site)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -87,6 +87,18 @@ class StatsSqlUtils
         return null
     }
 
+    fun deleteAllStats(): Int {
+        return WellSql.delete(StatsBlockBuilder::class.java).execute()
+    }
+
+    fun deleteSiteStats(site: SiteModel): Int {
+        return WellSql.delete(StatsBlockBuilder::class.java)
+                .where()
+                .equals(StatsBlockTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .execute()
+    }
+
     private fun createSelectStatement(
         site: SiteModel,
         blockType: BlockType,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.TIMEOUT
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.persistence.InsightTypeSqlUtils
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.ALL_TIME_STATS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.COMMENTS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.MOST_POPULAR_DAY_AND_HOUR
@@ -48,13 +49,23 @@ import kotlin.coroutines.CoroutineContext
 
 val DEFAULT_INSIGHTS = listOf(POSTING_ACTIVITY, TODAY_STATS, ALL_TIME_STATS, MOST_POPULAR_DAY_AND_HOUR, COMMENTS)
 const val INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN = "INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN"
+
 @Singleton
 class StatsStore
 @Inject constructor(
     private val coroutineContext: CoroutineContext,
     private val insightTypeSqlUtils: InsightTypeSqlUtils,
-    private val preferenceUtils: PreferenceUtilsWrapper
+    private val preferenceUtils: PreferenceUtilsWrapper,
+    private val statsSqlUtils: StatsSqlUtils
 ) {
+    suspend fun deleteAllData() = withContext(coroutineContext) {
+        statsSqlUtils.deleteAllStats()
+    }
+
+    suspend fun deleteSiteData(site: SiteModel) = withContext(coroutineContext) {
+        statsSqlUtils.deleteSiteStats(site)
+    }
+
     suspend fun getInsightTypes(site: SiteModel): List<StatsType> = withContext(coroutineContext) {
         val types = mutableListOf<StatsType>()
         if (!preferenceUtils.getFluxCPreferences().getBoolean(INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN, false)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -58,11 +58,11 @@ class StatsStore
     private val preferenceUtils: PreferenceUtilsWrapper,
     private val statsSqlUtils: StatsSqlUtils
 ) {
-    suspend fun deleteAllData() = withContext(coroutineContext) {
+    fun deleteAllData() {
         statsSqlUtils.deleteAllStats()
     }
 
-    suspend fun deleteSiteData(site: SiteModel) = withContext(coroutineContext) {
+    fun deleteSiteData(site: SiteModel) {
         statsSqlUtils.deleteSiteStats(site)
     }
 


### PR DESCRIPTION
This PR introduces methods that delete all the stats data when the user logs out in WPAndroid.