### PR TITLE
Woo: Fetch Reviews and Products in batch

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductReviewChanged
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -50,6 +51,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     private val remoteProductReviewId = BuildConfig.TEST_WC_PRODUCT_REVIEW_ID.toLong()
 
     private var lastEvent: OnProductChanged? = null
+    private var lastReviewEvent:OnProductReviewChanged? = null
 
     @Throws(Exception::class)
     override fun setUp() {
@@ -167,7 +169,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
         // Verify results
         val fetchReviewsId = productStore.getProductReviewsForSite(sSite)
-        assertEquals(3, fetchReviewsId.size)
+        assertEquals(idsToFetch.size, fetchReviewsId.size)
 
         /*
          * TEST 3: Fetch product reviews for a list of product
@@ -257,6 +259,20 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
                 assertEquals(TestEvent.FETCHED_PRODUCT_VARIATIONS, nextEvent)
                 mCountDownLatch.countDown()
             }
+            else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductReviewChanged(event: OnProductReviewChanged) {
+        event.error?.let {
+            throw AssertionError("OnProductReviewChanged has unexpected error: " + it.type)
+        }
+
+        lastReviewEvent = event
+
+        when (event.causeOfChange) {
             WCProductAction.FETCH_SINGLE_PRODUCT_REVIEW -> {
                 assertEquals(TestEvent.FETCHED_SINGLE_PRODUCT_REVIEW, nextEvent)
                 mCountDownLatch.countDown()

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -51,7 +51,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     private val remoteProductReviewId = BuildConfig.TEST_WC_PRODUCT_REVIEW_ID.toLong()
 
     private var lastEvent: OnProductChanged? = null
-    private var lastReviewEvent:OnProductReviewChanged? = null
+    private var lastReviewEvent: OnProductReviewChanged? = null
 
     @Throws(Exception::class)
     override fun setUp() {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -182,12 +182,14 @@ class ProductRestClient(
      *
      * @param [site] The site to fetch product reviews for
      * @param [offset] The offset to use for the fetch
-     * @param [productIds] Optional. A list of remote product ID's to fetch product reviews for.
+     * @param [reviewIds] Optional. A list of remote product review ID's to fetch
+     * @param [productIds] Optional. A list of remote product ID's to fetch product reviews for
      * @param [filterByStatus] Optional. A list of product review statuses to fetch
      */
     fun fetchProductReviews(
         site: SiteModel,
         offset: Int,
+        reviewIds: List<Long>? = null,
         productIds: List<Long>? = null,
         filterByStatus: List<String>? = null
     ) {
@@ -199,6 +201,9 @@ class ProductRestClient(
                 "per_page" to WCProductStore.NUM_REVIEWS_PER_FETCH.toString(),
                 "offset" to offset.toString(),
                 "status" to statusFilter)
+        reviewIds?.let { ids ->
+            params.put("include", ids.map { it }.joinToString())
+        }
         productIds?.let { ids ->
             params.put("product", ids.map { it }.joinToString())
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -89,7 +89,8 @@ class ProductRestClient(
     fun fetchProducts(
         site: SiteModel,
         offset: Int = 0,
-        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING
+        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
+        remoteProductIds: List<Long>? = null
     ) {
         // orderby (string) Options: date, id, include, title and slug. Default is date.
         val orderBy = when (sortType) {
@@ -103,11 +104,15 @@ class ProductRestClient(
 
         val url = WOOCOMMERCE.products.pathV3
         val responseType = object : TypeToken<List<ProductApiResponse>>() {}.type
-        val params = mapOf(
+        val params = mutableMapOf(
                 "per_page" to WCProductStore.NUM_PRODUCTS_PER_FETCH.toString(),
                 "orderBy" to orderBy,
                 "order" to sortOrder,
                 "offset" to offset.toString())
+        remoteProductIds?.let { ids ->
+            params.put("include", ids.map { it }.joinToString())
+        }
+
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<ProductApiResponse>? ->
                     val productModels = response?.map {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -38,7 +38,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class FetchProductsPayload(
         var site: SiteModel,
         var offset: Int = 0,
-        var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING
+        var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
+        var remoteProductIds: List<Long>? = null
     ) : Payload<BaseNetworkError>()
 
     class FetchProductVariationsPayload(
@@ -244,7 +245,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun fetchProducts(payload: FetchProductsPayload) {
-        with(payload) { wcProductRestClient.fetchProducts(site, offset, sorting) }
+        with(payload) { wcProductRestClient.fetchProducts(site, offset, sorting, remoteProductIds) }
     }
 
     private fun fetchProductVariations(payload: FetchProductVariationsPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -50,6 +50,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class FetchProductReviewsPayload(
         var site: SiteModel,
         var offset: Int = 0,
+        var reviewIds: List<Long>? = null,
         var productIds: List<Long>? = null,
         var filterByStatus: List<String>? = null
     ) : Payload<BaseNetworkError>()
@@ -253,7 +254,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun fetchProductReviews(payload: FetchProductReviewsPayload) {
-        with(payload) { wcProductRestClient.fetchProductReviews(site, offset, productIds, filterByStatus) }
+        with(payload) { wcProductRestClient.fetchProductReviews(site, offset, reviewIds, productIds, filterByStatus) }
     }
 
     private fun fetchSingleProductReview(payload: FetchSingleProductReviewPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -186,6 +186,13 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var canLoadMore: Boolean = false
     ) : OnChanged<ProductError>()
 
+    class OnProductReviewChanged(
+        var rowsAffected: Int,
+        var canLoadMore: Boolean = false
+    ) : OnChanged<ProductError>() {
+        var causeOfChange: WCProductAction? = null
+    }
+
     /**
      * returns the corresponding product from the database as a [WCProductModel].
      */
@@ -354,10 +361,10 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun handleFetchProductReviews(payload: FetchProductReviewsResponsePayload) {
-        val onProductReviewChanged: OnProductChanged
+        val onProductReviewChanged: OnProductReviewChanged
 
         if (payload.isError) {
-            onProductReviewChanged = OnProductChanged(0).also { it.error = payload.error }
+            onProductReviewChanged = OnProductReviewChanged(0).also { it.error = payload.error }
         } else {
             // Clear existing product reviews if this is a fresh fetch (loadMore = false).
             // This is the simplest way to keep our local reviews in sync with remote reviews
@@ -366,7 +373,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
                 ProductSqlUtils.deleteAllProductReviewsForSite(payload.site)
             }
             val rowsAffected = ProductSqlUtils.insertOrUpdateProductReviews(payload.reviews)
-            onProductReviewChanged = OnProductChanged(rowsAffected, canLoadMore = payload.canLoadMore)
+            onProductReviewChanged = OnProductReviewChanged(rowsAffected, canLoadMore = payload.canLoadMore)
         }
 
         onProductReviewChanged.causeOfChange = WCProductAction.FETCH_PRODUCT_REVIEWS
@@ -374,15 +381,15 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun handleFetchSingleProductReview(payload: RemoteProductReviewPayload) {
-        val onProductReviewChanged: OnProductChanged
+        val onProductReviewChanged: OnProductReviewChanged
 
         if (payload.isError) {
-            onProductReviewChanged = OnProductChanged(0).also { it.error = payload.error }
+            onProductReviewChanged = OnProductReviewChanged(0).also { it.error = payload.error }
         } else {
             val rowsAffected = payload.productReview?.let {
                 ProductSqlUtils.insertOrUpdateProductReview(it)
             } ?: 0
-            onProductReviewChanged = OnProductChanged(rowsAffected)
+            onProductReviewChanged = OnProductReviewChanged(rowsAffected)
         }
 
         onProductReviewChanged.causeOfChange = WCProductAction.FETCH_SINGLE_PRODUCT_REVIEW
@@ -390,15 +397,15 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun handleUpdateProductReviewStatus(payload: RemoteProductReviewPayload) {
-        val onProductReviewChanged: OnProductChanged
+        val onProductReviewChanged: OnProductReviewChanged
 
         if (payload.isError) {
-            onProductReviewChanged = OnProductChanged(0).also { it.error = payload.error }
+            onProductReviewChanged = OnProductReviewChanged(0).also { it.error = payload.error }
         } else {
             val rowsAffected = payload.productReview?.let {
                 ProductSqlUtils.insertOrUpdateProductReview(it)
             } ?: 0
-            onProductReviewChanged = OnProductChanged(rowsAffected)
+            onProductReviewChanged = OnProductReviewChanged(rowsAffected)
         }
 
         onProductReviewChanged.causeOfChange = WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS


### PR DESCRIPTION
Adds support for fetching product reviews and products in batch by passing in a list of remote_ids to the appropriate event. Tests have also been included to verify functionality. 