### PR TITLE
Woo: add methods to update a product

### DIFF
--- a/example/src/androidTest/resources/wc-fetch-product-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-success.json
@@ -68,7 +68,7 @@
     "date_on_sale_to_gmt": null,
     "default_attributes": [
     ],
-    "description": "",
+    "description": "Testing product description update",
     "dimensions": {
       "height": "1",
       "length": "2",

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
+import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
@@ -70,6 +71,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooProductsFragmentInjector(): WooProductsFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooUpdateProductFragmentInjector(): WooUpdateProductFragment
 
     @ContributesAndroidInjector
     abstract fun provideWooOrdersFragmentInjector(): WooOrdersFragment

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_R
 import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
@@ -179,7 +180,7 @@ class WooProductsFragment : Fragment() {
         }
 
         update_product.setOnClickListener {
-            // TODO: redirect to a new screen that includes updates to product description, title, sku etc
+            replaceFragment(WooUpdateProductFragment.newInstance(selectedPos))
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -177,6 +177,10 @@ class WooProductsFragment : Fragment() {
                 }
             }
         }
+
+        update_product.setOnClickListener {
+            // TODO: redirect to a new screen that includes updates to product description, title, sku etc
+        }
     }
 
     /**

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -1,0 +1,126 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_update_product.*
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductUpdated
+import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class WooUpdateProductFragment : Fragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var wcProductStore: WCProductStore
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    private var selectedSitePosition: Int = -1
+    private var selectedProductModel: WCProductModel? = null
+
+    companion object {
+        const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
+
+        fun newInstance(selectedSitePosition: Int): WooUpdateProductFragment {
+            val fragment = WooUpdateProductFragment()
+            val args = Bundle()
+            args.putInt(ARG_SELECTED_SITE_POS, selectedSitePosition)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        arguments?.let {
+            selectedSitePosition = it.getInt(ARG_SELECTED_SITE_POS, 0)
+        }
+    }
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(layout.fragment_woo_update_product, container, false)
+
+    override fun onStart() {
+        super.onStart()
+        dispatcher.register(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        dispatcher.unregister(this)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        product_enter_product_id.setOnClickListener {
+            showSingleLineDialog(activity, "Enter the remoteProductId of product to fetch:") { editText ->
+                val selectedRemoteProductId = editText.text.toString().toLongOrNull()
+                selectedRemoteProductId?.let { id ->
+                    updateSelectedProductId(id)
+                    enableProductDependentButtons()
+                    product_entered_product_id.text = editText.text.toString()
+                } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+            }
+        }
+
+        update_product_description.setOnClickListener {
+            getWCSite()?.let { site ->
+                showSingleLineDialog(activity, "Enter product description:") { editText ->
+                    selectedProductModel?.let { productModel ->
+                        productModel.description = editText.text.toString()
+                        val payload = UpdateProductPayload(site, productModel)
+                        dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
+                    } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+                }
+            }
+        }
+    }
+
+    private fun updateSelectedProductId(remoteProductId: Long) {
+        getWCSite()?.let {
+            selectedProductModel = wcProductStore.getProductByRemoteId(it, remoteProductId)
+                    ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
+        } ?: prependToLog("No valid site found...doing nothing")
+    }
+
+    private fun getWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(selectedSitePosition)
+
+    private fun enableProductDependentButtons() {
+        for (i in 0 until buttonContainer.childCount) {
+            val child = buttonContainer.getChildAt(i)
+            if (child is Button) {
+                child.isEnabled = true
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductUpdated(event: OnProductUpdated) {
+        if (event.isError) {
+            prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
+            return
+        }
+        prependToLog("Product updated ${event.rowsAffected}")
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductUpdated
@@ -88,8 +89,29 @@ class WooUpdateProductFragment : Fragment() {
                 showSingleLineDialog(activity, "Enter product description:") { editText ->
                     selectedProductModel?.let { productModel ->
                         productModel.description = editText.text.toString()
-                        val payload = UpdateProductPayload(site, productModel)
-                        dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
+                        updateProductAction(site, productModel)
+                    } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+                }
+            }
+        }
+
+        update_product_name.setOnClickListener {
+            getWCSite()?.let { site ->
+                showSingleLineDialog(activity, "Enter product name:") { editText ->
+                    selectedProductModel?.let { productModel ->
+                        productModel.name = editText.text.toString()
+                        updateProductAction(site, productModel)
+                    } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+                }
+            }
+        }
+
+        update_product_sku.setOnClickListener {
+            getWCSite()?.let { site ->
+                showSingleLineDialog(activity, "Enter product sku:") { editText ->
+                    selectedProductModel?.let { productModel ->
+                        productModel.sku = editText.text.toString()
+                        updateProductAction(site, productModel)
                     } ?: prependToLog("No valid remoteProductId defined...doing nothing")
                 }
             }
@@ -101,6 +123,11 @@ class WooUpdateProductFragment : Fragment() {
             selectedProductModel = wcProductStore.getProductByRemoteId(it, remoteProductId)
                     ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
+    }
+
+    private fun updateProductAction(site: SiteModel, productModel: WCProductModel) {
+        val payload = UpdateProductPayload(site, productModel)
+        dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
     }
 
     private fun getWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(selectedSitePosition)

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -94,5 +94,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Update Product Images"/>
+
+        <Button
+            android:id="@+id/update_product"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update Product"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -44,5 +44,19 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Update Product Description" />
+
+        <Button
+            android:id="@+id/update_product_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update Product name" />
+
+        <Button
+            android:id="@+id/update_product_sku"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update Product sku" />
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -1,0 +1,48 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:text="Perform actions on a selected product Id:"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/product_enter_product_id"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Enter Product Id" />
+
+            <TextView
+                android:id="@+id/product_entered_product_id"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingLeft="10dp"
+                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+                android:textColor="@android:color/holo_blue_bright" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/update_product_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update Product Description" />
+    </LinearLayout>
+</ScrollView>

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -15,8 +15,10 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload;
 
 @ActionEnum
@@ -38,6 +40,8 @@ public enum WCProductAction implements IAction {
     UPDATE_PRODUCT_REVIEW_STATUS,
     @Action(payloadType = UpdateProductImagesPayload.class)
     UPDATE_PRODUCT_IMAGES,
+    @Action(payloadType = UpdateProductPayload.class)
+    UPDATE_PRODUCT,
 
     // Remote responses
     @Action(payloadType = RemoteProductPayload.class)
@@ -55,5 +59,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteProductReviewPayload.class)
     UPDATED_PRODUCT_REVIEW_STATUS,
     @Action(payloadType = RemoteUpdateProductImagesPayload.class)
-    UPDATED_PRODUCT_IMAGES
+    UPDATED_PRODUCT_IMAGES,
+    @Action(payloadType = RemoteUpdateProductPayload.class)
+    UPDATED_PRODUCT
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -221,13 +221,7 @@ class ProductRestClient(
         val remoteProductId = updatedProductModel.remoteProductId
         val url = WOOCOMMERCE.products.id(remoteProductId).pathV3
         val responseType = object : TypeToken<ProductApiResponse>() {}.type
-
-        // build json body of items to be updated to the backend
-        val body = HashMap<String, Any>()
-        body["id"] = remoteProductId
-        body["sku"] = updatedProductModel.sku
-        body["name"] = updatedProductModel.name
-        body["description"] = updatedProductModel.description
+        val body = productModelToProductJsonBody(updatedProductModel)
 
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, body, responseType,
                 { response: ProductApiResponse? ->
@@ -423,6 +417,25 @@ class ProductRestClient(
                     dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductReviewStatusAction(payload))
                 })
         add(request)
+    }
+
+    /**
+     * build json body of product items to be updated to the backend
+     */
+    private fun productModelToProductJsonBody(productModel: WCProductModel): HashMap<String, Any> {
+        val body = HashMap<String, Any>()
+        body["id"] = productModel.remoteProductId
+        if (productModel.description.isNotEmpty()) {
+            body["description"] = productModel.description
+        }
+        if (productModel.name.isNotEmpty()) {
+            body["name"] = productModel.name
+        }
+        if (productModel.sku.isNotEmpty()) {
+            body["sku"] = productModel.sku
+        }
+
+        return body
     }
 
     private fun productResponseToProductModel(response: ProductApiResponse): WCProductModel {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -82,6 +82,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var imageList: List<WCProductImageModel>
     ) : Payload<BaseNetworkError>()
 
