### PR TITLE
Add the ability to set the mobile editor preference on all sites with one call 

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -14,6 +14,8 @@ import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityR
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferStatusResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartPayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
+import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorForAllSitesPayload;
+import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorForAllSitesResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatedPrimaryDomainPayload;
@@ -51,6 +53,8 @@ public enum SiteAction implements IAction {
     FETCH_SITE_EDITORS,
     @Action(payloadType = DesignateMobileEditorPayload.class)
     DESIGNATE_MOBILE_EDITOR,
+    @Action(payloadType = DesignateMobileEditorForAllSitesPayload.class)
+    DESIGNATE_MOBILE_EDITOR_FOR_ALL_SITES,
     @Action(payloadType = SiteModel.class)
     FETCH_USER_ROLES,
     @Action(payloadType = SiteModel.class)
@@ -97,6 +101,8 @@ public enum SiteAction implements IAction {
     FETCHED_POST_FORMATS,
     @Action(payloadType = FetchedEditorsPayload.class)
     FETCHED_SITE_EDITORS,
+    @Action(payloadType = DesignateMobileEditorForAllSitesResponsePayload.class)
+    DESIGNATED_MOBILE_EDITOR_FOR_ALL_SITES,
     @Action(payloadType = FetchedUserRolesPayload.class)
     FETCHED_USER_ROLES,
     @Action(payloadType = DeleteSiteResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -42,6 +42,7 @@ import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferError;
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferStatusResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteError;
+import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorForAllSitesResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainError;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatedPrimaryDomainPayload;
@@ -326,6 +327,36 @@ public class SiteRestClient extends BaseWPComRestClient {
                                 FetchedEditorsPayload payload = new FetchedEditorsPayload(site, "", "");
                                 payload.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
                                 mDispatcher.dispatch(SiteActionBuilder.newFetchedSiteEditorsAction(payload));
+                            }
+                        });
+        add(request);
+    }
+
+    public void designateMobileEditorForAllSites(final String mobileEditorName) {
+        Map<String, Object> params = new HashMap<>();
+        String url = WPCOMV2.me.gutenberg.getUrl();
+        params.put("editor", mobileEditorName);
+        params.put("platform", "mobile");
+        // FIXME: check the response type
+        final WPComGsonRequest<SitesEditorMigrationResponse> request = WPComGsonRequest
+                .buildPostRequest(url, params, SitesEditorMigrationResponse.class,
+                        new Listener<SitesEditorMigrationResponse>() {
+                            @Override
+                            public void onResponse(SitesEditorMigrationResponse response) {
+                                DesignateMobileEditorForAllSitesResponsePayload payload =
+                                        new DesignateMobileEditorForAllSitesResponsePayload();
+                                mDispatcher.dispatch(
+                                        SiteActionBuilder.newDesignatedMobileEditorForAllSitesAction(payload));
+                            }
+                        },
+                        new WPComErrorListener() {
+                            @Override
+                            public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                                DesignateMobileEditorForAllSitesResponsePayload payload =
+                                        new DesignateMobileEditorForAllSitesResponsePayload();
+                                payload.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
+                                mDispatcher.dispatch(
+                                        SiteActionBuilder.newDesignatedMobileEditorForAllSitesAction(payload));
                             }
                         });
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -359,7 +359,6 @@ public class SiteRestClient extends BaseWPComRestClient {
                             }
                         })
            );
