### PR TITLE
Issue/1422 product variations image null fix

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -225,6 +225,8 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertNull(payload.error)
         assertEquals(payload.remoteProductId, remoteProductId)
         assertEquals(payload.variations.size, 3)
+        assertEquals(payload.variations[0].imageUrl, "")
+        assertNotNull(payload.variations[1].imageUrl)
 
         // save the variation to the db
         assertEquals(ProductSqlUtils.insertOrUpdateProductVariations(payload.variations), 3)

--- a/example/src/androidTest/resources/wc-fetch-product-variations-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-variations-response-success.json
@@ -48,16 +48,7 @@
       "downloads": [
       ],
       "id": 181,
-      "image": {
-        "alt": "",
-        "date_created": "2019-03-14T07:34:12",
-        "date_created_gmt": "2019-03-14T16:34:12",
-        "date_modified": "2019-03-15T10:25:58",
-        "date_modified_gmt": "2019-03-15T19:25:58",
-        "id": 175,
-        "name": "profile-rockem-sockem",
-        "src": "https://example.com/wp-content/uploads/2019/03/profile-rockem-sockem.png?fit=300%2C225&ssl=1"
-      },
+      "image": null,
       "manage_stock": false,
       "menu_order": 0,
       "meta_data": [

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -496,8 +496,10 @@ class ProductRestClient(
                 height = json.getString("height") ?: ""
             }
 
-            response.image?.asJsonObject?.let { json ->
-                imageUrl = json.getString("src") ?: ""
+            response.image?.let {
+                (it as? JsonObject)?.let { json ->
+                    imageUrl = json.getString("src") ?: ""
+                } ?: ""
             }
         }
     }


### PR DESCRIPTION
Fixes #1422. Evidently, when there are no images associated with variants of a product, the `/wc/v3/products/<product_id>/variations` API returns a null response for the `image` field. This PR adds a fix to handle this scenario. 