### PR TITLE
Wc/fetch order list error

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/WCOrderFetcher.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WCOrderFetcher.kt
@@ -55,7 +55,6 @@ class WCOrderFetcher @Inject constructor(
         if (event.isError) {
             Log.e(WCOrderFetcher::class.java.simpleName,
                     "Error fetching orders by remoteOrderId: ${event.error.message}")
-            return
         }
         ongoingRequests.removeAll(event.orderIds)
     }

--- a/example/src/main/res/layout/activity_wc_order_list.xml
+++ b/example/src/main/res/layout/activity_wc_order_list.xml
@@ -5,6 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:padding="12dp"
     tools:ignore="HardcodedText"
     tools:context=".WCOrderListActivity">
 
@@ -14,13 +15,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:layout_marginLeft="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
         android:padding="12dp"
         android:text="Search:"
         android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="@+id/ptr_layout"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
@@ -28,13 +26,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginRight="8dp"
         android:layout_weight="1"
-        android:inputType="text"
         android:hint="Filter by status"
-        app:layout_constraintEnd_toEndOf="@+id/order_search_query"
-        app:layout_constraintStart_toStartOf="@+id/order_search_query"
+        android:inputType="text"
+        app:layout_constraintEnd_toStartOf="@+id/guideline"
+        app:layout_constraintStart_toEndOf="@+id/textView2"
         app:layout_constraintTop_toBottomOf="@+id/order_search_query" />
 
     <TextView
@@ -47,16 +43,12 @@
         android:text="Filter:"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="@+id/textView"
-        app:layout_constraintStart_toStartOf="@+id/textView"
-        app:layout_constraintTop_toBottomOf="@+id/textView"/>
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
 
     <EditText
         android:id="@+id/order_search_query"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginRight="8dp"
         android:layout_weight="1"
         android:hint="Search by text"
         android:inputType="text"
@@ -68,46 +60,38 @@
         android:id="@+id/order_search_submit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
-        android:src="@drawable/ic_check"
         android:importantForAccessibility="no"
+        android:src="@drawable/ic_check"
         app:layout_constraintBottom_toBottomOf="@+id/order_filter"
-        app:layout_constraintEnd_toStartOf="@+id/order_search_clear"
-        app:layout_constraintTop_toBottomOf="@+id/exclude_future_orders" />
+        app:layout_constraintEnd_toStartOf="@+id/order_search_clear" />
 
     <ImageButton
         android:id="@+id/order_search_clear"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginRight="8dp"
-        android:src="@drawable/ic_clear"
         android:importantForAccessibility="no"
+        android:src="@drawable/ic_clear"
         app:layout_constraintBottom_toBottomOf="@+id/order_filter"
-        app:layout_constraintEnd_toEndOf="@+id/ptr_layout"
-        app:layout_constraintTop_toBottomOf="@+id/exclude_future_orders" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/exclude_future_orders"
+        app:layout_constraintVertical_bias="1.0" />
 
     <CheckBox
         android:id="@+id/exclude_future_orders"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginRight="8dp"
+        android:layout_height="0dp"
         android:text="Exclude Future Orders"
-        app:layout_constraintBottom_toBottomOf="@+id/order_search_query"
+        app:layout_constraintBottom_toTopOf="@+id/order_search_submit"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/guideline"
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/ptr_layout"
-        android:layout_width="388dp"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_alignParentBottom="true"
         android:layout_marginTop="16dp"

--- a/example/src/main/res/layout/list_item_woo_order.xml
+++ b/example/src/main/res/layout/list_item_woo_order.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="50dp"
-    android:layout_margin="10dp">
+    android:padding="10dp">
 
     <TextView
         android:id="@+id/woo_order_number"
@@ -35,7 +35,6 @@
         android:id="@+id/woo_order_status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:padding="5dp"
         app:layout_constraintStart_toStartOf="@+id/woo_order_name"
         app:layout_constraintTop_toBottomOf="@+id/woo_order_name"
@@ -57,7 +56,6 @@
         android:id="@+id/woo_order_date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:padding="5dp"
         app:layout_constraintStart_toStartOf="@+id/woo_order_status"
         app:layout_constraintTop_toBottomOf="@+id/woo_order_status"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListConfig.kt
@@ -1,10 +1,26 @@
 package org.wordpress.android.fluxc.model.list
 
+import org.wordpress.android.fluxc.store.ListStore
+import androidx.paging.PagedList.Config.Builder
+
 private const val DB_PAGE_SIZE = 10
 private const val INITIAL_LOAD_SIZE = 20
 private const val NETWORK_PAGE_SIZE = 60
 private const val PRE_FETCH_DISTANCE = DB_PAGE_SIZE * 3
 
+/**
+ * Configures how the [ListStore] loads content from its DataSource.
+ *
+ * @param networkPageSize The number of items to request when fetching a page of data from the API.
+ * @param initialLoadSize How many items to load when first load occurs. Typically larger than [networkPageSize] so
+ * a large enough range of content is loaded to cover small scrolls.
+ * See [Builder.setInitialLoadSizeHint] for more information.
+ * @param dbPageSize The number of items loaded at once from the DataSource (should be several times the number
+ * of visible items onscreen). Smaller page sizes improve memory usage, latency, and avoid GC churn. Larger pages
+ * generally improve loading throughput, to a point.
+ * See [Builder.setPageSize] for more information.
+ * @param prefetchDistance ?
+ */
 class ListConfig(val networkPageSize: Int, val initialLoadSize: Int, val dbPageSize: Int, val prefetchDistance: Int) {
     companion object {
         val default = ListConfig(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -181,13 +181,15 @@ class OrderRestClient(
 
                     val payload = FetchOrdersByIdsResponsePayload(
                             site = site,
-                            orders = orderModels
+                            remoteOrderIds = remoteOrderIds,
+                            fetchedOrders = orderModels
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersByIdsAction(payload))
                 },
                 WPComErrorListener { networkError ->
                     val orderError = networkErrorToOrderError(networkError)
-                    val payload = FetchOrdersByIdsResponsePayload(error = orderError, site = site)
+                    val payload = FetchOrdersByIdsResponsePayload(
+                            error = orderError, site = site, remoteOrderIds = remoteOrderIds)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersByIdsAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })


### PR DESCRIPTION
Fixes #1411 by updating the `fetchOrdersById` logic in `WCOrderStore` and `OrderRestClient` to always pass in the original list of `remoteOrderIds` to the `FetchOrdersByIdsResponsePayload` so it can be included in the `OnOrdersFetchedByIds` event even if the request to fetch these orders failed. This allows us to remove the list of ID's from `WCOrderFetcher.ongoingRequests` so when we retry to fetch the orders later `WCOrderFetcher` will not see them as already pending and instead attempt to fetch.

**Also included:**
- Did some minor tweaks to the layout files for the Order List view to better accommodate Samsung and LG devices. 
- Added some class comments to `ListConfig` so it will be easier to figure out how each parameter is used. 

## To Test

1. Perform a fresh install of the app and login
2. Click on Woo -> Orders -> Orders List - quickly turn on airplane mode before the list is finished loading. There should still be items in "Loading..." state. 
3. Turn off airplane mode and wait for the device to reconnect. 
4. Do a pull-to-refresh on the order list.
5. Verify the "Loading..."  items are now populated with data. 