### PR TITLE
Wc/cache order shipping methods

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 91
+        return 92
     }
 
     override fun getDbName(): String {
@@ -1013,6 +1013,9 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "GATEWAY_ID TEXT NOT NULL," +
                                     "DATA TEXT NOT NULL)"
                     )
+                }
+                91 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCOrderModel ADD SHIPPING_LINES TEXT NULL")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -140,4 +140,6 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         val responseType = object : TypeToken<List<ShippingLine>>() {}.type
         return gson.fromJson(shippingLines, responseType) as? List<ShippingLine> ?: emptyList()
     }
+
+    fun isMultiShippingLinesAvailable() = getShippingLineList()?.size > 1
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -61,8 +61,15 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
 
     @Column var lineItems = ""
 
+    @Column var shippingLines = ""
+
     companion object {
         private val gson by lazy { Gson() }
+    }
+
+    class ShippingLine {
+        @SerializedName("method_title")
+        val methodTitle: String? = null
     }
 
     class LineItem {
@@ -124,5 +131,13 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
      */
     fun getOrderSubtotal(): Double {
         return getLineItemList().sumByDouble { it.subtotal?.toDoubleOrNull() ?: 0.0 }
+    }
+
+    /**
+     * Deserializes the JSON contained in [shippingLines] into a list of [ShippingLine] objects.
+     */
+    fun getShippingLineList(): List<ShippingLine> {
+        val responseType = object : TypeToken<List<ShippingLine>>() {}.type
+        return gson.fromJson(shippingLines, responseType) as? List<ShippingLine> ?: emptyList()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -66,4 +66,8 @@ class OrderApiResponse : Response {
     val line_items: JsonElement? = null
 
     val refunds: List<Refund>? = null
+
+    // This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand.
+    // See WCOrderModel.ShippingLines
+    val shipping_lines: JsonElement? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -58,7 +58,7 @@ class OrderRestClient(
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     private val ORDER_FIELDS = "id,number,status,currency,date_created_gmt,total,total_tax,shipping_total," +
             "payment_method,payment_method_title,prices_include_tax,customer_note,discount_total," +
-            "coupon_lines,refunds,billing,shipping,line_items,date_paid_gmt"
+            "coupon_lines,refunds,billing,shipping,line_items,date_paid_gmt,shipping_lines"
     private val TRACKING_FIELDS = "tracking_id,tracking_number,tracking_link,tracking_provider,date_shipped"
 
     /**
@@ -686,6 +686,7 @@ class OrderRestClient(
             shippingCountry = response.shipping?.country ?: ""
 
             lineItems = response.line_items.toString()
+            shippingLines = response.shipping_lines.toString()
         }
     }
 


### PR DESCRIPTION
Fixes #1415 . This PR adds the `shipping_lines` field to the `OrderAPIResponse` and adds an option to store the field locally in `WCOrderModel`.

### Changes:
- Adds the `shipping_lines` field to `OrderApiResponse`.
- Adds a migration script to add the `shipping_lines` field to `WCOrderModel`.
- Adds logic to store the `shipping_lines` field to `WCOrderModel`.
- Adds method to check if multiple shipping lines are available for an order. This is needed to display a warning message to the user in the order detail screen.
