### PR TITLE
Issue/1335 v4 visitor stats changes

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.example.SitesFragment
 import org.wordpress.android.fluxc.example.TaxonomiesFragment
 import org.wordpress.android.fluxc.example.ThemeFragment
 import org.wordpress.android.fluxc.example.UploadsFragment
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
@@ -72,4 +73,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideSiteSelectorDialogInjector(): SiteSelectorDialog
+
+    @ContributesAndroidInjector
+    abstract fun provideStoreSelectorDialogInjector(): StoreSelectorDialog
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectorDialog.kt
@@ -1,0 +1,83 @@
+package org.wordpress.android.fluxc.example.ui
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import androidx.fragment.app.DialogFragment
+import dagger.android.support.AndroidSupportInjection
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class StoreSelectorDialog : DialogFragment() {
+    companion object {
+        @JvmStatic
+        fun newInstance(listener: Listener, selectedPos: Int) = StoreSelectorDialog().apply {
+            this.listener = listener
+            this.selectedPos = selectedPos
+        }
+    }
+
+    interface Listener {
+        fun onSiteSelected(site: SiteModel, pos: Int)
+    }
+
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    var listener: Listener? = null
+    var selectedPos: Int = -1
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return activity?.let {
+            val adapter = SiteAdapter(it, wooCommerceStore.getWooCommerceSites())
+
+            // Use the Builder class for convenient dialog construction
+            val builder = AlertDialog.Builder(it)
+            builder.setTitle("Select a site")
+                    .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
+                        val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
+                        val site = adapter.getItem(which)
+                        listener?.onSiteSelected(site, which)
+                        dialog.dismiss()
+                    }
+            // Create the AlertDialog object and return it
+            builder.create()
+        } ?: throw IllegalStateException("Activity cannot be null")
+    }
+
+    class SiteAdapter(
+        ctx: Context,
+        items: MutableList<SiteModel>
+    ) : ArrayAdapter<SiteModel>(ctx, android.R.layout.simple_list_item_1, items) {
+        fun refreshSites(newItems: List<SiteModel>) {
+            setNotifyOnChange(true)
+            addAll(newItems)
+        }
+
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+            val cv = convertView
+                    ?: LayoutInflater.from(context)
+                            .inflate(android.R.layout.simple_list_item_single_choice, parent, false)
+            val site = getItem(position)
+            (cv as TextView).text = site.displayName ?: site.name
+            return cv
+        }
+
+        override fun getItemId(position: Int) = getItem(position).id.toLong()
+
+        override fun hasStableIds() = true
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -13,14 +13,16 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCStatsAction
 import org.wordpress.android.fluxc.example.R
-import org.wordpress.android.fluxc.example.SiteSelectorDialog
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCStatsStore
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchNewVisitorStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -45,7 +47,7 @@ class WooRevenueStatsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         stats_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : SiteSelectorDialog.Listener {
+            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -117,6 +119,34 @@ class WooRevenueStatsFragment : Fragment() {
                 dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
             } ?: prependToLog("No site selected!")
         }
+
+        fetch_current_day_visitor_stats.setOnClickListener {
+            selectedSite?.let {
+                val payload = FetchNewVisitorStatsPayload(site = it, granularity = StatsGranularity.DAYS)
+                dispatcher.dispatch(WCStatsActionBuilder.newFetchNewVisitorStatsAction(payload))
+            } ?: prependToLog("No site selected!")
+        }
+
+        fetch_current_week_visitor_stats_forced.setOnClickListener {
+            selectedSite?.let {
+                val payload = FetchNewVisitorStatsPayload(it, StatsGranularity.WEEKS, forced = true)
+                dispatcher.dispatch(WCStatsActionBuilder.newFetchNewVisitorStatsAction(payload))
+            } ?: prependToLog("No site selected!")
+        }
+
+        fetch_current_month_visitor_stats.setOnClickListener {
+            selectedSite?.let {
+                val payload = FetchNewVisitorStatsPayload(site = it, granularity = StatsGranularity.MONTHS)
+                dispatcher.dispatch(WCStatsActionBuilder.newFetchNewVisitorStatsAction(payload))
+            } ?: prependToLog("No site selected!")
+        }
+
+        fetch_current_year_visitor_stats_forced.setOnClickListener {
+            selectedSite?.let {
+                val payload = FetchNewVisitorStatsPayload(it, StatsGranularity.YEARS, forced = true)
+                dispatcher.dispatch(WCStatsActionBuilder.newFetchNewVisitorStatsAction(payload))
+            } ?: prependToLog("No site selected!")
+        }
     }
 
     override fun onStart() {
@@ -159,10 +189,48 @@ class WooRevenueStatsFragment : Fragment() {
         }
     }
 
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: SiteSelectorDialog.Listener) {
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCStatsChanged(event: OnWCStatsChanged) {
+        if (event.isError) {
+            prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
+            return
+        }
+
+        val site = selectedSite
+        when (event.causeOfChange) {
+            WCStatsAction.FETCH_NEW_VISITOR_STATS -> {
+                val visitorStatsMap = wcStatsStore.getNewVisitorStats(
+                        site!!,
+                        event.granularity,
+                        event.quantity,
+                        event.date,
+                        event.isCustomField
+                )
+                if (visitorStatsMap.isEmpty()) {
+                    prependToLog("No visitor stats were stored for site " + site.name + " =(")
+                } else {
+                    if (event.isCustomField) {
+                        prependToLog(
+                                "Fetched visitor stats for " + visitorStatsMap.size + " " +
+                                        event.granularity.toString().toLowerCase() + " from " + site.name +
+                                        " with quantity " + event.quantity + " and date " + event.date
+                        )
+                    } else {
+                        prependToLog(
+                                "Fetched visitor stats for " + visitorStatsMap.size + " " +
+                                        event.granularity.toString().toLowerCase() + " from " + site.name
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
         fragmentManager?.let { fm ->
-            val dialog = SiteSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "SiteSelectorDialog")
+            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
+            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 
@@ -176,5 +244,9 @@ class WooRevenueStatsFragment : Fragment() {
         fetch_current_month_revenue_stats_forced.isEnabled = enabled
         fetch_current_year_revenue_stats.isEnabled = enabled
         fetch_current_year_revenue_stats_forced.isEnabled = enabled
+        fetch_current_day_visitor_stats.isEnabled = enabled
+        fetch_current_week_visitor_stats_forced.isEnabled = enabled
+        fetch_current_month_visitor_stats.isEnabled = enabled
+        fetch_current_year_visitor_stats_forced.isEnabled = enabled
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_revenue_stats.*
@@ -235,18 +236,11 @@ class WooRevenueStatsFragment : Fragment() {
     }
 
     private fun toggleSiteDependentButtons(enabled: Boolean) {
-        fetch_revenue_stats_availability.isEnabled = enabled
-        fetch_current_day_revenue_stats.isEnabled = enabled
-        fetch_current_day_revenue_stats_forced.isEnabled = enabled
-        fetch_current_week_revenue_stats.isEnabled = enabled
-        fetch_current_week_revenue_stats_forced.isEnabled = enabled
-        fetch_current_month_revenue_stats.isEnabled = enabled
-        fetch_current_month_revenue_stats_forced.isEnabled = enabled
-        fetch_current_year_revenue_stats.isEnabled = enabled
-        fetch_current_year_revenue_stats_forced.isEnabled = enabled
-        fetch_current_day_visitor_stats.isEnabled = enabled
-        fetch_current_week_visitor_stats_forced.isEnabled = enabled
-        fetch_current_month_visitor_stats.isEnabled = enabled
-        fetch_current_year_visitor_stats_forced.isEnabled = enabled
+        for (i in 0 until buttonContainer.childCount) {
+            val child = buttonContainer.getChildAt(i)
+            if (child is Button) {
+                child.isEnabled = enabled
+            }
+        }
     }
 }

--- a/example/src/main/res/layout/fragment_woo_revenue_stats.xml
+++ b/example/src/main/res/layout/fragment_woo_revenue_stats.xml
@@ -100,5 +100,33 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Fetch current year Revenue Stats (Forced)"/>
+
+        <Button
+            android:id="@+id/fetch_current_day_visitor_stats"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch current day Visitor Stats"/>
+
+        <Button
+            android:id="@+id/fetch_current_week_visitor_stats_forced"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch current week Visitor Stats (Forced)"/>
+
+        <Button
+            android:id="@+id/fetch_current_month_visitor_stats"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch current month Visitor Stats" />
+
+        <Button
+            android:id="@+id/fetch_current_year_visitor_stats_forced"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch current year Visitor Stats (Forced)"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woo_revenue_stats.xml
+++ b/example/src/main/res/layout/fragment_woo_revenue_stats.xml
@@ -6,6 +6,7 @@
     tools:context="org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment">
 
     <LinearLayout
+        android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCNewVisitorStatsModel
 import org.wordpress.android.fluxc.model.WCOrderStatsModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.WCVisitorStatsModel
@@ -57,7 +58,8 @@ class WCStatsStoreTest {
         val config = SingleStoreWellSqlConfigForTests(
                 appContext, listOf(WCOrderStatsModel::class.java,
                 WCRevenueStatsModel::class.java,
-                WCVisitorStatsModel::class.java),
+                WCVisitorStatsModel::class.java,
+                WCNewVisitorStatsModel::class.java),
                 WellSqlConfig.ADDON_WOOCOMMERCE
         )
         WellSql.init(config)
@@ -231,225 +233,225 @@ class WCStatsStoreTest {
 
     @Test
     fun testGetQuantityForDays() {
-        val quantity1 = wcStatsStore.getQuantityByGranularity("2018-01-25", "2018-01-28",
-                StatsGranularity.DAYS, 30)
+        val quantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-25", "2018-01-28",
+                OrderStatsApiUnit.DAY, 30)
         assertEquals(4, quantity1)
 
-        val quantity2 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2018-01-01",
-                StatsGranularity.DAYS, 30)
+        val quantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-01",
+                OrderStatsApiUnit.DAY, 30)
         assertEquals(1, quantity2)
 
-        val quantity3 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2018-01-31",
-                StatsGranularity.DAYS, 30)
+        val quantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-31",
+                OrderStatsApiUnit.DAY, 30)
         assertEquals(31, quantity3)
 
-        val quantity4 = wcStatsStore.getQuantityByGranularity("2018-01-28", "2018-01-25",
-                StatsGranularity.DAYS, 30)
+        val quantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-28", "2018-01-25",
+                OrderStatsApiUnit.DAY, 30)
         assertEquals(4, quantity4)
 
-        val quantity5 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2018-01-01",
-                StatsGranularity.DAYS, 30)
+        val quantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-01",
+                OrderStatsApiUnit.DAY, 30)
         assertEquals(1, quantity5)
 
-        val quantity6 = wcStatsStore.getQuantityByGranularity("2018-01-31", "2018-01-01",
-                StatsGranularity.DAYS, 30)
+        val quantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-31", "2018-01-01",
+                OrderStatsApiUnit.DAY, 30)
         assertEquals(31, quantity6)
 
