### PR TITLE
Issue/1425 wc remove product image

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -450,7 +450,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertEquals(rowsAffected, 1)
 
         // update the product's images with our test list
-        rowsAffected = ProductSqlUtils.updateProductImages(siteModel, productTest, generateTestImageList())
+        rowsAffected = ProductSqlUtils.updateProductImages(productTest, generateTestImageList())
         assertEquals(rowsAffected, 1)
 
         // make sure two images are attached to the product

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
@@ -388,13 +389,26 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         val imageList = ArrayList<WCProductImageModel>()
         with(WCProductImageModel(1)) {
             dateCreated = DateUtils.getCurrentDateString()
+            alt = ""
+            src = ""
+            name = ""
             imageList.add(this)
         }
         with(WCProductImageModel(2)) {
             dateCreated = DateUtils.getCurrentDateString()
+            alt = ""
+            src = ""
+            name = ""
             imageList.add(this)
         }
         return imageList
+    }
+
+    private fun generateTestProduct(): WCProductModel {
+        return WCProductModel(1).also {
+            it.localSiteId = siteModel.id
+            it.remoteProductId = remoteProductId
+        }
     }
 
     @Test
@@ -426,6 +440,32 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertEquals(WCProductAction.UPDATED_PRODUCT_IMAGES, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteUpdateProductImagesPayload
         assertTrue(payload.isError)
+    }
+
+    @Test
+    fun testDeleteProductImageFromDb() {
+        // add our test product to the db
+        val productTest = generateTestProduct()
+        var rowsAffected = ProductSqlUtils.insertOrUpdateProduct(productTest)
+        assertEquals(rowsAffected, 1)
+
+        // update the product's images with our test list
+        rowsAffected = ProductSqlUtils.updateProductImages(siteModel, productTest, generateTestImageList())
+        assertEquals(rowsAffected, 1)
+
+        // make sure two images are attached to the product
+        val productBefore = ProductSqlUtils.getProductByRemoteId(siteModel, remoteProductId)
+        assertNotNull(productBefore)
+        assertEquals(productBefore!!.getImages().size, 2)
+
+        // remove one of the images
+        val didDelete = ProductSqlUtils.deleteProductImage(siteModel, remoteProductId, 1)
+        assertTrue(didDelete)
+
+        // now make sure only one image is attached to the product
+        val productAfter = ProductSqlUtils.getProductByRemoteId(siteModel, remoteProductId)
+        assertNotNull(productAfter)
+        assertEquals(productAfter!!.getImages().size, 1)
     }
 
     @Suppress("unused")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -270,7 +270,7 @@ object ProductSqlUtils {
         return insertOrUpdateProduct(product)
     }
 
-    fun removeProductImage(site: SiteModel, remoteProductId: Long, remoteMediaId: Long): Boolean {
+    fun deleteProductImage(site: SiteModel, remoteProductId: Long, remoteMediaId: Long): Boolean {
         val product = getProductByRemoteId(site, remoteProductId) ?: return false
 
         // build a new image list containing all the product images except the passed one

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -266,7 +266,8 @@ object ProductSqlUtils {
                 jsonImageList.add(jsonImage)
             }
         }
-        product.images = jsonImageList.asString
+        // TODO: verify this change
+        product.images = jsonImageList.toString()
         return insertOrUpdateProduct(product)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -255,7 +255,7 @@ object ProductSqlUtils {
 
     fun deleteAllProductReviews() = WellSql.delete(WCProductReviewModel::class.java).execute()
 
-    fun updateProductImages(site: SiteModel, product: WCProductModel, imageList: List<WCProductImageModel>): Int {
+    fun updateProductImages(product: WCProductModel, imageList: List<WCProductImageModel>): Int {
         val jsonImageList = JsonArray()
         imageList.forEach { image ->
             JsonObject().also { jsonImage ->
@@ -285,6 +285,6 @@ object ProductSqlUtils {
             return false
         }
 
-        return updateProductImages(site, product, imageList) > 0
+        return updateProductImages(product, imageList) > 0
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -266,7 +266,7 @@ object ProductSqlUtils {
                 jsonImageList.add(jsonImage)
             }
         }
-        // TODO: verify this change
+
         product.images = jsonImageList.toString()
         return insertOrUpdateProduct(product)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -266,8 +266,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     fun deleteAllProductReviews() = ProductSqlUtils.deleteAllProductReviews()
 
-    fun removeProductImage(site: SiteModel, remoteProductId: Long, remoteMediaId: Long) =
-            ProductSqlUtils.removeProductImage(site, remoteProductId, remoteMediaId)
+    fun deleteProductImage(site: SiteModel, remoteProductId: Long, remoteMediaId: Long) =
+            ProductSqlUtils.deleteProductImage(site, remoteProductId, remoteMediaId)
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -266,6 +266,9 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     fun deleteAllProductReviews() = ProductSqlUtils.deleteAllProductReviews()
 
+    fun removeProductImage(site: SiteModel, remoteProductId: Long, remoteMediaId: Long) =
+            ProductSqlUtils.removeProductImage(site, remoteProductId, remoteMediaId)
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? WCProductAction ?: return


### PR DESCRIPTION
Closes #1425 - adds a method to delete a single image from a product, with a related test.