### PR TITLE
Fix issue with duplicate posts in PostModel table

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/PostSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/PostSqlUtilsTest.kt
@@ -21,8 +21,6 @@ import kotlin.test.assertNull
 class PostSqlUtilsTest {
     private val postSqlUtils = PostSqlUtils()
 
-    private lateinit var site: SiteModel
-
     @Before
     fun setUp() {
         val appContext = RuntimeEnvironment.application.applicationContext
@@ -30,9 +28,6 @@ class PostSqlUtilsTest {
         val config = WellSqlConfig(appContext)
         WellSql.init(config)
         config.reset()
-
-        site = SiteModel()
-        site.id = 100
     }
 
     @Test
@@ -41,6 +36,8 @@ class PostSqlUtilsTest {
         val revisionId = 999L
         val modifiedDate = "test date"
         val previewUrl = "test url"
+
+        val site = createSite()
 
         var post = PostModel()
         post.localSiteId = site.id
@@ -70,10 +67,12 @@ class PostSqlUtilsTest {
     @Test
     fun `insertOrUpdatePost deletes posts with duplicate REMOTE_POST_ID`() {
         // Given
-        val localPost = createPost(localId = 900, remoteId = 8571)
+        val site = createSite()
+
+        val localPost = createPost(localSiteId = site.id, localId = 900, remoteId = 8571)
         postSqlUtils.insertPostForResult(localPost)
 
-        val postFromFetch = createPost(localId = 100_00, remoteId = localPost.remotePostId)
+        val postFromFetch = createPost(localSiteId = site.id, localId = 100_00, remoteId = localPost.remotePostId)
         postSqlUtils.insertPostForResult(postFromFetch)
 
         // When
@@ -95,10 +94,14 @@ class PostSqlUtilsTest {
         assertThat(postsWithSameRemotePostId).hasSize(1)
     }
 
-    private fun createPost(localId: Int, remoteId: Long) = PostModel().apply {
+    private fun createPost(localSiteId: Int, localId: Int, remoteId: Long) = PostModel().apply {
         id = localId
         remotePostId = remoteId
 
-        localSiteId = site.id
+        this.localSiteId = localSiteId
+    }
+
+    private fun createSite() = SiteModel().apply {
+        id = 100
     }
 }


### PR DESCRIPTION
Fixes issue in WPAndroid - https://github.com/wordpress-mobile/WordPress-Android/issues/10525

If we call `pushPost` and `fetchPost` in parallel, we might end up with a duplicated entry in the `PostModelTable`. 
When we found a duplicate entry before this PR we'd delete the entry which didn't have `remotePostId` (the entry on which we invoked `pushPost`). However, the problem was that the deleted `localPostId` might be used/cached in the client app -> the client app didn't expect it'd just disappear from the database. 
I think safer approach is to delete the entry we recently got from `fetchPost` as the chance the client app is already using/caching this value is definitely lower.
I can't think of any really good solution which doesn't require significant changes. Imo the root of the issue is that we have two types of ids - local and remote. Ideally the client app would create a UUID which would be used even on the server so we couldn't end up in a state where we have duplicated entries in the `PostModelTable`.

Steps which are causing the issue are described [here](https://github.com/wordpress-mobile/WordPress-Android/issues/10525#issuecomment-535393775).

To test
- Test in WPAndroid - https://github.com/wordpress-mobile/WordPress-Android/pull/10529

