### PR TITLE
Do not filter out non-standard post types in Posts and Pages

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
@@ -7,14 +7,22 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType
 import org.wordpress.android.fluxc.model.stats.time.TimeStatsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.AuthorsRestClient.AuthorsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ClicksRestClient.ClicksResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.CountryViewsRestClient.CountryViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse.ViewsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse.ViewsResponse.PostViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
+import org.wordpress.android.fluxc.store.stats.time.POST_AND_PAGE_VIEWS_RESPONSE
+import org.wordpress.android.fluxc.store.stats.time.POST_ID
+import org.wordpress.android.fluxc.store.stats.time.POST_TITLE
+import org.wordpress.android.fluxc.store.stats.time.POST_URL
+import org.wordpress.android.fluxc.store.stats.time.POST_VIEWS
 
 @RunWith(MockitoJUnitRunner::class)
 class TimeStatsMapperTest {
@@ -24,6 +32,29 @@ class TimeStatsMapperTest {
     @Before
     fun setUp() {
         timeStatsMapper = TimeStatsMapper(gson)
+    }
+
+    @Test
+    fun `parses portfolio page type`() {
+        val portfolioResponse = PostViewsResponse(
+                POST_ID,
+                POST_TITLE,
+                "jetpack-portfolio",
+                POST_URL,
+                POST_VIEWS
+        )
+        val response = POST_AND_PAGE_VIEWS_RESPONSE.copy(
+                days = mapOf(
+                        "2019-01-01" to ViewsResponse(
+                                listOf(portfolioResponse), 10
+                        )
+                )
+        )
+
+        val mappedResult = timeStatsMapper.map(response, LimitMode.All)
+
+        assertThat(mappedResult.views).hasSize(1)
+        assertThat(mappedResult.views.first().type).isEqualTo(ViewsType.OTHER)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.store.stats.DATE
 import org.wordpress.android.fluxc.store.stats.POST_COUNT
 
 const val DAY_GRANULARITY = "day"
+const val TYPE = "post"
 const val TOTAL_VIEWS = 100
 const val POST_ID = 1L
 const val POST_TITLE = "ABCD"
@@ -41,7 +42,7 @@ const val POST_VIEWS = 10
 val DAY_POST_VIEW_RESPONSE = PostViewsResponse(
         POST_ID,
         POST_TITLE,
-        DAY_GRANULARITY,
+        TYPE,
         POST_URL,
         POST_VIEWS
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/PostAndPageViewsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/PostAndPageViewsModel.kt
@@ -12,6 +12,7 @@ data class PostAndPageViewsModel(val views: List<ViewsModel>, val hasMore: Boole
     enum class ViewsType {
         POST,
         PAGE,
-        HOMEPAGE
+        HOMEPAGE,
+        OTHER
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -33,17 +33,16 @@ class TimeStatsMapper
             } else {
                 return@let it
             }
-        }.mapNotNull { item ->
+        }.map { item ->
             val type = when (item.type) {
                 "post" -> ViewsType.POST
                 "page" -> ViewsType.PAGE
                 "homepage" -> ViewsType.HOMEPAGE
                 else -> {
-                    AppLog.e(STATS, "PostAndPageViewsResponse.type: Unexpected view type: ${item.type}")
-                    null
+                    ViewsType.OTHER
                 }
             }
-            type?.let {
+            type.let {
                 if (item.id == null || item.title == null || item.href == null) {
                     AppLog.e(STATS, "PostAndPageViewsResponse.type: Non-nullable fields are null - $item")
                 }


### PR DESCRIPTION
Current implementation of the Posts and Pages card filters out other posts/pages view types. We only accept "post", "page" and "homepage". This is based on the previous implementation. Based on this ticket https://github.com/wordpress-mobile/WordPress-Android/issues/9167 we will now stop filtering out the custom types. In this PR I'm introducing an `OTHER` type which is set when the type is not known. 

This should be tested with the related WPAndroid PR.