### PR TITLE
Add new autosave fields to the PostModel

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.PostStore.FetchPostListResponsePayload
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.PostStore.PostListItem
+import org.wordpress.android.fluxc.store.PostStore.PostListItem.PostListAutoSave
 
 @RunWith(MockitoJUnitRunner::class)
 class PostStoreTest {
@@ -241,6 +242,6 @@ class PostStoreTest {
         post: PostModel,
         status: String = post.status,
         lastModified: String = post.lastModified,
-        autoSaveModified: String = post.autoSaveModified
-    ) = PostListItem(post.remotePostId, lastModified, status, autoSaveModified)
+        autoSave: PostListAutoSave = mock()
+    ) = PostListItem(post.remotePostId, lastModified, status, autoSave)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -73,7 +73,9 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private String mAutoSaveModified; // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @Column private String mRemoteAutoSaveModified; // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @Column private String mAutoSavePreviewUrl;
-
+    @Column private String mAutoSaveTitle;
+    @Column private String mAutoSaveContent;
+    @Column private String mAutoSaveExcerpt;
 
     // Local only
     @Column private boolean mIsLocalDraft;
@@ -394,6 +396,30 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
 
     public void setAutoSavePreviewUrl(String autoSavePreviewUrl) {
         mAutoSavePreviewUrl = autoSavePreviewUrl;
+    }
+
+    public String getAutoSaveTitle() {
+        return mAutoSaveTitle;
+    }
+
+    public void setAutoSaveTitle(String autoSaveTitle) {
+        mAutoSaveTitle = autoSaveTitle;
+    }
+
+    public String getAutoSaveContent() {
+        return mAutoSaveContent;
+    }
+
+    public void setAutoSaveContent(String autoSaveContent) {
+        mAutoSaveContent = autoSaveContent;
+    }
+
+    public String getAutoSaveExcerpt() {
+        return mAutoSaveExcerpt;
+    }
+
+    public void setAutoSaveExcerpt(String autoSaveExcerpt) {
+        mAutoSaveExcerpt = autoSaveExcerpt;
     }
 
     @Deprecated

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -126,12 +126,14 @@ public class PostRestClient extends BaseWPComRestClient {
                         List<PostListItem> postListItems = new ArrayList<>(response.getPosts().size());
                         for (PostWPComRestResponse postResponse : response.getPosts()) {
                             String autoSaveModified = null;
+                            long autoSaveRevisionId = 0;
                             if (postResponse.getPostAutoSave() != null) {
+                                autoSaveRevisionId = postResponse.getPostAutoSave().getRevisionId();
                                 autoSaveModified = postResponse.getPostAutoSave().getModified();
                             }
                             postListItems
                                     .add(new PostListItem(postResponse.getRemotePostId(), postResponse.getModified(),
-                                            postResponse.getStatus(), autoSaveModified));
+                                            postResponse.getStatus(), autoSaveModified, autoSaveRevisionId));
                         }
                         boolean canLoadMore = postListItems.size() == pageSize;
                         FetchPostListResponsePayload responsePayload =

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -47,6 +47,7 @@ import org.wordpress.android.fluxc.store.PostStore.FetchRevisionsResponsePayload
 import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostListItem;
+import org.wordpress.android.fluxc.store.PostStore.PostListItem.PostListAutoSave;
 import org.wordpress.android.fluxc.store.PostStore.RemoteAutoSavePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.util.StringUtils;
