### PR TITLE
Move failing test to WPCom from Jetpack

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -31,6 +31,7 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_ActivityLogTestJetpack test);
     void inject(ReleaseStack_InsightsTestJetpack test);
     void inject(ReleaseStack_TimeStatsTestJetpack test);
+    void inject(ReleaseStack_TimeStatsTestWPCom test);
     void inject(ReleaseStack_ManageInsightsTestJetpack test);
     void inject(ReleaseStack_CommentTestWPCom test);
     void inject(ReleaseStack_CommentTestXMLRPC test);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -267,30 +267,6 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
         }
     }
 
-    @Test
-    fun testFetchFileDownloads() {
-        val site = authenticate()
-
-        for (granularity in StatsGranularity.values()) {
-            val fetchedInsights = runBlocking {
-                fileDownloadsStore.fetchFileDownloads(
-                        site,
-                        granularity,
-                        LIMIT_MODE,
-                        SELECTED_DATE,
-                        true
-                )
-            }
-
-            assertNotNull(fetchedInsights)
-            assertNotNull(fetchedInsights.model)
-
-            val insightsFromDb = fileDownloadsStore.getFileDownloads(site, granularity, LIMIT_MODE, SELECTED_DATE)
-
-            assertEquals(fetchedInsights.model, insightsFromDb)
-        }
-    }
-
     private fun authenticate(): SiteModel {
         authenticateWPComAndFetchSites(
                 BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestWPCom.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestWPCom.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.fluxc.release
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.stats.time.FileDownloadsStore
+import java.util.Calendar
+import javax.inject.Inject
+
+private const val ITEMS_TO_LOAD = 8
+private val LIMIT_MODE = LimitMode.Top(ITEMS_TO_LOAD)
+
+class ReleaseStack_TimeStatsTestWPCom : ReleaseStack_WPComBase() {
+    @Inject lateinit var fileDownloadsStore: FileDownloadsStore
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mReleaseStackAppComponent.inject(this)
+        // Register
+        init()
+    }
+
+    @Test
+    fun testFetchFileDownloads() {
+        val selectedDate = Calendar.getInstance()
+        selectedDate.set(2019, 7, 7)
+
+        for (granularity in StatsGranularity.values()) {
+            val fetchedInsights = runBlocking {
+                fileDownloadsStore.fetchFileDownloads(
+                        sSite,
+                        granularity,
+                        LIMIT_MODE,
+                        selectedDate.time,
+                        true
+                )
+            }
+
+            assertNotNull(fetchedInsights)
+            assertNotNull(fetchedInsights.model)
+
+            val insightsFromDb = fileDownloadsStore.getFileDownloads(
+                    sSite,
+                    granularity,
+                    LIMIT_MODE,
+                    selectedDate.time
+            )
+
+            assertEquals(fetchedInsights.model, insightsFromDb)
+        }
+    }
+}


### PR DESCRIPTION
A test was failing because it was running on a Jetpack account instead of WPCom. This PR extracts the test and creates a new class that runs it with a WPCom account.