### PR TITLE
Woo: Simplify process to update Product Review status

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
@@ -339,7 +338,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     @Test
     fun testUpdateProductReviewStatusSuccess() {
         interceptor.respondWith("wc-update-product-review-response-success.json")
-        productRestClient.updateProductReviewStatus(siteModel, WCProductReviewModel(), "spam")
+        productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -369,7 +368,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     @Test
     fun testUpdateProductReviewStatusFailed() {
         interceptor.respondWithError("wc-response-failure-invalid-param.json")
-        productRestClient.updateProductReviewStatus(siteModel, WCProductReviewModel(), "spam")
+        productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -226,7 +226,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             mCountDownLatch = CountDownLatch(1)
             mDispatcher.dispatch(
                     WCProductActionBuilder.newUpdateProductReviewStatusAction(
-                            UpdateProductReviewStatusPayload(sSite, review, newStatus)))
+                            UpdateProductReviewStatusPayload(sSite, review.remoteProductReviewId, newStatus)))
             assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
             // Verify results

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -286,11 +286,7 @@ class ProductRestClient(
                 },
                 WPComErrorListener { networkError ->
                     val productReviewError = networkErrorToProductError(networkError)
-                    val payload = RemoteProductReviewPayload(
-                            error = productReviewError,
-                            site = site,
-                            productReview = WCProductReviewModel()
-                                    .apply { remoteProductReviewId = remoteReviewId })
+                    val payload = RemoteProductReviewPayload(error = productReviewError, site = site)
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedSingleProductReviewAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })
@@ -299,16 +295,16 @@ class ProductRestClient(
 
     /**
      * Makes a PUT call to `/wc/v3/products/reviews/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * updating the status for the given [productReview] to [newStatus].
+     * updating the status for the given product review to [newStatus].
      *
      * Dispatches a [WCProductAction.UPDATED_PRODUCT_REVIEW_STATUS]
      *
      * @param [site] The site to fetch product reviews for
-     * @param [productReview] The [WCProductReviewModel] to be updated
+     * @param [remoteReviewId] The remote ID of the product review to be updated
      * @param [newStatus] The new status to update the product review to
      */
-    fun updateProductReviewStatus(site: SiteModel, productReview: WCProductReviewModel, newStatus: String) {
-        val url = WOOCOMMERCE.products.reviews.id(productReview.remoteProductReviewId).pathV3
+    fun updateProductReviewStatus(site: SiteModel, remoteReviewId: Long, newStatus: String) {
+        val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
         val responseType = object : TypeToken<ProductReviewApiResponse>() {}.type
         val params = mapOf("status" to newStatus)
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, params, responseType,
@@ -323,7 +319,7 @@ class ProductRestClient(
                 },
                 WPComErrorListener { networkError ->
                     val productReviewError = networkErrorToProductError(networkError)
-                    val payload = RemoteProductReviewPayload(productReviewError, site, productReview)
+                    val payload = RemoteProductReviewPayload(productReviewError, site)
                     dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductReviewStatusAction(payload))
                 })
         add(request)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -199,6 +199,9 @@ object ProductSqlUtils {
         }
     }
 
+    fun deleteProductReview(productReview: WCProductReviewModel) =
+            WellSql.delete(WCProductReviewModel::class.java).whereId(productReview)
+
     fun getProductReviewByRemoteId(
         localSiteId: Int,
         remoteReviewId: Long

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -200,7 +200,10 @@ object ProductSqlUtils {
     }
 
     fun deleteProductReview(productReview: WCProductReviewModel) =
-            WellSql.delete(WCProductReviewModel::class.java).whereId(productReview)
+            WellSql.delete(WCProductReviewModel::class.java)
+                    .where()
+                    .equals(WCProductReviewModelTable.REMOTE_PRODUCT_REVIEW_ID, productReview.remoteProductReviewId)
+                    .endWhere().execute()
 
     fun getProductReviewByRemoteId(
         localSiteId: Int,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -71,7 +71,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     class UpdateProductReviewStatusPayload(
         var site: SiteModel,
-        var productReview: WCProductReviewModel,
+        var remoteReviewId: Long,
         var newStatus: String
     ) : Payload<BaseNetworkError>()
 
@@ -154,9 +154,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     ) : Payload<ProductError>() {
         constructor(
             error: ProductError,
-            site: SiteModel,
-            productReview: WCProductReviewModel
-        ) : this(site, productReview) {
+            site: SiteModel
+        ) : this(site) {
             this.error = error
         }
     }
@@ -306,7 +305,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun updateProductReviewStatus(payload: UpdateProductReviewStatusPayload) {
-        with(payload) { wcProductRestClient.updateProductReviewStatus(site, productReview, newStatus) }
+        with(payload) { wcProductRestClient.updateProductReviewStatus(site, remoteReviewId, newStatus) }
     }
 
     private fun handleFetchSingleProductCompleted(payload: RemoteProductPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -401,8 +401,14 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         if (payload.isError) {
             onProductReviewChanged = OnProductReviewChanged(0).also { it.error = payload.error }
         } else {
-            val rowsAffected = payload.productReview?.let {
-                ProductSqlUtils.insertOrUpdateProductReview(it)
+            val rowsAffected = payload.productReview?.let { review ->
+                if (review.status == "spam" || review.status == "trash") {
+                    // Delete this review from the database
+                    ProductSqlUtils.deleteProductReview(review)
+                } else {
+                    // Insert or update in the database
+                    ProductSqlUtils.insertOrUpdateProductReview(review)
+                }
             } ?: 0
             onProductReviewChanged = OnProductReviewChanged(rowsAffected)
         }


### PR DESCRIPTION
Fixes #1383 by removing the requirements to pass the full `WCProductReviewModel` in the `UpdateProductReviewStatusPayload` and instead only require the `remoteProductReviewId` since this is the only value needed to process the request.

Also adds the logic to delete the successfully updated product review from the db if the new status is "trash" or "spam"