-        val defaultQuantity1 = wcStatsStore.getQuantityByGranularity("", "",
-                StatsGranularity.DAYS, 30)
+        val defaultQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("", "",
+                OrderStatsApiUnit.DAY, 30)
         assertEquals(30, defaultQuantity1)
 
-        val defaultQuantity2 = wcStatsStore.getQuantityByGranularity(null, null,
-                StatsGranularity.DAYS, 30)
+        val defaultQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit(null, null,
+                OrderStatsApiUnit.DAY, 30)
         assertEquals(30, defaultQuantity2)
     }
 
     @Test
     fun testGetQuantityForWeeks() {
-        val quantity1 = wcStatsStore.getQuantityByGranularity("2018-10-22", "2018-10-23",
-                StatsGranularity.WEEKS, 17)
+        val quantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-10-22", "2018-10-23",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(1, quantity1)
 
-        val quantity2 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2018-01-01",
-                StatsGranularity.WEEKS, 17)
+        val quantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-01",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(53, quantity2)
 
-        val quantity3 = wcStatsStore.getQuantityByGranularity("2019-01-20", "2019-01-13",
-                StatsGranularity.WEEKS, 17)
+        val quantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-20", "2019-01-13",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(2, quantity3)
 
-        val quantity4 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2018-03-01",
-                StatsGranularity.WEEKS, 17)
+        val quantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-03-01",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(61, quantity4)
 
-        val quantity5 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2018-01-31",
-                StatsGranularity.WEEKS, 17)
+        val quantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-31",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(5, quantity5)
 
-        val quantity6 = wcStatsStore.getQuantityByGranularity("2018-12-01", "2018-12-31",
-                StatsGranularity.WEEKS, 17)
+        val quantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-12-01", "2018-12-31",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(6, quantity6)
 
-        val quantity7 = wcStatsStore.getQuantityByGranularity("2018-11-01", "2018-11-30",
-                StatsGranularity.WEEKS, 17)
+        val quantity7 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-11-01", "2018-11-30",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(5, quantity7)
 
-        val inverseQuantity1 = wcStatsStore.getQuantityByGranularity("2018-10-23", "2018-10-22",
-                StatsGranularity.WEEKS, 17)
+        val inverseQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-10-23", "2018-10-22",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(1, inverseQuantity1)
 
-        val inverseQuantity2 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2017-01-01",
-                StatsGranularity.WEEKS, 17)
+        val inverseQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2017-01-01",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(53, inverseQuantity2)
 
-        val inverseQuantity3 = wcStatsStore.getQuantityByGranularity("2019-01-13", "2019-01-20",
-                StatsGranularity.WEEKS, 17)
+        val inverseQuantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-13", "2019-01-20",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(2, inverseQuantity3)
 
-        val inverseQuantity4 = wcStatsStore.getQuantityByGranularity("2018-03-01", "2017-01-01",
-                StatsGranularity.WEEKS, 17)
+        val inverseQuantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-03-01", "2017-01-01",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(61, inverseQuantity4)
 
-        val inverseQuantity5 = wcStatsStore.getQuantityByGranularity("2018-01-31", "2018-01-01",
-                StatsGranularity.WEEKS, 17)
+        val inverseQuantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-31", "2018-01-01",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(5, inverseQuantity5)
 
-        val inverseQuantity6 = wcStatsStore.getQuantityByGranularity("2018-12-31", "2018-12-01",
-                StatsGranularity.WEEKS, 17)
+        val inverseQuantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-12-31", "2018-12-01",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(6, inverseQuantity6)
 
-        val inverseQuantity7 = wcStatsStore.getQuantityByGranularity("2018-11-30", "2018-11-01",
-                StatsGranularity.WEEKS, 17)
+        val inverseQuantity7 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-11-30", "2018-11-01",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(5, inverseQuantity7)
 
-        val defaultQuantity1 = wcStatsStore.getQuantityByGranularity("", "",
-                StatsGranularity.WEEKS, 17)
+        val defaultQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("", "",
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(17, defaultQuantity1)
 
-        val defaultQuantity2 = wcStatsStore.getQuantityByGranularity(null, null,
-                StatsGranularity.WEEKS, 17)
+        val defaultQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit(null, null,
+                OrderStatsApiUnit.WEEK, 17)
         assertEquals(17, defaultQuantity2)
     }
 
     @Test
     fun testGetQuantityForMonths() {
-        val quantity1 = wcStatsStore.getQuantityByGranularity("2018-10-22", "2018-10-23",
-                StatsGranularity.MONTHS, 12)
+        val quantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-10-22", "2018-10-23",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(1, quantity1)
 
-        val quantity2 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2018-01-01",
-                StatsGranularity.MONTHS, 12)
+        val quantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-01",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(13, quantity2)
 
-        val quantity3 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2018-01-01",
-                StatsGranularity.MONTHS, 12)
+        val quantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-01",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(1, quantity3)
 
-        val quantity4 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2018-03-01",
-                StatsGranularity.MONTHS, 12)
+        val quantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-03-01",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(15, quantity4)
 
-        val quantity5 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2018-01-31",
-                StatsGranularity.MONTHS, 12)
+        val quantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-31",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(13, quantity5)
 
-        val quantity6 = wcStatsStore.getQuantityByGranularity("2018-12-31", "2019-01-01",
-                StatsGranularity.MONTHS, 1)
+        val quantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-12-31", "2019-01-01",
+                OrderStatsApiUnit.MONTH, 1)
         assertEquals(2, quantity6)
 
-        val inverseQuantity1 = wcStatsStore.getQuantityByGranularity("2018-10-23", "2018-10-22",
-                StatsGranularity.MONTHS, 12)
+        val inverseQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-10-23", "2018-10-22",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(1, inverseQuantity1)
 
-        val inverseQuantity2 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2017-01-01",
-                StatsGranularity.MONTHS, 12)
+        val inverseQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2017-01-01",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(13, inverseQuantity2)
 
-        val inverseQuantity3 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2018-01-01",
-                StatsGranularity.MONTHS, 12)
+        val inverseQuantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-01",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(1, inverseQuantity3)
 
-        val inverseQuantity4 = wcStatsStore.getQuantityByGranularity("2018-03-01", "2017-01-01",
-                StatsGranularity.MONTHS, 12)
+        val inverseQuantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-03-01", "2017-01-01",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(15, inverseQuantity4)
 
-        val inverseQuantity5 = wcStatsStore.getQuantityByGranularity("2018-01-31", "2017-01-01",
-                StatsGranularity.MONTHS, 12)
+        val inverseQuantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-31", "2017-01-01",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(13, inverseQuantity5)
 
-        val inverseQuantity6 = wcStatsStore.getQuantityByGranularity("2019-01-01", "2018-12-31",
-                StatsGranularity.MONTHS, 1)
+        val inverseQuantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-01", "2018-12-31",
+                OrderStatsApiUnit.MONTH, 1)
         assertEquals(2, inverseQuantity6)
 
-        val defaultQuantity1 = wcStatsStore.getQuantityByGranularity("", "",
-                StatsGranularity.MONTHS, 12)
+        val defaultQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("", "",
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(12, defaultQuantity1)
 
-        val defaultQuantity2 = wcStatsStore.getQuantityByGranularity(null, null,
-                StatsGranularity.MONTHS, 12)
+        val defaultQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit(null, null,
+                OrderStatsApiUnit.MONTH, 12)
         assertEquals(12, defaultQuantity2)
     }
 
     @Test
     fun testGetQuantityForYears() {
-        val quantity1 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2018-01-01",
-                StatsGranularity.YEARS, 1)
+        val quantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(2, quantity1)
 
-        val quantity2 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2018-03-01",
-                StatsGranularity.YEARS, 1)
+        val quantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-03-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(2, quantity2)
 
-        val quantity3 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2018-01-05",
-                StatsGranularity.YEARS, 1)
+        val quantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-05",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(2, quantity3)
 
-        val quantity4 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2019-03-01",
-                StatsGranularity.YEARS, 1)
+        val quantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2019-03-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(3, quantity4)
 
-        val quantity5 = wcStatsStore.getQuantityByGranularity("2015-03-05", "2017-01-01",
-                StatsGranularity.YEARS, 1)
+        val quantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2015-03-05", "2017-01-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(3, quantity5)
 
-        val quantity6 = wcStatsStore.getQuantityByGranularity("2018-12-31", "2019-01-01",
-                StatsGranularity.YEARS, 1)
+        val quantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-12-31", "2019-01-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(2, quantity6)
 
-        val quantity7 = wcStatsStore.getQuantityByGranularity("2019-01-25", "2019-01-25",
-                StatsGranularity.YEARS, 1)
+        val quantity7 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-25", "2019-01-25",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(1, quantity7)
 
-        val inverseQuantity1 = wcStatsStore.getQuantityByGranularity("2018-01-01", "2017-01-01",
-                StatsGranularity.YEARS, 1)
+        val inverseQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2017-01-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(2, inverseQuantity1)
 
-        val inverseQuantity2 = wcStatsStore.getQuantityByGranularity("2018-03-01", "2017-01-01",
-                StatsGranularity.YEARS, 1)
+        val inverseQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-03-01", "2017-01-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(2, inverseQuantity2)
 
