### PR TITLE
Add React Native store for making calls to a given path

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -66,4 +66,6 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_TransactionsTest test);
     void inject(ReleaseStack_WCOrderListTest test);
     void inject(ReleaseStack_PostSchedulingTestJetpack test);
+    void inject(ReleaseStack_ReactNativeWPAPIRequestTest test);
+    void inject(ReleaseStack_ReactNativeWPComRequestTest test);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
@@ -1,27 +1,14 @@
 package org.wordpress.android.fluxc.release
 
 import kotlinx.coroutines.runBlocking
-import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.example.BuildConfig
-import org.wordpress.android.fluxc.generated.AccountActionBuilder
-import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
-import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
-import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
 import org.wordpress.android.fluxc.store.ReactNativeStore
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
-import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.AppLog.T
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 
 class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
@@ -33,59 +20,15 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
     override fun setUp() {
         super.setUp()
         mReleaseStackAppComponent.inject(this)
-        init()
     }
 
     @Test
-    fun testWPAPICall() {
-        authenticate()
-
-        val url = "http://do.wpmt.co/jp-1/wp-json/wp/v2/media/"
+    fun testWPAPICallOnSelfHosted() {
+        val url = BuildConfig.TEST_WPORG_URL_SH_WPAPI_SIMPLE + "/wp-json/wp/v2/media/"
         val params = mapOf("context" to "view")
         val response = runBlocking { reactNativeStore.performWPAPIRequest(url, params) }
 
         val failureMessage = "Call failed with error: ${(response as? Error)?.error}"
         assertTrue(failureMessage, response is Success)
-    }
-
-    private fun authenticate() {
-        val payload = AuthenticatePayload(
-                BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
-                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY
-        )
-        mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-        mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-        mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-        assertTrue(siteStore.sitesCount > 0)
-    }
-
-    @Subscribe
-    fun onAuthenticationChanged(event: OnAuthenticationChanged) {
-        if (event.isError) {
-            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
-        }
-        mCountDownLatch.countDown()
-    }
-
-    @Subscribe
-    fun onAccountChanged(event: OnAccountChanged) {
-        AppLog.d(T.TESTS, "Received OnAccountChanged event")
-        if (event.isError) {
-            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
-        }
-        mCountDownLatch.countDown()
-    }
-
-    @Subscribe
-    fun onSiteChanged(event: OnSiteChanged) {
-        AppLog.i(T.TESTS, "site count " + siteStore.sitesCount)
-        assertTrue(siteStore.hasSite())
-        mCountDownLatch.countDown()
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.fluxc.release
+
+import kotlinx.coroutines.runBlocking
+import org.greenrobot.eventbus.Subscribe
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.example.BuildConfig
+import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
+import org.wordpress.android.fluxc.store.ReactNativeStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import javax.inject.Inject
+
+class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
+    @Inject lateinit var reactNativeStore: ReactNativeStore
+    @Inject internal lateinit var siteStore: SiteStore
+    @Inject internal lateinit var accountStore: AccountStore
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mReleaseStackAppComponent.inject(this)
+        init()
+    }
+
+    @Test
+    fun testWPAPICall() {
+        authenticate()
+
+        val url = "http://do.wpmt.co/jp-1/wp-json/wp/v2/media/"
+        val params = mapOf("context" to "view")
+        val response = runBlocking { reactNativeStore.performWPAPIRequest(url, params) }
+
+        val failureMessage = "Call failed with error: ${(response as? Error)?.error}"
+        assertTrue(failureMessage, response is Success)
+    }
+
+    private fun authenticate() {
+        val payload = AuthenticatePayload(
+                BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
+                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY
+        )
+        mCountDownLatch = CountDownLatch(1)
+        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        mCountDownLatch = CountDownLatch(1)
+        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        mCountDownLatch = CountDownLatch(1)
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(siteStore.sitesCount > 0)
+    }
+
+    @Subscribe
+    fun onAuthenticationChanged(event: OnAuthenticationChanged) {
+        if (event.isError) {
+            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
+        }
+        mCountDownLatch.countDown()
+    }
+
+    @Subscribe
+    fun onAccountChanged(event: OnAccountChanged) {
+        AppLog.d(T.TESTS, "Received OnAccountChanged event")
+        if (event.isError) {
+            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
+        }
+        mCountDownLatch.countDown()
+    }
+
+    @Subscribe
+    fun onSiteChanged(event: OnSiteChanged) {
+        AppLog.i(T.TESTS, "site count " + siteStore.sitesCount)
+        assertTrue(siteStore.hasSite())
+        mCountDownLatch.countDown()
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.fluxc.release
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
+import org.wordpress.android.fluxc.store.ReactNativeStore
+import javax.inject.Inject
+
+class ReleaseStack_ReactNativeWPComRequestTest : ReleaseStack_WPComBase() {
+    @Inject lateinit var reactNativeStore: ReactNativeStore
+
+    override fun setUp() {
+        super.setUp()
+        mReleaseStackAppComponent.inject(this)
+        init()
+    }
+
+    @Test
+    fun testWpComCall() {
+        val url = "https://public-api.wordpress.com/wp/v2/media"
+        val params = mapOf("context" to "edit")
+        val response = runBlocking { reactNativeStore.performWPComRequest(url, params) }
+
+        val failureMessage = "Call failed with error: ${(response as? Error)?.error}"
+        assertTrue(failureMessage, response is Success)
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
@@ -19,7 +19,7 @@ class ReleaseStack_ReactNativeWPComRequestTest : ReleaseStack_WPComBase() {
 
     @Test
     fun testWpComCall() {
-        val url = "https://public-api.wordpress.com/wp/v2/media"
+        val url = "https://public-api.wordpress.com/wp/v2/sites/${siteFromDb.siteId}/media"
         val params = mapOf("context" to "edit")
         val response = runBlocking { reactNativeStore.performWPComRequest(url, params) }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -91,6 +91,7 @@ class MainFragment : Fragment() {
         themes.setOnClickListener(getOnClickListener(ThemeFragment()))
         woo.setOnClickListener(getOnClickListener(WooCommerceFragment()))
         notifs.setOnClickListener(getOnClickListener(NotificationsFragment()))
+        reactnative.setOnClickListener(getOnClickListener(ReactNativeFragment()))
     }
 
     // Private methods

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
@@ -1,0 +1,80 @@
+package org.wordpress.android.fluxc.example
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_reactnative.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
+import org.wordpress.android.fluxc.store.ReactNativeStore
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+
+class ReactNativeFragment : Fragment() {
+    @Inject internal lateinit var reactNativeStore: ReactNativeStore
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_reactnative, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        wp_api_request_button.setOnClickListener {
+            makeCall(reactNativeStore::performWPAPIRequest, wp_api_url_field, "WP api")
+        }
+        wp_com_request_button.setOnClickListener {
+            makeCall(reactNativeStore::performWPComRequest, wp_com_url_field, "WP.com")
+        }
+    }
+
+    private fun makeCall(
+        callFunction: suspend (path: String, params: Map<String, String>) -> ReactNativeFetchResponse,
+        urlField: EditText,
+        callType: String
+    ) {
+        try {
+            val fullPath = urlField.text.toString()
+            val (path, paramMap) = if (fullPath.contains("?")) {
+                val (pathWithoutParams, rawParams) = fullPath.split("?")
+                val params = rawParams.split("&").map {
+                    val (key, value) = it.split("=")
+                    key to value
+                }.toMap()
+                Pair(pathWithoutParams, params)
+            } else {
+                Pair(fullPath, emptyMap())
+            }
+
+            GlobalScope.launch(Dispatchers.Main) {
+                val response = withContext(Dispatchers.IO) {
+                    callFunction(path, paramMap)
+                }
+
+                when (response) {
+                    is Success -> {
+                        prependToLog("$callType call succeeded")
+                        AppLog.i(AppLog.T.API, "$callType call result: ${response.result}")
+                    }
+                    is Error -> prependToLog("$callType call failed: ${response.error}")
+                }
+            }
+        } catch (e: IndexOutOfBoundsException) {
+            prependToLog("Error parsing url")
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.example.MainFragment
 import org.wordpress.android.fluxc.example.MediaFragment
 import org.wordpress.android.fluxc.example.NotificationsFragment
 import org.wordpress.android.fluxc.example.PostsFragment
+import org.wordpress.android.fluxc.example.ReactNativeFragment
 import org.wordpress.android.fluxc.example.SignedOutActionsFragment
 import org.wordpress.android.fluxc.example.SiteSelectorDialog
 import org.wordpress.android.fluxc.example.SitesFragment
@@ -84,4 +85,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideStoreSelectorDialogInjector(): StoreSelectorDialog
+
+    @ContributesAndroidInjector
+    abstract fun provideReactNativeFramgmentInjector(): ReactNativeFragment
 }

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -123,6 +123,13 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
                 android:text="Notifications"/>
+
+            <Button
+                android:id="@+id/reactnative"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="right"
+                android:text="React Native"/>
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_reactnative.xml
+++ b/example/src/main/res/layout/fragment_reactnative.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    >
+
+    <FrameLayout
+        android:id="@+id/wp_com_box"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="#1000"
+        android:padding="30dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/wp_com_request_button"
+        />
+
+    <EditText
+        android:id="@+id/wp_com_url_field"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:hint="Enter full WP.com path"
+        app:layout_constraintTop_toTopOf="@+id/wp_com_box"
+        app:layout_constraintStart_toStartOf="@id/wp_com_box"
+        app:layout_constraintEnd_toEndOf="@+id/wp_com_box"
+        />
+
+    <Button
+        android:id="@+id/wp_com_request_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:text="Execute WP.com Request"
+        app:layout_constraintTop_toBottomOf="@+id/wp_com_url_field"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
+
+
+    <FrameLayout
+        android:id="@+id/wp_api_box"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="#1000"
+        android:layout_marginTop="30dp"
+        android:paddingBottom="30dp"
+        app:layout_constraintTop_toBottomOf="@id/wp_com_box"
+        app:layout_constraintBottom_toBottomOf="@+id/wp_api_request_button"
+        />
+
+    <EditText
+        android:id="@+id/wp_api_url_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:hint="Enter full WP api path"
+        app:layout_constraintTop_toTopOf="@+id/wp_api_box"
+        app:layout_constraintStart_toStartOf="@+id/wp_api_box"
+        app:layout_constraintEnd_toEndOf="@+id/wp_api_box"
+        />
+
+    <Button
+        android:id="@+id/wp_api_request_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Execute WP api Request"
+        app:layout_constraintTop_toBottomOf="@+id/wp_api_url_field"
+        app:layout_constraintStart_toStartOf="@id/wp_api_box"
+        app:layout_constraintEnd_toEndOf="@id/wp_api_box"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
@@ -1,0 +1,99 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.reactnative
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.JsonElement
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import junit.framework.AssertionFailedError
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse
+import org.wordpress.android.fluxc.test
+
+class ReactNativeWPComRestClientTest {
+    private val wpComGsonRequestBuilder = mock<WPComGsonRequestBuilder>()
+    private val context = mock<Context>()
+    private val dispatcher = mock<Dispatcher>()
+    private val requestQueue = mock<RequestQueue>()
+    private val accessToken = mock<AccessToken>()
+    private val userAgent = mock<UserAgent>()
+
+    private val url = "a_url"
+    val params = mapOf("a_key" to "a_value")
+
+    private lateinit var subject: ReactNativeWPComRestClient
+
+    @Before
+    fun setUp() {
+        subject = ReactNativeWPComRestClient(
+                wpComGsonRequestBuilder,
+                context,
+                dispatcher,
+                requestQueue,
+                accessToken,
+                userAgent)
+    }
+
+    @Test
+    fun `fetch handles successful response`() = test {
+        val errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse = { _ ->
+            throw AssertionFailedError("errorHandler should not have been called")
+        }
+
+        val expected = mock<ReactNativeFetchResponse>()
+        val expectedJson = mock<JsonElement>()
+        val successHandler = { data: JsonElement ->
+            if (data != expectedJson) fail("expected data was not passed to successHandler")
+            expected
+        }
+
+        val expectedRestCallResponse = Success(expectedJson)
+        verifyRestApi(successHandler, errorHandler, expectedRestCallResponse, expected)
+    }
+
+    @Test
+    fun `fetch handles failure response`() = test {
+        val successHandler = { _: JsonElement ->
+            throw AssertionFailedError("successHandler should not have been called")
+        }
+
+        val expected = mock<ReactNativeFetchResponse>()
+        val expectedBaseNetworkError = mock<WPComGsonNetworkError>()
+        val errorHandler = { error: BaseNetworkError ->
+            if (error != expectedBaseNetworkError) fail("expected error was not passed to errorHandler")
+            expected
+        }
+
+        val mockedRestCallResponse = Error<JsonElement>(expectedBaseNetworkError)
+        verifyRestApi(successHandler, errorHandler, mockedRestCallResponse, expected)
+    }
+
+    private suspend fun verifyRestApi(
+        successHandler: (JsonElement) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
+        expectedRestCallResponse: WPComGsonRequestBuilder.Response<JsonElement>,
+        expected: ReactNativeFetchResponse
+    ) {
+        whenever(wpComGsonRequestBuilder.syncGetRequest(
+                subject,
+                url,
+                params,
+                JsonElement::class.java,
+                true)
+        ).thenReturn(expectedRestCallResponse)
+
+        val actual = subject.fetch(url, params, successHandler, errorHandler)
+        assertEquals(expected, actual)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreTest.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.fluxc.store
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.Dispatchers.Unconfined
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.fluxc.network.rest.wpapi.reactnative.ReactNativeWPAPIRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.reactnative.ReactNativeWPComRestClient
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
+import org.wordpress.android.fluxc.test
+import kotlin.test.assertEquals
+
+class ReactNativeStoreTest {
+    private val wpComRestClient = mock<ReactNativeWPComRestClient>()
+    private val wpApiRestClient = mock<ReactNativeWPAPIRestClient>()
+
+    private val PATH = "a_url_path"
+    private val PARAMS = mapOf("a_key" to "a_value")
+
+    private lateinit var store: ReactNativeStore
+
+    @Before
+    fun setup() {
+        store = ReactNativeStore(wpComRestClient, wpApiRestClient, Unconfined)
+    }
+
+    @Test
+    fun `makes call to WPcom`() = test {
+        val expectedResponse = mock<ReactNativeFetchResponse>()
+        whenever(wpComRestClient.fetch(PATH, PARAMS, ::Success, ::Error)).thenReturn(expectedResponse)
+        val actualResponse = store.performWPComRequest(PATH, PARAMS)
+        assertEquals(expectedResponse, actualResponse)
+    }
+
+    @Test
+    fun `makes call to WP api`() = test {
+        val expectedResponse = mock<ReactNativeFetchResponse>()
+        whenever(wpApiRestClient.fetch(PATH, PARAMS, ::Success, ::Error)).thenReturn(expectedResponse)
+        val actualResponse = store.performWPAPIRequest(PATH, PARAMS)
+        assertEquals(expectedResponse, actualResponse)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.fluxc.network.rest.wpapi
+
+import com.android.volley.Request.Method
+import com.android.volley.Response.Listener
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.BaseRequest.BaseErrorListener
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder.Response.Success
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class WPAPIGsonRequestBuilder @Inject constructor() {
+    suspend fun <T> syncGetRequest(
+        restClient: BaseWPAPIRestClient,
+        url: String,
+        params: Map<String, String>,
+        body: Map<String, String>,
+        clazz: Class<T>,
+        enableCaching: Boolean = false,
+        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME
+    ) = suspendCoroutine<Response<T>> { cont ->
+        val request = WPAPIGsonRequest(Method.GET, url, params, body, clazz, Listener {
+            response -> cont.resume(Success(response))
+        }, BaseErrorListener {
+            error -> cont.resume(Response.Error(error))
+        })
+        if (enableCaching) {
+            request.enableCaching(cacheTimeToLive)
+        }
+
+        restClient.add(request)
+    }
+
+    sealed class Response<T> {
+        data class Success<T>(val data: T) : Response<T>()
+        data class Error<T>(val error: BaseNetworkError) : Response<T>()
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.reactnative
+package org.wordpress.android.fluxc.network.rest.wpapi.reactnative
 
 import com.android.volley.RequestQueue
 import com.google.gson.JsonElement

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPAPIRestClient.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.reactnative
+
+import com.android.volley.RequestQueue
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder.Response.Error as Error
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class ReactNativeWPAPIRestClient @Inject constructor(
+    private val wpapiGsonRequestBuilder: WPAPIGsonRequestBuilder,
+    dispatcher: Dispatcher,
+    @Named("regular") requestQueue: RequestQueue,
+    userAgent: UserAgent
+) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
+    suspend fun fetch(
+        url: String,
+        params: Map<String, String>,
+        successHandler: (data: JsonElement) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse
+    ): ReactNativeFetchResponse {
+        val response =
+                wpapiGsonRequestBuilder.syncGetRequest(this, url, params, emptyMap(), JsonElement::class.java, true)
+        return when (response) {
+            is Success -> successHandler(response.data)
+            is Error -> errorHandler(response.error)
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.reactnative
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error as Error
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class ReactNativeWPComRestClient @Inject constructor(
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    dispatcher: Dispatcher,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetch(
+        url: String,
+        params: Map<String, String>,
+        successHandler: (data: JsonElement) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse
+    ): ReactNativeFetchResponse {
+        val response =
+                wpComGsonRequestBuilder.syncGetRequest(this, url, params, JsonElement::class.java, true)
+        return when (response) {
+            is Success -> successHandler(response.data)
+            is Error -> errorHandler(response.error)
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.fluxc.store
+
+import com.google.gson.JsonElement
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.reactnative.ReactNativeWPAPIRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.reactnative.ReactNativeWPComRestClient
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
+import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * This store is for use making calls that originate from React Native. It does not use
+ * a higher-level api for the requests and responses because of the unique requirements
+ * around React Native. Calls originating from native code should not use this class.
+ */
+@Singleton
+class ReactNativeStore
+@Inject constructor(
+    private val wpComRestClient: ReactNativeWPComRestClient,
+    private val wpAPIRestClient: ReactNativeWPAPIRestClient,
+    private val coroutineContext: CoroutineContext
+) {
+    suspend fun performWPComRequest(url: String, params: Map<String, String>): ReactNativeFetchResponse =
+            withContext(coroutineContext) {
+                return@withContext wpComRestClient.fetch(url, params, ::Success, ::Error)
+            }
+
+    suspend fun performWPAPIRequest(url: String, params: Map<String, String>): ReactNativeFetchResponse =
+            withContext(coroutineContext) {
+                return@withContext wpAPIRestClient.fetch(url, params, ::Success, ::Error)
+            }
+}
+
+sealed class ReactNativeFetchResponse {
+    class Success(val result: JsonElement) : ReactNativeFetchResponse()
+    class Error(networkError: BaseNetworkError) : ReactNativeFetchResponse() {
+        val error = networkError.volleyError?.message
+                ?: (networkError as? WPComGsonNetworkError)?.apiError
+                ?: networkError.message
+                ?: "Unknown ${networkError.javaClass.simpleName}"
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -38,9 +38,20 @@ class ReactNativeStore
 sealed class ReactNativeFetchResponse {
     class Success(val result: JsonElement) : ReactNativeFetchResponse()
     class Error(networkError: BaseNetworkError) : ReactNativeFetchResponse() {
-        val error = networkError.volleyError?.message
-                ?: (networkError as? WPComGsonNetworkError)?.apiError
-                ?: networkError.message
-                ?: "Unknown ${networkError.javaClass.simpleName}"
+        val error: String
+
+        init {
+            val volleyError = networkError.volleyError?.message
+            val wpComError = (networkError as? WPComGsonNetworkError)?.apiError
+            val baseError = networkError.message
+            val errorType = networkError.type?.toString()
+            error = when {
+                volleyError?.isNotBlank() == true -> volleyError
+                wpComError?.isNotBlank() == true -> wpComError
+                baseError?.isNotBlank() == true -> baseError
+                errorType?.isNotBlank() == true -> errorType
+                else -> "Unknown ${networkError.javaClass.simpleName} Error"
+            }
+        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -4,7 +4,7 @@ import com.google.gson.JsonElement
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
-import org.wordpress.android.fluxc.network.rest.wpcom.reactnative.ReactNativeWPAPIRestClient
+import org.wordpress.android.fluxc.network.rest.wpapi.reactnative.ReactNativeWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.reactnative.ReactNativeWPComRestClient
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error


### PR DESCRIPTION
## Summary 
This adds a `ReactNativeStore` class for purposes of taking a given `String` path that is provided from javascript, and performing an api call to that path. 

This is most likely going to be a temporary measure and it obviously goes against the point of FluxC providing a well-typed higher-level interface for api calls. For that reason, this new functionality should most likely never be used outside the context of React Native. I have given these classes React-Native-specific names in order to help avoid any temptation there might be to use this class for calls originating from native code.

Note that these calls do have caching enabled (last boolean parameter passed to the request builder methods), as requested by @hypest . I am a bit concerned about this because it could lead to a user making changes on the web side that are not reflected locally. Admittedly, this may not be much of an issue with the available image sizes since the creation of the different image size urls is not a user-directed activity. Currently the cache is set to the default time of 1 hour. Perhaps we should lower this time for these calls?

Related WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10779

## TODO
- [X] Tests added, so marking this as ready for review. ~Keeping this PR in draft state at this time until I get some integration tests added.~