### PR TITLE
issue/1438-woo-product-sorting

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -113,7 +113,7 @@ class ProductRestClient(
         val responseType = object : TypeToken<List<ProductApiResponse>>() {}.type
         val params = mutableMapOf(
                 "per_page" to pageSize.toString(),
-                "orderBy" to orderBy,
+                "orderby" to orderBy,
                 "order" to sortOrder,
                 "offset" to offset.toString(),
                 "search" to (searchQuery ?: ""))


### PR DESCRIPTION
Fixes #1438 - changes the product sorting param to "orderby". Previously we had "orderBy" (uppercase "B") which caused the products to always be returned using the default date sorting.

http://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-products