### PR TITLE
Change Refunds to Refund

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/refunds/WooRefundsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/refunds/WooRefundsFragment.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCRefundsStore
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsResult
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundResult
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
@@ -123,7 +123,7 @@ class WooRefundsFragment : Fragment() {
         }
     }
 
-    private fun printRefund(response: RefundsResult<WCRefundModel>) {
+    private fun printRefund(response: RefundResult<WCRefundModel>) {
         response.error?.let {
             prependToLog("${it.type}: ${it.message}")
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/refunds/WooRefundsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/refunds/WooRefundsFragment.kt
@@ -19,14 +19,14 @@ import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.store.WCOrderStore
-import org.wordpress.android.fluxc.store.WCRefundsStore
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundResult
+import org.wordpress.android.fluxc.store.WCRefundStore
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundResult
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 class WooRefundsFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
-    @Inject internal lateinit var refundsStore: WCRefundsStore
+    @Inject internal lateinit var refundsStore: WCRefundStore
     @Inject internal lateinit var ordersStore: WCOrderStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundFixtures.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.wc.refunds
 
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundsRestClient.RefundResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient.RefundResponse
 
 val REFUND_RESPONSE = RefundResponse(
         1L,

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundStoreTest.kt
@@ -19,11 +19,11 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
 import org.wordpress.android.fluxc.persistence.WCRefundSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
-import org.wordpress.android.fluxc.store.WCRefundsStore
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundResult
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundError
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundErrorType.INVALID_REFUND_ID
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundPayload
+import org.wordpress.android.fluxc.store.WCRefundStore
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundResult
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundError
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundErrorType.INVALID_REFUND_ID
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundPayload
 import org.wordpress.android.fluxc.test
 
 @Config(manifest = Config.NONE)
@@ -32,7 +32,7 @@ class RefundStoreTest {
     private val restClient = mock<RefundRestClient>()
     private val site = mock<SiteModel>()
     private val mapper = RefundMapper()
-    private lateinit var store: WCRefundsStore
+    private lateinit var store: WCRefundStore
 
     private val orderId = 1L
     private val refundId = REFUND_RESPONSE.refundId
@@ -49,7 +49,7 @@ class RefundStoreTest {
         WellSql.init(config)
         config.reset()
 
-        store = WCRefundsStore(
+        store = WCRefundStore(
                 restClient,
                 Unconfined,
                 mapper
@@ -120,8 +120,8 @@ class RefundStoreTest {
                 restClient.fetchAllRefunds(
                         site,
                         orderId,
-                        WCRefundsStore.DEFAULT_PAGE,
-                        WCRefundsStore.DEFAULT_PAGE_SIZE
+                        WCRefundStore.DEFAULT_PAGE,
+                        WCRefundStore.DEFAULT_PAGE_SIZE
                 )
         ).thenReturn(
                 fetchRefundsPayload
@@ -130,8 +130,8 @@ class RefundStoreTest {
                 restClient.fetchAllRefunds(
                         site,
                         2,
-                        WCRefundsStore.DEFAULT_PAGE,
-                        WCRefundsStore.DEFAULT_PAGE_SIZE
+                        WCRefundStore.DEFAULT_PAGE,
+                        WCRefundStore.DEFAULT_PAGE_SIZE
                 )
         ).thenReturn(
                 RefundPayload(error)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundStoreTest.kt
@@ -14,36 +14,36 @@ import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
-import org.wordpress.android.fluxc.model.refunds.RefundsMapper
+import org.wordpress.android.fluxc.model.refunds.RefundMapper
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundsRestClient
-import org.wordpress.android.fluxc.persistence.WCRefundsSqlUtils
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
+import org.wordpress.android.fluxc.persistence.WCRefundSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCRefundsStore
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsResult
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsError
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsErrorType.INVALID_REFUND_ID
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsPayload
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundResult
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundError
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundErrorType.INVALID_REFUND_ID
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundPayload
 import org.wordpress.android.fluxc.test
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
-class RefundsStoreTest {
-    private val restClient = mock<RefundsRestClient>()
+class RefundStoreTest {
+    private val restClient = mock<RefundRestClient>()
     private val site = mock<SiteModel>()
-    private val mapper = RefundsMapper()
+    private val mapper = RefundMapper()
     private lateinit var store: WCRefundsStore
 
     private val orderId = 1L
     private val refundId = REFUND_RESPONSE.refundId
-    private val error = RefundsError(INVALID_REFUND_ID, NOT_FOUND, "Invalid order ID")
+    private val error = RefundError(INVALID_REFUND_ID, NOT_FOUND, "Invalid order ID")
 
     @Before
     fun setUp() {
         val appContext = RuntimeEnvironment.application.applicationContext
         val config = SingleStoreWellSqlConfigForTests(
                 appContext,
-                listOf(WCRefundsSqlUtils.RefundsBuilder::class.java),
+                listOf(WCRefundSqlUtils.RefundBuilder::class.java),
                 WellSqlConfig.ADDON_WOOCOMMERCE
         )
         WellSql.init(config)
@@ -97,8 +97,8 @@ class RefundsStoreTest {
         assertThat(refund).isEqualTo(mapper.map(REFUND_RESPONSE))
     }
 
-    private suspend fun fetchSpecificTestRefund(): RefundsResult<WCRefundModel> {
-        val fetchRefundsPayload = RefundsPayload(
+    private suspend fun fetchSpecificTestRefund(): RefundResult<WCRefundModel> {
+        val fetchRefundsPayload = RefundPayload(
                 REFUND_RESPONSE
         )
         whenever(restClient.fetchRefund(site, orderId, refundId)).thenReturn(
@@ -106,14 +106,14 @@ class RefundsStoreTest {
         )
 
         whenever(restClient.fetchRefund(site, 2, refundId)).thenReturn(
-                RefundsPayload(error)
+                RefundPayload(error)
         )
         return store.fetchRefund(site, orderId, refundId)
     }
 
-    private suspend fun fetchAllTestRefunds(): RefundsResult<List<WCRefundModel>> {
+    private suspend fun fetchAllTestRefunds(): RefundResult<List<WCRefundModel>> {
         val data = arrayOf(REFUND_RESPONSE, REFUND_RESPONSE)
-        val fetchRefundsPayload = RefundsPayload(
+        val fetchRefundsPayload = RefundPayload(
                 data
         )
         whenever(
@@ -134,7 +134,7 @@ class RefundsStoreTest {
                         WCRefundsStore.DEFAULT_PAGE_SIZE
                 )
         ).thenReturn(
-                RefundsPayload(error)
+                RefundPayload(error)
         )
         return store.fetchAllRefunds(site, orderId)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/WCRefundSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/WCRefundSqlUtilsTest.kt
@@ -9,8 +9,8 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.persistence.WCRefundsSqlUtils
-import org.wordpress.android.fluxc.persistence.WCRefundsSqlUtils.RefundsBuilder
+import org.wordpress.android.fluxc.persistence.WCRefundSqlUtils
+import org.wordpress.android.fluxc.persistence.WCRefundSqlUtils.RefundBuilder
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
-class WCRefundsSqlUtilsTest {
+class WCRefundSqlUtilsTest {
     private val orderId = 1L
     private val site = SiteModel().apply { id = 2 }
 
@@ -27,7 +27,7 @@ class WCRefundsSqlUtilsTest {
         val appContext = RuntimeEnvironment.application.applicationContext
         val config = SingleStoreWellSqlConfigForTests(
                 appContext,
-                listOf(RefundsBuilder::class.java),
+                listOf(RefundBuilder::class.java),
                 WellSqlConfig.ADDON_WOOCOMMERCE)
         WellSql.init(config)
         config.reset()
@@ -35,8 +35,8 @@ class WCRefundsSqlUtilsTest {
 
     @Test
     fun `test refund insert`() {
-        WCRefundsSqlUtils.insertOrUpdate(site, orderId, REFUND_RESPONSE)
-        val refunds = WCRefundsSqlUtils.selectAllRefunds(site, orderId)
+        WCRefundSqlUtils.insertOrUpdate(site, orderId, REFUND_RESPONSE)
+        val refunds = WCRefundSqlUtils.selectAllRefunds(site, orderId)
         assertEquals(1, refunds.size)
         assertEquals(REFUND_RESPONSE, refunds.first())
     }
@@ -45,12 +45,12 @@ class WCRefundsSqlUtilsTest {
     fun `test refund update`() {
         val newAmount = "20"
 
-        WCRefundsSqlUtils.insertOrUpdate(site, orderId, REFUND_RESPONSE)
-        val refund = WCRefundsSqlUtils.selectRefund(site, orderId, REFUND_RESPONSE.refundId)!!
+        WCRefundSqlUtils.insertOrUpdate(site, orderId, REFUND_RESPONSE)
+        val refund = WCRefundSqlUtils.selectRefund(site, orderId, REFUND_RESPONSE.refundId)!!
         assertEquals(REFUND_RESPONSE.amount, refund.amount)
 
-        WCRefundsSqlUtils.insertOrUpdate(site, orderId, REFUND_RESPONSE.copy(amount = "20"))
-        val updatedRefund = WCRefundsSqlUtils.selectRefund(site, orderId, REFUND_RESPONSE.refundId)!!
+        WCRefundSqlUtils.insertOrUpdate(site, orderId, REFUND_RESPONSE.copy(amount = "20"))
+        val updatedRefund = WCRefundSqlUtils.selectRefund(site, orderId, REFUND_RESPONSE.refundId)!!
         assertEquals(newAmount, updatedRefund.amount)
     }
 
@@ -58,11 +58,11 @@ class WCRefundsSqlUtilsTest {
     fun `test select`() {
         val inserted = listOf(REFUND_RESPONSE, REFUND_RESPONSE.copy(refundId = 2, amount = "20"))
 
-        WCRefundsSqlUtils.insertOrUpdate(site, orderId, inserted)
-        val refunds = WCRefundsSqlUtils.selectAllRefunds(site, orderId)
+        WCRefundSqlUtils.insertOrUpdate(site, orderId, inserted)
+        val refunds = WCRefundSqlUtils.selectAllRefunds(site, orderId)
         assertEquals(inserted, refunds)
 
-        val refund = WCRefundsSqlUtils.selectRefund(site, orderId, 2)
+        val refund = WCRefundSqlUtils.selectRefund(site, orderId, 2)
         assertEquals(refunds[1], refund)
     }
 
@@ -70,11 +70,11 @@ class WCRefundsSqlUtilsTest {
     fun `test select empty result`() {
         val inserted = listOf(REFUND_RESPONSE, REFUND_RESPONSE.copy(refundId = 2, amount = "20"))
 
-        WCRefundsSqlUtils.insertOrUpdate(site, orderId, inserted)
-        val refunds = WCRefundsSqlUtils.selectAllRefunds(site, 2)
+        WCRefundSqlUtils.insertOrUpdate(site, orderId, inserted)
+        val refunds = WCRefundSqlUtils.selectAllRefunds(site, 2)
         assertTrue(refunds.isEmpty())
 
-        val refund = WCRefundsSqlUtils.selectRefund(site, orderId, 3)
+        val refund = WCRefundSqlUtils.selectRefund(site, orderId, 3)
         assertNull(refund)
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
@@ -2,14 +2,14 @@ package org.wordpress.android.fluxc.model.refunds
 
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.DATE_FORMAT_DAY
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundsRestClient.RefundResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient.RefundResponse
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 
-class RefundsMapper
+class RefundMapper
 @Inject constructor() {
     fun map(response: RefundResponse): WCRefundModel {
         return WCRefundModel(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -5,7 +5,7 @@ import com.android.volley.RequestQueue
 import dagger.Module
 import dagger.Provides
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.model.refunds.RefundsMapper
+import org.wordpress.android.fluxc.model.refunds.RefundMapper
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -68,7 +68,7 @@ class ReleaseWCNetworkModule {
         @Named("regular") requestQueue: RequestQueue,
         token: AccessToken,
         userAgent: UserAgent
-    ) = RefundsRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
+    ) = RefundRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
 
     @Singleton
     @Provides
@@ -78,7 +78,7 @@ class ReleaseWCNetworkModule {
 
     @Singleton
     @Provides
-    fun provideRefundsMapper(): RefundsMapper {
-        return RefundsMapper()
+    fun provideRefundsMapper(): RefundMapper {
+        return RefundMapper()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundPayload
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundPayload
 import org.wordpress.android.fluxc.store.toRefundError
 import javax.inject.Singleton
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -13,12 +13,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsPayload
-import org.wordpress.android.fluxc.store.toRefundsError
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundPayload
+import org.wordpress.android.fluxc.store.toRefundError
 import javax.inject.Singleton
 
 @Singleton
-class RefundsRestClient
+class RefundRestClient
 constructor(
     dispatcher: Dispatcher,
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
@@ -34,7 +34,7 @@ constructor(
         reason: String,
         automaticRefund: Boolean,
         partialRefundLineItems: List<LineItem> = emptyList()
-    ): RefundsPayload<RefundResponse> {
+    ): RefundPayload<RefundResponse> {
         val url = WOOCOMMERCE.orders.id(orderId).refunds.pathV3
 
         val params = mapOf(
@@ -52,10 +52,10 @@ constructor(
         )
         return when (response) {
             is JetpackSuccess -> {
-                RefundsPayload(response.data)
+                RefundPayload(response.data)
             }
             is JetpackError -> {
-                RefundsPayload(response.error.toRefundsError())
+                RefundPayload(response.error.toRefundError())
             }
         }
     }
@@ -64,7 +64,7 @@ constructor(
         site: SiteModel,
         orderId: Long,
         refundId: Long
-    ): RefundsPayload<RefundResponse> {
+    ): RefundPayload<RefundResponse> {
         val url = WOOCOMMERCE.orders.id(orderId).refunds.refund(refundId).pathV3
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
@@ -76,10 +76,10 @@ constructor(
         )
         return when (response) {
             is JetpackSuccess -> {
-                RefundsPayload(response.data)
+                RefundPayload(response.data)
             }
             is JetpackError -> {
-                RefundsPayload(response.error.toRefundsError())
+                RefundPayload(response.error.toRefundError())
             }
         }
     }
@@ -89,7 +89,7 @@ constructor(
         orderId: Long,
         page: Int,
         pageSize: Int
-    ): RefundsPayload<Array<RefundResponse>> {
+    ): RefundPayload<Array<RefundResponse>> {
         val url = WOOCOMMERCE.orders.id(orderId).refunds.pathV3
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
@@ -104,10 +104,10 @@ constructor(
         )
         return when (response) {
             is JetpackSuccess -> {
-                RefundsPayload(response.data)
+                RefundPayload(response.data)
             }
             is JetpackError -> {
-                RefundsPayload(response.error.toRefundsError())
+                RefundPayload(response.error.toRefundError())
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCRefundSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCRefundSqlUtils.kt
@@ -9,9 +9,9 @@ import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundsRestClient.RefundResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient.RefundResponse
 
-object WCRefundsSqlUtils {
+object WCRefundSqlUtils {
     private val gson: Gson by lazy {
         val builder = GsonBuilder()
         builder.create()
@@ -23,7 +23,7 @@ object WCRefundsSqlUtils {
     fun insertOrUpdate(site: SiteModel, orderId: Long, data: List<RefundResponse>) {
         data.forEach { item ->
             val json = gson.toJson(item)
-            WellSql.delete(RefundsBuilder::class.java)
+            WellSql.delete(RefundBuilder::class.java)
                 .where()
                 .equals(WCRefundsTable.LOCAL_SITE_ID, site.id)
                 .equals(WCRefundsTable.ORDER_ID, orderId)
@@ -31,7 +31,7 @@ object WCRefundsSqlUtils {
                 .endWhere()
                 .execute()
             WellSql.insert(
-                    RefundsBuilder(
+                    RefundBuilder(
                             localSiteId = site.id,
                             orderId = orderId,
                             refundId = item.refundId,
@@ -45,7 +45,7 @@ object WCRefundsSqlUtils {
         site: SiteModel,
         orderId: Long
     ): List<RefundResponse> {
-        val models = WellSql.select(RefundsBuilder::class.java)
+        val models = WellSql.select(RefundBuilder::class.java)
                 .where()
                 .equals(WCRefundsTable.LOCAL_SITE_ID, site.id)
                 .equals(WCRefundsTable.ORDER_ID, orderId)
@@ -59,7 +59,7 @@ object WCRefundsSqlUtils {
         orderId: Long,
         refundId: Long
     ): RefundResponse? {
-        val model = WellSql.select(RefundsBuilder::class.java)
+        val model = WellSql.select(RefundBuilder::class.java)
                 .where()
                 .equals(WCRefundsTable.LOCAL_SITE_ID, site.id)
                 .equals(WCRefundsTable.ORDER_ID, orderId)
@@ -71,7 +71,7 @@ object WCRefundsSqlUtils {
     }
 
     @Table(name = "WCRefunds")
-    data class RefundsBuilder(
+    data class RefundBuilder(
         @PrimaryKey @Column private var mId: Int = -1,
         @Column var localSiteId: Int,
         @Column var orderId: Long,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCRefundStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCRefundStore.kt
@@ -22,17 +22,17 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.TIMEOUT
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
 import org.wordpress.android.fluxc.persistence.WCRefundSqlUtils
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundError
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundErrorType
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundError
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundErrorType
 import org.wordpress.android.fluxc.store.Store.OnChangedError
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.WCRefundStore.RefundErrorType.GENERIC_ERROR
 import java.math.BigDecimal
 
 @Singleton
-class WCRefundsStore @Inject constructor(
+class WCRefundStore @Inject constructor(
     private val restClient: RefundRestClient,
     private val coroutineContext: CoroutineContext,
     private val refundsMapper: RefundMapper

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCRefundStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCRefundStore.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
-import org.wordpress.android.fluxc.model.refunds.RefundsMapper
+import org.wordpress.android.fluxc.model.refunds.RefundMapper
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.AUTHORIZATION_REQUIRED
@@ -20,22 +20,22 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.PARSE_ER
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.SERVER_ERROR
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.TIMEOUT
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundsRestClient
-import org.wordpress.android.fluxc.persistence.WCRefundsSqlUtils
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsError
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
+import org.wordpress.android.fluxc.persistence.WCRefundSqlUtils
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundError
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundErrorType
 import org.wordpress.android.fluxc.store.Store.OnChangedError
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
-import org.wordpress.android.fluxc.store.WCRefundsStore.RefundsErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.WCRefundsStore.RefundErrorType.GENERIC_ERROR
 import java.math.BigDecimal
 
 @Singleton
 class WCRefundsStore @Inject constructor(
-    private val restClient: RefundsRestClient,
+    private val restClient: RefundRestClient,
     private val coroutineContext: CoroutineContext,
-    private val refundsMapper: RefundsMapper
+    private val refundsMapper: RefundMapper
 ) {
     companion object {
         // Just get everything
@@ -49,7 +49,7 @@ class WCRefundsStore @Inject constructor(
         amount: BigDecimal,
         reason: String = "",
         autoRefund: Boolean = false
-    ): RefundsResult<WCRefundModel> =
+    ): RefundResult<WCRefundModel> =
             withContext(coroutineContext) {
                 val response = restClient.createRefund(
                         site,
@@ -59,14 +59,14 @@ class WCRefundsStore @Inject constructor(
                         autoRefund
                 )
                 return@withContext when {
-                    response.isError -> RefundsResult(response.error)
-                    response.result != null -> RefundsResult(refundsMapper.map(response.result))
-                    else -> RefundsResult(RefundsError(GENERIC_ERROR, UNKNOWN))
+                    response.isError -> RefundResult(response.error)
+                    response.result != null -> RefundResult(refundsMapper.map(response.result))
+                    else -> RefundResult(RefundError(GENERIC_ERROR, UNKNOWN))
                 }
             }
 
     fun getRefund(site: SiteModel, orderId: Long, refundId: Long): WCRefundModel? {
-        return WCRefundsSqlUtils.selectRefund(site, orderId, refundId)
+        return WCRefundSqlUtils.selectRefund(site, orderId, refundId)
                 ?.let { refundsMapper.map(it) }
     }
 
@@ -74,21 +74,21 @@ class WCRefundsStore @Inject constructor(
         site: SiteModel,
         orderId: Long,
         refundId: Long
-    ): RefundsResult<WCRefundModel> =
+    ): RefundResult<WCRefundModel> =
             withContext(coroutineContext) {
                 val response = restClient.fetchRefund(site, orderId, refundId)
                 return@withContext when {
-                    response.isError -> RefundsResult(response.error)
+                    response.isError -> RefundResult(response.error)
                     response.result != null -> {
-                        WCRefundsSqlUtils.insertOrUpdate(site, orderId, response.result)
-                        RefundsResult(refundsMapper.map(response.result))
+                        WCRefundSqlUtils.insertOrUpdate(site, orderId, response.result)
+                        RefundResult(refundsMapper.map(response.result))
                     }
-                    else -> RefundsResult(RefundsError(GENERIC_ERROR, UNKNOWN))
+                    else -> RefundResult(RefundError(GENERIC_ERROR, UNKNOWN))
                 }
             }
 
     fun getAllRefunds(site: SiteModel, orderId: Long): List<WCRefundModel> {
-        return WCRefundsSqlUtils.selectAllRefunds(site, orderId).map { refundsMapper.map(it) }
+        return WCRefundSqlUtils.selectAllRefunds(site, orderId).map { refundsMapper.map(it) }
     }
 
     suspend fun fetchAllRefunds(
@@ -96,7 +96,7 @@ class WCRefundsStore @Inject constructor(
         orderId: Long,
         page: Int = DEFAULT_PAGE,
         pageSize: Int = DEFAULT_PAGE_SIZE
-    ): RefundsResult<List<WCRefundModel>> =
+    ): RefundResult<List<WCRefundModel>> =
             withContext(coroutineContext) {
                 val response = restClient.fetchAllRefunds(
                         site,
@@ -106,37 +106,37 @@ class WCRefundsStore @Inject constructor(
                 )
                 return@withContext when {
                     response.isError -> {
-                        RefundsResult(response.error)
+                        RefundResult(response.error)
                     }
                     response.result != null -> {
-                        WCRefundsSqlUtils.insertOrUpdate(site, orderId, response.result.toList())
-                        RefundsResult(response.result.map { refundsMapper.map(it) })
+                        WCRefundSqlUtils.insertOrUpdate(site, orderId, response.result.toList())
+                        RefundResult(response.result.map { refundsMapper.map(it) })
                     }
-                    else -> RefundsResult(RefundsError(GENERIC_ERROR, UNKNOWN))
+                    else -> RefundResult(RefundError(GENERIC_ERROR, UNKNOWN))
                 }
             }
 
-    data class RefundsPayload<T>(
+    data class RefundPayload<T>(
         val result: T? = null
-    ) : Payload<RefundsError>() {
-        constructor(error: RefundsError) : this() {
+    ) : Payload<RefundError>() {
+        constructor(error: RefundError) : this() {
             this.error = error
         }
     }
 
-    data class RefundsResult<T>(val model: T? = null) : Store.OnChanged<RefundsError>() {
-        constructor(error: RefundsError) : this() {
+    data class RefundResult<T>(val model: T? = null) : Store.OnChanged<RefundError>() {
+        constructor(error: RefundError) : this() {
             this.error = error
         }
     }
 
-    class RefundsError(
-        var type: RefundsErrorType,
+    class RefundError(
+        var type: RefundErrorType,
         var original: GenericErrorType,
         var message: String? = null
     ) : OnChangedError
 
-    enum class RefundsErrorType {
+    enum class RefundErrorType {
         TIMEOUT,
         API_ERROR,
         INVALID_REFUND_ID,
@@ -146,22 +146,22 @@ class WCRefundsStore @Inject constructor(
     }
 }
 
-fun WPComGsonNetworkError.toRefundsError(): RefundsError {
+fun WPComGsonNetworkError.toRefundError(): RefundError {
     val type = when (type) {
-        TIMEOUT -> RefundsErrorType.TIMEOUT
+        TIMEOUT -> RefundErrorType.TIMEOUT
         NO_CONNECTION,
         SERVER_ERROR,
         INVALID_SSL_CERTIFICATE,
-        NETWORK_ERROR -> RefundsErrorType.API_ERROR
+        NETWORK_ERROR -> RefundErrorType.API_ERROR
         PARSE_ERROR,
         CENSORED,
-        INVALID_RESPONSE -> RefundsErrorType.INVALID_RESPONSE
+        INVALID_RESPONSE -> RefundErrorType.INVALID_RESPONSE
         HTTP_AUTH_ERROR,
         AUTHORIZATION_REQUIRED,
-        NOT_AUTHENTICATED -> RefundsErrorType.AUTHORIZATION_REQUIRED
-        NOT_FOUND -> RefundsErrorType.INVALID_REFUND_ID
+        NOT_AUTHENTICATED -> RefundErrorType.AUTHORIZATION_REQUIRED
+        NOT_FOUND -> RefundErrorType.INVALID_REFUND_ID
         UNKNOWN,
         null -> GENERIC_ERROR
     }
-    return RefundsError(type, this.type, message)
+    return RefundError(type, this.type, message)
 }


### PR DESCRIPTION
To match the naming convention of other classes, I renamed the use of `Refunds` to `Refund`. Everything else stayed the same.