+    class UpdateProductPayload(
+        var site: SiteModel,
+        val product: WCProductModel
+    ) : Payload<BaseNetworkError>()
+
     enum class ProductErrorType {
         INVALID_PARAM,
         INVALID_REVIEW_ID,
@@ -143,6 +148,19 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     class RemoteUpdateProductImagesPayload(
+        var site: SiteModel,
+        val product: WCProductModel
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel,
+            product: WCProductModel
+        ) : this(site, product) {
+            this.error = error
+        }
+    }
+
+    class RemoteUpdateProductPayload(
         var site: SiteModel,
         val product: WCProductModel
     ) : Payload<ProductError>() {


### PR DESCRIPTION
Fixes #1431. This PR adds the ability to update a product description, name + sku. 

### Changes
- Adds new actions for updating a product: `UPDATE_PRODUCT` and `UPDATED_PRODUCT`.
- Adds new payload classes for updating a product: `UpdateProductPayload`, `RemoteUpdateProductPayload`.
- Adds a new fragment to the example app to test updating a product description, name and sku.
- Adds new tests to `MockedStack_WCProductsTest` and `ReleaseStack_WCProductTest`.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/69239908-51f7a800-0bc1-11ea-9719-5d72489d5c2b.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/69239912-545a0200-0bc1-11ea-8ca2-36103dbc7ac5.png">
