### PR TITLE
Issue/1429 rename v4 stats endpoint

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/endpoints/WCWPAPIEndpointTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/endpoints/WCWPAPIEndpointTest.kt
@@ -22,6 +22,6 @@ class WCWPAPIEndpointTest {
 
     @Test
     fun testRevenueStatsUrl() {
-        assertEquals("/wc/v4/reports/revenue/stats/", WOOCOMMERCE.reports.revenue.stats.pathV4)
+        assertEquals("/wc-analytics/reports/revenue/stats/", WOOCOMMERCE.reports.revenue.stats.pathV4Analytics)
     }
 }

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -7,6 +7,8 @@ public class WCWPAPIEndpoint {
 
     private static final String WC_PREFIX_V4 = "wc/v4";
 
+    private static final String WC_PREFIX_V4_ANALYTICS = "wc-analytics";
+
     private final String mEndpoint;
 
     public WCWPAPIEndpoint(String endpoint) {
@@ -35,5 +37,9 @@ public class WCWPAPIEndpoint {
 
     public String getPathV4() {
         return "/" + WC_PREFIX_V4 + mEndpoint;
+    }
+
+    public String getPathV4Analytics() {
+        return "/" + WC_PREFIX_V4_ANALYTICS + mEndpoint;
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -181,7 +181,7 @@ class OrderStatsRestClient(
         perPage: Int,
         force: Boolean = false
     ) {
-        val url = WOOCOMMERCE.reports.revenue.stats.pathV4
+        val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
         val responseType = object : TypeToken<RevenueStatsApiResponse>() {}.type
         val params = mapOf(
                 "interval" to OrderStatsApiUnit.convertToRevenueStatsInterval(granularity).toString(),
@@ -237,7 +237,7 @@ class OrderStatsRestClient(
      * The _fields param is added to retrieve only the `Totals` field from the api
      */
     fun fetchRevenueStatsAvailability(site: SiteModel, startDate: String) {
-        val url = WOOCOMMERCE.reports.revenue.stats.pathV4
+        val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
         val responseType = object : TypeToken<RevenueStatsApiResponse>() {}.type
         val params = mapOf(
                 "interval" to OrderStatsApiUnit.YEAR.toString(),


### PR DESCRIPTION
Fixes #1429. In this [wc-admin PR](https://github.com/woocommerce/woocommerce-admin/pull/3204), the namespace was moved from the `wc/v4` API namespace to `wc-analytics`.

This PR adds the new endpoint (`wc-analytics`) specifically for v4 stats only while keeping the existing `wc/v4` endpoint for future use.  

#### Testing:
- In the example app, click on `Woo` -> `Revenue Stats`.
- Select a site without `wc-admin` version and click on `Fetch Revenue Stats Availability`. Verify that the response returned is false.
- Select a site with `wc-admin` less than v0.22 and click on `Fetch Revenue Stats Availability`. Verify that the response returned is false.
- Select a site with `wc-admin` v0.22 and click on `Fetch Revenue Stats Availability`. Verify that the response returned is true.

<img width="300" src="https://user-images.githubusercontent.com/22608780/69118364-428d3780-0ab9-11ea-8804-4ed91782a028.png">

