### PR TITLE
Issue/1353 woo product list

### DIFF
--- a/example/src/androidTest/resources/wc-fetch-products-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-products-response-success.json
@@ -1,0 +1,445 @@
+{
+  "data": [
+    {
+      "_links": {
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products"
+          }
+        ],
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/202"
+          }
+        ]
+      },
+      "attributes": [
+      ],
+      "average_rating": "3.00",
+      "backordered": false,
+      "backorders": "no",
+      "backorders_allowed": false,
+      "button_text": "",
+      "catalog_visibility": "hidden",
+      "categories": [
+      ],
+      "cross_sell_ids": [
+      ],
+      "date_created": "2019-04-09T15:36:08",
+      "date_created_gmt": "2019-04-09T20:36:08",
+      "date_modified": "2019-04-13T07:18:36",
+      "date_modified_gmt": "2019-04-13T12:18:36",
+      "date_on_sale_from": null,
+      "date_on_sale_from_gmt": null,
+      "date_on_sale_to": null,
+      "date_on_sale_to_gmt": null,
+      "default_attributes": [
+      ],
+      "description": "<p>This is a test product and isn't really for sale.</p>",
+      "dimensions": {
+        "height": "",
+        "length": "",
+        "width": ""
+      },
+      "download_expiry": 90,
+      "download_limit": 3,
+      "downloadable": true,
+      "downloads": [
+        {
+          "file": "https://example.com/wp-content/uploads/2019/04/1350747580204.jpg",
+          "id": "90b1b9a3-3794-4557-8e05-a6a750fd76fd",
+          "name": "1350747580204.jpg"
+        }
+      ],
+      "external_url": "",
+      "featured": false,
+      "grouped_products": [
+      ],
+      "id": 202,
+      "images": [
+        {
+          "alt": "",
+          "date_created": "2019-04-09T11:35:26",
+          "date_created_gmt": "2019-04-09T20:35:26",
+          "date_modified": "2019-04-09T11:35:26",
+          "date_modified_gmt": "2019-04-09T20:35:26",
+          "id": 203,
+          "name": "1350747580204",
+          "src": "https://i2.wp.com/example.com/wp-content/uploads/2019/04/1350747580204.jpg?fit=385%2C266&ssl=1"
+        }
+      ],
+      "jetpack_likes_enabled": true,
+      "jetpack_sharing_enabled": true,
+      "manage_stock": false,
+      "menu_order": 0,
+      "meta_data": [
+        {
+          "id": 1648,
+          "key": "_created_via",
+          "value": "post-new"
+        }
+      ],
+      "name": "Virtual Test Product",
+      "on_sale": false,
+      "parent_id": 0,
+      "permalink": "https://example.com/product/virtual-test-product/",
+      "price": "0.00",
+      "price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>0.00</span>",
+      "purchasable": true,
+      "purchase_note": "",
+      "rating_count": 1,
+      "regular_price": "0.00",
+      "related_ids": [
+      ],
+      "reviews_allowed": true,
+      "sale_price": "",
+      "shipping_class": "",
+      "shipping_class_id": 0,
+      "shipping_required": false,
+      "shipping_taxable": false,
+      "short_description": "",
+      "sku": "virtual-product-sku",
+      "slug": "virtual-test-product",
+      "sold_individually": false,
+      "status": "private",
+      "stock_quantity": null,
+      "stock_status": "instock",
+      "tags": [
+      ],
+      "tax_class": "",
+      "tax_status": "taxable",
+      "total_sales": 2,
+      "type": "simple",
+      "upsell_ids": [
+      ],
+      "variations": [
+      ],
+      "virtual": true,
+      "weight": ""
+    },
+    {
+      "_links": {
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products"
+          }
+        ],
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/152"
+          }
+        ]
+      },
+      "attributes": [
+        {
+          "id": 0,
+          "name": "Size",
+          "options": [
+            "Small",
+            "Large"
+          ],
+          "position": 0,
+          "variation": true,
+          "visible": false
+        },
+        {
+          "id": 0,
+          "name": "Color",
+          "options": [
+            "Blue",
+            "Red",
+            "Purple"
+          ],
+          "position": 1,
+          "variation": true,
+          "visible": false
+        }
+      ],
+      "average_rating": "3.00",
+      "backordered": false,
+      "backorders": "no",
+      "backorders_allowed": false,
+      "button_text": "",
+      "catalog_visibility": "hidden",
+      "categories": [
+        {
+          "id": 1373,
+          "name": "test",
+          "slug": "test"
+        },
+        {
+          "id": 1374,
+          "name": "test2",
+          "slug": "test2"
+        },
+        {
+          "id": 1375,
+          "name": "test3",
+          "slug": "test3"
+        }
+      ],
+      "cross_sell_ids": [
+      ],
+      "date_created": "2019-02-26T11:34:43",
+      "date_created_gmt": "2019-02-26T16:34:43",
+      "date_modified": "2019-08-12T13:19:10",
+      "date_modified_gmt": "2019-08-12T18:19:10",
+      "date_on_sale_from": null,
+      "date_on_sale_from_gmt": null,
+      "date_on_sale_to": null,
+      "date_on_sale_to_gmt": null,
+      "default_attributes": [
+      ],
+      "description": "<p>This is a test product which isn't really for sale.</p>",
+      "dimensions": {
+        "height": "3",
+        "length": "1",
+        "width": "1"
+      },
+      "download_expiry": 30,
+      "download_limit": 3,
+      "downloadable": false,
+      "downloads": [
+      ],
+      "external_url": "",
+      "featured": false,
+      "grouped_products": [
+      ],
+      "id": 152,
+      "images": [
+        {
+          "alt": "",
+          "date_created": "2019-02-26T06:32:20",
+          "date_created_gmt": "2019-02-26T16:32:20",
+          "date_modified": "2019-03-05T04:29:21",
+          "date_modified_gmt": "2019-03-05T14:29:21",
+          "id": 151,
+          "name": "profile-rockem-sockem",
+          "src": "https://i1.wp.com/example.com/wp-content/uploads/2019/02/profile-rockem-sockem.png?fit=300%2C225&ssl=1"
+        }
+      ],
+      "jetpack_likes_enabled": false,
+      "jetpack_sharing_enabled": false,
+      "manage_stock": true,
+      "menu_order": 0,
+      "meta_data": [
+        {
+          "id": 772,
+          "key": "_created_via",
+          "value": "post-new"
+        },
+        {
+          "id": 808,
+          "key": "_wc_pre_orders_enabled",
+          "value": "no"
+        },
+        {
+          "id": 809,
+          "key": "_wc_pre_orders_fee",
+          "value": ""
+        },
+        {
+          "id": 810,
+          "key": "switch_like_status",
+          "value": "0"
+        },
+        {
+          "id": 811,
+          "key": "sharing_disabled",
+          "value": "1"
+        },
+        {
+          "id": 1079,
+          "key": "_shipping-usps-envelope",
+          "value": "yes"
+        }
+      ],
+      "name": "Test Product",
+      "on_sale": false,
+      "parent_id": 0,
+      "permalink": "https://example.com/product/test-product/",
+      "price": "0",
+      "price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>0.00</span>",
+      "purchasable": true,
+      "purchase_note": "<p>This is the purchase note. It is not the slightest bit interesting. You are wasting your life by bothering to read this.</p>",
+      "rating_count": 46,
+      "regular_price": "",
+      "related_ids": [
+      ],
+      "reviews_allowed": true,
+      "sale_price": "",
+      "shipping_class": "booklet",
+      "shipping_class_id": 1372,
+      "shipping_required": true,
+      "shipping_taxable": true,
+      "short_description": "<p>This is the short description.</p>",
+      "sku": "test-product-sku",
+      "slug": "test-product",
+      "sold_individually": false,
+      "status": "private",
+      "stock_quantity": 99,
+      "stock_status": "instock",
+      "tags": [
+        {
+          "id": 1376,
+          "name": "tag1",
+          "slug": "tag1"
+        },
+        {
+          "id": 1377,
+          "name": "tag2",
+          "slug": "tag2"
+        },
+        {
+          "id": 1378,
+          "name": "tag3",
+          "slug": "tag3"
+        }
+      ],
+      "tax_class": "",
+      "tax_status": "taxable",
+      "total_sales": 12,
+      "type": "variable",
+      "upsell_ids": [
+      ],
+      "variations": [
+        192,
+        193
+      ],
+      "virtual": false,
+      "weight": "4"
+    },
+    {
+      "_links": {
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products"
+          }
+        ],
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/37"
+          }
+        ]
+      },
+      "attributes": [
+      ],
+      "average_rating": "0.00",
+      "backordered": false,
+      "backorders": "yes",
+      "backorders_allowed": true,
+      "button_text": "",
+      "catalog_visibility": "visible",
+      "categories": [
+      ],
+      "cross_sell_ids": [
+      ],
+      "date_created": "2019-02-21T06:40:58",
+      "date_created_gmt": "2019-02-21T11:40:58",
+      "date_modified": "2019-04-26T21:50:47",
+      "date_modified_gmt": "2019-04-27T02:50:47",
+      "date_on_sale_from": null,
+      "date_on_sale_from_gmt": null,
+      "date_on_sale_to": null,
+      "date_on_sale_to_gmt": null,
+      "default_attributes": [
+      ],
+      "description": "Printed booklet",
+      "dimensions": {
+        "height": "8.5",
+        "length": "",
+        "width": "11"
+      },
+      "download_expiry": -1,
+      "download_limit": -1,
+      "downloadable": false,
+      "downloads": [
+      ],
+      "external_url": "",
+      "featured": true,
+      "grouped_products": [
+      ],
+      "id": 37,
+      "images": [
+        {
+          "alt": "",
+          "date_created": "2019-02-23T07:24:23",
+          "date_created_gmt": "2019-02-23T17:24:23",
+          "date_modified": "2019-02-23T07:24:23",
+          "date_modified_gmt": "2019-02-23T17:24:23",
+          "id": 128,
+          "name": "product-promo-framed",
+          "src": "https://i0.wp.com/example.com/wp-content/uploads/2019/02/product-promo-framed.png?fit=1610%2C1400&ssl=1"
+        }
+      ],
+      "jetpack_likes_enabled": true,
+      "jetpack_sharing_enabled": true,
+      "manage_stock": true,
+      "menu_order": 0,
+      "meta_data": [
+        {
+          "id": 94,
+          "key": "_created_via",
+          "value": "calypso"
+        },
+        {
+          "id": 95,
+          "key": "_wpas_done_all",
+          "value": "1"
+        },
+        {
+          "id": 401,
+          "key": "_wc_pre_orders_enabled",
+          "value": "no"
+        },
+        {
+          "id": 403,
+          "key": "_wc_pre_orders_fee",
+          "value": "0.00"
+        },
+        {
+          "id": 404,
+          "key": "_wc_pre_orders_when_to_charge",
+          "value": "upon_release"
+        }
+      ],
+      "name": "Booklet",
+      "on_sale": false,
+      "parent_id": 0,
+      "permalink": "https://example.com/product/printed/",
+      "price": "19.99",
+      "price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>19.99</span>",
+      "purchasable": true,
+      "purchase_note": "",
+      "rating_count": 0,
+      "regular_price": "19.99",
+      "related_ids": [
+      ],
+      "reviews_allowed": true,
+      "sale_price": "",
+      "shipping_class": "booklet",
+      "shipping_class_id": 1372,
+      "shipping_required": true,
+      "shipping_taxable": true,
+      "short_description": "",
+      "sku": "booklet",
+      "slug": "printed",
+      "sold_individually": false,
+      "status": "publish",
+      "stock_quantity": 15,
+      "stock_status": "instock",
+      "tags": [
+      ],
+      "tax_class": "",
+      "tax_status": "taxable",
+      "total_sales": 7,
+      "type": "simple",
+      "upsell_ids": [
+      ],
+      "variations": [
+      ],
+      "virtual": false,
+      "weight": "12.30"
+    }
+  ]
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -12,6 +12,7 @@ import kotlinx.android.synthetic.main.fragment_woo_products.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_REVIEWS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIONS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
@@ -26,6 +27,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
@@ -73,6 +75,13 @@ class WooProductsFragment : Fragment() {
                         dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
                     } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
                 }
