### PR TITLE
Hotfix - 1.1.2 Copy old values of editor settings when site lists is refreshed

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1608,6 +1608,14 @@ public class SiteStore extends Store {
         UpdateSitesResult result = new UpdateSitesResult();
         for (SiteModel site : sites.getSites()) {
             try {
+                // The REST API doesn't return info about the editor(s). Make sure to copy current values
+                // available on the DB. Otherwise the apps will receive an update site without editor prefs set.
+                // The apps will dispatch the action to update editor(s) when necessary.
+                SiteModel siteFromDB = getSiteBySiteId(site.getSiteId());
+                if (siteFromDB != null) {
+                    site.setMobileEditor(siteFromDB.getMobileEditor());
+                    site.setWebEditor(siteFromDB.getWebEditor());
+                }
                 result.rowsAffected += SiteSqlUtils.insertOrUpdateSite(site);
             } catch (DuplicateSiteException caughtException) {
                 result.duplicateSiteFound = true;


### PR DESCRIPTION
This PR does fix an issue where the mobile editor value is empty for a short while, resulting in Aztec being shown.  Next start of editor does show GB.

I guess we didn't notice it while testing due to short response time from the server, but I throttled the connection and able to replicate the problem constantly.

To test: 
- Point `wp-android` 13.0 to this hash
- Start the app, wait a bit, open site settings and make sure the block editor is the default, and that it starts when you press "new post" button
- Now close the app
- Verify on the RC card that GB is the default editor
- Set a breakpoint in https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/fix/editor-setting-lost-on-sites-update?expand=1#diff-b53e7ac94134ff56178e112330b7464eR1614
- Start the app
- You should hit the breakpoint - See the value returned from fetchSites action has mobile editor  empty, this is due to the REST response that doesn't include the field, instead the local value is `gutenberg`
- if the breakpoint is not hit, tap on switch site, and pull to refresh
- with this patch the old value is copied, and pressing new post button does show GB as expected.


