### PR TITLE
WCOrderSummaryModel records should match WCOrderModel

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderSummaryModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderSummaryModel.kt
@@ -5,8 +5,18 @@ import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.list.datasource.ListItemDataSourceInterface
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
+/**
+ * Class represents the bare minimum fields needed to determine if an order is outdated and
+ * needs to be fetched. It's also important to store this information in the database so it
+ * can be used by the order list's implementation of [ListItemDataSourceInterface] to create a list
+ * of existing orders in the [WCOrderModel] table, as well as a list of orders being fetched by the
+ * API because they do not yet exist. Normally we wouldn't need this extra step to work with the
+ * [org.wordpress.android.fluxc.store.ListStore], but since we need the `dateCreated` field to group the
+ * orders into time-based groups, this extra table is necessary.
+ */
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 @RawConstraints(
         "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -5,8 +5,6 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.WCOrderAction
-import org.wordpress.android.fluxc.action.WCOrderAction.ADD_ORDER_SHIPMENT_TRACKING
-import org.wordpress.android.fluxc.action.WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.ListActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
@@ -524,17 +522,11 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
         // - WCOrderModel
         // - WCOrderNoteModel
         // - WCOrderShipmentTrackingModel
-
         if (!payload.isError) {
-            // Purge all WCOrderSummaryModel records on first fetch
-            if (!payload.loadedMore) {
-                OrderSqlUtils.deleteOrderSummariesForSite(payload.listDescriptor.site)
-            }
-
             // Save order summaries to the db
             OrderSqlUtils.insertOrUpdateOrderSummaries(payload.orderSummaries)
 
-            // Fetch missing or outdated orders using the list of order summaries
+            // Fetch outdated orders
             fetchOutdatedOrders(payload.listDescriptor.site, payload.orderSummaries)
         }
 
@@ -756,7 +748,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
             onOrderChanged = OnOrderChanged(rowsAffected)
         }
 
-        onOrderChanged.causeOfChange = ADD_ORDER_SHIPMENT_TRACKING
+        onOrderChanged.causeOfChange = WCOrderAction.ADD_ORDER_SHIPMENT_TRACKING
         emitChange(onOrderChanged)
     }
 
@@ -771,7 +763,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
             onOrderChanged = OnOrderChanged(rowsAffected)
         }
 
-        onOrderChanged.causeOfChange = DELETE_ORDER_SHIPMENT_TRACKING
+        onOrderChanged.causeOfChange = WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING
         emitChange(onOrderChanged)
     }
 


### PR DESCRIPTION
Fixes #1440 

It took me a while but I finally figured out why we needed the `WCOrderSummaryModel` table for the order list's `ListStore` implementation. It was because we use it to get the date of orders that are being fetched so we can show the loading view for that order while it’s being fetched.  So despite what the ticket says, we will be keeping the `WCOrderSummaryModel` table.

To address the original reason for the ticket, I removed the code to delete all records in `WCOrderSummaryModelTable` before inserting the latest batch. This is to fix an issue where orders that have been downloaded and cached for a particular `ListDescriptor` on the device won't show up on the device when it's offline because it doesn't have a matching `WCOrderSummaryModel` record.

### To Test
1. Log into example app
2. Go to Woo -> Orders -> Fetch Order List
3. Verify orders load properly. 
4. Filter the order list by an order status that is known to have matching orders.
5. Put the device in Airplane Mode to set it offline.
6. Clear the filter. If the cached orders are returned, then the fix is successful.

NOTE: This only fixes displaying lists that have already been used before going offline. So if you try to filter by a different status than the one used in the test above while offline, you will get no records back - even if you know there are cached records in the db. This is because the `ListStore` keeps a list of items in a different table (`ListItemModel`) to track items downloaded for each listDescriptor. So if you filter by "processing" while online, the `ListStore` will know about the results, but if you have never filtered by "processing" on this device, then the `ListStore` will have no record of the results. This is a workaround for this bit it needs to be addressed on the `ListItemDatasourceInterface` implementation - which lives on the client. 