### PR TITLE
Woo: support for hiding future-dated orders

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,6 +28,7 @@
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="120" />
       <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
       <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
       <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />

--- a/example/src/main/java/org/wordpress/android/fluxc/example/OrderListAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/OrderListAdapter.kt
@@ -12,6 +12,10 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.fluxc.example.WCOrderListItemUIType.LoadingItem
 import org.wordpress.android.fluxc.example.WCOrderListItemUIType.SectionHeader
 import org.wordpress.android.fluxc.example.WCOrderListItemUIType.WCOrderListUIItem
+import org.wordpress.android.util.DateTimeUtils
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 
 private const val VIEW_TYPE_ORDER_ITEM = 0
 private const val VIEW_TYPE_LOADING = 1
@@ -91,7 +95,7 @@ private val OrderListDiffItemCallback = object : DiffUtil.ItemCallback<WCOrderLi
         }
         if (oldItem is WCOrderListUIItem && newItem is WCOrderListUIItem) {
             // AS is lying, it's not actually smart casting, so we have to do it :sigh:
-            return (oldItem as WCOrderListUIItem) == (newItem as WCOrderListUIItem)
+            return oldItem == newItem
         }
         return false
     }
@@ -101,15 +105,22 @@ private class WCOrderItemUIViewHolder(
     @LayoutRes layout: Int,
     parentView: ViewGroup
 ) : RecyclerView.ViewHolder(LayoutInflater.from(parentView.context).inflate(layout, parentView, false)) {
+    private val utcDateFormatter by lazy {
+        SimpleDateFormat("M/d/yy HH:mm:ss", Locale.ROOT).apply { timeZone = TimeZone.getTimeZone("UTC") }
+    }
     private val orderNumberTv: TextView = itemView.findViewById(R.id.woo_order_number)
     private val orderNameTv: TextView = itemView.findViewById(R.id.woo_order_name)
     private val orderStatusTv: TextView = itemView.findViewById(R.id.woo_order_status)
     private val orderTotalTv: TextView = itemView.findViewById(R.id.woo_order_total)
+    private val orderDateTv: TextView = itemView.findViewById(R.id.woo_order_date)
     fun onBind(orderUIItem: WCOrderListUIItem) {
         orderNumberTv.text = orderUIItem.orderNumber
         orderNameTv.text = orderUIItem.orderName
         orderStatusTv.text = orderUIItem.status
         orderTotalTv.text = orderUIItem.orderTotal
+
+        val dateObj = DateTimeUtils.dateUTCFromIso8601(orderUIItem.dateCreated)
+        orderDateTv.text = utcDateFormatter.format(dateObj)
     }
 }
 

--- a/example/src/main/res/layout/activity_wc_order_list.xml
+++ b/example/src/main/res/layout/activity_wc_order_list.xml
@@ -5,7 +5,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".WooOrderListFragment">
+    tools:ignore="HardcodedText"
+    tools:context=".WCOrderListActivity">
 
 
     <TextView
@@ -20,19 +21,21 @@
         android:text="Search:"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="@+id/ptr_layout"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
         android:id="@+id/order_filter"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
-        android:layout_marginTop="8dp"
         android:layout_weight="1"
-        app:layout_constraintEnd_toStartOf="@+id/order_search_submit"
+        android:inputType="text"
+        android:hint="Filter by status"
+        app:layout_constraintEnd_toEndOf="@+id/order_search_query"
         app:layout_constraintStart_toStartOf="@+id/order_search_query"
-        app:layout_constraintTop_toBottomOf="@+id/order_search_query"/>
+        app:layout_constraintTop_toBottomOf="@+id/order_search_query" />
 
     <TextView
         android:id="@+id/textView2"
@@ -51,43 +54,60 @@
         android:id="@+id/order_search_query"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
-        android:layout_marginTop="8dp"
         android:layout_weight="1"
-        app:layout_constraintEnd_toStartOf="@+id/order_search_submit"
+        android:hint="Search by text"
+        android:inputType="text"
+        app:layout_constraintEnd_toStartOf="@+id/guideline"
         app:layout_constraintStart_toEndOf="@+id/textView"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageButton
         android:id="@+id/order_search_submit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
-        android:layout_marginTop="8dp"
         android:src="@drawable/ic_check"
+        android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="@+id/order_filter"
         app:layout_constraintEnd_toStartOf="@+id/order_search_clear"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@+id/exclude_future_orders" />
 
     <ImageButton
         android:id="@+id/order_search_clear"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
-        android:layout_marginTop="8dp"
         android:src="@drawable/ic_clear"
+        android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="@+id/order_filter"
         app:layout_constraintEnd_toEndOf="@+id/ptr_layout"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@+id/exclude_future_orders" />
