### PR TITLE
Fix PostModel.dateLocallyChanged and Comment.datePublished timezone

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -181,7 +181,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
 
         // Wait one sec
         Thread.sleep(1000);
-        Date testStartDate = DateTimeUtils.localDateToUTC(new Date());
+        Date testStartDate = new Date();
 
         // Check local change date is set and before "right now"
         assertNotNull(mPost.getDateLocallyChanged());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -171,7 +171,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Wait one sec
         Thread.sleep(1000);
-        Date testStartDate = DateTimeUtils.localDateToUTC(new Date());
+        Date testStartDate = new Date();
 
         // Check local change date is set and before "right now"
         assertNotNull(mPost.getDateLocallyChanged());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -28,6 +28,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -280,7 +281,7 @@ public class CommentStore extends Store {
         comment.setLocalSiteId(site.getId());
         // Init with defaults
         comment.setContent("");
-        comment.setDatePublished(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
+        comment.setDatePublished(DateTimeUtils.iso8601UTCFromDate(new Date()));
         comment.setStatus(CommentStatus.APPROVED.toString());
         comment.setAuthorName("");
         comment.setAuthorEmail("");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -54,6 +54,7 @@ import org.wordpress.android.util.DateTimeUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -347,7 +348,7 @@ public class PostStore extends Store {
         post.setLocalSiteId(site.getId());
         post.setIsLocalDraft(true);
         post.setIsPage(isPage);
-        post.setDateLocallyChanged((DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC())));
+        post.setDateLocallyChanged((DateTimeUtils.iso8601UTCFromDate(new Date())));
         if (categoryIds != null && !categoryIds.isEmpty()) {
             post.setCategoryIdList(categoryIds);
         }
@@ -883,7 +884,7 @@ public class PostStore extends Store {
 
     private void updatePost(PostModel post, boolean changeLocalDate) {
         if (changeLocalDate) {
-            post.setDateLocallyChanged((DateTimeUtils.iso8601UTCFromDate(DateTimeUtils.nowUTC())));
+            post.setDateLocallyChanged((DateTimeUtils.iso8601UTCFromDate(new Date())));
         }
         int rowsAffected = mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(post);
         CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.UpdatePost(post.getId(), post.getRemotePostId());


### PR DESCRIPTION
Fixes #1326

The `DateTimeUtils.nowUTC()` and `DateTimeUtils.localDateToUTC` don't work as expected and as a result we are setting a wrong date to PostModel.dateLocallyChanged and Comment.datePublished More info wordpress-mobile/WordPress-Utils-Android#25

This should be merged at the same time as https://github.com/wordpress-mobile/WordPress-Android/pull/10306


Note:
- I realize users already have the wrong dates stored in their local databases. I couldn't think of any scenario under which it might be a problem. Wdyt? 