-        val inverseQuantity3 = wcStatsStore.getQuantityByGranularity("2018-01-05", "2017-01-01",
-                StatsGranularity.YEARS, 1)
+        val inverseQuantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-05", "2017-01-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(2, inverseQuantity3)
 
-        val inverseQuantity4 = wcStatsStore.getQuantityByGranularity("2019-03-01", "2017-01-01",
-                StatsGranularity.YEARS, 1)
+        val inverseQuantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-03-01", "2017-01-01",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(3, inverseQuantity4)
 
-        val inverseQuantity5 = wcStatsStore.getQuantityByGranularity("2017-01-01", "2015-03-05",
-                StatsGranularity.YEARS, 1)
+        val inverseQuantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2015-03-05",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(3, inverseQuantity5)
 
-        val inverseQuantity6 = wcStatsStore.getQuantityByGranularity("2019-01-01", "2018-12-31",
-                StatsGranularity.YEARS, 1)
+        val inverseQuantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-01", "2018-12-31",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(2, inverseQuantity6)
 
-        val defaultQuantity1 = wcStatsStore.getQuantityByGranularity("", "",
-                StatsGranularity.YEARS, 1)
+        val defaultQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("", "",
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(1, defaultQuantity1)
 
-        val defaultQuantity2 = wcStatsStore.getQuantityByGranularity(null, null,
-                StatsGranularity.YEARS, 1)
+        val defaultQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit(null, null,
+                OrderStatsApiUnit.YEAR, 1)
         assertEquals(1, defaultQuantity2)
     }
 
@@ -632,7 +634,7 @@ class WCStatsStoreTest {
         wcStatsStore.onAction(WCStatsActionBuilder.newFetchOrderStatsAction(payload))
 
         val quantity: Long =
-                wcStatsStore.getQuantityByGranularity(startDate, endDate, StatsGranularity.DAYS, 30)
+                wcStatsStore.getQuantityByOrderStatsApiUnit(startDate, endDate, OrderStatsApiUnit.DAY, 30)
 
         val quantityArgument = argumentCaptor<Long>()
         verify(mockOrderStatsRestClient)
@@ -652,7 +654,7 @@ class WCStatsStoreTest {
         wcStatsStore.onAction(WCStatsActionBuilder.newFetchOrderStatsAction(payload))
 
         val quantity: Long =
-                wcStatsStore.getQuantityByGranularity(startDate, endDate, StatsGranularity.WEEKS, 17)
+                wcStatsStore.getQuantityByOrderStatsApiUnit(startDate, endDate, OrderStatsApiUnit.WEEK, 17)
 
         val quantityArgument = argumentCaptor<Long>()
         verify(mockOrderStatsRestClient)
@@ -672,7 +674,7 @@ class WCStatsStoreTest {
         wcStatsStore.onAction(WCStatsActionBuilder.newFetchOrderStatsAction(payload))
 
         val quantity: Long =
-                wcStatsStore.getQuantityByGranularity(startDate, endDate, StatsGranularity.MONTHS, 12)
+                wcStatsStore.getQuantityByOrderStatsApiUnit(startDate, endDate, OrderStatsApiUnit.MONTH, 12)
 
         val quantityArgument = argumentCaptor<Long>()
         verify(mockOrderStatsRestClient)
@@ -692,7 +694,7 @@ class WCStatsStoreTest {
         wcStatsStore.onAction(WCStatsActionBuilder.newFetchOrderStatsAction(payload))
 
         val quantity: Long =
-                wcStatsStore.getQuantityByGranularity(startDate, endDate, StatsGranularity.YEARS, 12)
+                wcStatsStore.getQuantityByOrderStatsApiUnit(startDate, endDate, OrderStatsApiUnit.YEAR, 12)
 
         val quantityArgument = argumentCaptor<Long>()
         verify(mockOrderStatsRestClient)
@@ -1607,6 +1609,215 @@ class WCStatsStoreTest {
         WCVisitorStatsSqlUtils.insertOrUpdateVisitorStats(customMonthVisitorStatsModel2)
 
         val customMonthVisitorStats2 = wcStatsStore.getVisitorStats(
+                site, StatsGranularity.MONTHS, customMonthVisitorStatsModel2.quantity,
+                customMonthVisitorStatsModel2.endDate, customMonthVisitorStatsModel2.isCustomField
+        )
+        assertTrue(customMonthVisitorStats2.isNotEmpty())
+        assertTrue(customMonthVisitorStats.isNotEmpty())
+    }
+
+    @Test
+    fun testGetVisitorStatsForCurrentDayGranularity() {
+        // Test Scenario - 1: Generate default visitor stats i.e. isCustomField - false
+        // Get visitor Stats of the same site and granularity and assert not null
+        val defaultDayVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel()
+        val site = SiteModel().apply { id = defaultDayVisitorStatsModel.localSiteId }
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultDayVisitorStatsModel)
+
+        val defaultDayVisitorStats = wcStatsStore.getNewVisitorStats(site, StatsGranularity.DAYS)
+        assertTrue(defaultDayVisitorStats.isNotEmpty())
+
+        // Test Scenario - 2: Generate default visitor stats with a different date
+        // Get visitor of the same site and granularity and assert not null
+        val defaultDayVisitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                endDate = "2019-08-02"
+        )
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultDayVisitorStatsModel2)
+        val defaultDayVisitorStats2 = wcStatsStore.getNewVisitorStats(site, StatsGranularity.DAYS)
+        assertTrue(defaultDayVisitorStats2.isNotEmpty())
+
+        // Test Scenario - 3: Generate custom stats for same site i.e. isCustomField - true
+        // Get visitor Stats of the same site and granularity and assert not null
+        val customDayVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                quantity = "1", endDate = "2019-08-06", startDate = "2019-08-06"
+        )
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customDayVisitorStatsModel)
+
+        val customDayVisitorStats = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.DAYS, customDayVisitorStatsModel.quantity,
+                customDayVisitorStatsModel.endDate, customDayVisitorStatsModel.isCustomField
+        )
+        assertTrue(customDayVisitorStats.isNotEmpty())
+
+        // Test Scenario - 4: Query for custom visitor stats that is not present in local cache:
+        // for same site, same quantity, different date
+        // Get visitor Stats of the same site and granularity and assert null
+        val customDayVisitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                quantity = "1", endDate = "2019-01-01", startDate = "2019-01-01"
+        )
+        val customDayVisitorStats2 = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.DAYS, customDayVisitorStatsModel2.quantity,
+                customDayVisitorStatsModel2.endDate, customDayVisitorStatsModel2.isCustomField
+        )
+        assertTrue(customDayVisitorStats2.isEmpty())
+
+        // Test Scenario - 5: Query for custom visitor stats that is not present in local cache:
+        // for same site, different quantity, different date
+        // Get visitor Stats of the same site and granularity and assert null
+        val customDayVisitorStatsModel3 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                quantity = "1", endDate = "2019-01-01", startDate = "2019-01-01"
+        )
+
+        val customDayVisitorStats3 = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.DAYS, customDayVisitorStatsModel3.quantity,
+                customDayVisitorStatsModel3.endDate, customDayVisitorStatsModel3.isCustomField
+        )
+        assertTrue(customDayVisitorStats3.isEmpty())
+
+        // Test Scenario - 6: Generate custom visitor stats for same site with different granularity (WEEKS),
+        // same date(2019-01-01), same quantity (1) i.e. isCustomField - true
+        // Get visitor Stats and assert Not Null
+        // Now if another query ran for granularity - DAYS, with same date and same quantity: assert null
+        val customWeekVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                quantity = "1",
+                endDate = "2019-02-01", startDate = "2019-02-01",
+                granularity = StatsGranularity.WEEKS.toString()
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customWeekVisitorStatsModel)
+
+        val customWeekVisitorStats = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.WEEKS, customWeekVisitorStatsModel.quantity,
+                customWeekVisitorStatsModel.endDate, customWeekVisitorStatsModel.isCustomField
+        )
+        assertTrue(customWeekVisitorStats.isNotEmpty())
+
+        val customDayVisitorStats4 = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.DAYS, customDayVisitorStatsModel.quantity,
+                customDayVisitorStatsModel.endDate, customDayVisitorStatsModel.isCustomField
+        )
+        assertTrue(customDayVisitorStats4.isEmpty())
+
+        // Test Scenario - 7: Generate custom stats for different site(8) with same granularity(WEEKS),
+        // same date(2019-01-01), same quantity(1) i.e. isCustomField - true
+        // Get visitor Stats and assert Not Null
+        // Now if scenario 4 is run again it should assert NOT NULL, since the stats is for different sites
+        val customWeekVisitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                localSiteId = 8, granularity = StatsGranularity.WEEKS.toString(),
+                quantity = "1", endDate = "2019-02-01", startDate = "2019-02-01"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customWeekVisitorStatsModel2)
+
+        val customWeekVisitorStats2 = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.WEEKS, customWeekVisitorStatsModel2.quantity,
+                customWeekVisitorStatsModel2.endDate, customWeekVisitorStatsModel2.isCustomField
+        )
+        assertTrue(customWeekVisitorStats2.isNotEmpty())
+        assertTrue(customWeekVisitorStats.isNotEmpty())
+    }
+
+    @Test
+    fun testGetVisitorStatsForThisWeekGranularity() {
+        // Test Scenario - 1: Generate default visitor stats i.e. isCustomField - false
+        // Get visitor Stats of the same site and granularity and assert not null
+        val defaultWeekVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.WEEKS.toString()
+        )
+        val site = SiteModel().apply { id = defaultWeekVisitorStatsModel.localSiteId }
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultWeekVisitorStatsModel)
+
+        val defaultWeekVisitorStats = wcStatsStore.getNewVisitorStats(site, StatsGranularity.WEEKS)
+        assertTrue(defaultWeekVisitorStats.isNotEmpty())
+
+        // query for days granularity. the visitor stats should be empty
+        val defaultDayVisitorStats = wcStatsStore.getNewVisitorStats(site, StatsGranularity.DAYS)
+        assertTrue(defaultDayVisitorStats.isEmpty())
+
+        // Test Scenario - 2: Generate default visitor stats with a different date
+        // Get visitor of the same site and granularity and assert not null
+        val defaultWeekVisitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.WEEKS.toString(), endDate = "2019-03-20"
+        )
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultWeekVisitorStatsModel2)
+        val defaultWeekVisitorStats2 = wcStatsStore.getNewVisitorStats(site, StatsGranularity.WEEKS)
+        assertTrue(defaultWeekVisitorStats2.isNotEmpty())
+
+        // Test Scenario - 3: Generate custom stats for same site i.e. isCustomField - true
+        // Get visitor Stats of the same site and granularity and assert not null
+        val customWeekVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.WEEKS.toString(), quantity = "1",
+                endDate = "2019-08-01", startDate = "2019-08-01"
+        )
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customWeekVisitorStatsModel)
+
+        val customWeekVisitorStats = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.WEEKS, customWeekVisitorStatsModel.quantity,
+                customWeekVisitorStatsModel.endDate, customWeekVisitorStatsModel.isCustomField
+        )
+        assertTrue(customWeekVisitorStats.isNotEmpty())
+
+        // Test Scenario - 4: Query for custom visitor stats that is not present in local cache:
+        // for same site, same quantity, different date
+        // Get visitor Stats of the same site and granularity and assert null
+        val customWeekVisitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.WEEKS.toString(), quantity = "1",
+                endDate = "2019-07-01", startDate = "2019-07-01"
+        )
+        val customWeekVisitorStats2 = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.WEEKS, customWeekVisitorStatsModel2.quantity,
+                customWeekVisitorStatsModel2.endDate, customWeekVisitorStatsModel2.isCustomField
+        )
+        assertTrue(customWeekVisitorStats2.isEmpty())
+
+        // Test Scenario - 5: Query for custom visitor stats that is not present in local cache:
+        // for same site, different quantity, different date
+        // Get visitor Stats of the same site and granularity and assert null
+        val customWeekVisitorStatsModel3 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.WEEKS.toString(), quantity = "1",
+                endDate = "2019-07-01", startDate = "2019-07-01"
+        )
+
+        val customWeekVisitorStats3 = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.WEEKS, customWeekVisitorStatsModel3.quantity,
+                customWeekVisitorStatsModel3.endDate, customWeekVisitorStatsModel3.isCustomField
+        )
+        assertTrue(customWeekVisitorStats3.isEmpty())
+
+        // Test Scenario - 6: Generate custom visitor stats for same site with different granularity (MONTHS),
+        // same date(2019-01-01), same quantity (1) i.e. isCustomField - true
+        // Get visitor Stats and assert Not Null
+        // Now if another query ran for granularity - WEEKS, with same date and same quantity: assert null
+        val customMonthVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                quantity = "1", endDate = "2019-08-01", startDate = "2019-08-01",
+                granularity = StatsGranularity.MONTHS.toString())
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customMonthVisitorStatsModel)
+
+        val customMonthVisitorStats = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.MONTHS, customMonthVisitorStatsModel.quantity,
+                customMonthVisitorStatsModel.endDate, customMonthVisitorStatsModel.isCustomField
+        )
+        assertTrue(customMonthVisitorStats.isNotEmpty())
+
+        val customWeekVisitorStats4 = wcStatsStore.getNewVisitorStats(
+                site, StatsGranularity.WEEKS, customWeekVisitorStatsModel.quantity,
+                customWeekVisitorStatsModel.endDate, customWeekVisitorStatsModel.isCustomField
+        )
+        assertTrue(customWeekVisitorStats4.isEmpty())
+
+        // Test Scenario - 7: Generate custom stats for different site(8) with same granularity(MONTHS),
+        // same date(2019-01-01), same quantity(1) i.e. isCustomField - true
+        // Get visitor Stats and assert Not Null
+        // Now if scenario 4 is run again it should assert NOT NULL, since the stats is for different sites
+        val customMonthVisitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                localSiteId = 8, granularity = StatsGranularity.MONTHS.toString(),
+                quantity = "1", endDate = "2019-08-01", startDate = "2019-08-01"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customMonthVisitorStatsModel2)
+
+        val customMonthVisitorStats2 = wcStatsStore.getNewVisitorStats(
                 site, StatsGranularity.MONTHS, customMonthVisitorStatsModel2.quantity,
                 customMonthVisitorStatsModel2.endDate, customMonthVisitorStatsModel2.isCustomField
         )

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsTestUtils.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.wc.stats
 
 import org.wordpress.android.fluxc.UnitTestUtils
