### PR TITLE
issue/1373-woo-stats-timezone-fix

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -5,6 +5,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.utils.DateUtils
 import org.wordpress.android.fluxc.utils.SiteUtils
 import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.WeekFields
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
@@ -13,6 +16,7 @@ import kotlin.test.assertEquals
 class DateUtilsTest {
     companion object {
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
+        private const val DATE_TIME_FORMAT_START = "yyyy-MM-dd'T'00:00:00"
     }
 
     @Test
@@ -211,6 +215,69 @@ class DateUtilsTest {
             val expectedDate1 = "${SiteUtils.getCurrentDateTimeForSite(site, "yyyy-MM-dd")}T23:59:59"
             val actualDate1 = DateUtils.getEndDateForSite(site)
             assertEquals(expectedDate1, actualDate1)
+        }
+    }
+
+    @Test
+    fun testGetStartDayOfCurrentWeekForSite() {
+        val site = SiteModel().apply { id = 1 }
+
+        val fieldISO = WeekFields.of(Locale.ROOT).dayOfWeek()
+        val expectedDate = LocalDate.now()
+                .with(fieldISO, 1)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+        val expectedDateString = DateUtils.formatDate(DATE_TIME_FORMAT_START, Date.from(expectedDate))
+
+        // test get start date for current day
+        for (i in -20..20) {
+            site.timezone = i.toString()
+            // format the current date to string
+            // get the formatted date string for the site in the format yyyy-MM-ddThh:mm:ss
+            // get the expected start date string for the site in the format yyyy-MM-ddThh:mm:ss
+            val dateString1 = DateUtils.getFirstDayOfCurrentWeekBySite(site)
+            assertEquals(expectedDateString, dateString1)
+        }
+    }
+
+    @Test
+    fun testGetStartDayOfCurrentMonthForSite() {
+        val site = SiteModel().apply { id = 1 }
+
+        val expectedDate = LocalDate.now()
+                .withDayOfMonth(1)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+        val expectedDateString = DateUtils.formatDate(DATE_TIME_FORMAT_START, Date.from(expectedDate))
+
+        // test get start date for current day
+        for (i in -20..20) {
+            site.timezone = i.toString()
+            // format the current date to string
+            // get the formatted date string for the site in the format yyyy-MM-ddThh:mm:ss
+            // get the expected start date string for the site in the format yyyy-MM-ddThh:mm:ss
+            val dateString1 = DateUtils.getFirstDayOfCurrentMonthBySite(site)
+            assertEquals(expectedDateString, dateString1)
+        }
+    }
+
+    @Test
+    fun testGetStartDayOfCurrentYearForSite() {
+        val site = SiteModel().apply { id = 1 }
+        val expectedDate = LocalDate.now()
+                .withDayOfYear(1)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+        val expectedDateString = DateUtils.formatDate(DATE_TIME_FORMAT_START, Date.from(expectedDate))
+
+        // test get start date for current day
+        for (i in -20..20) {
+            site.timezone = i.toString()
+            // format the current date to string
+            // get the formatted date string for the site in the format yyyy-MM-ddThh:mm:ss
+            // get the expected start date string for the site in the format yyyy-MM-ddThh:mm:ss
+            val dateString1 = DateUtils.getFirstDayOfCurrentYearBySite(site)
+            assertEquals(expectedDateString, dateString1)
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -662,17 +662,16 @@ class WCStatsStore @Inject constructor(
         granularity: StatsGranularity,
         startDate: String?
     ): String {
-        val date = if (startDate.isNullOrEmpty()) {
+        return if (startDate.isNullOrEmpty()) {
             when (granularity) {
-                StatsGranularity.DAYS -> DateUtils.getStartOfCurrentDay()
-                StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeek()
-                StatsGranularity.MONTHS -> DateUtils.getFirstDayOfCurrentMonth()
-                StatsGranularity.YEARS -> DateUtils.getFirstDayOfCurrentYear()
+                StatsGranularity.DAYS -> DateUtils.getStartDateForSite(site, DateUtils.getStartOfCurrentDay())
+                StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeekBySite(site)
+                StatsGranularity.MONTHS -> DateUtils.getFirstDayOfCurrentMonthBySite(site)
+                StatsGranularity.YEARS -> DateUtils.getFirstDayOfCurrentYearBySite(site)
             }
         } else {
-            startDate
+            DateUtils.getStartDateForSite(site, startDate)
         }
-        return DateUtils.getStartDateForSite(site, date)
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -52,8 +52,8 @@ object DateUtils {
      * returns a [Date] instance
      * based on {@param pattern} and {@param dateString}
      */
-    fun getDateFromString(dateString: String): Date {
-        val dateFormat = SimpleDateFormat(DATE_FORMAT_DEFAULT, Locale.ROOT)
+    fun getDateFromString(dateString: String, pattern: String = DATE_FORMAT_DEFAULT): Date {
+        val dateFormat = SimpleDateFormat(pattern, Locale.ROOT)
         return dateFormat.parse(dateString)
     }
 
@@ -291,5 +291,36 @@ object DateUtils {
         val cal = Calendar.getInstance()
         cal.set(Calendar.DAY_OF_YEAR, cal.getActualMinimum(Calendar.DAY_OF_YEAR))
         return formatDate(DATE_FORMAT_DEFAULT, cal.time)
+    }
+
+    fun getFirstDayOfCurrentWeekBySite(site: SiteModel): String {
+        val cal = Calendar.getInstance()
+        cal.time = getCurrentDateFromSite(site)
+        cal.set(Calendar.DAY_OF_WEEK, cal.getActualMinimum(Calendar.DAY_OF_WEEK))
+        return formatDate(DATE_TIME_FORMAT_START, cal.time)
+    }
+
+    fun getFirstDayOfCurrentMonthBySite(site: SiteModel): String {
+        val cal = Calendar.getInstance()
+        cal.time = getCurrentDateFromSite(site)
+        cal.set(Calendar.DAY_OF_MONTH, cal.getActualMinimum(Calendar.DAY_OF_MONTH))
+        return formatDate(DATE_TIME_FORMAT_START, cal.time)
+    }
+
+    fun getFirstDayOfCurrentYearBySite(site: SiteModel): String {
+        val cal = Calendar.getInstance()
+        cal.time = getCurrentDateFromSite(site)
+        cal.set(Calendar.DAY_OF_YEAR, cal.getActualMinimum(Calendar.DAY_OF_YEAR))
+        return formatDate(DATE_TIME_FORMAT_START, cal.time)
+    }
+
+    /**
+     * Given a [SiteModel] instance, returns a [Date] instance for the current date
+     *
+     * The date format is in yyyy-MM-dd'T'00:00:00
+     */
+    private fun getCurrentDateFromSite(site: SiteModel): Date {
+        val dateString = SiteUtils.getCurrentDateTimeForSite(site, DATE_TIME_FORMAT_START)
+        return getDateFromString(dateString, DATE_TIME_FORMAT_START)
     }
 }


### PR DESCRIPTION
Fixes #1373. We need to pass a `before` and `after` param to the v4 stats API request. Currently, the `after` i.e. start date is calculated based on the `StatsGranularity`.

- `DAYS` -> current date
- `WEEKS` -> the first day of the current week
- `MONTHS` -> the first day of the current month
- `YEARS` -> the first day of the current year

The logic was to fetch the the above dates and then convert it according to the site's timezone. This was causing problems with timezones of the site and in some timezones, the start date was calculated as:
- `WEEKS` -> the last day of the previous week
- `MONTHS` -> the last day of the previous month
- `YEARS` -> the last day of the previous year

This PR modifies the logic to calculate the start date by first fetching the current date according to the site's timezone and then modifying the date based on the `StatsGranularity`. 

### Testing
- It would be good to test with multiple timezones to verify if the dates passed to the API request is correct. I changed the timezone of my testing device to GMT+14 and fetched the revenue stats in the example app for the current day, this week, this month and this year. 
- Using Sethos, notice that the `after` param passed to the revenue stats API request for `This Week`, `This month` and `This year` is incorrect.
- Pull changes from the PR and notice that the `after` param value for `This Week`, `This month` and `This year` is correct. 
- Run the tests in `DateUtilsTest`