### PR TITLE
Added method to parse attributes field in WCProductVariationModel

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.model
 
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
@@ -50,5 +52,19 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
 
     override fun setId(id: Int) {
         this.id = id
+    }
+
+    class ProductVariantOption {
+        val id: Long? = null
+        val name: String? = null
+        val option: String? = null
+    }
+
+    /**
+     * Deserializes the JSON contained in [attributes] into a list of [ProductVariantOption] objects.
+     */
+    fun getProductVariantOptions(): List<ProductVariantOption> {
+        val responseType = object : TypeToken<List<ProductVariantOption>>() {}.type
+        return Gson().fromJson(attributes, responseType) as? List<ProductVariantOption> ?: emptyList()
     }
 }


### PR DESCRIPTION
Fixes #1420 by adding a method to `WCProductVariantionModel` that returns a list of attributes/options for a particular variant. 

