### PR TITLE
Issue/1362 woo product variation count

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -77,6 +77,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(product.getAttributes().size, 2)
             assertEquals(product.getAttributes().get(0).options.size, 3)
             assertEquals(product.getAttributes().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
+            assertEquals(product.getNumVariations(), 2)
         }
 
         // save the product to the db
@@ -94,6 +95,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(product.getAttributes().size, 2)
             assertEquals(product.getAttributes().get(0).options.size, 3)
             assertEquals(product.getAttributes().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
+            assertEquals(product.getNumVariations(), 2)
         }
     }
 

--- a/example/src/androidTest/resources/wc-fetch-product-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-success.json
@@ -218,8 +218,7 @@
     "type": "simple",
     "upsell_ids": [
     ],
-    "variations": [
-    ],
+    "variations": [192, 193],
     "virtual": false,
     "weight": ""
   }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -167,7 +167,12 @@ class WooProductsFragment : Fragment() {
                         pendingFetchSingleProductRemoteId = null
                         val product = wcProductStore.getProductByRemoteId(site, remoteId)
                         product?.let {
-                            prependToLog("Single product fetched successfully! ${it.name}")
+                            val numVariations = it.getNumVariations()
+                            if (numVariations > 0) {
+                                prependToLog("Single product with $numVariations variations fetched! ${it.name}")
+                            } else {
+                                prependToLog("Single product fetched! ${it.name}")
+                            }
                         } ?: prependToLog("WARNING: Fetched product not found in the local database!")
                     }
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -212,6 +212,15 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return fileList
     }
 
+    fun getNumVariations(): Int {
+        try {
+            return Gson().fromJson<JsonElement>(variations, JsonElement::class.java).asJsonArray.size()
+        } catch (e: JsonParseException) {
+            AppLog.e(T.API, e)
+            return 0
+        }
+    }
+
     fun getCategories() = getTriplets(categories)
 
     fun getCommaSeparatedCategoryNames() = getCommaSeparatedTripletNames(getCategories())


### PR DESCRIPTION
Closes #1362 - We currently store a product's variation ids as raw json, like this:

```
[192, 193]
```

This PR adds a method and related tests to get the variation count for a product.