### PR TITLE
Fix migration issue

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -579,7 +579,7 @@ public class WellSqlConfig extends DefaultWellConfig {
                 oldVersion++;
             case 79:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
-                db.execSQL("alter table PostModel add CHANGES_CONFIRMED_CONTENT_HASHCODE TEXT;");
+                db.execSQL("alter table PostModel add CHANGES_CONFIRMED_CONTENT_HASHCODE INTEGER;");
                 oldVersion++;
             case 80:
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));


### PR DESCRIPTION
Fixes migration of `CHANGES_CONFIRMED_CONTENT_HASHCODE` field as it had a wrong type in the migration script.

cc @loremattei This PR should fix the issue with migration in WPAndroid 13.1. However, I've fixed the migration script so the fix won't work for users who have already updated the app. But AFAIU WPAndroid 13.1 hasn't been released to anyone yet (not even to beta users), right?


Testing steps in WPAndroid
1. Install `release/13.0`
2. Log in and open post list
3. Checkout `release/13.1` and update FluxC hash to `5aa79629b12dabd24784548b8cf183bca458846b`
4. Update the app
4. Open Post List and scroll down -> notice the app doesn't crash