### PR TITLE
Add usernameCanBeChanged to AccountModel

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
@@ -59,6 +59,7 @@ public class AccountModelTest {
         copyAccount.setNewEmail("copyNewEmail");
         copyAccount.setPendingEmailChange(!testAccount.getPendingEmailChange());
         copyAccount.setTracksOptOut(!testAccount.getTracksOptOut());
+        copyAccount.setUsernameCanBeChanged(!testAccount.getUsernameCanBeChanged());
         copyAccount.setWebAddress("copyWebAddress");
         copyAccount.setUserId(testAccount.getUserId() + 1);
         Assert.assertFalse(copyAccount.equals(testAccount));

--- a/example/src/test/java/org/wordpress/android/fluxc/account/AccountSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/account/AccountSqlUtilsTest.java
@@ -66,9 +66,11 @@ public class AccountSqlUtilsTest {
         ContentValues testFields = new ContentValues();
         testFields.put(AccountModelTable.ABOUT_ME, testAboutMe);
         testFields.put(AccountModelTable.EMAIL, testEmail);
+        testFields.put(AccountModelTable.USERNAME_CAN_BE_CHANGED, true);
         Assert.assertEquals(1, AccountSqlUtils.updateAccount(testAccount.getId(), testFields));
         AccountModel dbAccount = AccountSqlUtils.getAccountByLocalId(testAccount.getId());
         Assert.assertNotNull(dbAccount);
+        Assert.assertTrue(dbAccount.getUsernameCanBeChanged());
         Assert.assertEquals(dbAccount.getAboutMe(), testAboutMe);
         Assert.assertEquals(dbAccount.getEmail(), testEmail);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -36,6 +36,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
     @Column private boolean mPendingEmailChange;
     @Column private String mWebAddress; // WPCom rest API: user_URL
     @Column private boolean mTracksOptOut;
+    @Column private boolean mUsernameCanBeChanged;
 
     public AccountModel() {
         init();
@@ -76,7 +77,8 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
                && getPendingEmailChange() == otherAccount.getPendingEmailChange()
                && StringUtils.equals(getWebAddress(), otherAccount.getWebAddress())
                && getHasUnseenNotes() == otherAccount.getHasUnseenNotes()
-               && getTracksOptOut() == otherAccount.getTracksOptOut();
+               && getTracksOptOut() == otherAccount.getTracksOptOut()
+               && getUsernameCanBeChanged() == otherAccount.getUsernameCanBeChanged();
     }
 
     public void init() {
@@ -98,6 +100,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
         mPendingEmailChange = false;
         mWebAddress = "";
         mTracksOptOut = false;
+        mUsernameCanBeChanged = false;
     }
 
     /**
@@ -134,6 +137,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
         setTracksOptOut(other.getTracksOptOut());
         setWebAddress(other.getWebAddress());
         setDisplayName(other.getDisplayName());
+        setUsernameCanBeChanged(other.getUsernameCanBeChanged());
     }
 
     public long getUserId() {
@@ -286,5 +290,13 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
 
     public void setTracksOptOut(boolean tracksOptOut) {
         mTracksOptOut = tracksOptOut;
+    }
+
+    public boolean getUsernameCanBeChanged() {
+        return mUsernameCanBeChanged;
+    }
+
+    public void setUsernameCanBeChanged(boolean usernameCanBeChanged) {
+        mUsernameCanBeChanged = usernameCanBeChanged;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -1130,9 +1130,6 @@ public class AccountRestClient extends BaseWPComRestClient {
         if (from.containsKey("primary_site_ID")) {
             accountModel.setPrimarySiteId(((Double) from.get("primary_site_ID")).longValue());
         }
-        if (from.containsKey("user_login_can_be_changed")) {
-            accountModel.setUsernameCanBeChanged((Boolean) from.get("user_login_can_be_changed"));
-        }
         return !old.equals(accountModel);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -1093,6 +1093,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         account.setNewEmail(from.new_user_email);
         account.setAvatarUrl(from.avatar_URL);
         account.setPendingEmailChange(from.user_email_change_pending);
+        account.setUsernameCanBeChanged(from.user_login_can_be_changed);
         account.setTracksOptOut(from.tracks_opt_out);
         account.setWebAddress(from.user_URL);
         account.setPrimarySiteId(from.primary_site_ID);
@@ -1128,6 +1129,9 @@ public class AccountRestClient extends BaseWPComRestClient {
         if (from.containsKey("user_URL")) accountModel.setWebAddress((String) from.get("user_URL"));
         if (from.containsKey("primary_site_ID")) {
             accountModel.setPrimarySiteId(((Double) from.get("primary_site_ID")).longValue());
+        }
+        if (from.containsKey("user_login_can_be_changed")) {
+            accountModel.setUsernameCanBeChanged((Boolean) from.get("user_login_can_be_changed"));
         }
         return !old.equals(accountModel);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSettingsResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSettingsResponse.java
@@ -16,6 +16,7 @@ public class AccountSettingsResponse implements Response {
     public String description;
     public String new_user_email;
     public boolean user_email_change_pending;
+    public boolean user_login_can_be_changed;
     public String user_URL;
     public String avatar_URL;
     public long primary_site_ID;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -593,6 +593,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
                 oldVersion++;
+            case 83:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("ALTER TABLE AccountModel ADD USERNAME_CAN_BE_CHANGED boolean");
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -930,9 +934,6 @@ public class WellSqlConfig extends DefaultWellConfig {
                     AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
                     db.execSQL("ALTER TABLE WCOrderModel ADD COLUMN DATE_PAID TEXT NOT NULL DEFAULT '';");
                     break;
-                case 83:
-                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
-                    db.execSQL("ALTER TABLE AccountModel ADD USERNAME_CAN_BE_CHANGED boolean");
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 83;
+        return 84;
     }
 
     @Override
@@ -929,6 +929,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 case 82:
                     AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
                     db.execSQL("ALTER TABLE WCOrderModel ADD COLUMN DATE_PAID TEXT NOT NULL DEFAULT '';");
+                    break;
+                case 83:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("ALTER TABLE AccountModel ADD USERNAME_CAN_BE_CHANGED boolean");
             }
         }
     }


### PR DESCRIPTION
This PR fixes #1346 by adding `usernameCanBeChanged` to the `AccountModel` and updating the  `AccountRestClient` with the associated `user_login_can_be_changed` property.

**Testing**

- [x]  Unit tests :`AccountModelTest` and `AccountSqlUtilsTest` were updated with the new column and all their tests passed. 
- [x]  Instrumented Tests : Ran `MockedStack_AccountTest` and all tests passed. Run `ReleaseStack_AccountTest` to verify the account api layer still functions accurately. - Having an `AuthenticationError` so I am digging into that to resolve it. 
- [x] Example app tests: Run the `AccountFragment` to fetch sample account settings. N.B example app was not updated to show this property since it doesn't seem necessary to do so. 
- [x] Test in WPAndroid - called `accountStore.getAccount().getUsernameCanBeChanged()` and got back a result. 