### PR TITLE
Clean up after testAutoSaveScheduledPost

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -667,7 +667,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         PostModel post = createNewPost();
         post.setStatus(PostStatus.PUBLISHED.toString());
 
-        testAutoSavePostOrPage(post, false);
+        testAutoSavePostOrPage(post, false, false);
     }
 
     @Test
@@ -677,7 +677,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         post.setStatus(PostStatus.SCHEDULED.toString());
         post.setDateCreated("2075-10-14T10:51:11+00:00");
 
-        testAutoSavePostOrPage(post, false);
+        testAutoSavePostOrPage(post, false, true);
     }
 
     @Test
@@ -686,10 +686,10 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         PostModel post = createNewPost();
         post.setStatus(PostStatus.PUBLISHED.toString());
 
-        testAutoSavePostOrPage(post, true);
+        testAutoSavePostOrPage(post, true, false);
     }
 
-    private void testAutoSavePostOrPage(PostModel post, boolean isPage) throws InterruptedException {
+    private void testAutoSavePostOrPage(PostModel post, boolean isPage, boolean cleanUp) throws InterruptedException {
         // Arrange
         setupPostAttributes(post);
 
@@ -707,6 +707,13 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertNotNull(postAfterAutoSave.getAutoSaveModified());
         assertNotNull(postAfterAutoSave.getAutoSavePreviewUrl());
         assertNotEquals(0, postAfterAutoSave.getAutoSaveRevisionId());
+
+        // We don't want to perform the clean up unless necessary to keep the tests as quick as
+        // possible. However, creating for example scheduled posts during a test may affect other
+        // tests and hence they need to be trashed.
+        if (cleanUp) {
+            deletePost(uploadedPost);
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR adds a clean up phase to `testAutoSaveScheduledPost` test. This tests schedules a post which needs to be trashed when the test finishes so it doesn't affect other tests => see an example how it can affect other tests below.

```
1. The ReleaseStack_PostTestWPCom#testAutoSaveScheduledPost test creates a post with future status
https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/69bd2a93ba1fe7f9f5024211497a4a39a99d9866/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java#L673-L681
2. The post isn’t cleaned up at the end of the test
3. Once the tests run enough times, the first 20 posts fetched from the test site are all future status
4. A few comment tests rely on mFirstPost, which is the first published post
https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/69bd2a93ba1fe7f9f5024211497a4a39a99d9866/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
5. The tests just fetch the post list once, in a batch of 20
6. At this point all 20 posts are future, none are publish, so mFirstPost is null, and the tests fail
```

To test:
Verify the post gets trashed.