### PR TITLE
Add signup_flow_name parameter to /auth/send-signup-email

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -227,6 +227,10 @@ public class Authenticator {
             params.put("source", payload.source.toString());
         }
 
+        if (payload.signupFlowName != null && !TextUtils.isEmpty(payload.signupFlowName)) {
+            params.put("signup_flow_name", payload.signupFlowName);
+        }
+
         WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, params, AuthEmailWPComRestResponse.class,
                 new Response.Listener<AuthEmailWPComRestResponse>() {
                     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -80,6 +80,7 @@ public class AccountStore extends Store {
         public AuthEmailPayloadFlow flow;
         public AuthEmailPayloadSource source;
         public String emailOrUsername;
+        public String signupFlowName;
         public boolean isSignup;
 
         public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailPayloadFlow flow,


### PR DESCRIPTION
This PR adds the ability to attach a `signup_flow_name` parameter to `/auth/send-signup-email` to address https://github.com/wordpress-mobile/WordPress-Android/issues/10625.

It's the Android counterpart of: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/190

To test:
Follow the testing instructions in the WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10627