### PR TITLE
Issue/1348 json null get as string

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/JsonObjectExtensionsTests.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/JsonObjectExtensionsTests.kt
@@ -16,6 +16,7 @@ private const val sampleJson =
     "string": "Some string",
     "escaped_string": "\\ \" '",
     "number": 37,
+    "nullstring": null,
     "object": {
         "name": "Object name"
     }
@@ -41,6 +42,7 @@ class JsonObjectExtensionsTests {
         assertEquals("Some string", jsonObject.getString("string"))
         assertEquals("\\ \" '", jsonObject.getString("escaped_string", true))
         assertNull(jsonObject.getString("doesn't exist"))
+        assertNull(jsonObject.getString("nullstring"))
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/JsonObjectExtensions.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/JsonObjectExtensions.kt
@@ -24,6 +24,13 @@ fun JsonObject?.getJsonObject(property: String): JsonObject? {
     return if (obj?.isJsonObject == true) obj.asJsonObject else null
 }
 
-private fun JsonObject?.checkAndGet(property: String): JsonElement? = if (this?.has(property) == true) {
-    this.get(property)
-} else null
+private fun JsonObject?.checkAndGet(property: String): JsonElement? {
+    return if (this?.has(property) == true) {
+        val jsonElement = this.get(property)
+        if (jsonElement.isJsonNull) {
+            null
+        } else {
+            jsonElement
+        }
+    } else null
+}


### PR DESCRIPTION
Closes #1348 by updating the `JsonObjectExtensions` function `checkAndGet` to handle null values.