+import org.wordpress.android.fluxc.model.WCNewVisitorStatsModel
 import org.wordpress.android.fluxc.model.WCOrderStatsModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.WCVisitorStatsModel
@@ -73,6 +74,33 @@ object WCStatsTestUtils {
         return WCVisitorStatsModel().apply {
             this.localSiteId = localSiteId
             this.unit = unit
+            this.quantity = quantity
+            this.endDate = endDate
+            this.fields = fields
+            this.data = data
+            this.date = endDate
+            startDate?.let {
+                this.startDate = it
+                this.isCustomField = true
+            }
+        }
+    }
+
+    /**
+     * Generates a sample [WCNewVisitorStatsModel]
+     */
+    fun generateSampleNewVisitorStatsModel(
+        localSiteId: Int = 6,
+        granularity: String = StatsGranularity.DAYS.toString(),
+        quantity: String = "30",
+        startDate: String? = null,
+        endDate: String = DateTimeFormatter.ofPattern("YYYY-MM-dd").format(LocalDateTime.now()),
+        fields: String = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/visitor-stats-fields.json"),
+        data: String = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/visitor-stats-data.json")
+    ): WCNewVisitorStatsModel {
+        return WCNewVisitorStatsModel().apply {
+            this.localSiteId = localSiteId
+            this.granularity = granularity
             this.quantity = quantity
             this.endDate = endDate
             this.fields = fields

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCVisitorStatsSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCVisitorStatsSqlUtilsTest.kt
@@ -9,10 +9,12 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCNewVisitorStatsModel
 import org.wordpress.android.fluxc.model.WCVisitorStatsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
 import org.wordpress.android.fluxc.persistence.WCVisitorStatsSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -25,7 +27,7 @@ class WCVisitorStatsSqlUtilsTest {
         val appContext = RuntimeEnvironment.application.applicationContext
         val config = SingleStoreWellSqlConfigForTests(
                 appContext,
-                listOf(WCVisitorStatsModel::class.java),
+                listOf(WCVisitorStatsModel::class.java, WCNewVisitorStatsModel::class.java),
                 WellSqlConfig.ADDON_WOOCOMMERCE)
         WellSql.init(config)
         config.reset()
@@ -401,5 +403,377 @@ class WCVisitorStatsSqlUtilsTest {
         )
         assertNotNull(defaultVisitorStats)
         assertEquals(OrderStatsApiUnit.MONTH.toString(), defaultVisitorStats.unit)
+    }
+
+    @Test
+    fun testSimpleInsertionAndRetrievalOfNewVisitorStats() {
+        // insert a visitor stats entry and verify that it is stored correctly
+        val visitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel()
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(visitorStatsModel)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(1, size)
+            assertEquals(visitorStatsModel.granularity, first().granularity)
+            assertEquals(visitorStatsModel.startDate, first().startDate)
+            assertEquals(visitorStatsModel.endDate, first().endDate)
+        }
+
+        // Create a second visitor stats entry for this site with same quantity but with different unit
+        val visitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.MONTHS.toString(), quantity = "12", data = "fake-data"
+        )
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(visitorStatsModel2)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(2, size)
+            assertEquals(visitorStatsModel.granularity, first().granularity)
+            assertEquals(visitorStatsModel.startDate, first().startDate)
+            assertEquals(visitorStatsModel.endDate, first().endDate)
+            assertEquals(visitorStatsModel2.granularity, get(1).granularity)
+            assertEquals(visitorStatsModel2.startDate, get(1).startDate)
+            assertEquals(visitorStatsModel2.endDate, get(1).endDate)
+        }
+
+        // Create a third stats entry for this site with same interval but different start & end date
+        // i.e. custom stats
+        val visitorStatsModel3 =
+                WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                        data = "fake-data2", startDate = "2019-07-07", endDate = "2019-07-13"
+                )
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(visitorStatsModel3)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(3, size)
+            assertEquals(visitorStatsModel.granularity, first().granularity)
+            assertEquals(visitorStatsModel.startDate, first().startDate)
+            assertEquals(visitorStatsModel.endDate, first().endDate)
+            assertEquals(visitorStatsModel2.granularity, get(1).granularity)
+            assertEquals(visitorStatsModel2.startDate, get(1).startDate)
+            assertEquals(visitorStatsModel2.endDate, get(1).endDate)
+            assertEquals(visitorStatsModel3.granularity, get(2).granularity)
+            assertEquals(visitorStatsModel3.startDate, get(2).startDate)
+            assertEquals(visitorStatsModel3.endDate, get(2).endDate)
+        }
+
+        // Overwrite an existing entry and verify that update is happening correctly
+        val visitorStatsModel4 = WCStatsTestUtils.generateSampleNewVisitorStatsModel()
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(visitorStatsModel4)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(3, size)
+            assertEquals(visitorStatsModel.granularity, first().granularity)
+            assertEquals(visitorStatsModel.startDate, first().startDate)
+            assertEquals(visitorStatsModel.endDate, first().endDate)
+            assertEquals(visitorStatsModel2.granularity, get(1).granularity)
+            assertEquals(visitorStatsModel2.startDate, get(1).startDate)
+            assertEquals(visitorStatsModel2.endDate, get(1).endDate)
+            assertEquals(visitorStatsModel3.granularity, get(2).granularity)
+            assertEquals(visitorStatsModel3.startDate, get(2).startDate)
+            assertEquals(visitorStatsModel3.endDate, get(2).endDate)
+        }
+
+        // Add another "day" entry, but for another site
+        val visitorStatsModel5 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(localSiteId = 8)
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(visitorStatsModel5)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(4, size)
+            assertEquals(visitorStatsModel.granularity, first().granularity)
+            assertEquals(visitorStatsModel.startDate, first().startDate)
+            assertEquals(visitorStatsModel.endDate, first().endDate)
+            assertEquals(visitorStatsModel2.granularity, get(1).granularity)
+            assertEquals(visitorStatsModel2.startDate, get(1).startDate)
+            assertEquals(visitorStatsModel2.endDate, get(1).endDate)
+            assertEquals(visitorStatsModel3.granularity, get(2).granularity)
+            assertEquals(visitorStatsModel3.startDate, get(2).startDate)
+            assertEquals(visitorStatsModel3.endDate, get(2).endDate)
+            assertEquals(visitorStatsModel5.granularity, get(3).granularity)
+            assertEquals(visitorStatsModel5.localSiteId, get(3).localSiteId)
+            assertEquals(visitorStatsModel5.startDate, get(3).startDate)
+            assertEquals(visitorStatsModel5.endDate, get(3).endDate)
+        }
+    }
+
+    @Test
+    fun testGetNewRawVisitorStatsForSiteAndGranularity() {
+        val dayOrderStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel()
+        val site = SiteModel().apply { id = dayOrderStatsModel.localSiteId }
+        val monthOrderStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.MONTHS.toString(), fields = "fake-data", data = "fake-data"
+        )
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(dayOrderStatsModel)
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(monthOrderStatsModel)
+
+        val site2 = SiteModel().apply { id = 8 }
+        val altSiteOrderStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(localSiteId = site2.id)
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(altSiteOrderStatsModel)
+
+        val dayOrderStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.DAYS
+        )
+        assertNotNull(dayOrderStats)
+        with(dayOrderStats) {
+            assertEquals(dayOrderStatsModel.granularity, granularity)
+            assertEquals(false, isCustomField)
+        }
+
+        val dayOrderCustomStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(startDate = "2019-01-15",
+                endDate = "2019-02-13")
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(dayOrderCustomStatsModel)
+        val dayOrderCustomStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.DAYS, dayOrderCustomStatsModel.quantity,
+                dayOrderCustomStatsModel.date, dayOrderCustomStatsModel.isCustomField
+        )
+        assertNotNull(dayOrderCustomStats)
+        with(dayOrderCustomStats) {
+            assertEquals(dayOrderCustomStatsModel.granularity, granularity)
+            assertEquals(true, isCustomField)
+        }
+        assertNotNull(dayOrderStats)
+
+        val altSiteDayOrderStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site2, StatsGranularity.DAYS
+        )
+        assertNotNull(altSiteDayOrderStats)
+
+        val monthOrderStatus = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.MONTHS
+        )
+        assertNotNull(monthOrderStatus)
+        with(monthOrderStatus) {
+            assertEquals(monthOrderStatsModel.granularity, granularity)
+            assertEquals(false, isCustomField)
+        }
+
+        val nonExistentSite = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                SiteModel().apply { id = 88 }, StatsGranularity.DAYS
+        )
+        assertNull(nonExistentSite)
+
+        val missingData = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.YEARS
+        )
+        assertNull(missingData)
+    }
+
+    @Test
+    fun testSimpleInsertionAndRetrievalOfNewCustomVisitorStats() {
+        // Test Scenario - 1: Generate default stats with granularity - DAYS, quantity - 30, date - current date
+        // and isCustomField - false
+        // The total size of the local db table = 1
+        val defaultDayVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel()
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultDayVisitorStatsModel)
+
+        val site = SiteModel().apply { id = defaultDayVisitorStatsModel.localSiteId }
+
+        val defaultDayVisitorStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.DAYS
+        )
+
+        assertEquals(defaultDayVisitorStatsModel.granularity, defaultDayVisitorStats?.granularity)
+        assertEquals(defaultDayVisitorStatsModel.quantity, defaultDayVisitorStats?.quantity)
+        assertEquals(defaultDayVisitorStatsModel.date, defaultDayVisitorStats?.date)
+        assertEquals(defaultDayVisitorStatsModel.isCustomField, defaultDayVisitorStats?.isCustomField)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(1, size)
+        }
+
+        // Test Scenario - 2: Generate custom stats for same site with granularity - DAYS, quantity - 1,
+        // date - 2019-01-01 and isCustomField - true
+        // The total size of the local db table = 2
+        val customDayVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                quantity = "1", endDate = "2019-01-01", startDate = "2018-12-31"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customDayVisitorStatsModel)
+        val customDayVisitorStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.DAYS, customDayVisitorStatsModel.quantity,
+                customDayVisitorStatsModel.date, customDayVisitorStatsModel.isCustomField
+        )
+
+        assertEquals(customDayVisitorStatsModel.granularity, customDayVisitorStats?.granularity)
+        assertEquals(customDayVisitorStatsModel.quantity, customDayVisitorStats?.quantity)
+        assertEquals(customDayVisitorStatsModel.endDate, customDayVisitorStats?.endDate)
+        assertEquals(customDayVisitorStatsModel.startDate, customDayVisitorStats?.startDate)
+        assertEquals(customDayVisitorStatsModel.date, customDayVisitorStats?.date)
+        assertEquals(customDayVisitorStatsModel.isCustomField, customDayVisitorStats?.isCustomField)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(2, size)
+        }
+
+        // Test Scenario - 3: Overwrite an existing default stats for same site, same unit, same quantity and same date,
+        // The total size of the local db table = 2 (since no new data is inserted)
+        val defaultDayVisitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel()
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultDayVisitorStatsModel2)
+        val defaultDayVisitorStats2 = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.DAYS
+        )
+
+        assertEquals(defaultDayVisitorStatsModel2.granularity, defaultDayVisitorStats2?.granularity)
+        assertEquals(defaultDayVisitorStatsModel2.quantity, defaultDayVisitorStats2?.quantity)
+        assertEquals(defaultDayVisitorStatsModel2.date, defaultDayVisitorStats2?.date)
+        assertEquals(defaultDayVisitorStatsModel2.isCustomField, defaultDayVisitorStats2?.isCustomField)
+        assertEquals("", defaultDayVisitorStats2?.startDate)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(2, size)
+        }
+
+        // Test Scenario - 4: Overwrite an existing custom stats for same site, same unit, same quantity and same date,
+        // The total size of the local db table = 2 (since no new data is inserted)
+        val customDayVisitorStatsModel2 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                quantity = "1", endDate = "2019-01-01", startDate = "2018-12-31"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customDayVisitorStatsModel2)
+        val customDayVisitorStats2 = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.DAYS, customDayVisitorStatsModel2.quantity,
+                customDayVisitorStatsModel2.endDate, customDayVisitorStatsModel2.isCustomField
+        )
+
+        assertEquals(customDayVisitorStatsModel2.granularity, customDayVisitorStats2?.granularity)
+        assertEquals(customDayVisitorStatsModel2.quantity, customDayVisitorStats2?.quantity)
+        assertEquals(customDayVisitorStatsModel2.endDate, customDayVisitorStats2?.endDate)
+        assertEquals(customDayVisitorStatsModel2.startDate, customDayVisitorStats2?.startDate)
+        assertEquals(customDayVisitorStatsModel2.date, customDayVisitorStats2?.date)
+        assertEquals(customDayVisitorStatsModel2.isCustomField, customDayVisitorStats2?.isCustomField)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(2, size)
+        }
+
+        // Test Scenario - 5: Overwrite an existing custom stats for same site, unit, quantity but different date,
+        // The total size of the local db table = 2 (since no old data was purged and new data was inserted)
+        val customDayVisitorStatsModel3 = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                quantity = "1", endDate = "2018-12-31", startDate = "2018-12-31"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customDayVisitorStatsModel3)
+        val customDayVisitorStats3 = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.DAYS, customDayVisitorStatsModel3.quantity,
+                customDayVisitorStatsModel3.endDate, customDayVisitorStatsModel3.isCustomField
+        )
+
+        assertEquals(customDayVisitorStatsModel3.granularity, customDayVisitorStats3?.granularity)
+        assertEquals(customDayVisitorStatsModel3.quantity, customDayVisitorStats3?.quantity)
+        assertEquals(customDayVisitorStatsModel3.endDate, customDayVisitorStats3?.endDate)
+        assertEquals(customDayVisitorStatsModel3.startDate, customDayVisitorStats3?.startDate)
+        assertEquals(customDayVisitorStatsModel3.date, customDayVisitorStats3?.date)
+        assertEquals(customDayVisitorStatsModel3.isCustomField, customDayVisitorStats3?.isCustomField)
+
+        /* expected size of local cache would still be 2 because there can only be one
+         * custom stats row stored in local cache at any point of time. Before storing incoming data,
+         * the existing data will be purged */
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(2, size)
+        }
+
+        // Test Scenario - 6: Generate default stats for same site with different unit,
+        // The total size of the local db table = 3 (since stats with DAYS granularity would be stored already)
+        val defaultWeekVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.WEEKS.toString(), quantity = "17"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultWeekVisitorStatsModel)
+        val defaultWeekVisitorStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.WEEKS
+        )
+
+        assertEquals(defaultWeekVisitorStatsModel.granularity, defaultWeekVisitorStats?.granularity)
+        assertEquals(defaultWeekVisitorStatsModel.quantity, defaultWeekVisitorStats?.quantity)
+        assertEquals(defaultWeekVisitorStatsModel.endDate, defaultWeekVisitorStats?.endDate)
+        assertEquals(defaultWeekVisitorStatsModel.date, defaultWeekVisitorStats?.date)
+        assertEquals(defaultWeekVisitorStatsModel.isCustomField, defaultWeekVisitorStats?.isCustomField)
+        assertEquals("", defaultWeekVisitorStats?.startDate)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(3, size)
+        }
+
+        // Test Scenario - 7: Generate custom stats for same site with different unit:
+        // The total size of the local db table = 3 (since stats with DAYS granularity would be stored already)
+        val customWeekVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                granularity = StatsGranularity.WEEKS.toString(), quantity = "2",
+                endDate = "2019-01-28", startDate = "2019-01-25"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customWeekVisitorStatsModel)
+        val customWeekVisitorStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, StatsGranularity.WEEKS, customWeekVisitorStatsModel.quantity,
+                customWeekVisitorStatsModel.date, customWeekVisitorStatsModel.isCustomField
+        )
+
+        assertEquals(customWeekVisitorStatsModel.granularity, customWeekVisitorStats?.granularity)
+        assertEquals(customWeekVisitorStatsModel.quantity, customWeekVisitorStats?.quantity)
+        assertEquals(customWeekVisitorStatsModel.endDate, customWeekVisitorStats?.endDate)
+        assertEquals(customWeekVisitorStatsModel.startDate, customWeekVisitorStats?.startDate)
+        assertEquals(customWeekVisitorStatsModel.date, customWeekVisitorStats?.date)
+        assertEquals(customWeekVisitorStatsModel.isCustomField, customWeekVisitorStats?.isCustomField)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(3, size)
+        }
+
+        // Test Scenario - 8: Generate default stats for different site with different unit:
+        // The total size of the local db table = 5 (since stats with DAYS and WEEKS data would be stored already)
+        val site2 = SiteModel().apply { id = 8 }
+        val defaultMonthVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                localSiteId = site2.id, granularity = StatsGranularity.MONTHS.toString(), quantity = "12"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultMonthVisitorStatsModel)
+        val defaultMonthVisitorStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site2, StatsGranularity.MONTHS
+        )
+
+        assertEquals(defaultMonthVisitorStatsModel.granularity, defaultMonthVisitorStats?.granularity)
+        assertEquals(defaultMonthVisitorStatsModel.quantity, defaultMonthVisitorStats?.quantity)
+        assertEquals(defaultMonthVisitorStatsModel.date, defaultMonthVisitorStats?.date)
+        assertEquals(defaultMonthVisitorStatsModel.isCustomField, defaultMonthVisitorStats?.isCustomField)
+        assertEquals("", defaultMonthVisitorStats?.startDate)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(4, size)
+        }
+
+        // Test Scenario - 9: Generate custom stats for different site with different unit and different date
+        // The total size of the local db table = 5 (since 3 default stats for another site would be stored already
+        // and 1 stats for site 8 would be stored). No purging of data would take place
+        val customMonthVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
+                localSiteId = site2.id, granularity = StatsGranularity.MONTHS.toString(), quantity = "2",
+                endDate = "2019-01-28", startDate = "2018-12-31"
+        )
+
+        WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(customMonthVisitorStatsModel)
+        val customMonthVisitorStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site2, StatsGranularity.MONTHS, customMonthVisitorStatsModel.quantity,
+                customMonthVisitorStatsModel.date, customMonthVisitorStatsModel.isCustomField
+        )
+
+        assertEquals(customMonthVisitorStatsModel.granularity, customMonthVisitorStats?.granularity)
+        assertEquals(customMonthVisitorStatsModel.quantity, customMonthVisitorStats?.quantity)
+        assertEquals(customMonthVisitorStatsModel.endDate, customMonthVisitorStats?.endDate)
+        assertEquals(customMonthVisitorStatsModel.startDate, customMonthVisitorStats?.startDate)
+        assertEquals(customMonthVisitorStatsModel.date, customMonthVisitorStats?.date)
+        assertEquals(customMonthVisitorStatsModel.isCustomField, customMonthVisitorStats?.isCustomField)
+
+        with(WellSql.select(WCNewVisitorStatsModel::class.java).asModel) {
+            assertEquals(5, size)
+        }
+
+        // Test Scenario - 10: Check for missing stats data. Query should return null
+        val missingData = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site2, StatsGranularity.YEARS, "1", "2019-01-01"
+        )
+        assertNull(missingData)
+
+        // Test Scenario - 11: Fetch data with only site(8) and granularity (MONTHS)
+        val defaultVisitorStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site2, StatsGranularity.MONTHS
+        )
+        assertNotNull(defaultVisitorStats)
+        assertEquals(StatsGranularity.MONTHS.toString(), defaultVisitorStats.granularity)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 80;
+        return 81;
     }
 
     @Override
