### PR TITLE
Woo Stats: Added option to check v4 revenue stats api availability

### DIFF
--- a/example/src/main/res/layout/fragment_woo_revenue_stats.xml
+++ b/example/src/main/res/layout/fragment_woo_revenue_stats.xml
@@ -39,6 +39,13 @@
         </LinearLayout>
 
         <Button
+            android:id="@+id/fetch_revenue_stats_availability"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Revenue Stats availability"/>
+
+        <Button
             android:id="@+id/fetch_current_day_revenue_stats"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
@@ -5,6 +5,8 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload;
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload;
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsPayload;
@@ -21,6 +23,9 @@ public enum WCStatsAction implements IAction {
     @Action(payloadType = FetchRevenueStatsPayload.class)
     FETCH_REVENUE_STATS,
 
+    @Action(payloadType = FetchRevenueStatsAvailabilityPayload.class)
+    FETCH_REVENUE_STATS_AVAILABILITY,
+
     @Action(payloadType = FetchVisitorStatsPayload.class)
     FETCH_VISITOR_STATS,
 
@@ -33,6 +38,9 @@ public enum WCStatsAction implements IAction {
 
     @Action(payloadType = FetchRevenueStatsResponsePayload.class)
     FETCHED_REVENUE_STATS,
+
+    @Action(payloadType = FetchRevenueStatsAvailabilityResponsePayload.class)
+    FETCHED_REVENUE_STATS_AVAILABILITY,
 
     @Action(payloadType = FetchVisitorStatsResponsePayload.class)
     FETCHED_VISITOR_STATS,


### PR DESCRIPTION
Fixes #1324 . This PR adds logic to check if the v4 revenue stats api is available for a site. We could use the existing API endpoint to check this availability (`/wc/v4/reports/revenue/stats`). But the API response time is too long and the api size is much too large, just to check if availability of the v4 revenue stats.

### Changes:
- Adds an action to `WcStatsAction`: `FETCH_REVENUE_STATS_AVAILABILITY` and `FETCHED_REVENUE_STATS_AVAILABILITY` 
- Adds two payload classes to `WcStatsStore`: `FetchRevenueStatsAvailabilityPayload` and `FetchRevenueStatsAvailabilityResponsePayload`. This class includes a `SiteModel` parameter and a `available` boolean flag. We can use this flag in the Woo app to check if the v4 revenue stats for a particular site is supported.
- Adds a new method in `OrderStatsRestClient`: `fetchRevenueStatsAvailability`. This method call the v4 revenue stats api with the `interval` set to `YEAR` and the `after` date set to the current date. The `_fields` param is added to the request to reduce the size of the API response. Since we only need the response code and have no need for the actual response. While adding this parameter does reduce the size of the response, the response time is still over 1s at times. 
- Adds a new button to the `WooRevenueStatsFragment` to check the v4 revenue stats api is supported for a selected site.
- Added mocked tests to `MockedStack_WCStatsTest`

### Screenshot
<img width="300" src="https://user-images.githubusercontent.com/22608780/62112670-cc2db500-b2d0-11e9-9a71-b71bfeecd051.png">
