### PR TITLE
Hotfix - Do not override server values on bulk migration of mobile editor preferences

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -337,6 +337,8 @@ public class SiteRestClient extends BaseWPComRestClient {
         String url = WPCOMV2.me.gutenberg.getUrl();
         params.put("editor", mobileEditorName);
         params.put("platform", "mobile");
+        params.put("set_only_if_empty", "true");
+
         add(WPComGsonRequest
                 .buildPostRequest(url, params, Map.class,
                         new Listener<Map<String, String>>() {


### PR DESCRIPTION
This PR does use the parameter `set_only_if_empty` when bulk migrating editor preferences for wpcom sites. 

**To test** use this wp-android PR here: https://github.com/wordpress-mobile/WordPress-Android/pull/10339