### PR TITLE
Issue/1372 add order status count

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -477,7 +477,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
 
         val orderStatusOptions = getFirstWCSite()?.let {
             wcOrderStore.getOrderStatusOptionsForSite(it)
-        }?.map { it.label }
+        }?.map { it.label to it.statusCount }?.toMap()
         prependToLog("Fetched order status options from the api: $orderStatusOptions " +
                 "- updated ${event.rowsAffected} in the db")
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -196,6 +196,7 @@ class OrderSqlUtilsTest {
         assertEquals(firstOptionDb.localSiteId, firstOption.id)
         assertEquals(firstOptionDb.statusKey, firstOption.statusKey)
         assertEquals(firstOptionDb.label, firstOption.label)
+        assertEquals(firstOptionDb.statusCount, firstOption.statusCount)
 
         // Save full list, but only all but the first 2 should be inserted
         rowsAffected = orderStatusOptions.sumBy { OrderSqlUtils.insertOrUpdateOrderStatusOption(it) }
@@ -210,6 +211,7 @@ class OrderSqlUtilsTest {
             it.statusKey == firstOption.statusKey
         }
         assertEquals(firstOption.label, newFirstOption.label)
+        assertEquals(firstOption.statusCount, newFirstOption.statusCount)
 
         // Get order status options from the database
         val orderStatusOptionsDb = OrderSqlUtils.getOrderStatusOptionsForSite(siteModel)
@@ -253,6 +255,7 @@ class OrderSqlUtilsTest {
         val firstOption = OrderSqlUtils.getOrderStatusOptionForSiteByKey(siteModel, orderStatusOptions[0].statusKey)
         assertNotNull(firstOption)
         assertEquals(firstOption.label, orderStatusOptions[0].label)
+        assertEquals(firstOption.statusCount, orderStatusOptions[0].statusCount)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -75,6 +75,7 @@ object OrderTestUtils {
                 localSiteId = siteId
                 statusKey = it.slug ?: ""
                 label = it.name ?: ""
+                statusCount = it.total
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.java
@@ -44,7 +44,7 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     @Override
     public int getDbVersion() {
-        return 83;
+        return 84;
     }
 
     @Override
@@ -593,6 +593,10 @@ public class WellSqlConfig extends DefaultWellConfig {
                 AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
                 migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
                 oldVersion++;
+            case 83:
+                AppLog.d(T.DB, "Migrating to version " + (oldVersion + 1));
+                migrateAddOn(ADDON_WOOCOMMERCE, db, oldVersion);
+                oldVersion++;
         }
         db.setTransactionSuccessful();
         db.endTransaction();
@@ -929,6 +933,11 @@ public class WellSqlConfig extends DefaultWellConfig {
                 case 82:
                     AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
                     db.execSQL("ALTER TABLE WCOrderModel ADD COLUMN DATE_PAID TEXT NOT NULL DEFAULT '';");
+                    break;
+                case 83:
+                    AppLog.d(T.DB, "Migrating addon " + addOnName + " to version " + (oldDbVersion + 1));
+                    db.execSQL("ALTER TABLE WCOrderStatusModel ADD STATUS_COUNT INTEGER");
+                    break;
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatusModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatusModel.kt
@@ -11,6 +11,7 @@ data class WCOrderStatusModel(@PrimaryKey @Column private var id: Int = 0) : Ide
     @Column var localSiteId = 0
     @Column var statusKey = ""
     @Column var label = ""
+    @Column var statusCount = 0
 
     override fun setId(id: Int) {
         this.id = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -715,6 +715,7 @@ class OrderRestClient(
             localSiteId = site.id
             statusKey = response.slug ?: ""
             label = response.name ?: ""
+            statusCount = response.total
         }
     }
 


### PR DESCRIPTION
Closes #1372 by adding the total status count to the order status api response. 

### Changes
- Added a new column to `WcOrderStatusModel` called `statusCount` to store the order status total to the local db.
- Modified the unit tests to verify that the total count is stored correctly.
- Modified the example app to include the total count of order status.

<img width="300" src="https://user-images.githubusercontent.com/22608780/63918503-70368780-ca5a-11e9-8f94-18c61ac210cb.png">