### PR TITLE
Woo: Product Reviews misc bug fixes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -279,7 +279,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         payload.productReview?.let {
             with(it) {
                 assertEquals(5499, remoteProductReviewId)
-                assertEquals("2019-07-09T09:48:07", dateCreated)
+                assertEquals("2019-07-09T15:48:07Z", dateCreated)
                 assertEquals(18, remoteProductId)
                 assertEquals("approved", status)
                 assertEquals("Johnny", reviewerName)
@@ -323,7 +323,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         payload.productReview?.let {
             with(it) {
                 assertEquals(5499, remoteProductReviewId)
-                assertEquals("2019-07-09T09:48:07", dateCreated)
+                assertEquals("2019-07-09T15:48:07Z", dateCreated)
                 assertEquals(18, remoteProductId)
                 assertEquals("spam", status)
                 assertEquals("Johnny", reviewerName)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -31,7 +31,7 @@ object ProductTestUtils {
                 localSiteId = siteId
                 remoteProductReviewId = it.id ?: 0L
                 remoteProductId = it.product_id ?: 0L
-                dateCreated = it.date_created_gmt ?: ""
+                dateCreated = it.date_created_gmt?.let { "${it}Z" } ?: ""
                 status = it.status ?: ""
                 reviewerName = it.reviewer ?: ""
                 reviewerEmail = it.reviewer_email ?: ""

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -31,7 +31,7 @@ object ProductTestUtils {
                 localSiteId = siteId
                 remoteProductReviewId = it.id ?: 0L
                 remoteProductId = it.product_id ?: 0L
-                dateCreated = it.date_created ?: ""
+                dateCreated = it.date_created_gmt ?: ""
                 status = it.status ?: ""
                 reviewerName = it.reviewer ?: ""
                 reviewerEmail = it.reviewer_email ?: ""

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductReviewModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductReviewModelTest.kt
@@ -21,7 +21,7 @@ class WCProductReviewModelTest {
 
         val review = reviews[0]
         assertEquals(0, review.id)
-        assertEquals("2019-07-09T09:48:07", review.dateCreated)
+        assertEquals("2019-07-09T15:48:07Z", review.dateCreated)
         assertEquals(18, review.remoteProductId)
         assertEquals("Johnny", review.reviewerName)
         assertEquals("johnny@gmail.com", review.reviewerEmail)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductReviewModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductReviewModel.kt
@@ -33,7 +33,7 @@ data class WCProductReviewModel(@PrimaryKey @Column private var id: Int = 0) : I
     @Column var remoteProductId = 0L
 
     /**
-     * The date the review was created, in the site's timezone
+     * The date the review was created, in UTC, ISO8601 formatted
      */
     @Column var dateCreated = ""
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -411,7 +411,7 @@ class ProductRestClient(
         return WCProductReviewModel().apply {
             remoteProductReviewId = response.id
             remoteProductId = response.product_id
-            dateCreated = response.date_created ?: ""
+            dateCreated = response.date_created_gmt?.let { "${it}Z" } ?: ""
             status = response.status ?: ""
             reviewerName = response.reviewer ?: ""
             reviewerEmail = response.reviewer_email ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductReviewApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductReviewApiResponse.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.fluxc.network.Response
 @Suppress("PropertyName")
 class ProductReviewApiResponse : Response {
     val id: Long = 0L
-    val date_created: String? = null
+    val date_created_gmt: String? = null
     val product_id: Long = 0L
     val status: String? = null
     val reviewer: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -218,6 +218,7 @@ object ProductSqlUtils {
                 .where()
                 .equals(WCProductReviewModelTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
+                .orderBy(WCProductReviewModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
                 .asModel
     }
 
@@ -230,6 +231,7 @@ object ProductSqlUtils {
                 .equals(WCProductReviewModelTable.REMOTE_PRODUCT_ID, remoteProductId)
                 .equals(WCProductReviewModelTable.LOCAL_SITE_ID, localSiteId)
                 .endGroup().endWhere()
+                .orderBy(WCProductReviewModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
                 .asModel
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -311,6 +311,12 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         if (payload.isError) {
             onProductReviewChanged = OnProductChanged(0).also { it.error = payload.error }
         } else {
+            // Clear existing product reviews if this is a fresh fetch (loadMore = false).
+            // This is the simplest way to keep our local reviews in sync with remote reviews
+            // in case of deletions.
+            if (!payload.loadedMore) {
+                ProductSqlUtils.deleteAllProductReviewsForSite(payload.site)
+            }
             val rowsAffected = ProductSqlUtils.insertOrUpdateProductReviews(payload.reviews)
             onProductReviewChanged = OnProductChanged(rowsAffected, canLoadMore = payload.canLoadMore)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -312,7 +312,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             onProductReviewChanged = OnProductChanged(0).also { it.error = payload.error }
         } else {
             val rowsAffected = ProductSqlUtils.insertOrUpdateProductReviews(payload.reviews)
-            onProductReviewChanged = OnProductChanged(rowsAffected)
+            onProductReviewChanged = OnProductChanged(rowsAffected, canLoadMore = payload.canLoadMore)
         }
 
         onProductReviewChanged.causeOfChange = WCProductAction.FETCH_PRODUCT_REVIEWS


### PR DESCRIPTION
Small fix to update the `WCProductReviewModel` to use `date_created_gmt` (UTC) and to properly format it in ISO8601 so it can be properly formatted and localized in the UI.

Also fixed a bug where `canLoadMore` was not properly being set in the response to fetch more product reviews.

Delete existing product reviews for the current site when doing a fresh fetch (offset == 0). This will keep the table in sync with the remote similar to the way we handle orders. 