### PR TITLE
Issue/1388 update order status

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -683,7 +683,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
                 existingOptions.iterator().forEach eoi@{ existingOption ->
                     if (newOption.statusKey == existingOption.statusKey) {
                         exists = true
-                        if (newOption.label != existingOption.label) {
+                        if (newOption.label != existingOption.label ||
+                                newOption.statusCount != existingOption.statusCount) {
                             addOrUpdateOptions.add(newOption)
                         }
                         return@eoi


### PR DESCRIPTION
Fixes #1388. This tiny PR adds logic to check if the order status count has been changed when updating  order status options list to the local db.

### Testing:
- In the example app, click on `Woo` -> `Orders` -> `Fetch order status options`.
- For the same site, change the order status of an order.
- Follow step 1 again. Notice that the order status count has not changed in the app, even though the api response has the updated status count.
- Pull changes from this PR and follow the above steps again.
- Verify that the order status count has changed.
- Run `WCOrderStoreTest`.

### Screenshots:
<img width="300" src="https://user-images.githubusercontent.com/22608780/65593106-79f5d100-dfad-11e9-922a-b249e43b138f.png">