@@ -581,6 +581,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("alter table PostModel add CHANGES_CONFIRMED_CONTENT_HASHCODE TEXT;");
                 oldVersion++;
+            case 80:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -872,6 +876,20 @@ public class WellSqlConfig extends DefaultWellConfig {
                     db.execSQL("CREATE TABLE WCVisitorStatsModel(\n"
                                + "  LOCAL_SITE_ID INTEGER,\n"
                                + "  UNIT TEXT NOT NULL,\n"
+                               + "  DATE TEXT NOT NULL,\n"
+                               + "  START_DATE TEXT NOT NULL,\n"
+                               + "  END_DATE TEXT NOT NULL,\n"
+                               + "  QUANTITY TEXT NOT NULL,\n"
+                               + "  IS_CUSTOM_FIELD INTEGER,\n"
+                               + "  FIELDS TEXT NOT NULL,\n"
+                               + "  DATA TEXT NOT NULL,\n"
+                               + "  _id INTEGER PRIMARY KEY AUTOINCREMENT)");
+                    break;
+                case 80:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("CREATE TABLE WCNewVisitorStatsModel(\n"
+                               + "  LOCAL_SITE_ID INTEGER,\n"
+                               + "  GRANULARITY TEXT NOT NULL,\n"
                                + "  DATE TEXT NOT NULL,\n"
                                + "  START_DATE TEXT NOT NULL,\n"
                                + "  END_DATE TEXT NOT NULL,\n"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
@@ -3,6 +3,8 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchNewVisitorStatsPayload;
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchNewVisitorStatsResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload;
@@ -29,6 +31,9 @@ public enum WCStatsAction implements IAction {
     @Action(payloadType = FetchVisitorStatsPayload.class)
     FETCH_VISITOR_STATS,
 
+    @Action(payloadType = FetchNewVisitorStatsPayload.class)
+    FETCH_NEW_VISITOR_STATS,
+
     @Action(payloadType = FetchTopEarnersStatsPayload.class)
     FETCH_TOP_EARNERS_STATS,
 
@@ -44,6 +49,9 @@ public enum WCStatsAction implements IAction {
 
     @Action(payloadType = FetchVisitorStatsResponsePayload.class)
     FETCHED_VISITOR_STATS,
+
+    @Action(payloadType = FetchNewVisitorStatsResponsePayload.class)
+    FETCHED_NEW_VISITOR_STATS,
 
     @Action(payloadType = FetchTopEarnersStatsResponsePayload.class)
     FETCHED_TOP_EARNERS_STATS

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCNewVisitorStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCNewVisitorStatsModel.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.fluxc.model
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+data class WCNewVisitorStatsModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var granularity = "" // The granularity ("days", "weeks", "months", "years")
+    @Column var date = "" // The formatted end date of the data
+    @Column var startDate = "" // The start date of the data
+    @Column var endDate = "" // The end date of the data
+    @Column var quantity = "" // The quantity based on unit. i.e. 30 days, 17 weeks, 12 months, 2 years
+    @Column var isCustomField = false // to check if the data is for custom stats or default stats
+        @JvmName("setIsCustomField")
+        set
+    @Column var fields = "" // JSON - A map of numerical index to stat name, used to lookup the stat in the data object
+    @Column var data = "" // JSON - A list of lists; each nested list contains the data for a time period
+
+    // The fields JSON deserialized into a list of strings
+    val fieldsList by lazy {
+        val responseType = object : TypeToken<List<String>>() {}.type
+        gson.fromJson(fields, responseType) as? List<String> ?: emptyList()
+    }
+
+    // The data JSON deserialized into a list of lists of arbitrary type
+    val dataList by lazy {
+        val responseType = object : TypeToken<List<List<Any>>>() {}.type
+        gson.fromJson(data, responseType) as? List<List<Any>> ?: emptyList()
+    }
+
+    enum class VisitorStatsField {
+        PERIOD,
+        VISITORS;
+
+        override fun toString() = name.toLowerCase()
+    }
+
+    companion object {
+        private val gson by lazy { Gson() }
+    }
+
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    fun getIndexForField(field: VisitorStatsField) = fieldsList.indexOf(field.toString())
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -74,10 +74,10 @@ class OrderStatsRestClient(
 
             /**
              * Based on the design changes, when:
-             *  `Today` tab is selected: [OrderStatsApiUnit] field passed to the API should be [HOUR]
-             *  `This week` tab is selected: [OrderStatsApiUnit] field passed to the API should be [DAY]
-             *  `This month` tab is selected: [OrderStatsApiUnit] field passed to the API should be [DAY]
-             *  `This year` tab is selected: [OrderStatsApiUnit] field passed to the API should be [MONTH]
+             *  `Today` tab is selected: [OrderStatsApiUnit] field passed to the visitor stats API should be [DAY]
+             *  `This week` tab is selected: [OrderStatsApiUnit] field passed to the visitor stats API should be [DAY]
+             *  `This month` tab is selected: [OrderStatsApiUnit] field passed to the visitor stats API should be [DAY]
+             *  `This year` tab is selected: [OrderStatsApiUnit] field passed to the visitor stats API should be [MONTH]
              */
             fun convertToVisitorsStatsApiUnit(granularity: StatsGranularity): OrderStatsApiUnit {
                 return when (granularity) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCVisitorStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCVisitorStatsSqlUtils.kt
@@ -1,10 +1,14 @@
 package org.wordpress.android.fluxc.persistence
 
+import com.wellsql.generated.WCNewVisitorStatsModelTable
 import com.wellsql.generated.WCVisitorStatsModelTable
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCVisitorStatsModel
+import org.wordpress.android.fluxc.model.WCNewVisitorStatsModel
+
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 
 object WCVisitorStatsSqlUtils {
     fun insertOrUpdateVisitorStats(stats: WCVisitorStatsModel): Int {
@@ -49,14 +53,6 @@ object WCVisitorStatsSqlUtils {
         }
     }
 
-    private fun getFirstRawStatsForSite(site: SiteModel): WCVisitorStatsModel? {
-        return WellSql.select(WCVisitorStatsModel::class.java)
-                .where()
-                .equals(WCVisitorStatsModelTable.LOCAL_SITE_ID, site.id)
-                .endWhere()
-                .asModel.firstOrNull()
-    }
-
     fun getRawVisitorStatsForSiteUnitQuantityAndDate(
         site: SiteModel,
         unit: OrderStatsApiUnit,
@@ -95,6 +91,96 @@ object WCVisitorStatsSqlUtils {
                 .where()
                 .equals(WCVisitorStatsModelTable.LOCAL_SITE_ID, siteId)
                 .equals(WCVisitorStatsModelTable.IS_CUSTOM_FIELD, true)
+                .endWhere()
+                .execute()
+    }
+
+    /**
+     * Methods to support the new v4 stats changes
+     */
+    fun insertOrUpdateNewVisitorStats(stats: WCNewVisitorStatsModel): Int {
+        val statsResult = if (stats.isCustomField) {
+            WellSql.select(WCNewVisitorStatsModel::class.java)
+                    .where().beginGroup()
+                    .equals(WCNewVisitorStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
+                    .equals(WCNewVisitorStatsModelTable.GRANULARITY, stats.granularity)
+                    .equals(WCNewVisitorStatsModelTable.DATE, stats.date)
+                    .equals(WCNewVisitorStatsModelTable.QUANTITY, stats.quantity)
+                    .equals(WCNewVisitorStatsModelTable.IS_CUSTOM_FIELD, stats.isCustomField)
+                    .endGroup().endWhere()
+                    .asModel
+        } else {
+            WellSql.select(WCNewVisitorStatsModel::class.java)
+                    .where().beginGroup()
+                    .equals(WCNewVisitorStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
+                    .equals(WCNewVisitorStatsModelTable.GRANULARITY, stats.granularity)
+                    .equals(WCNewVisitorStatsModelTable.IS_CUSTOM_FIELD, stats.isCustomField)
+                    .endGroup().endWhere()
+                    .asModel
+        }
+
+        if (statsResult.isEmpty()) {
+            /*
+             * if no visitor stats available for this particular date, quantity, granularity and site:
+             * - check if the incoming data is custom data or default data.
+             *      - if custom data, we need to delete any previously cached custom data
+             *        for the particular site before inserting incoming data
+             */
+            if (stats.isCustomField) {
+                deleteNewCustomVisitorStatsForSite(stats.localSiteId)
+            }
+
+            WellSql.insert(stats).asSingleTransaction(true).execute()
+            return 1
+        } else {
+            // Update
+            val oldId = statsResult[0].id
+            return WellSql.update(WCNewVisitorStatsModel::class.java).whereId(oldId)
+                    .put(stats, UpdateAllExceptId(WCNewVisitorStatsModel::class.java)).execute()
+        }
+    }
+
+    fun getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        quantity: String? = null,
+        date: String? = null,
+        isCustomField: Boolean = false
+    ): WCNewVisitorStatsModel? {
+        if (!isCustomField)
+            return getNewRawVisitorStatsForSiteAndGranularity(site, granularity)
+
+        return WellSql.select(WCNewVisitorStatsModel::class.java)
+                .where()
+                .beginGroup()
+                .equals(WCNewVisitorStatsModelTable.LOCAL_SITE_ID, site.id)
+                .equals(WCNewVisitorStatsModelTable.GRANULARITY, granularity)
+                .equals(WCNewVisitorStatsModelTable.QUANTITY, quantity)
+                .equals(WCNewVisitorStatsModelTable.DATE, date)
+                .equals(WCNewVisitorStatsModelTable.IS_CUSTOM_FIELD, isCustomField)
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+    }
+
+    private fun getNewRawVisitorStatsForSiteAndGranularity(
+        site: SiteModel,
+        granularity: StatsGranularity
+    ): WCNewVisitorStatsModel? {
+        return WellSql.select(WCNewVisitorStatsModel::class.java)
+                .where()
+                .beginGroup()
+                .equals(WCNewVisitorStatsModelTable.LOCAL_SITE_ID, site.id)
+                .equals(WCNewVisitorStatsModelTable.GRANULARITY, granularity)
+                .equals(WCNewVisitorStatsModelTable.IS_CUSTOM_FIELD, false)
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+    }
+
+    private fun deleteNewCustomVisitorStatsForSite(siteId: Int): Int {
+        return WellSql.delete(WCNewVisitorStatsModel::class.java)
+                .where()
+                .equals(WCNewVisitorStatsModelTable.LOCAL_SITE_ID, siteId)
+                .equals(WCNewVisitorStatsModelTable.IS_CUSTOM_FIELD, true)
                 .endWhere()
                 .execute()
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.WCStatsAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCNewVisitorStatsModel
 import org.wordpress.android.fluxc.model.WCOrderStatsModel
 import org.wordpress.android.fluxc.model.WCOrderStatsModel.OrderStatsField
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
@@ -172,6 +173,31 @@ class WCStatsStore @Inject constructor(
         }
     }
 
+    /**
+     * Describes the parameters for fetching visitor stats for [site], up to the current day, month, or year
+     * (depending on the given [granularity]). These classes are used exclusively for the new v4 stats API changes
+     *
+     * @param[granularity] the time units for the requested data
+     * @param[forced] if true, ignores any cached result and forces a refresh from the server
+     */
+    class FetchNewVisitorStatsPayload(
+        val site: SiteModel,
+        val granularity: StatsGranularity,
+        val forced: Boolean = false,
+        val startDate: String? = null,
+        val endDate: String? = null
+    ) : Payload<BaseNetworkError>()
+
+    class FetchNewVisitorStatsResponsePayload(
+        val site: SiteModel,
+        val granularity: StatsGranularity,
+        val stats: WCNewVisitorStatsModel? = null
+    ) : Payload<OrderStatsError>() {
+        constructor(error: OrderStatsError, site: SiteModel, granularity: StatsGranularity) : this(site, granularity) {
+            this.error = error
+        }
+    }
+
     class FetchTopEarnersStatsPayload(
         val site: SiteModel,
         val granularity: StatsGranularity,
@@ -230,6 +256,7 @@ class WCStatsStore @Inject constructor(
             WCStatsAction.FETCH_REVENUE_STATS_AVAILABILITY ->
                 fetchRevenueStatsAvailability(action.payload as FetchRevenueStatsAvailabilityPayload)
             WCStatsAction.FETCH_VISITOR_STATS -> fetchVisitorStats(action.payload as FetchVisitorStatsPayload)
+            WCStatsAction.FETCH_NEW_VISITOR_STATS -> fetchNewVisitorStats(action.payload as FetchNewVisitorStatsPayload)
             WCStatsAction.FETCH_TOP_EARNERS_STATS -> fetchTopEarnersStats(action.payload as FetchTopEarnersStatsPayload)
             WCStatsAction.FETCHED_ORDER_STATS ->
                 handleFetchOrderStatsCompleted(action.payload as FetchOrderStatsResponsePayload)
@@ -240,6 +267,8 @@ class WCStatsStore @Inject constructor(
             )
             WCStatsAction.FETCHED_VISITOR_STATS ->
                 handleFetchVisitorStatsCompleted(action.payload as FetchVisitorStatsResponsePayload)
+            WCStatsAction.FETCHED_NEW_VISITOR_STATS ->
+                handleFetchNewVisitorStatsCompleted(action.payload as FetchNewVisitorStatsResponsePayload)
             WCStatsAction.FETCHED_TOP_EARNERS_STATS ->
                 handleFetchTopEarnersStatsCompleted(action.payload as FetchTopEarnersStatsResponsePayload)
         }
@@ -327,6 +356,33 @@ class WCStatsStore @Inject constructor(
     }
 
     /**
+     * Returns the visitor data by date for the given [site] and [granularity].
+     * The returned map has the format: "2018-05-01" -> 15
+     */
+    fun getNewVisitorStats(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        quantity: String? = null,
+        date: String? = null,
+        isCustomField: Boolean = false
+    ): Map<String, Int> {
+        val rawStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+                site, granularity, quantity, date, isCustomField)
+        rawStats?.let { visitorStatsModel ->
+            val periodIndex = visitorStatsModel.getIndexForField(WCNewVisitorStatsModel.VisitorStatsField.PERIOD)
+            val fieldIndex = visitorStatsModel.getIndexForField(WCNewVisitorStatsModel.VisitorStatsField.VISITORS)
+            if (periodIndex == -1 || fieldIndex == -1) {
+                return mapOf()
+            }
+
+            // Years are returned as numbers by the API, and Gson interprets them as floats - clean up the decimal
+            return visitorStatsModel.dataList.map {
+                it[periodIndex].toString().removeSuffix(".0") to (it[fieldIndex] as Number).toInt()
+            }.toMap()
+        } ?: return mapOf()
+    }
+
+    /**
      * Returns the currency code associated with stored stats for the [site], as an ISO 4217 currency code (eg. USD).
      */
     fun getStatsCurrencyForSite(site: SiteModel): String? {
@@ -348,33 +404,33 @@ class WCStatsStore @Inject constructor(
      * returns the quantity (how far back to go) to use when requesting stats for a specific granularity
      * and the date range
      */
-    private fun getQuantityForGranularity(
+    private fun getQuantityForOrderStatsApiUnit(
         site: SiteModel,
-        granularity: StatsGranularity,
+        unit: OrderStatsApiUnit,
         startDate: String?,
         endDate: String?
     ): Int {
-        val defaultValue = when (granularity) {
-            StatsGranularity.DAYS -> STATS_QUANTITY_DAYS
-            StatsGranularity.WEEKS -> STATS_QUANTITY_WEEKS
-            StatsGranularity.MONTHS -> STATS_QUANTITY_MONTHS
-            StatsGranularity.YEARS -> {
+        val defaultValue = when (unit) {
+            OrderStatsApiUnit.WEEK -> STATS_QUANTITY_WEEKS
+            OrderStatsApiUnit.MONTH -> STATS_QUANTITY_MONTHS
+            OrderStatsApiUnit.YEAR -> {
                 // Years since 2011 (WooCommerce initial release), inclusive
                 SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_YEAR).toInt() - 2011 + 1
             }
+            else -> STATS_QUANTITY_DAYS
         }
-        return getQuantityByGranularity(startDate, endDate, granularity, defaultValue).toInt()
+        return getQuantityByOrderStatsApiUnit(startDate, endDate, unit, defaultValue).toInt()
     }
 
     /**
-     * Given a {@param d1} start date, {@param d2} end date and the {@param granularity} granularity,
+     * Given a {@param d1} start date, {@param d2} end date and the {@param unit} unit,
      * returns a quantity value.
      * If the start date or end date is empty, returns {@param defaultValue}
      */
-    fun getQuantityByGranularity(
+    fun getQuantityByOrderStatsApiUnit(
         startDateString: String?,
         endDateString: String?,
-        granularity: StatsGranularity,
+        unit: OrderStatsApiUnit,
         defaultValue: Int
     ): Long {
         if (startDateString.isNullOrEmpty() || endDateString.isNullOrEmpty()) return defaultValue.toLong()
@@ -385,20 +441,21 @@ class WCStatsStore @Inject constructor(
         val startDateCalendar = DateUtils.getStartDateCalendar(if (startDate.before(endDate)) startDate else endDate)
         val endDateCalendar = DateUtils.getEndDateCalendar(if (startDate.before(endDate)) endDate else startDate)
 
-        return when (granularity) {
-            StatsGranularity.WEEKS -> DateUtils.getQuantityInWeeks(startDateCalendar, endDateCalendar)
-            StatsGranularity.MONTHS -> DateUtils.getQuantityInMonths(startDateCalendar, endDateCalendar)
-            StatsGranularity.YEARS -> DateUtils.getQuantityInYears(startDateCalendar, endDateCalendar)
+        return when (unit) {
+            OrderStatsApiUnit.WEEK -> DateUtils.getQuantityInWeeks(startDateCalendar, endDateCalendar)
+            OrderStatsApiUnit.MONTH -> DateUtils.getQuantityInMonths(startDateCalendar, endDateCalendar)
+            OrderStatsApiUnit.YEAR -> DateUtils.getQuantityInYears(startDateCalendar, endDateCalendar)
             else -> DateUtils.getQuantityInDays(startDateCalendar, endDateCalendar)
         }
     }
 
     private fun fetchOrderStats(payload: FetchOrderStatsPayload) {
-        val quantity = getQuantityForGranularity(payload.site, payload.granularity, payload.startDate, payload.endDate)
+        val apiUnit = OrderStatsApiUnit.fromStatsGranularity(payload.granularity)
+        val quantity = getQuantityForOrderStatsApiUnit(payload.site, apiUnit, payload.startDate, payload.endDate)
         wcOrderStatsClient.fetchStats(
                 payload.site,
-                OrderStatsApiUnit.fromStatsGranularity(payload.granularity),
-                getFormattedDate(payload.site, payload.granularity, payload.endDate),
+                apiUnit,
+                getFormattedDateByOrderStatsApiUnit(payload.site, apiUnit, payload.endDate),
                 quantity,
                 payload.forced,
                 payload.startDate,
@@ -406,15 +463,38 @@ class WCStatsStore @Inject constructor(
     }
 
     private fun fetchVisitorStats(payload: FetchVisitorStatsPayload) {
-        val quantity = getQuantityForGranularity(payload.site, payload.granularity, payload.startDate, payload.endDate)
+        val apiUnit = OrderStatsApiUnit.fromStatsGranularity(payload.granularity)
+        val quantity = getQuantityForOrderStatsApiUnit(payload.site, apiUnit, payload.startDate, payload.endDate)
         wcOrderStatsClient.fetchVisitorStats(
                 payload.site,
-                OrderStatsApiUnit.fromStatsGranularity(payload.granularity),
-                getFormattedDate(payload.site, payload.granularity, payload.endDate),
+                apiUnit,
+                getFormattedDateByOrderStatsApiUnit(payload.site, apiUnit, payload.endDate),
                 quantity,
                 payload.forced,
                 payload.startDate,
                 payload.endDate
+        )
+    }
+
+    private fun fetchNewVisitorStats(payload: FetchNewVisitorStatsPayload) {
+        val apiUnit = OrderStatsApiUnit.convertToVisitorsStatsApiUnit(payload.granularity)
+        val startDate = payload.startDate ?: when (payload.granularity) {
+            StatsGranularity.DAYS -> DateUtils.getStartOfCurrentDay()
+            StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeek()
+            StatsGranularity.MONTHS -> DateUtils.getFirstDayOfCurrentMonth()
+            StatsGranularity.YEARS -> DateUtils.getFirstDayOfCurrentYear()
+        }
+        val endDate = payload.endDate ?: DateUtils.getStartOfCurrentDay()
+        val quantity = getQuantityForOrderStatsApiUnit(payload.site, apiUnit, startDate, endDate)
+        wcOrderStatsClient.fetchNewVisitorStats(
+                payload.site,
+                apiUnit,
+                payload.granularity,
+                getFormattedDateByOrderStatsApiUnit(payload.site, apiUnit, endDate),
+                quantity,
+                payload.forced,
+                startDate,
+                endDate
         )
     }
 
@@ -458,6 +538,20 @@ class WCStatsStore @Inject constructor(
         emitChange(onStatsChanged)
     }
 
+    private fun handleFetchNewVisitorStatsCompleted(payload: FetchNewVisitorStatsResponsePayload) {
+        val onStatsChanged = with(payload) {
+            if (isError || stats == null) {
+                return@with OnWCStatsChanged(0, granularity).also { it.error = payload.error }
+            } else {
+                val rowsAffected = WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(stats)
+                return@with OnWCStatsChanged(rowsAffected, granularity, stats.quantity, stats.date, stats.isCustomField)
+            }
+        }
+
+        onStatsChanged.causeOfChange = WCStatsAction.FETCH_NEW_VISITOR_STATS
+        emitChange(onStatsChanged)
+    }
+
     private fun handleFetchTopEarnersStatsCompleted(payload: FetchTopEarnersStatsResponsePayload) {
         val granularity = StatsGranularity.fromOrderStatsApiUnit(payload.apiUnit)
         val onTopEarnersChanged = OnWCTopEarnersChanged(payload.topEarners, granularity)
@@ -481,12 +575,16 @@ class WCStatsStore @Inject constructor(
      * Given a {@param endDate} end date, formats the end date based on the site's timezone
      * If the start date or end date is empty, formats the current date
      */
-    private fun getFormattedDate(site: SiteModel, granularity: StatsGranularity, endDate: String?): String {
-        return when (granularity) {
-            StatsGranularity.DAYS -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_DAY, endDate)
-            StatsGranularity.WEEKS -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_WEEK, endDate)
-            StatsGranularity.MONTHS -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_MONTH, endDate)
-            StatsGranularity.YEARS -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_YEAR, endDate)
+    private fun getFormattedDateByOrderStatsApiUnit(
+        site: SiteModel,
+        unit: OrderStatsApiUnit,
+        endDate: String?
+    ): String {
+        return when (unit) {
+            OrderStatsApiUnit.WEEK -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_WEEK, endDate)
+            OrderStatsApiUnit.MONTH -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_MONTH, endDate)
+            OrderStatsApiUnit.YEAR -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_YEAR, endDate)
+            else -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_DAY, endDate)
         }
     }
 


### PR DESCRIPTION
Fixes #1335. This PR adds logic to get the visitor stats data for the new date ranges as defined in [here](https://github.com/woocommerce/woocommerce-android/issues/1199). We would use the existing API endpoint `/rest/v1.1/sites/{{site_id}}/stats/visits`. But as described [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1335), the `quantity`, `unit` and `date` fields would need to be modified to satisfy the new v4 stats UI.

Since we will be supporting both stats UI for the foreseeable future, I thought it made sense to implement the v4 changes for the visitor stats separately for better code readability and maintenance.

### Changes:
- Created a new table and model class - `WCNewVisitorStatsModel`. - The only difference between this model class and the `WcVisitorStatsModel` class is that we are storing the `StatsGranularity` to the `WCNewVisitorStatsModel` instead of `OrderStatsApiUnit`. This is because the current visitor stats implementation fetches the visitor data by `WEEKS` or `MONTHS`. In the new stats UI, we would need to fetch the visitor stats in `DAYS` for the current week or month. 
- Adds an action to `WCStatsAction`: `FETCH_NEW_VISITOR_STATS` and `FETCHED_NEW_VISITOR_STATS`  - for fetching visitor stats with a different `StatsGranularity` and `quantity` and handling visitor stats response. 
- Adds two payload classes to `WcStatsStore`: `FetchNewVisitorStatsPayload` and `FetchNewVisitorStatsResponsePayload`. 
- Adds a new method in `OrderStatsRestClient`: `fetchNewVisitorStats` to store the response data separately. This will be used by the new stats UI.
- Adds new buttons to the `WooRevenueStatsFragment` to test the visitor stats api for the current day, week, month and year and verify that the data is consistent with the date range.
- Added mocked tests to `MockedStack_WCStatsTest`
- Keeping in mind @nbradbury 's suggestion [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1325#pullrequestreview-268432017), created a new `StoreSelectorDialog` that displays only WooCommerce sites :)  

### Testing:
- Run all tests in `MockedStack_WCStatsTest`
- Run all tests in `WCStatsStoreTest`
- Run all tests in `WCVisitorStatsSqlUtilsTest`.
- Verify that the visitor stats fields are consistent with the `StatsGranularity` selected. Also note that the size of the visitors data map fetched from the local cache should match the `quantity` field:

| `TAB`  | `quantity` field | `date` field | `unit` field |
| ------------- | ---------------- | ---------------- | ---------------- |
| TODAY  | 1  | current date i.e. `2019-08-06` |  `OrderStatsApiUnit.DAY`  |
| This WEEK  | 3  | current date i.e. `2019-08-06` |  `OrderStatsApiUnit.DAY` (since we need the data in days i.e. for each day from the first of this week till the current date)  |
| This MONTH  | 6  | current date i.e. `2019-08-06` |  `OrderStatsApiUnit.DAY` (since we need the data in days i.e. for each day from the first of this month till the current date)  |
| This YEAR  | 8  | current date i.e. `2019-08-06` |  `OrderStatsApiUnit.MONTH` (since we need the data in months) - The API currently responds with 9 quantities, even though we have specified it as 8.  |

- Verify that the current implementation of visitor stats is working correctly, as a sanity check.
- Verify that upgrading to the changes in this PR does not lead to a crash.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/62520226-c133d100-b84a-11e9-8654-3ea5b5e42276.png">