### PR TITLE
Fix for returning correct editor details when fetching site details

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -183,6 +183,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     public void onResponse(SiteWPComRestResponse response) {
                         if (response != null) {
                             SiteModel newSite = siteResponseToSiteModel(response);
+                            newSite.setId(site.getId());
                             mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(newSite));
                         } else {
                             AppLog.e(T.API, "Received empty response to /sites/$site/ for " + site.getUrl());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -183,11 +183,6 @@ public class SiteRestClient extends BaseWPComRestClient {
                     public void onResponse(SiteWPComRestResponse response) {
                         if (response != null) {
                             SiteModel newSite = siteResponseToSiteModel(response);
-                            // The REST API doesn't return info about the editor(s). Make sure to copy old values
-                            // otherwise the apps will receive an update site without editor prefs set.
-                            // The apps will dispatch the action to update editor(s) when necessary.
-                            newSite.setMobileEditor(site.getMobileEditor());
-                            newSite.setWebEditor(site.getWebEditor());
                             mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(newSite));
                         } else {
                             AppLog.e(T.API, "Received empty response to /sites/$site/ for " + site.getUrl());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -183,7 +183,11 @@ public class SiteRestClient extends BaseWPComRestClient {
                     public void onResponse(SiteWPComRestResponse response) {
                         if (response != null) {
                             SiteModel newSite = siteResponseToSiteModel(response);
-                            newSite.setId(site.getId());
+                            // local ID is not copied into the new model, let's make sure it is
+                            // otherwise the call that updates the DB can add a new row?
+                            if (site.getId() > 0) {
+                                newSite.setId(site.getId());
+                            }
                             mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(newSite));
                         } else {
                             AppLog.e(T.API, "Received empty response to /sites/$site/ for " + site.getUrl());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1526,6 +1526,11 @@ public class SiteStore extends Store {
             event.error = SiteErrorUtils.genericToSiteError(siteModel.error);
         } else {
             try {
+                // The REST API doesn't return info about the editor(s). Make sure to copy current values
+                // available on the DB. Otherwise the apps will receive an update site without editor prefs set.
+                // The apps will dispatch the action to update editor(s) when necessary.
+                SiteModel freshSiteFromDB = getSiteByLocalId(siteModel.getId());
+                siteModel.setMobileEditor(freshSiteFromDB.getMobileEditor());
                 event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
             } catch (DuplicateSiteException e) {
                 event.error = new SiteError(SiteErrorType.DUPLICATE_SITE);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1494,7 +1494,7 @@ public class SiteStore extends Store {
 
     private void fetchSite(SiteModel site) {
         if (site.isUsingWpComRestApi()) {
-            AppLog.d(T.API, "aggiorno il sito con local id " + site.getId());
+            AppLog.d(T.API, "Fetching the site with local ID: " + site.getId());
             mSiteRestClient.fetchSite(site);
         } else {
             mSiteXMLRPCClient.fetchSite(site);
@@ -1532,10 +1532,10 @@ public class SiteStore extends Store {
                 // The apps will dispatch the action to update editor(s) when necessary.
                 SiteModel freshSiteFromDB = getSiteByLocalId(siteModel.getId());
                 if (freshSiteFromDB != null) {
-                    AppLog.d(T.API, "impostato il vecchio valore per editor mobile: " + freshSiteFromDB.getMobileEditor());
+                    AppLog.d(T.API, "Old value for editor mobile: " + freshSiteFromDB.getMobileEditor());
                     siteModel.setMobileEditor(freshSiteFromDB.getMobileEditor());
                 } else {
-                    AppLog.d(T.API, "Il sito non era stato trovato " + siteModel.getUrl());
+                    AppLog.d(T.API, "site not found " + siteModel.getUrl() + " " + siteModel.getId());
                 }
                 event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
             } catch (DuplicateSiteException e) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1532,10 +1532,7 @@ public class SiteStore extends Store {
                 // The apps will dispatch the action to update editor(s) when necessary.
                 SiteModel freshSiteFromDB = getSiteByLocalId(siteModel.getId());
                 if (freshSiteFromDB != null) {
-                    AppLog.d(T.API, "Old value for editor mobile: " + freshSiteFromDB.getMobileEditor());
                     siteModel.setMobileEditor(freshSiteFromDB.getMobileEditor());
-                } else {
-                    AppLog.d(T.API, "site not found " + siteModel.getUrl() + " " + siteModel.getId());
                 }
                 event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
             } catch (DuplicateSiteException e) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1494,6 +1494,7 @@ public class SiteStore extends Store {
 
     private void fetchSite(SiteModel site) {
         if (site.isUsingWpComRestApi()) {
+            AppLog.d(T.API, "aggiorno il sito con local id " + site.getId());
             mSiteRestClient.fetchSite(site);
         } else {
             mSiteXMLRPCClient.fetchSite(site);
@@ -1532,10 +1533,10 @@ public class SiteStore extends Store {
                 SiteModel freshSiteFromDB = getSiteByLocalId(siteModel.getId());
                 if (freshSiteFromDB != null) {
                     AppLog.d(T.API, "impostato il vecchio valore per editor mobile: " + freshSiteFromDB.getMobileEditor());
+                    siteModel.setMobileEditor(freshSiteFromDB.getMobileEditor());
                 } else {
                     AppLog.d(T.API, "Il sito non era stato trovato " + siteModel.getUrl());
                 }
-                siteModel.setMobileEditor(freshSiteFromDB.getMobileEditor());
                 event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
             } catch (DuplicateSiteException e) {
                 event.error = new SiteError(SiteErrorType.DUPLICATE_SITE);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1494,7 +1494,6 @@ public class SiteStore extends Store {
 
     private void fetchSite(SiteModel site) {
         if (site.isUsingWpComRestApi()) {
-            AppLog.d(T.API, "Fetching the site with local ID: " + site.getId());
             mSiteRestClient.fetchSite(site);
         } else {
             mSiteXMLRPCClient.fetchSite(site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1532,6 +1532,7 @@ public class SiteStore extends Store {
                 SiteModel freshSiteFromDB = getSiteByLocalId(siteModel.getId());
                 if (freshSiteFromDB != null) {
                     siteModel.setMobileEditor(freshSiteFromDB.getMobileEditor());
+                    siteModel.setWebEditor(freshSiteFromDB.getWebEditor());
                 }
                 event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
             } catch (DuplicateSiteException e) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1687,20 +1687,21 @@ public class SiteStore extends Store {
     }
 
     private void designateMobileEditor(DesignateMobileEditorPayload payload) {
+        // wpcom sites sync the new value with the backend
         if (payload.site.isUsingWpComRestApi()) {
             mSiteRestClient.designateMobileEditor(payload.site, payload.editor);
-        } else {
-            // .ORG sites: Just update the editor pref on the DB and emit the change
-            SiteModel site = payload.site;
-            site.setMobileEditor(payload.editor);
-            OnSiteEditorsChanged event = new OnSiteEditorsChanged(site);
-            try {
-                event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(site);
-            } catch (Exception e) {
-                event.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
-            }
-            emitChange(event);
         }
+
+        // Update the editor pref on the DB, and emit the change immediately
+        SiteModel site = payload.site;
+        site.setMobileEditor(payload.editor);
+        OnSiteEditorsChanged event = new OnSiteEditorsChanged(site);
+        try {
+            event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(site);
+        } catch (Exception e) {
+            event.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
+        }
+        emitChange(event);
     }
 
     private void updateSiteEditors(FetchedEditorsPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1530,6 +1530,11 @@ public class SiteStore extends Store {
                 // available on the DB. Otherwise the apps will receive an update site without editor prefs set.
                 // The apps will dispatch the action to update editor(s) when necessary.
                 SiteModel freshSiteFromDB = getSiteByLocalId(siteModel.getId());
+                if (freshSiteFromDB != null) {
+                    AppLog.d(T.API, "impostato il vecchio valore per editor mobile: " + freshSiteFromDB.getMobileEditor());
+                } else {
+                    AppLog.d(T.API, "Il sito non era stato trovato " + siteModel.getUrl());
+                }
                 siteModel.setMobileEditor(freshSiteFromDB.getMobileEditor());
                 event.rowsAffected = SiteSqlUtils.insertOrUpdateSite(siteModel);
             } catch (DuplicateSiteException e) {


### PR DESCRIPTION
It seems to me that the code that fetches site details from the backend doesn't proper set the local ID of the [new SiteModel](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7de37009030be38cd9e23072e0bc154f321de2cb/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java#L191) when the response is receive from the network, resulting in dispatching a `newUpdateSiteAction` with a SiteModel that doesn't have a local ID set. 

On the other side of the code, before emitting a `OnSiteChanged` event, we need to make sure the value for mobile_editor (and maybe later for web_editor) are copied from the DB to this new model. So the localID was necessary to correctly retrieve it from DB.

I'm not quite sure if we introduce the duplicate rows issue when added the editor items, but here https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/fix/return-fresh-mobile-editor-value-on-site-fetch?expand=1#diff-b53e7ac94134ff56178e112330b7464eR1536 it seems a new row was added instead of upgraded, and the host app receiving empty editor(s).


Edited: This PR does also write the new editor value to the DB before starting network calls. https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1322/commits/a8b6845345820da6082e381a48ae79d2b9366040