+
+    <CheckBox
+        android:id="@+id/exclude_future_orders"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:text="Exclude Future Orders"
+        app:layout_constraintBottom_toBottomOf="@+id/order_search_query"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/ptr_layout"
-        android:layout_width="0dp"
+        android:layout_width="388dp"
         android:layout_height="0dp"
         android:layout_alignParentBottom="true"
         android:layout_marginTop="16dp"
@@ -101,7 +121,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            android:scrollbars="vertical"/>
+            android:scrollbars="vertical" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
@@ -120,5 +140,12 @@
         app:layout_constraintEnd_toEndOf="@+id/ptr_layout"
         app:layout_constraintStart_toStartOf="@+id/ptr_layout"
         tools:visibility="visible"/>
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.64" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/layout/list_item_woo_order.xml
+++ b/example/src/main/res/layout/list_item_woo_order.xml
@@ -1,40 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:minHeight="50dp"
-              android:layout_margin="10dp"
-              android:gravity="center_vertical"
-              android:orientation="horizontal">
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="50dp"
+    android:layout_margin="10dp">
 
     <TextView
         android:id="@+id/woo_order_number"
-        android:layout_width="wrap_content"
+        android:layout_width="60dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="0dp"
         android:padding="5dp"
-        tools:text="2700"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="2700" />
 
     <TextView
         android:id="@+id/woo_order_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
         android:padding="5dp"
-        tools:text="Marlin Bryant"/>
+        app:layout_constraintEnd_toStartOf="@+id/woo_order_total"
+        app:layout_constraintStart_toEndOf="@+id/woo_order_number"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Marlin Bryant" />
 
     <TextView
         android:id="@+id/woo_order_status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:padding="5dp"
-        tools:text="processing"/>
+        app:layout_constraintStart_toStartOf="@+id/woo_order_name"
+        app:layout_constraintTop_toBottomOf="@+id/woo_order_name"
+        tools:text="processing" />
 
     <TextView
         android:id="@+id/woo_order_total"
         android:layout_width="80dp"
         android:layout_height="wrap_content"
-        android:gravity="right"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="0dp"
+        android:gravity="end"
         android:padding="5dp"
-        tools:text="366.00"/>
-</LinearLayout>
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="366.00" />
+
+    <TextView
+        android:id="@+id/woo_order_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:padding="5dp"
+        app:layout_constraintStart_toStartOf="@+id/woo_order_status"
+        app:layout_constraintTop_toBottomOf="@+id/woo_order_status"
+        tools:text="5/16/19 07:00:12" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
@@ -8,13 +8,15 @@ import org.wordpress.android.fluxc.model.list.ListDescriptorUniqueIdentifier
 class WCOrderListDescriptor(
     val site: SiteModel,
     val statusFilter: String? = null,
-    val searchQuery: String? = null
+    val searchQuery: String? = null,
+    val excludeFutureOrders: Boolean = false
 ) : ListDescriptor {
     override val config: ListConfig = ListConfig.default
 
     override val uniqueIdentifier: ListDescriptorUniqueIdentifier by lazy {
         ListDescriptorUniqueIdentifier(
-                "woo-site-order-list-${site.id}-sf${statusFilter.orEmpty()}-sq${searchQuery.orEmpty()}".hashCode())
+                ("woo-site-order-list-${site.id}-sf${statusFilter.orEmpty()}-sq${searchQuery.orEmpty()}" +
+                        "-efo$excludeFutureOrders").hashCode())
     }
 
     override val typeIdentifier: ListDescriptorTypeIdentifier by lazy {


### PR DESCRIPTION
This PR fixes #1409 and includes the following:

- Adds a new `excludeFutureOrders` parameter to the `WCOrderListDescriptor` 
- Updated the "Order LIst" view in the example app to include a new option to **exclude future orders** (see screenshot), as well as a new future orders time group section to be displayed in the list.

**NOTE**: I'm excluding orders programmatically in the `WCOrderListItemDataSource` because the API to fetch orders does not have an option for excluding orders dated for the future. Since the new list management design uses the results of the API call for everything, I had to move this logic into the datasource.

### Screenshots

New "Exclude Future Orders" checkbox and the "GROUP_FUTURE" section to display orders dated for the future:

<img src="https://user-images.githubusercontent.com/5810477/67614808-dfd5a400-f777-11e9-81d7-6b1905b988c5.png" width="300"/>

Excluding filter orders:

<img src="https://user-images.githubusercontent.com/5810477/67614809-e401c180-f777-11e9-8ff3-6e44a798adb6.png" width="300"/>

### Recommended Test Scenarios

- Manually modify the created date of an order to change it to a date in the future. 
- Verify it shows up in the "FUTURE" section of the list. 
- check "Exclude Future Orders" - verify the future orders are not included in the list results