### PR TITLE
Fix ReleaseStack_SiteTestWPCom#testFetchSiteEditors

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -147,7 +147,8 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
         String siteEditor = firstSite.getMobileEditor();
         // Test mobile editors for a wpcom site
-        assertTrue(siteEditor.equals("aztec") || siteEditor.equals("gutenberg"));
+        assertTrue(siteEditor.equals("")
+                || siteEditor.equals("aztec") || siteEditor.equals("gutenberg"));
     }
 
     @Test


### PR DESCRIPTION
The test `testFetchSiteEditors` started to fail on automated test runs, since the backend changed the default returned value recently.

This PR fixes the mobile editor preference test by including n the pool of the expected responses the new default from the server. 
Honestly this is not a great test anyway. We should change it in the future, or at least add another test that sets and verifies the new response.

