### PR TITLE
Issue/1359 woo product sort order

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -9,13 +9,12 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.NAME_ASC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.NAME_DESC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.STOCK_ASC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.STOCK_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
 
 object ProductSqlUtils {
     fun insertOrUpdateProduct(product: WCProductModel): Int {
@@ -77,14 +76,16 @@ object ProductSqlUtils {
                 .exists()
     }
 
-    fun getProductsForSite(site: SiteModel, sortType: ProductSorting): List<WCProductModel> {
+    fun getProductsForSite(
+        site: SiteModel,
+        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING
+    ): List<WCProductModel> {
         val sortOrder = when (sortType) {
-            NAME_ASC, STOCK_ASC, DATE_ASC -> SelectQuery.ORDER_ASCENDING
+            TITLE_ASC, DATE_ASC -> SelectQuery.ORDER_ASCENDING
             else -> SelectQuery.ORDER_DESCENDING
         }
         val sortField = when (sortType) {
-            NAME_ASC, NAME_DESC -> WCProductModelTable.NAME
-            STOCK_ASC, STOCK_DESC -> WCProductModelTable.STOCK_QUANTITY
+            TITLE_ASC, TITLE_DESC -> WCProductModelTable.NAME
             DATE_ASC, DATE_DESC -> WCProductModelTable.DATE_CREATED
         }
         return WellSql.select(WCProductModel::class.java)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -9,6 +9,13 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.NAME_ASC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.NAME_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.STOCK_ASC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.STOCK_DESC
 
 object ProductSqlUtils {
     fun insertOrUpdateProduct(product: WCProductModel): Int {
@@ -70,12 +77,21 @@ object ProductSqlUtils {
                 .exists()
     }
 
-    fun getProductsForSite(site: SiteModel): List<WCProductModel> {
+    fun getProductsForSite(site: SiteModel, sortType: ProductSorting): List<WCProductModel> {
+        val sortOrder = when (sortType) {
+            NAME_ASC, STOCK_ASC, DATE_ASC -> SelectQuery.ORDER_ASCENDING
+            else -> SelectQuery.ORDER_DESCENDING
+        }
+        val sortField = when (sortType) {
+            NAME_ASC, NAME_DESC -> WCProductModelTable.NAME
+            STOCK_ASC, STOCK_DESC -> WCProductModelTable.STOCK_QUANTITY
+            DATE_ASC, DATE_DESC -> WCProductModelTable.DATE_CREATED
+        }
         return WellSql.select(WCProductModel::class.java)
                 .where()
                 .equals(WCProductModelTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
-                .orderBy(WCProductModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
+                .orderBy(sortField, sortOrder)
                 .asModel
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -82,7 +82,7 @@ object ProductSqlUtils {
     ): List<WCProductModel> {
         val sortOrder = when (sortType) {
             TITLE_ASC, DATE_ASC -> SelectQuery.ORDER_ASCENDING
-            else -> SelectQuery.ORDER_DESCENDING
+            TITLE_DESC, DATE_DESC -> SelectQuery.ORDER_DESCENDING
         }
         val sortField = when (sortType) {
             TITLE_ASC, TITLE_DESC -> WCProductModelTable.NAME

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -37,7 +37,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     class FetchProductsPayload(
         var site: SiteModel,
-        var offset: Int = 0
+        var offset: Int = 0,
+        var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING
     ) : Payload<BaseNetworkError>()
 
     class FetchProductVariationsPayload(
@@ -244,7 +245,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun fetchProducts(payload: FetchProductsPayload) {
-        with(payload) { wcProductRestClient.fetchProducts(site, offset) }
+        with(payload) { wcProductRestClient.fetchProducts(site, offset, sorting) }
     }
 
     private fun fetchProductVariations(payload: FetchProductVariationsPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -181,7 +181,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getProductsByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): List<WCProductModel> =
             ProductSqlUtils.getProductsByRemoteIds(site, remoteProductIds)
 
-    fun getProductsForSite(site: SiteModel, sortType: ProductSorting) = ProductSqlUtils.getProductsForSite(site, sortType)
+    fun getProductsForSite(site: SiteModel, sortType: ProductSorting = DEFAULT_PRODUCT_SORTING) =
+            ProductSqlUtils.getProductsForSite(site, sortType)
 
     fun deleteProductsForSite(site: SiteModel) = ProductSqlUtils.deleteProductsForSite(site)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -74,6 +74,15 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     class ProductError(val type: ProductErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
 
+    enum class ProductSorting {
+        NAME_ASC,
+        NAME_DESC,
+        STOCK_ASC,
+        STOCK_DESC,
+        DATE_ASC,
+        DATE_DESC
+    }
+
     class RemoteProductPayload(
         val product: WCProductModel,
         val site: SiteModel
@@ -172,7 +181,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getProductsByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): List<WCProductModel> =
             ProductSqlUtils.getProductsByRemoteIds(site, remoteProductIds)
 
-    fun getProductsForSite(site: SiteModel) = ProductSqlUtils.getProductsForSite(site)
+    fun getProductsForSite(site: SiteModel, sortType: ProductSorting) = ProductSqlUtils.getProductsForSite(site, sortType)
 
     fun deleteProductsForSite(site: SiteModel) = ProductSqlUtils.deleteProductsForSite(site)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Locale
@@ -26,6 +27,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     companion object {
         const val NUM_PRODUCTS_PER_FETCH = 25
         const val NUM_REVIEWS_PER_FETCH = 25
+        val DEFAULT_PRODUCT_SORTING = DATE_DESC
     }
 
     class FetchSingleProductPayload(
@@ -75,10 +77,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class ProductError(val type: ProductErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
 
     enum class ProductSorting {
-        NAME_ASC,
-        NAME_DESC,
-        STOCK_ASC,
-        STOCK_DESC,
+        TITLE_ASC,
+        TITLE_DESC,
         DATE_ASC,
         DATE_DESC
     }


### PR DESCRIPTION
Closes #1359 - adds the ability to sort products when fetching them from the backend and from the database.