### PR TITLE
Add a new `hasCachedOrdersForSite()` method to WCOrderStore

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -365,6 +365,11 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     fun getShipmentProvidersForSite(site: SiteModel): List<WCOrderShipmentProviderModel> =
             OrderSqlUtils.getOrderShipmentProvidersForSite(site)
 
+    /**
+     * @return Returns true if orders for the provided site exist in the DB, else false.
+     */
+    fun hasCachedOrdersForSite(site: SiteModel) = OrderSqlUtils.getOrdersForSite(site).isNotEmpty()
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? WCOrderAction ?: return


### PR DESCRIPTION
Fixes #1418 by adding a new `hasCachedOrdersForSite(site)` method to `WCOrderStore`. 