+            }
+        }
+
+        fetch_products.setOnClickListener {
+            selectedSite?.let { site ->
+                val payload = FetchProductsPayload(site)
+                dispatcher.dispatch(WCProductActionBuilder.newFetchProductsAction(payload))
             }
         }
 
@@ -161,6 +170,9 @@ class WooProductsFragment : Fragment() {
                             prependToLog("Single product fetched successfully! ${it.name}")
                         } ?: prependToLog("WARNING: Fetched product not found in the local database!")
                     }
+                }
+                FETCH_PRODUCTS -> {
+                    prependToLog("Fetched ${event.rowsAffected} products")
                 }
                 FETCH_PRODUCT_VARIATIONS -> {
                     prependToLog("Fetched ${event.rowsAffected} product variations")

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -47,6 +47,13 @@
             android:text="Fetch Single Product"/>
 
         <Button
+            android:id="@+id/fetch_products"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Products"/>
+
+        <Button
             android:id="@+id/fetch_product_variations"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -76,6 +76,23 @@ class ProductSqlUtilsTest {
     }
 
     @Test
+    fun testInsertOrUpdateProducts() {
+        val site = SiteModel().apply { id = 2 }
+        val products = ArrayList<WCProductModel>().apply {
+            this.add(ProductTestUtils.generateSampleProduct(40, siteId = site.id))
+            this.add(ProductTestUtils.generateSampleProduct(41, siteId = site.id))
+            this.add(ProductTestUtils.generateSampleProduct(42, siteId = site.id))
+        }
+
+        // Delete all products for this site, then test inserting the above products
+        ProductSqlUtils.deleteProductsForSite(site)
+        val insertedProductCount = ProductSqlUtils.insertOrUpdateProducts(products)
+        assertEquals(3, insertedProductCount)
+        val storedProductsCount = ProductSqlUtils.getProductCountForSite(site)
+        assertEquals(3, storedProductsCount)
+    }
+
+    @Test
     fun testGetProductsForSite() {
         // insert products for one site
         val site1 = SiteModel().apply { id = 2 }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -6,8 +6,10 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload;
@@ -18,6 +20,8 @@ public enum WCProductAction implements IAction {
     // Remote actions
     @Action(payloadType = FetchSingleProductPayload.class)
     FETCH_SINGLE_PRODUCT,
+    @Action(payloadType = FetchProductsPayload.class)
+    FETCH_PRODUCTS,
     @Action(payloadType = FetchProductVariationsPayload.class)
     FETCH_PRODUCT_VARIATIONS,
     @Action(payloadType = FetchProductReviewsPayload.class)
@@ -30,6 +34,8 @@ public enum WCProductAction implements IAction {
     // Remote responses
     @Action(payloadType = RemoteProductPayload.class)
     FETCHED_SINGLE_PRODUCT,
+    @Action(payloadType = RemoteProductListPayload.class)
+    FETCHED_PRODUCTS,
     @Action(payloadType = RemoteProductVariationsPayload.class)
     FETCHED_PRODUCT_VARIATIONS,
     @Action(payloadType = FetchProductReviewsResponsePayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -80,7 +80,7 @@ class ProductRestClient(
      *
      * Dispatches a [WCProductAction.FETCHED_PRODUCTS] action with the resulting list of products.
      */
-    fun fetchProducts(site: SiteModel, offset: Int) {
+    fun fetchProducts(site: SiteModel, offset: Int = 0) {
         val url = WOOCOMMERCE.products.pathV3
         val responseType = object : TypeToken<List<ProductApiResponse>>() {}.type
         val params = mapOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -70,6 +70,15 @@ object ProductSqlUtils {
                 .exists()
     }
 
+    fun getProductsForSite(site: SiteModel): List<WCProductModel> {
+        return WellSql.select(WCProductModel::class.java)
+                .where()
+                .equals(WCProductModelTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .orderBy(WCProductModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
+                .asModel
+    }
+
     fun deleteProductsForSite(site: SiteModel): Int {
         return WellSql.delete(WCProductModel::class.java)
                 .where().beginGroup()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -35,6 +35,14 @@ object ProductSqlUtils {
         }
     }
 
+    fun insertOrUpdateProducts(products: List<WCProductModel>): Int {
+        var rowsAffected = 0
+        products.forEach {
+            rowsAffected += insertOrUpdateProduct(it)
+        }
+        return rowsAffected
+    }
+
     fun getProductByRemoteId(site: SiteModel, remoteProductId: Long): WCProductModel? {
         return WellSql.select(WCProductModel::class.java)
                 .where().beginGroup()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -172,6 +172,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getProductsByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): List<WCProductModel> =
             ProductSqlUtils.getProductsByRemoteIds(site, remoteProductIds)
 
+    fun getProductsForSite(site: SiteModel) = ProductSqlUtils.getProductsForSite(site)
+
     fun deleteProductsForSite(site: SiteModel) = ProductSqlUtils.deleteProductsForSite(site)
 
     fun getProductReviewsForSite(site: SiteModel): List<WCProductReviewModel> =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -24,10 +24,16 @@ import javax.inject.Singleton
 class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcProductRestClient: ProductRestClient) :
         Store(dispatcher) {
     companion object {
+        const val NUM_PRODUCTS_PER_FETCH = 25
         const val NUM_REVIEWS_PER_FETCH = 25
     }
 
     class FetchSingleProductPayload(
+        var site: SiteModel,
+        var remoteProductId: Long
+    ) : Payload<BaseNetworkError>()
+
+    class FetchProductsPayload(
         var site: SiteModel,
         var remoteProductId: Long
     ) : Payload<BaseNetworkError>()
@@ -77,6 +83,20 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             product: WCProductModel,
             site: SiteModel
         ) : this(product, site) {
+            this.error = error
+        }
+    }
+
+    class RemoteProductListPayload(
+        val site: SiteModel,
+        val products: List<WCProductModel> = emptyList(),
+        var loadedMore: Boolean = false,
+        var canLoadMore: Boolean = false
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel
+        ) : this(site) {
             this.error = error
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -35,7 +35,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     class FetchProductsPayload(
         var site: SiteModel,
-        var offset: Int
+        var offset: Int = 0
     ) : Payload<BaseNetworkError>()
 
     class FetchProductVariationsPayload(
@@ -232,7 +232,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun fetchProducts(payload: FetchProductsPayload) {
-        with(payload) { wcProductRestClient.fetchProducts(site, offset)}
+        with(payload) { wcProductRestClient.fetchProducts(site, offset) }
     }
 
     private fun fetchProductVariations(payload: FetchProductVariationsPayload) {

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -7,6 +7,7 @@
 
 /products/<id>/
 /products/<id>/variations/
+/products/
 
 /products/reviews/
 /products/reviews/<id>/


### PR DESCRIPTION
Closes #1353 - adds the ability to fetch a list of products for a site, with an optional offset for paging. Includes release & mocked tests, and a "Fetch products"  button has been added to the example app.

![Screenshot_1566248315](https://user-images.githubusercontent.com/3903757/63298986-c3fae100-c2a2-11e9-96c8-081a08c44d2a.png)


