### PR TITLE
Introduce number of auto upload attempts

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/UploadAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/UploadAction.java
@@ -21,6 +21,8 @@ public enum UploadAction implements IAction {
 
     // Local actions
     @Action(payloadType = PostModel.class)
+    INCREMENT_NUMBER_OF_AUTO_UPLOAD_ATTEMPTS,
+    @Action(payloadType = PostModel.class)
     CANCEL_POST,
     @Action(payloadType = ClearMediaPayload.class)
     CLEAR_MEDIA_FOR_POST

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostUploadModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostUploadModel.java
@@ -49,6 +49,7 @@ public class PostUploadModel extends Payload<BaseNetworkError> implements Identi
     @Column private String mErrorType;
     @Column private String mErrorMessage;
     @Column private int mNumberOfUploadErrorsOrCancellations;
+    @Column private int mNumberOfAutoUploadAttempts;
 
     public PostUploadModel() {}
 
@@ -169,5 +170,17 @@ public class PostUploadModel extends Payload<BaseNetworkError> implements Identi
 
     public void setNumberOfUploadErrorsOrCancellations(int numberOfUploadErrorsOrCancellations) {
         mNumberOfUploadErrorsOrCancellations = numberOfUploadErrorsOrCancellations;
+    }
+
+    public int getNumberOfAutoUploadAttempts() {
+        return mNumberOfAutoUploadAttempts;
+    }
+
+    public void setNumberOfAutoUploadAttempts(int numberOfAutoUploadAttempts) {
+        mNumberOfAutoUploadAttempts = numberOfAutoUploadAttempts;
+    }
+
+    public void incNumberOfAutoUploadAttempts() {
+        mNumberOfAutoUploadAttempts += 1;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 84;
+        return 85;
     }
 
     @Override
@@ -603,6 +603,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_CONTENT TEXT");
                 db.execSQL("ALTER TABLE PostModel ADD AUTO_SAVE_EXCERPT TEXT");
                 oldVersion++;
+            case 84:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                db.execSQL("ALTER TABLE PostUploadModel ADD NUMBER_OF_AUTO_UPLOAD_ATTEMPTS INTEGER");
+                oldVersion++;
+
         }
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -607,7 +607,6 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 db.execSQL("ALTER TABLE PostUploadModel ADD NUMBER_OF_AUTO_UPLOAD_ATTEMPTS INTEGER");
                 oldVersion++;
-
         }
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -222,6 +222,14 @@ public class UploadStore extends Store {
         return postUploadModel.getNumberOfUploadErrorsOrCancellations();
     }
 
+    public int getNumberOfPostAutoUploadAttempts(PostModel post) {
+        PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(post.getId());
+        if (postUploadModel == null) {
+            return 0;
+        }
+        return postUploadModel.getNumberOfAutoUploadAttempts();
+    }
+
     /**
      * If the {@code postModel} has been registered as uploading with the UploadStore, this will return the associated
      * {@link PostError}, if any.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -115,6 +115,9 @@ public class UploadStore extends Store {
                 mDispatcher
                         .dispatch(PostActionBuilder.newRemoteAutoSavedPostAction((RemoteAutoSavePostPayload) payload));
                 break;
+            case INCREMENT_NUMBER_OF_AUTO_UPLOAD_ATTEMPTS:
+                handleIncrementNumberOfAutoUploadAttempts((PostModel) payload);
+                break;
             case CANCEL_POST:
                 handleCancelPost((PostModel) payload);
                 break;
@@ -403,6 +406,14 @@ public class UploadStore extends Store {
 
             // Delete the PostUploadModel itself
             UploadSqlUtils.deletePostUploadModelWithLocalId(localPostId);
+        }
+    }
+
+    private void handleIncrementNumberOfAutoUploadAttempts(PostModel post) {
+        PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(post.getId());
+        if (postUploadModel != null) {
+            postUploadModel.incNumberOfAutoUploadAttempts();
+            UploadSqlUtils.insertOrUpdatePost(postUploadModel);
         }
     }
 


### PR DESCRIPTION
We've introduced `PostModel.mNumberOfUploadErrorsOrCancellations` a few weeks ago. We were planning to use this field to limit the number of attempts the `UploadStarter` in WPAndroid tries to auto-upload/save a post. We don't want to keep retrying indefinitely.

However, as it turned out we can't use it. We start media upload as soon as a media item is added to the post content (even in offline). Such media upload always fails and the `mNumberOfUploadErrorsOrCancellations` gets incremented. The result is that if the user adds multiple images in offline the `mNumberOfUploadErrorsOrCancellations` is incremented after each failed upload -> the `UploadStarter` will never initiate the auto-upload/save.

This PR fixes this issue by introducing `numberOfAutoUploadAttempts` which is incremented directly from the `UploadStarter`. Therefore it's incremented only when the actual auto-upload/save is initiated.

Note: I wanted to remove `mNumberOfUploadErrorsOrCancellations` as we don't need it anymore, however, SQLite doesn't support rename/drop column (it supports it in a new version but this version isn't available on older devices). Dropping the whole table seemed risky and creating a temporary backup table seemed like it's not worth it.