@@ -125,15 +126,17 @@ public class PostRestClient extends BaseWPComRestClient {
                     public void onResponse(PostsResponse response) {
                         List<PostListItem> postListItems = new ArrayList<>(response.getPosts().size());
                         for (PostWPComRestResponse postResponse : response.getPosts()) {
-                            String autoSaveModified = null;
-                            long autoSaveRevisionId = 0;
+                            PostListAutoSave postListAutoSave = new PostListAutoSave();
                             if (postResponse.getPostAutoSave() != null) {
-                                autoSaveRevisionId = postResponse.getPostAutoSave().getRevisionId();
-                                autoSaveModified = postResponse.getPostAutoSave().getModified();
+                                postListAutoSave.revisionId = postResponse.getPostAutoSave().getRevisionId();
+                                postListAutoSave.title = postResponse.getPostAutoSave().getTitle();
+                                postListAutoSave.content = postResponse.getPostAutoSave().getContent();
+                                postListAutoSave.excerpt = postResponse.getPostAutoSave().getExcerpt();
+                                postListAutoSave.previewUrl = postResponse.getPostAutoSave().getPreviewUrl();
                             }
                             postListItems
                                     .add(new PostListItem(postResponse.getRemotePostId(), postResponse.getModified(),
-                                            postResponse.getStatus(), autoSaveModified, autoSaveRevisionId));
+                                            postResponse.getStatus(), postListAutoSave));
                         }
                         boolean canLoadMore = postListItems.size() == pageSize;
                         FetchPostListResponsePayload responsePayload =

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -39,7 +39,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsRespons
 import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsResponse.DiffResponsePart;
 import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsResponse.RevisionResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse;
-import org.wordpress.android.fluxc.store.PostStore.RemoteAutoSavePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.DeletedPostPayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostListResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostResponsePayload;
@@ -48,6 +47,7 @@ import org.wordpress.android.fluxc.store.PostStore.FetchRevisionsResponsePayload
 import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostListItem;
+import org.wordpress.android.fluxc.store.PostStore.RemoteAutoSavePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.util.StringUtils;
 
@@ -418,6 +418,9 @@ public class PostRestClient extends BaseWPComRestClient {
             post.setAutoSaveModified(autoSave.getModified());
             post.setRemoteAutoSaveModified(autoSave.getModified());
             post.setAutoSavePreviewUrl(autoSave.getPreviewUrl());
+            post.setAutoSaveTitle(autoSave.getTitle());
+            post.setAutoSaveContent(autoSave.getContent());
+            post.setAutoSaveExcerpt(autoSave.getExcerpt());
         }
 
         if (from.getCapabilities() != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -55,7 +55,10 @@ data class PostWPComRestResponse(
             data class PostAutoSave(
                 @SerializedName("ID") var revisionId: Long = 0,
                 @SerializedName("modified") var modified: String? = null,
-                @SerializedName("preview_URL") var previewUrl: String? = null
+                @SerializedName("preview_URL") var previewUrl: String? = null,
+                @SerializedName("title") var title: String? = null,
+                @SerializedName("content") var content: String? = null,
+                @SerializedName("excerpt") var excerpt: String? = null
             )
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -347,7 +347,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified_gmt");
             String lastModifiedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(lastModifiedGmt);
 
-            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus, null));
+            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus, null, 0));
         }
         return postListItems;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -40,6 +40,7 @@ import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import org.wordpress.android.fluxc.store.PostStore.PostListItem;
+import org.wordpress.android.fluxc.store.PostStore.PostListItem.PostListAutoSave;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -347,7 +348,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified_gmt");
             String lastModifiedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(lastModifiedGmt);
 
-            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus, null, 0));
+            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus, new PostListAutoSave()));
         }
         return postListItems;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -348,7 +348,8 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified_gmt");
             String lastModifiedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(lastModifiedGmt);
 
-            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus, new PostListAutoSave()));
+            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus,
+                    new PostListAutoSave()));
         }
         return postListItems;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -591,6 +591,9 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_MODIFIED TEXT");
                 db.execSQL("ALTER TABLE PostModel ADD REMOTE_AUTO_SAVE_MODIFIED TEXT");
                 db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_PREVIEW_URL TEXT");
