### PR TITLE
Woo: Removed unnecessary product_id dependency for product reviews

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -47,7 +47,6 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         remoteProductId = BuildConfig.TEST_WC_PRODUCT_WITH_VARIATIONS_ID.toLong()
         dateCreated = "2018-04-20T15:45:14Z"
     }
-    private val remoteProductWithReviewsId = BuildConfig.TEST_WC_PRODUCT_WITH_REVIEWS_ID.toLong()
     private val remoteProductReviewId = BuildConfig.TEST_WC_PRODUCT_REVIEW_ID.toLong()
 
     private var lastEvent: OnProductChanged? = null
@@ -163,7 +162,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
         // Verify results
         val review = productStore
-                .getProductReviewByRemoteId(sSite.id, remoteProductWithReviewsId, remoteProductReviewId)
+                .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
         assertNotNull(review)
 
         // Update review status
@@ -181,7 +180,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
             // Verify results
             val savedReview = productStore
-                    .getProductReviewByRemoteId(sSite.id, remoteProductWithReviewsId, remoteProductReviewId)
+                    .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
             assertNotNull(savedReview)
             assertEquals(newStatus, savedReview!!.status)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -172,7 +172,7 @@ class ProductSqlUtilsTest {
         var rowsAffected = ProductSqlUtils.insertOrUpdateProductReview(review)
         assertEquals(1, rowsAffected)
         var savedReview = ProductSqlUtils.getProductReviewByRemoteId(
-                site.id, review.remoteProductId, review.remoteProductReviewId
+                site.id, review.remoteProductReviewId
         )
         assertNotNull(savedReview)
         assertEquals(review.remoteProductReviewId, savedReview.remoteProductReviewId)
@@ -193,7 +193,7 @@ class ProductSqlUtilsTest {
         rowsAffected = ProductSqlUtils.insertOrUpdateProductReview(review)
         assertEquals(1, rowsAffected)
         savedReview = ProductSqlUtils.getProductReviewByRemoteId(
-                site.id, review.remoteProductId, review.remoteProductReviewId
+                site.id, review.remoteProductReviewId
         )
         assertNotNull(savedReview)
         assertEquals(review.verified, savedReview.verified)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -181,7 +181,6 @@ object ProductSqlUtils {
                 .equals(WCProductReviewModelTable.ID, productReview.id)
                 .or()
                 .beginGroup()
-                .equals(WCProductReviewModelTable.REMOTE_PRODUCT_ID, productReview.remoteProductId)
                 .equals(WCProductReviewModelTable.REMOTE_PRODUCT_REVIEW_ID, productReview.remoteProductReviewId)
                 .equals(WCProductReviewModelTable.LOCAL_SITE_ID, productReview.localSiteId)
                 .endGroup()
@@ -202,14 +201,12 @@ object ProductSqlUtils {
 
     fun getProductReviewByRemoteId(
         localSiteId: Int,
-        remoteProductId: Long,
         remoteReviewId: Long
     ): WCProductReviewModel? {
         return WellSql.select(WCProductReviewModel::class.java)
                 .where()
                 .beginGroup()
                 .equals(WCProductReviewModelTable.LOCAL_SITE_ID, localSiteId)
-                .equals(WCProductReviewModelTable.REMOTE_PRODUCT_ID, remoteProductId)
                 .equals(WCProductReviewModelTable.REMOTE_PRODUCT_REVIEW_ID, remoteReviewId)
                 .endGroup()
                 .endWhere()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -195,10 +195,9 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     fun getProductReviewByRemoteId(
         localSiteId: Int,
-        remoteProductId: Long,
         remoteReviewId: Long
     ): WCProductReviewModel? = ProductSqlUtils
-            .getProductReviewByRemoteId(localSiteId, remoteProductId, remoteReviewId)
+            .getProductReviewByRemoteId(localSiteId, remoteReviewId)
 
     fun deleteProductReviewsForSite(site: SiteModel) = ProductSqlUtils.deleteAllProductReviewsForSite(site)
 


### PR DESCRIPTION
Closes #1356 by removing the `product_id` dependency for product reviews where not necessary. Product review IDs are unique at the site level, so there is no need to specify a product_id unless we are specifically trying to fetch reviews for a specific product. Removing them here just simplifies the code needed to work with this feature.