### PR TITLE
Retry connected tests on CircleCI once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
         type: string
       timeout:
         type: string
+      num-flaky-test-attempts:
+        type: integer
       post-slack-status:
         type: boolean
       device:
@@ -110,6 +112,7 @@ jobs:
           device: << parameters.device >>
           project: api-project-108380595987
           timeout: << parameters.timeout >>
+          num-flaky-test-attempts: << parameters.num-flaky-test-attempts >>
           no-record-video: true
       - android/save-gradle-cache:
           cache-prefix: connected-tests
@@ -145,6 +148,7 @@ workflows:
           package: org.wordpress.android.fluxc.mocked
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           timeout: 10m
+          num-flaky-test-attempts: 0
           post-slack-status: false
   nightly:
     triggers:
@@ -161,4 +165,5 @@ workflows:
           package: org.wordpress.android.fluxc
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           timeout: 30m
+          num-flaky-test-attempts: 1
           post-slack-status: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  android: wordpress-mobile/android@1.0
+  android: wordpress-mobile/android@dev:firebase-flaky-test-config
   slack: circleci/slack@2.5.0
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  android: wordpress-mobile/android@dev:firebase-flaky-test-config
+  android: wordpress-mobile/android@1.0
   slack: circleci/slack@2.5.0
 
 commands:


### PR DESCRIPTION
Updates the nightly connected test run on Firebase to rerun the tests once if there is a failure, to limit failure reports due to flaky tests. See the [--num-flaky-test-attempts](https://href.li/?https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run#--num-flaky-test-attempts) argument in the Firebase documentation.

Relies on https://github.com/wordpress-mobile/circleci-orbs/pull/45 to update the Android CircleCI orb - once that's merged I'll revert the use of a dev orb branch in this PR.

To test:
1. Verify that CI passes for this branch (the mocked tests which run on every PR are using the retry argument too, but it's set to `0` (== don't retry - the same as the default behavior from before))
2. Look at [this CI build](https://circleci.com/gh/wordpress-mobile/WordPress-FluxC-Android/3990), which was this branch plus extra changes where I broke a test and forced the nightly build to run on each PR. You can see that the build failed and that the test results posted on Firebase show two attempts (`--num-flaky-test-attempts` was set to 1).