### PR TITLE
Fix crash in PageStore - continuation already resumed

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PageStore.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType.DELETE
 import org.wordpress.android.fluxc.store.PostStore.PostError
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNKNOWN_POST
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 import org.wordpress.android.util.DateTimeUtils


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/8401

I'm not sure how to reproduce this, but the change should be easy to review. We always stored a continuation into a local variable even when we synchronously resumed it since the post wasn't found -> I believe we want to store it into a local variable only when we emit a bus event.