+                db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_TITLE TEXT");
+                db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_CONTENT TEXT");
+                db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_EXCERPT TEXT");
                 oldVersion++;
         }
         db.setTransactionSuccessful();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -87,19 +87,24 @@ public class PostStore extends Store {
     }
 
     public static class PostListItem {
+        public static class PostListAutoSave {
+            public long revisionId = 0;
+            public String previewUrl;
+            public String title;
+            public String content;
+            public String excerpt;
+        }
+
         public Long remotePostId;
         public String lastModified;
         public String status;
-        public String autoSaveModified;
-        public long autoSaveRevisionId;
+        public PostListAutoSave autoSave;
 
-        public PostListItem(Long remotePostId, String lastModified, String status, String autoSaveModified,
-                            long autoSaveRevisionId) {
+        public PostListItem(Long remotePostId, String lastModified, String status, PostListAutoSave autoSave) {
             this.remotePostId = remotePostId;
             this.lastModified = lastModified;
             this.status = status;
-            this.autoSaveModified = autoSaveModified;
-            this.autoSaveRevisionId = autoSaveRevisionId;
+            this.autoSave = autoSave;
         }
     }
 
@@ -712,7 +717,7 @@ public class PostStore extends Store {
                 boolean isPostChanged =
                         !post.getLastModified().equals(item.lastModified)
                         || !post.getStatus().equals(item.status)
-                        || item.autoSaveRevisionId > 0;
+                        || item.autoSave.revisionId != post.getAutoSaveRevisionId();
 
                 /*
                  * This is a hacky workaround. When `/autosave` endpoint is invoked on a draft, the server
@@ -725,8 +730,7 @@ public class PostStore extends Store {
                   * was updated. However, if we know the last modified date is equal to the date we have in local
                   * autosave object we are sure that our invocation of /autosave updated the post directly.
                  */
-                if (isPostChanged && item.lastModified.equals(post.getAutoSaveModified())
-                    && item.autoSaveModified == null) {
+                if (isPostChanged && item.lastModified.equals(post.getAutoSaveModified())) {
                     isPostChanged = false;
                 }
 
@@ -740,7 +744,11 @@ public class PostStore extends Store {
                         // both locally and on the remote), so flag the local version of the Post so the
                         // hosting app can inform the user and the user can decide and take action
                         post.setRemoteLastModified(item.lastModified);
-                        post.setAutoSaveRevisionId(item.autoSaveRevisionId);
+                        post.setAutoSaveRevisionId(item.autoSave.revisionId);
+                        post.setAutoSaveTitle(item.autoSave.title);
+                        post.setAutoSaveContent(item.autoSave.content);
+                        post.setAutoSaveExcerpt(item.autoSave.excerpt);
+                        post.setAutoSavePreviewUrl(item.autoSave.previewUrl);
                         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -91,12 +91,15 @@ public class PostStore extends Store {
         public String lastModified;
         public String status;
         public String autoSaveModified;
+        public long autoSaveRevisionId;
 
-        public PostListItem(Long remotePostId, String lastModified, String status, String autoSaveModified) {
+        public PostListItem(Long remotePostId, String lastModified, String status, String autoSaveModified,
+                            long autoSaveRevisionId) {
             this.remotePostId = remotePostId;
             this.lastModified = lastModified;
             this.status = status;
             this.autoSaveModified = autoSaveModified;
+            this.autoSaveRevisionId = autoSaveRevisionId;
         }
     }
 
@@ -708,7 +711,8 @@ public class PostStore extends Store {
                 // will not be updated.
                 boolean isPostChanged =
                         !post.getLastModified().equals(item.lastModified)
-                        || !post.getStatus().equals(item.status);
+                        || !post.getStatus().equals(item.status)
+                        || item.autoSaveRevisionId > 0;
 
                 /*
                  * This is a hacky workaround. When `/autosave` endpoint is invoked on a draft, the server
@@ -736,6 +740,7 @@ public class PostStore extends Store {
                         // both locally and on the remote), so flag the local version of the Post so the
                         // hosting app can inform the user and the user can decide and take action
                         post.setRemoteLastModified(item.lastModified);
+                        post.setAutoSaveRevisionId(item.autoSaveRevisionId);
                         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
                     }
                 }


### PR DESCRIPTION
Add 3 new fields to the PostModel + migration plan, to be used in wpandroid for restoring title/content/excerpt.

Also updated the `PostStore` and `PostRestClient` to update the AutoSaveRevisionId when fetching the post list (needed to detect unhandled auto saves in the post list).

Autosave restoration logic will be done on the client side.