### PR TITLE
Merge master (v1.1.3) into develop

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -337,6 +337,8 @@ public class SiteRestClient extends BaseWPComRestClient {
         String url = WPCOMV2.me.gutenberg.getUrl();
         params.put("editor", mobileEditorName);
         params.put("platform", "mobile");
+        params.put("set_only_if_empty", "true");
+
         add(WPComGsonRequest
                 .buildPostRequest(url, params, Map.class,
                         new Listener<Map<String, String>>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1608,6 +1608,14 @@ public class SiteStore extends Store {
         UpdateSitesResult result = new UpdateSitesResult();
         for (SiteModel site : sites.getSites()) {
             try {
+                // The REST API doesn't return info about the editor(s). Make sure to copy current values
+                // available on the DB. Otherwise the apps will receive an update site without editor prefs set.
+                // The apps will dispatch the action to update editor(s) when necessary.
+                SiteModel siteFromDB = getSiteBySiteId(site.getSiteId());
+                if (siteFromDB != null) {
+                    site.setMobileEditor(siteFromDB.getMobileEditor());
+                    site.setWebEditor(siteFromDB.getWebEditor());
+                }
                 result.rowsAffected += SiteSqlUtils.insertOrUpdateSite(site);
             } catch (DuplicateSiteException caughtException) {
                 result.duplicateSiteFound = true;


### PR DESCRIPTION
Merge current master (tagged version 1.1.3 - e1ddee3ba2ee08569004d19aacb914675750617e) into develop.  
Fixed https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1340