### PR TITLE
Request only the required fields in fetchPostList request

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -114,7 +114,7 @@ public class PostRestClient extends BaseWPComRestClient {
                         listDescriptor.getOrderBy().getValue(), listDescriptor.getSearchQuery());
 
         // We want to fetch only the minimal data required in order to save users' data
-        params.put("meta_fields","autosave.modified");
+        params.put("meta_fields", "autosave.modified");
 
         final boolean loadedMore = offset > 0;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -107,14 +107,14 @@ public class PostRestClient extends BaseWPComRestClient {
         String url = WPCOMREST.sites.site(listDescriptor.getSite().getSiteId()).posts.getUrlV1_1();
 
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
-        // TODO the meta object can be quite large and it partially beats the purpose of this approach where we fetch
-        //  minimal number of data from which we can determine whether the local version of the post is in sync with
-        //  the remote version. Ideally we'd fetch just "meta.data.autosave.modified", not the whole meta object.
         String fields = TextUtils.join(",", Arrays.asList("ID", "modified", "status", "meta"));
         Map<String, String> params =
                 createFetchPostListParameters(false, offset, pageSize, listDescriptor.getStatusList(),
                         listDescriptor.getAuthor(), fields, listDescriptor.getOrder().getValue(),
                         listDescriptor.getOrderBy().getValue(), listDescriptor.getSearchQuery());
+
+        // We want to fetch only the minimal data required in order to save users' data
+        params.put("meta_fields","autosave.modified");
 
         final boolean loadedMore = offset > 0;
 


### PR DESCRIPTION
Fixes #1277 

~Note: This is just a draft PR since the change on the API hasn't been merged yet `D29715-pha`.~

Modifies the fetchPostList request so we don't waste users' data. We were previously fetching the whole meta object, because further filtering wasn't supported on the API level. However, filtering support was added in `D29715-pha`.

To test
1. Use this version of FluxC in WPAndroid
2. Open the Post list
3. Use for example Stetho to check details of the request
4. Make sure the meta.autosave object doesn't contain any other data but "modified".

cc @jkmassel 