### PR TITLE
Implement equals and hashCode for LocalOrRemoteId

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/LocalOrRemoteId.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/LocalOrRemoteId.kt
@@ -3,4 +3,22 @@ package org.wordpress.android.fluxc.model
 sealed class LocalOrRemoteId {
     data class LocalId(val value: Int) : LocalOrRemoteId()
     data class RemoteId(val value: Long) : LocalOrRemoteId()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (this is LocalId && other is LocalId) {
+            return this.value == other.value
+        }
+        if (this is RemoteId && other is RemoteId) {
+            return this.value == other.value
+        }
+        return false
+    }
+
+    override fun hashCode(): Int {
+        return when(this) {
+            is LocalId -> this.hashCode()
+            is RemoteId -> this.hashCode()
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/LocalOrRemoteId.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/LocalOrRemoteId.kt
@@ -16,7 +16,7 @@ sealed class LocalOrRemoteId {
     }
 
     override fun hashCode(): Int {
-        return when(this) {
+        return when (this) {
             is LocalId -> this.hashCode()
             is RemoteId -> this.hashCode()
         }


### PR DESCRIPTION
Unfortunately Kotlin compiler is not smart enough to check that all subclasses of a `sealed class` properly implement `equals` method. Or it doesn't want to make the assumption that different subclasses of a `sealed class`es are not equal to each other. In either case, the lack of `equals` method for `LocalOrRemoteId` is throwing a lint error with Gradle 5.4.1 in WPAndroid. So, I thought we'd just add a proper `equals` method here instead of fixing the lint in WPAndroid.