-
     }
 
     public void fetchPostFormats(@NonNull final SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -337,14 +337,13 @@ public class SiteRestClient extends BaseWPComRestClient {
         String url = WPCOMV2.me.gutenberg.getUrl();
         params.put("editor", mobileEditorName);
         params.put("platform", "mobile");
-        // FIXME: check the response type
-        final WPComGsonRequest<SitesEditorMigrationResponse> request = WPComGsonRequest
-                .buildPostRequest(url, params, SitesEditorMigrationResponse.class,
-                        new Listener<SitesEditorMigrationResponse>() {
+        add(WPComGsonRequest
+                .buildPostRequest(url, params, Map.class,
+                        new Listener<Map<String, String>>() {
                             @Override
-                            public void onResponse(SitesEditorMigrationResponse response) {
+                            public void onResponse(Map<String, String> response) {
                                 DesignateMobileEditorForAllSitesResponsePayload payload =
-                                        new DesignateMobileEditorForAllSitesResponsePayload();
+                                        new DesignateMobileEditorForAllSitesResponsePayload(response);
                                 mDispatcher.dispatch(
                                         SiteActionBuilder.newDesignatedMobileEditorForAllSitesAction(payload));
                             }
@@ -353,13 +352,14 @@ public class SiteRestClient extends BaseWPComRestClient {
                             @Override
                             public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
                                 DesignateMobileEditorForAllSitesResponsePayload payload =
-                                        new DesignateMobileEditorForAllSitesResponsePayload();
+                                        new DesignateMobileEditorForAllSitesResponsePayload(null);
                                 payload.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
                                 mDispatcher.dispatch(
                                         SiteActionBuilder.newDesignatedMobileEditorForAllSitesAction(payload));
                             }
-                        });
-        add(request);
+                        })
+           );
+
     }
 
     public void fetchPostFormats(@NonNull final SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SitesEditorMigrationResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SitesEditorMigrationResponse.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.network.rest.wpcom.site;
 
 import org.wordpress.android.fluxc.network.Response;
 
-public class SitesEditorMigrationResponse implements Response {
-    public boolean success;
+import java.util.ArrayList;
+
+
+public class SitesEditorMigrationResponse extends ArrayList<String> implements Response {
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SitesEditorMigrationResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SitesEditorMigrationResponse.java
@@ -1,9 +1,0 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.site;
-
-import org.wordpress.android.fluxc.network.Response;
-
-import java.util.ArrayList;
-
-
-public class SitesEditorMigrationResponse extends ArrayList<String> implements Response {
-}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SitesEditorMigrationResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SitesEditorMigrationResponse.java
@@ -1,0 +1,7 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site;
+
+import org.wordpress.android.fluxc.network.Response;
+
+public class SitesEditorMigrationResponse implements Response {
+    public boolean success;
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1742,7 +1742,7 @@ public class SiteStore extends Store {
                 wpcomPostRequestRequired = true;
             }
             try {
-                rowsAffected = SiteSqlUtils.insertOrUpdateSite(site);
+                rowsAffected += SiteSqlUtils.insertOrUpdateSite(site);
             } catch (Exception e) {
                 event.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1787,7 +1787,10 @@ public class SiteStore extends Store {
                 SiteModel currentModel = getSiteBySiteId(Long.parseLong(entry.getKey()));
 
                 if (currentModel == null) {
-                    // this should never happen normally
+                    // this could happen when a site was added to the current account with another app, or on the web
+                    AppLog.e(T.API, "handleDesignatedMobileEditorForAllSites - The backend returned info for "
+                                    + "the following siteID " + entry.getKey() + " but there is no site with that "
+                                    + "remote ID in SiteStore.");
                     continue;
                 }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -112,6 +112,14 @@ public class SiteStore extends Store {
         }
     }
 
+    public static class DesignateMobileEditorForAllSitesPayload extends Payload<SiteEditorsError> {
+        public String editor;
+
+        public DesignateMobileEditorForAllSitesPayload(@NonNull String editorName) {
+            this.editor = editorName;
+        }
+    }
+
     public static class DesignateMobileEditorPayload extends Payload<SiteEditorsError> {
         public SiteModel site;
         public String editor;
@@ -131,6 +139,11 @@ public class SiteStore extends Store {
             this.site = site;
             this.mobileEditor = mobileEditor;
             this.webEditor = webEditor;
+        }
+    }
+
+    public static class DesignateMobileEditorForAllSitesResponsePayload extends Payload<SiteEditorsError> {
+        public DesignateMobileEditorForAllSitesResponsePayload() {
         }
     }
 
@@ -568,6 +581,13 @@ public class SiteStore extends Store {
 
         public OnSiteEditorsChanged(SiteModel site) {
             this.site = site;
+        }
+    }
+
+    public static class OnAllSitesMobileEditorChanged extends OnChanged<SiteEditorsError> {
+        public int rowsAffected;
+
+        public OnAllSitesMobileEditorChanged() {
         }
     }
 
@@ -1396,8 +1416,15 @@ public class SiteStore extends Store {
             case DESIGNATE_MOBILE_EDITOR:
                 designateMobileEditor((DesignateMobileEditorPayload) action.getPayload());
                 break;
+            case DESIGNATE_MOBILE_EDITOR_FOR_ALL_SITES:
+                designateMobileEditorForAllSites((DesignateMobileEditorForAllSitesPayload) action.getPayload());
+                break;
             case FETCHED_SITE_EDITORS:
                 updateSiteEditors((FetchedEditorsPayload) action.getPayload());
+                break;
+            case DESIGNATED_MOBILE_EDITOR_FOR_ALL_SITES:
+                handleDesignatedMobileEditorForAllSites(
+                        (DesignateMobileEditorForAllSitesResponsePayload) action.getPayload());
                 break;
             case FETCH_USER_ROLES:
                 fetchUserRoles((SiteModel) action.getPayload());
@@ -1705,6 +1732,30 @@ public class SiteStore extends Store {
         emitChange(event);
     }
 
+    private void designateMobileEditorForAllSites(DesignateMobileEditorForAllSitesPayload payload) {
+        int rowsAffected = 0;
+        OnAllSitesMobileEditorChanged event = new OnAllSitesMobileEditorChanged();
+        boolean wpcomPostRequestRequired = false;
+        for (SiteModel site : getSites()) {
+            site.setMobileEditor(payload.editor);
+            if (!wpcomPostRequestRequired && site.isUsingWpComRestApi()) {
+                wpcomPostRequestRequired = true;
+            }
+            try {
+                rowsAffected = SiteSqlUtils.insertOrUpdateSite(site);
+            } catch (Exception e) {
+                event.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
+            }
+        }
+
+        if (wpcomPostRequestRequired) {
+            mSiteRestClient.designateMobileEditorForAllSites(payload.editor);
+        }
+
+        event.rowsAffected = rowsAffected;
+        emitChange(event);
+    }
+
     private void updateSiteEditors(FetchedEditorsPayload payload) {
         SiteModel site = payload.site;
         OnSiteEditorsChanged event = new OnSiteEditorsChanged(site);
@@ -1721,6 +1772,16 @@ public class SiteStore extends Store {
         }
 
         emitChange(event);
+    }
+
+    private void handleDesignatedMobileEditorForAllSites(DesignateMobileEditorForAllSitesResponsePayload payload) {
+        OnAllSitesMobileEditorChanged event = new OnAllSitesMobileEditorChanged();
+        if (payload.isError()) {
+            event.error = payload.error;
+            emitChange(event);
+        } else {
+           // Do nothing here, we're already stored all the info to the local DB and emitted the event
+        }
     }
 
     private void fetchUserRoles(SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -589,6 +589,7 @@ public class SiteStore extends Store {
 
     public static class OnAllSitesMobileEditorChanged extends OnChanged<SiteEditorsError> {
         public int rowsAffected;
+        public boolean isNetworkResponse; // True when all sites are self-hosted or wpcom backend response
 
         public OnAllSitesMobileEditorChanged() {
         }
@@ -1753,6 +1754,9 @@ public class SiteStore extends Store {
 
         if (wpcomPostRequestRequired) {
             mSiteRestClient.designateMobileEditorForAllSites(payload.editor);
+            event.isNetworkResponse = false;
+        } else {
+            event.isNetworkResponse = true;
         }
 
         event.rowsAffected = rowsAffected;
@@ -1806,6 +1810,7 @@ public class SiteStore extends Store {
                 }
             }
         }
+        event.isNetworkResponse = true;
         emitChange(event);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1785,17 +1785,20 @@ public class SiteStore extends Store {
             // Loop over the returned sites and make sure we've the fresh values for editor prop stored locally
             for (Map.Entry<String, String> entry : payload.editors.entrySet()) {
                 SiteModel currentModel = getSiteBySiteId(Long.parseLong(entry.getKey()));
-                if (currentModel != null) {
-                    if (currentModel.getMobileEditor() == null
-                        || !currentModel.getMobileEditor().equals(entry.getValue())) {
-                        // the current editor is either null or != from the value on the server
-                        // we need to update it
-                        currentModel.setMobileEditor(entry.getValue());
-                        try {
-                            event.rowsAffected += SiteSqlUtils.insertOrUpdateSite(currentModel);
-                        } catch (Exception e) {
-                            // nope
-                        }
+
+                if (currentModel == null) {
+                    // this should never happen normally
+                    continue;
+                }
+
+                if (currentModel.getMobileEditor() == null
+                    || !currentModel.getMobileEditor().equals(entry.getValue())) {
+                    // the current editor is either null or != from the value on the server. Update it
+                    currentModel.setMobileEditor(entry.getValue());
+                    try {
+                        event.rowsAffected += SiteSqlUtils.insertOrUpdateSite(currentModel);
+                    } catch (Exception e) {
+                        event.error = new SiteEditorsError(SiteEditorsErrorType.GENERIC_ERROR);
                     }
                 }
             }

--- a/fluxc/src/main/tools/wp-com-v2-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-v2-endpoints.txt
@@ -17,3 +17,5 @@
 /verticals/prompt
 
 /plans/mobile
+
+/me/gutenberg/


### PR DESCRIPTION
This PR adds the ability to bulk set the mobile editor preference on all sites with just one network call to a new WordPress.com REST API Endpoint (`https://public-api.wordpress.com/wpcom/v2/me/gutenberg/`). 

The endpoint is not deployed yet, and the response format is still in brainstorming, but we can start coding the request/response flow.

wp-android side PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10332
