### PR TITLE
Fix retry media upload action on self-hosted sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
+import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import org.wordpress.android.fluxc.store.PostStore.RemoteAutoSavePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.fluxc.utils.MediaUtils;
@@ -373,7 +374,12 @@ public class UploadStore extends Store {
     }
 
     private void handleRemoteAutoSavedPost(@NonNull RemoteAutoSavePostPayload payload) {
-        handlePostUploadedOrAutoSaved(payload.localPostId, payload.error);
+        if (payload.error.type == PostErrorType.UNSUPPORTED_ACTION) {
+            // The remote-auto-save is not supported -> lets just delete the post from the queue
+            UploadSqlUtils.deletePostUploadModelWithLocalId(payload.localPostId);
+        } else {
+            handlePostUploadedOrAutoSaved(payload.localPostId, payload.error);
+        }
     }
 
     private void handlePostUploaded(@NonNull RemotePostPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -374,7 +374,7 @@ public class UploadStore extends Store {
     }
 
     private void handleRemoteAutoSavedPost(@NonNull RemoteAutoSavePostPayload payload) {
-        if (payload.error.type == PostErrorType.UNSUPPORTED_ACTION) {
+        if (payload.error != null && payload.error.type == PostErrorType.UNSUPPORTED_ACTION) {
             // The remote-auto-save is not supported -> lets just delete the post from the queue
             UploadSqlUtils.deletePostUploadModelWithLocalId(payload.localPostId);
         } else {


### PR DESCRIPTION
This PR should fix https://github.com/wordpress-mobile/WordPress-Android/issues/10513 in WPAndroid app.

The WPAndroid app automatically enqueues posts when it's about to upload or finished uploading their media items. The problem is that if the user adds a media item into a post and leaves the editor without confirming the changes, `remote-auto-save` is invoked instead of `pushPost`. However, `remote-auto-save` is not supported on self-hosted sites.

Ideal solution would be to prevent the WPAndroid app from enqueueing the post during media upload on self-hosted sites when the changes are not confirmed -> so `remote-auto-save` is never invoked on self-hosted sites. However, as it turned out it's not a simple task. Moreover, the result code was quite complicated and it required quite a few changes. Therefore I decided for this simpler solution which basically dequeues the post when the `remote-auto-save` isn't supported.

To test:
Test in WPAndroid - https://github.com/wordpress-mobile/WordPress-Android/pull/10517



