### PR TITLE
Account Store : Updated in-memory Account when username changes

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -1045,6 +1045,7 @@ public class AccountStore extends Store {
     private void handlePushUsernameCompleted(AccountPushUsernameResponsePayload payload) {
         if (!payload.isError()) {
             AccountSqlUtils.updateUsername(getAccount(), payload.username);
+            getAccount().setUserName(payload.username);
         }
 
         OnUsernameChanged onUsernameChanged = new OnUsernameChanged();


### PR DESCRIPTION
Fixes #1377 

## Solution

Updates the `username` field of the in-memory account. 

## Testing

1. Utilize the commit hash in and update the FluxC version number in the [change username functionality PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10436).

2. Navigate to Account Settings, update the username and check to see if even with account refreshes & subsequent username updates the new username will remain intact. 