### PR TITLE
Woo: Update product fields

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -409,6 +409,8 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         return WCProductModel(1).also {
             it.localSiteId = siteModel.id
             it.remoteProductId = remoteProductId
+            it.name = "Product name"
+            it.sku = "34343-343776"
         }
     }
 
@@ -448,8 +450,12 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         interceptor.respondWith("wc-fetch-product-response-success.json")
 
         val testProduct = generateTestProduct()
-        testProduct.description = "Testing product description update"
-        productRestClient.updateProduct(siteModel, testProduct)
+        val updatedProduct = testProduct.copy().apply {
+            name = testProduct.name
+            sku = testProduct.sku
+            description = "Testing product description update"
+        }
+        productRestClient.updateProduct(siteModel, testProduct, updatedProduct)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -459,7 +465,9 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         with(payload) {
             assertNull(error)
             assertEquals(remoteProductId, product.remoteProductId)
-            assertEquals(testProduct.description, product.description)
+            assertEquals(updatedProduct.description, product.description)
+            assertEquals(updatedProduct.name, product.name)
+            assertEquals(updatedProduct.sku, product.sku)
         }
     }
 
@@ -467,8 +475,10 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     fun testUpdateProductFailed() {
         interceptor.respondWithError("wc-response-failure-invalid-param.json")
         val testProduct = generateTestProduct()
-        testProduct.description = "Testing product description"
-        productRestClient.updateProduct(siteModel, testProduct)
+        val updatedProduct = testProduct.copy().apply {
+            description = "Testing product description"
+        }
+        productRestClient.updateProduct(siteModel, testProduct, updatedProduct)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/androidTest/resources/wc-fetch-product-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-success.json
@@ -170,7 +170,7 @@
         "value": "no"
       }
     ],
-    "name": "Stranger Things T-Shirt (Product Add-On - Text Field)",
+    "name": "Product name",
     "on_sale": false,
     "parent_id": 0,
     "permalink": "https://jamosova3.mystagingwebsite.com/product/stranger-things-t-shirt-product-add-on-text-field/",

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/FloatingLabelEditText.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/FloatingLabelEditText.kt
@@ -31,7 +31,7 @@ class FloatingLabelEditText@JvmOverloads constructor(ctx: Context, attrs: Attrib
     }
 
     fun setText(text: String) {
-        edit_text.setText(text)
+        edit_text.post { edit_text.setText(text) }
     }
 
     override fun setEnabled(isEnabled: Boolean) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/FloatingLabelEditText.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/FloatingLabelEditText.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.fluxc.example.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.constraintlayout.widget.ConstraintLayout
+import kotlinx.android.synthetic.main.view_floating_edittext.view.*
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.utils.onTextChanged
+
+class FloatingLabelEditText@JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null) : ConstraintLayout(
+        ctx,
+        attrs
+) {
+    init {
+        View.inflate(context, R.layout.view_floating_edittext, this)
+        attrs?.let {
+            val attrArray = context.obtainStyledAttributes(it, R.styleable.FloatingLabelEditText)
+            try {
+                val hintText = attrArray.getString(R.styleable.FloatingLabelEditText_textHint).orEmpty()
+                txt_hint.text = hintText
+                edit_text.hint = hintText
+            } finally {
+                attrArray.recycle()
+            }
+        }
+    }
+
+    fun onTextChanged(cb: (String) -> Unit) {
+        edit_text.onTextChanged(cb)
+    }
+
+    fun setText(text: String) {
+        edit_text.setText(text)
+    }
+
+    override fun setEnabled(isEnabled: Boolean) {
+        edit_text.isEnabled = isEnabled
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/ListSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/ListSelectorDialog.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.fluxc.example.ui
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.fragment.app.DialogFragment
+
+class ListSelectorDialog : DialogFragment() {
+    companion object {
+        @JvmStatic
+        fun newInstance(listItems: List<String>, listener: Listener) = ListSelectorDialog().apply {
+            this.listener = listener
+            this.listItems = listItems
+        }
+    }
+
+    interface Listener {
+        fun onListItemSelected(selectedItem: String?)
+    }
+
+    var listener: Listener? = null
+    var listItems: List<String>? = null
+
+    override fun onResume() {
+        super.onResume()
+        dialog.window?.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return activity?.let {
+            val builder = AlertDialog.Builder(it)
+            builder.setTitle("Select a list item")
+                    .setSingleChoiceItems(listItems?.toTypedArray(), 0) { dialog, which ->
+                        listener?.onListItemSelected(listItems?.get(which))
+                        dialog.dismiss()
+                    }
+            builder.create()
+        } ?: throw IllegalStateException("Activity cannot be null")
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -17,9 +17,9 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Listener
-import org.wordpress.android.fluxc.example.utils.onTextChanged
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.WCProductModel
@@ -116,7 +116,7 @@ class WooUpdateProductFragment : Fragment() {
             selectedProductModel?.manageStock = isChecked
             for (i in 0 until manageStockContainer.childCount) {
                 val child = manageStockContainer.getChildAt(i)
-                if (child is Button || child is EditText) {
+                if (child is Button || child is FloatingLabelEditText) {
                     child.isEnabled = isChecked
                 }
             }
@@ -202,6 +202,7 @@ class WooUpdateProductFragment : Fragment() {
                 product_stock_status.text = it.stockStatus
                 product_back_orders.text = it.backorders
                 product_stock_quantity.setText(it.stockQuantity.toString())
+                product_stock_quantity.isEnabled = product_manage_stock.isChecked
             } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -156,14 +156,14 @@ class WooUpdateProductFragment : Fragment() {
         }
 
         product_from_date.setOnClickListener {
-            showDatePickerDialog(selectedProductModel?.dateOnSaleFrom, OnDateSetListener { _, year, month, dayOfMonth ->
+            showDatePickerDialog(product_from_date.text.toString(), OnDateSetListener { _, year, month, dayOfMonth ->
                 product_from_date.text = DateUtils.getFormattedDateString(year, month, dayOfMonth)
                 selectedProductModel?.dateOnSaleFrom = product_from_date.text.toString()
             })
         }
 
         product_to_date.setOnClickListener {
-            showDatePickerDialog(selectedProductModel?.dateOnSaleTo, OnDateSetListener { _, year, month, dayOfMonth ->
+            showDatePickerDialog(product_to_date.text.toString(), OnDateSetListener { _, year, month, dayOfMonth ->
                 product_to_date.text = DateUtils.getFormattedDateString(year, month, dayOfMonth)
                 selectedProductModel?.dateOnSaleTo = product_to_date.text.toString()
             })
@@ -196,8 +196,8 @@ class WooUpdateProductFragment : Fragment() {
                 product_weight.setText(it.weight)
                 product_tax_status.text = it.taxStatus
                 product_sold_individually.isChecked = it.soldIndividually
-                product_from_date.text = it.dateOnSaleFrom
-                product_to_date.text = it.dateOnSaleTo
+                product_from_date.text = it.dateOnSaleFrom.split('T')[0]
+                product_to_date.text = it.dateOnSaleTo.split('T')[0]
                 product_manage_stock.isChecked = it.manageStock
                 product_stock_status.text = it.stockStatus
                 product_back_orders.text = it.backorders

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -1,11 +1,14 @@
 package org.wordpress.android.fluxc.example.ui.products
 
+import android.app.DatePickerDialog
+import android.app.DatePickerDialog.OnDateSetListener
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.EditText
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_update_product.*
@@ -14,14 +17,21 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Listener
+import org.wordpress.android.fluxc.example.utils.onTextChanged
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductBackOrders
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductTaxStatus
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductUpdated
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.DateUtils
+import java.util.Calendar
 import javax.inject.Inject
 
 class WooUpdateProductFragment : Fragment() {
@@ -84,58 +94,141 @@ class WooUpdateProductFragment : Fragment() {
             }
         }
 
-        update_product_description.setOnClickListener {
-            getWCSite()?.let { site ->
-                showSingleLineDialog(activity, "Enter product description:") { editText ->
-                    selectedProductModel?.let { productModel ->
-                        productModel.description = editText.text.toString()
-                        updateProductAction(site, productModel)
-                    } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+        product_name.onTextChanged { selectedProductModel?.name = it }
+        product_description.onTextChanged { selectedProductModel?.description = it }
+        product_sku.onTextChanged { selectedProductModel?.sku = it }
+        product_short_desc.onTextChanged { selectedProductModel?.shortDescription = it }
+        product_regular_price.onTextChanged { selectedProductModel?.regularPrice = it }
+        product_sale_price.onTextChanged { selectedProductModel?.salePrice = it }
+        product_width.onTextChanged { selectedProductModel?.width = it }
+        product_height.onTextChanged { selectedProductModel?.height = it }
+        product_length.onTextChanged { selectedProductModel?.length = it }
+        product_weight.onTextChanged { selectedProductModel?.weight = it }
+        product_stock_quantity.onTextChanged {
+            if (it.isNotEmpty()) { selectedProductModel?.stockQuantity = it.toInt() }
+        }
+
+        product_sold_individually.setOnCheckedChangeListener { _, isChecked ->
+            selectedProductModel?.soldIndividually = isChecked
+        }
+
+        product_manage_stock.setOnCheckedChangeListener { _, isChecked ->
+            selectedProductModel?.manageStock = isChecked
+            for (i in 0 until manageStockContainer.childCount) {
+                val child = manageStockContainer.getChildAt(i)
+                if (child is Button || child is EditText) {
+                    child.isEnabled = isChecked
                 }
             }
         }
 
-        update_product_name.setOnClickListener {
-            getWCSite()?.let { site ->
-                showSingleLineDialog(activity, "Enter product name:") { editText ->
-                    selectedProductModel?.let { productModel ->
-                        productModel.name = editText.text.toString()
-                        updateProductAction(site, productModel)
-                    } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+        product_tax_status.setOnClickListener {
+            showListSelectorDialog(CoreProductTaxStatus.values().map { it.value }.toList(), object : Listener {
+                override fun onListItemSelected(selectedItem: String?) {
+                    selectedItem?.let {
+                        product_tax_status.text = it
+                        selectedProductModel?.taxStatus = it
+                    }
                 }
-            }
+            })
         }
 
-        update_product_sku.setOnClickListener {
-            getWCSite()?.let { site ->
-                showSingleLineDialog(activity, "Enter product sku:") { editText ->
-                    selectedProductModel?.let { productModel ->
-                        productModel.sku = editText.text.toString()
-                        updateProductAction(site, productModel)
-                    } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+        product_stock_status.setOnClickListener {
+            showListSelectorDialog(CoreProductStockStatus.values().map { it.value }.toList(), object : Listener {
+                override fun onListItemSelected(selectedItem: String?) {
+                    selectedItem?.let {
+                        product_stock_status.text = it
+                        selectedProductModel?.stockStatus = it
+                    }
                 }
-            }
+            })
+        }
+
+        product_back_orders.setOnClickListener {
+            showListSelectorDialog(CoreProductBackOrders.values().map { it.value }.toList(), object : Listener {
+                override fun onListItemSelected(selectedItem: String?) {
+                    selectedItem?.let {
+                        product_back_orders.text = it
+                        selectedProductModel?.backorders = it
+                    }
+                }
+            })
+        }
+
+        product_from_date.setOnClickListener {
+            showDatePickerDialog(selectedProductModel?.dateOnSaleFrom, OnDateSetListener { _, year, month, dayOfMonth ->
+                product_from_date.text = DateUtils.getFormattedDateString(year, month, dayOfMonth)
+                selectedProductModel?.dateOnSaleFrom = product_from_date.text.toString()
+            })
+        }
+
+        product_to_date.setOnClickListener {
+            showDatePickerDialog(selectedProductModel?.dateOnSaleTo, OnDateSetListener { _, year, month, dayOfMonth ->
+                product_to_date.text = DateUtils.getFormattedDateString(year, month, dayOfMonth)
+                selectedProductModel?.dateOnSaleTo = product_to_date.text.toString()
+            })
+        }
+
+        product_update.setOnClickListener {
+            getWCSite()?.let { site ->
+                if (selectedProductModel?.remoteProductId != null) {
+                    val payload = UpdateProductPayload(site, selectedProductModel!!)
+                    dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
+                } else {
+                    prependToLog("No valid remoteProductId defined...doing nothing")
+                }
+            } ?: prependToLog("No site found...doing nothing")
         }
     }
 
     private fun updateSelectedProductId(remoteProductId: Long) {
-        getWCSite()?.let {
-            selectedProductModel = wcProductStore.getProductByRemoteId(it, remoteProductId)
-                    ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
+        getWCSite()?.let { siteModel ->
+            selectedProductModel = wcProductStore.getProductByRemoteId(siteModel, remoteProductId)?.also {
+                product_name.setText(it.name)
+                product_description.setText(it.description)
+                product_sku.setText(it.sku)
+                product_short_desc.setText(it.shortDescription)
+                product_regular_price.setText(it.regularPrice)
+                product_sale_price.setText(it.salePrice)
+                product_width.setText(it.width)
+                product_height.setText(it.height)
+                product_length.setText(it.length)
+                product_weight.setText(it.weight)
+                product_tax_status.text = it.taxStatus
+                product_sold_individually.isChecked = it.soldIndividually
+                product_from_date.text = it.dateOnSaleFrom
+                product_to_date.text = it.dateOnSaleTo
+                product_manage_stock.isChecked = it.manageStock
+                product_stock_status.text = it.stockStatus
+                product_back_orders.text = it.backorders
+                product_stock_quantity.setText(it.stockQuantity.toString())
+            } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
     }
 
-    private fun updateProductAction(site: SiteModel, productModel: WCProductModel) {
-        val payload = UpdateProductPayload(site, productModel)
-        dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
+    private fun showListSelectorDialog(listItems: List<String>, listener: Listener) {
+        fragmentManager?.let { fm ->
+            val dialog = ListSelectorDialog.newInstance(listItems, listener)
+            dialog.show(fm, "ListSelectorDialog")
+        }
+    }
+
+    private fun showDatePickerDialog(dateString: String?, listener: OnDateSetListener) {
+        val date = if (dateString.isNullOrEmpty()) {
+            DateUtils.getCurrentDateString()
+        } else dateString
+        val calendar = DateUtils.getCalendarInstance(date)
+        DatePickerDialog(requireActivity(), listener, calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH), calendar.get(Calendar.DATE))
+                .show()
     }
 
     private fun getWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(selectedSitePosition)
 
     private fun enableProductDependentButtons() {
-        for (i in 0 until buttonContainer.childCount) {
-            val child = buttonContainer.getChildAt(i)
-            if (child is Button) {
+        for (i in 0 until productContainer.childCount) {
+            val child = productContainer.getChildAt(i)
+            if (child is Button || child is EditText) {
                 child.isEnabled = true
             }
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/EditTextExt.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/EditTextExt.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.fluxc.example.utils
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.EditText
+
+fun EditText.onTextChanged(cb: (String) -> Unit) {
+    this.addTextChangedListener(object : TextWatcher {
+        override fun afterTextChanged(s: Editable?) { cb(s.toString()) }
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+    })
+}

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -61,80 +61,80 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/product_enter_product_id">
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:hint="Product name"
+            app:textHint="Product name"
             android:inputType="text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_description"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:hint="Product description"
+            app:textHint="Product description"
             android:inputType="textMultiLine"
             android:lines="2"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_name" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_sku"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:hint="Product SKU"
+            app:textHint="Product SKU"
             android:inputType="text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_description" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_short_desc"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:hint="Short description"
+            app:textHint="Short description"
             android:inputType="text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_sku" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_regular_price"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="10dp"
             android:layout_marginRight="10dp"
             android:enabled="false"
-            android:hint="Regular price"
+            app:textHint="Regular price"
             android:inputType="numberDecimal"
             app:layout_constraintEnd_toStartOf="@+id/product_sale_price"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_short_desc" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_sale_price"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
             android:layout_marginLeft="10dp"
             android:enabled="false"
-            android:hint="Sale price"
+            app:textHint="Sale price"
             android:inputType="numberDecimal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toEndOf="@+id/product_regular_price"
             app:layout_constraintTop_toBottomOf="@+id/product_short_desc" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_width"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -142,14 +142,14 @@
             android:layout_marginEnd="10dp"
             android:layout_marginRight="10dp"
             android:enabled="false"
-            android:hint="Product Width"
+            app:textHint="Product Width"
             android:inputType="numberDecimal"
             app:layout_constraintEnd_toStartOf="@+id/product_height"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_height"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -157,14 +157,14 @@
             android:layout_marginLeft="10dp"
             android:layout_marginTop="4dp"
             android:enabled="false"
-            android:hint="Product Height"
+            app:textHint="Product Height"
             android:inputType="numberDecimal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toEndOf="@+id/product_width"
             app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_length"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -172,14 +172,14 @@
             android:layout_marginEnd="10dp"
             android:layout_marginRight="10dp"
             android:enabled="false"
-            android:hint="Product Width"
+            app:textHint="Product Width"
             android:inputType="numberDecimal"
             app:layout_constraintEnd_toStartOf="@+id/product_weight"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_width" />
 
-        <EditText
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_weight"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -187,7 +187,7 @@
             android:layout_marginLeft="10dp"
             android:layout_marginTop="4dp"
             android:enabled="false"
-            android:hint="Product Height"
+            app:textHint="Product Height"
             android:inputType="numberDecimal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
@@ -297,12 +297,12 @@
                 app:layout_constraintStart_toEndOf="@+id/product_stock_status"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <EditText
+            <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
                 android:id="@+id/product_stock_quantity"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:enabled="false"
-                android:hint="Stock quantity"
+                app:textHint="Stock quantity"
                 android:inputType="number"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -1,62 +1,314 @@
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment">
+    android:padding="12dp"
+    tools:context="org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment"
+    tools:ignore="HardcodedText">
 
-    <LinearLayout
-        android:id="@+id/buttonContainer"
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Perform actions on a selected product Id:"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/product_enter_product_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Enter Product Id"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+    <TextView
+        android:id="@+id/product_entered_product_id"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="12dp"
+        android:gravity="center"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        android:textColor="@android:color/holo_blue_bright"
+        app:layout_constraintStart_toEndOf="@+id/product_enter_product_id"
+        app:layout_constraintTop_toBottomOf="@+id/textView"
+        tools:text="79" />
+
+    <ImageButton
+        android:id="@+id/product_update"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:clickable="false"
+        android:focusable="false"
+        android:src="@drawable/ic_check"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/productContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_marginTop="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/product_enter_product_id">
+
+        <EditText
+            android:id="@+id/product_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:hint="Product name"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <EditText
+            android:id="@+id/product_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:hint="Product description"
+            android:inputType="textMultiLine"
+            android:lines="2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_name" />
+
+        <EditText
+            android:id="@+id/product_sku"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:hint="Product SKU"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_description" />
+
+        <EditText
+            android:id="@+id/product_short_desc"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:hint="Short description"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_sku" />
+
+        <EditText
+            android:id="@+id/product_regular_price"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
+            android:layout_marginRight="10dp"
+            android:enabled="false"
+            android:hint="Regular price"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toStartOf="@+id/product_sale_price"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_short_desc" />
+
+        <EditText
+            android:id="@+id/product_sale_price"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginLeft="10dp"
+            android:enabled="false"
+            android:hint="Sale price"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_regular_price"
+            app:layout_constraintTop_toBottomOf="@+id/product_short_desc" />
+
+        <EditText
+            android:id="@+id/product_width"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="10dp"
+            android:layout_marginRight="10dp"
+            android:enabled="false"
+            android:hint="Product Width"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toStartOf="@+id/product_height"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
+
+        <EditText
+            android:id="@+id/product_height"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:hint="Product Height"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_width"
+            app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
+
+        <EditText
+            android:id="@+id/product_length"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="10dp"
+            android:layout_marginRight="10dp"
+            android:enabled="false"
+            android:hint="Product Width"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toStartOf="@+id/product_weight"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_width" />
+
+        <EditText
+            android:id="@+id/product_weight"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:hint="Product Height"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_length"
+            app:layout_constraintTop_toBottomOf="@+id/product_width" />
+
+        <Button
+            android:id="@+id/product_tax_status"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Tax Status"
+            app:layout_constraintEnd_toStartOf="@+id/product_sold_individually"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_length" />
+
+        <CheckBox
+            android:id="@+id/product_sold_individually"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:enabled="false"
+            android:text="Sold Individually"
+            app:layout_constraintEnd_toEndOf="@+id/product_weight"
+            app:layout_constraintStart_toStartOf="@+id/product_weight"
+            app:layout_constraintTop_toBottomOf="@+id/product_weight" />
 
         <TextView
+            android:id="@+id/product_schedule_sale"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Perform actions on a selected product Id:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
+            android:layout_marginTop="10dp"
+            android:text="Schedule Sale"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_tax_status" />
 
-        <LinearLayout
+        <Button
+            android:id="@+id/product_from_date"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Start Date"
+            app:layout_constraintEnd_toStartOf="@+id/product_to_date"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_schedule_sale" />
+
+        <Button
+            android:id="@+id/product_to_date"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="End Date"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_from_date"
+            app:layout_constraintTop_toBottomOf="@+id/product_schedule_sale" />
+
+        <Switch
+            android:id="@+id/product_manage_stock"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:enabled="false"
+            android:text="Manage Stock"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_from_date" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/manageStockContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_manage_stock">
 
             <Button
-                android:id="@+id/product_enter_product_id"
-                android:layout_width="wrap_content"
+                android:id="@+id/product_stock_status"
+                style="?android:attr/spinnerStyle"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="Enter Product Id" />
+                android:layout_marginTop="4dp"
+                android:enabled="false"
+                android:text="Stock Status"
+                app:layout_constraintEnd_toStartOf="@+id/product_back_orders"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/product_entered_product_id"
-                android:layout_width="wrap_content"
+            <Button
+                android:id="@+id/product_back_orders"
+                style="?android:attr/spinnerStyle"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:paddingStart="10dp"
-                android:paddingLeft="10dp"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright" />
-        </LinearLayout>
+                android:layout_marginTop="4dp"
+                android:enabled="false"
+                android:text="Allow Back Orders"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toEndOf="@+id/product_stock_status"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <Button
-            android:id="@+id/update_product_description"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:enabled="false"
-            android:text="Update Product Description" />
+            <EditText
+                android:id="@+id/product_stock_quantity"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:hint="Stock quantity"
+                android:inputType="number"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/product_stock_status" />
 
-        <Button
-            android:id="@+id/update_product_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:enabled="false"
-            android:text="Update Product name" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <Button
-            android:id="@+id/update_product_sku"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:enabled="false"
-            android:text="Update Product sku" />
-    </LinearLayout>
-</ScrollView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/layout/view_floating_edittext.xml
+++ b/example/src/main/res/layout/view_floating_edittext.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/txt_hint"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <EditText
+        android:id="@+id/edit_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txt_hint"
+        tools:ignore="LabelFor,TextFields" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/values/attrs.xml
+++ b/example/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="FloatingLabelEditText">
+        <attr name="textHint" format="string" />
+    </declare-styleable>
+</resources>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 92
+        return 93
     }
 
     override fun getDbName(): String {
@@ -1016,6 +1016,10 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 91 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCOrderModel ADD SHIPPING_LINES TEXT NULL")
+                }
+                92 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_FROM TEXT")
+                    db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_TO TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -43,6 +43,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var salePrice = ""
     @Column var onSale = false
     @Column var totalSales = 0
+    @Column var dateOnSaleFrom = ""
+    @Column var dateOnSaleTo = ""
 
     @Column var virtual = false
     @Column var downloadable = false

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductBackOrders.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductBackOrders.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+/**
+ * Standard Core WooCommerce product back order options
+ */
+enum class CoreProductBackOrders(val value: String) {
+    NO("no"),
+    NOTIFY("notify"),
+    YES("yes");
+
+    companion object {
+        private val valueMap = values().associateBy(CoreProductBackOrders::value)
+
+        /**
+         * Convert the base value into the associated CoreProductBackOrders object
+         */
+        fun fromValue(value: String) = valueMap[value]
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+/**
+ * Standard Core WooCommerce product stock statuses
+ */
+enum class CoreProductStockStatus(val value: String) {
+    IN_STOCK("instock"),
+    OUT_OF_STOCK("outofstock"),
+    ON_BACK_ORDER("onbackorder");
+
+    companion object {
+        private val valueMap = values().associateBy(CoreProductStockStatus::value)
+
+        /**
+         * Convert the base value into the associated CoreProductStockStatus object
+         */
+        fun fromValue(value: String) = valueMap[value]
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductTaxStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductTaxStatus.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+/**
+ * Standard Core WooCommerce product tax statuses
+ */
+enum class CoreProductTaxStatus(val value: String) {
+    TAXABLE("taxable"),
+    SHIPPING("shipping"),
+    NONE("none");
+
+    companion object {
+        private val valueMap = values().associateBy(CoreProductTaxStatus::value)
+
+        /**
+         * Convert the base value into the associated CoreProductTaxStatus object
+         */
+        fun fromValue(value: String) = valueMap[value]
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -40,6 +40,8 @@ class ProductApiResponse : Response {
     var manage_stock: String? = null
     var stock_quantity = 0
     var stock_status: String? = null
+    var date_on_sale_from: String? = null
+    var date_on_sale_to: String? = null
 
     var backorders: String? = null
     var backorders_allowed = false

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -535,6 +535,8 @@ class ProductRestClient(
 
             dateCreated = response.date_created ?: ""
             dateModified = response.date_modified ?: ""
+            dateOnSaleFrom = response.date_on_sale_from ?: ""
+            dateOnSaleTo = response.date_on_sale_to ?: ""
 
             type = response.type ?: ""
             status = response.status ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -228,15 +228,6 @@ class ProductRestClient(
         val responseType = object : TypeToken<ProductApiResponse>() {}.type
         val body = productModelToProductJsonBody(storedWCProductModel, updatedProductModel)
 
-        if (body.isEmpty()) {
-            val payload = RemoteUpdateProductPayload(
-                    ProductError(ProductErrorType.EMPTY_REQUEST_BODY, "No updates found!"),
-                    site, WCProductModel().apply { this.remoteProductId = remoteProductId }
-            )
-            dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductAction(payload))
-            return
-        }
-
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, body, responseType,
                 { response: ProductApiResponse? ->
                     response?.let {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -650,6 +650,7 @@ class ProductRestClient(
             "rest_invalid_param" -> ProductErrorType.INVALID_PARAM
             "woocommerce_rest_review_invalid_id" -> ProductErrorType.INVALID_REVIEW_ID
             "woocommerce_product_invalid_image_id" -> ProductErrorType.INVALID_IMAGE_ID
+            "product_invalid_sku" -> ProductErrorType.DUPLICATE_SKU
             else -> ProductErrorType.fromString(wpComError.apiError)
         }
         return ProductError(productErrorType, wpComError.message)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -215,13 +215,18 @@ class ProductRestClient(
      * Dispatches a WCProductAction.UPDATED_PRODUCT action with the result
      *
      * @param [site] The site to fetch product reviews for
+     * @param [storedWCProductModel] the stored model to compare with the [updatedProductModel]
      * @param [updatedProductModel] the product model that contains the update
      */
-    fun updateProduct(site: SiteModel, updatedProductModel: WCProductModel) {
+    fun updateProduct(
+        site: SiteModel,
+        storedWCProductModel: WCProductModel?,
+        updatedProductModel: WCProductModel
+    ) {
         val remoteProductId = updatedProductModel.remoteProductId
         val url = WOOCOMMERCE.products.id(remoteProductId).pathV3
         val responseType = object : TypeToken<ProductApiResponse>() {}.type
-        val body = productModelToProductJsonBody(updatedProductModel)
+        val body = productModelToProductJsonBody(storedWCProductModel, updatedProductModel)
 
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, body, responseType,
                 { response: ProductApiResponse? ->
@@ -422,17 +427,82 @@ class ProductRestClient(
     /**
      * build json body of product items to be updated to the backend
      */
-    private fun productModelToProductJsonBody(productModel: WCProductModel): HashMap<String, Any> {
+    private fun productModelToProductJsonBody(
+        storedWCProductModel: WCProductModel?,
+        updatedProductModel: WCProductModel
+    ): HashMap<String, Any> {
         val body = HashMap<String, Any>()
-        body["id"] = productModel.remoteProductId
-        if (productModel.description.isNotEmpty()) {
-            body["description"] = productModel.description
+        if (storedWCProductModel?.description != updatedProductModel.description) {
+            body["description"] = updatedProductModel.description
         }
-        if (productModel.name.isNotEmpty()) {
-            body["name"] = productModel.name
+        if (storedWCProductModel?.name != updatedProductModel.name) {
+            body["name"] = updatedProductModel.description
         }
-        if (productModel.sku.isNotEmpty()) {
-            body["sku"] = productModel.sku
+        if (storedWCProductModel?.sku != updatedProductModel.sku) {
+            body["sku"] = updatedProductModel.description
+        }
+        if (storedWCProductModel?.manageStock != updatedProductModel.manageStock) {
+            body["manage_stock"] = updatedProductModel.manageStock
+        }
+
+        // only allowed to change the following params if manageStock is enabled
+        if (updatedProductModel.manageStock) {
+            if (storedWCProductModel?.stockStatus != updatedProductModel.stockStatus) {
+                body["stock_status"] = updatedProductModel.stockStatus
+            }
+            if (storedWCProductModel?.stockQuantity != updatedProductModel.stockQuantity) {
+                body["stock_quantity"] = updatedProductModel.stockQuantity
+            }
+            if (storedWCProductModel?.backorders != updatedProductModel.backorders) {
+                body["backorders"] = updatedProductModel.backorders
+            }
+            if (storedWCProductModel?.backorders != updatedProductModel.backorders) {
+                body["backorders"] = updatedProductModel.backorders
+            }
+        }
+        if (storedWCProductModel?.soldIndividually != updatedProductModel.soldIndividually) {
+            body["sold_individually"] = updatedProductModel.soldIndividually
+        }
+        if (storedWCProductModel?.regularPrice != updatedProductModel.regularPrice) {
+            body["regular_price"] = updatedProductModel.regularPrice
+        }
+        if (storedWCProductModel?.salePrice != updatedProductModel.salePrice) {
+            body["sale_price"] = updatedProductModel.salePrice
+        }
+        if (storedWCProductModel?.dateOnSaleFrom != updatedProductModel.dateOnSaleFrom) {
+            body["date_on_sale_from"] = updatedProductModel.dateOnSaleFrom
+        }
+        if (storedWCProductModel?.dateOnSaleTo != updatedProductModel.dateOnSaleTo) {
+            body["date_on_sale_to"] = updatedProductModel.dateOnSaleTo
+        }
+        if (storedWCProductModel?.taxStatus != updatedProductModel.taxStatus) {
+            body["tax_status"] = updatedProductModel.taxStatus
+        }
+        if (storedWCProductModel?.taxClass != updatedProductModel.taxClass) {
+            body["tax_class"] = updatedProductModel.taxClass
+        }
+        if (storedWCProductModel?.weight != updatedProductModel.weight) {
+            body["weight"] = updatedProductModel.weight
+        }
+
+        val dimensionsBody = mutableMapOf<String, String>()
+        if (storedWCProductModel?.height != updatedProductModel.height) {
+            dimensionsBody["height"] = updatedProductModel.height
+        }
+        if (storedWCProductModel?.width != updatedProductModel.width) {
+            dimensionsBody["width"] = updatedProductModel.width
+        }
+        if (storedWCProductModel?.length != updatedProductModel.length) {
+            dimensionsBody["length"] = updatedProductModel.length
+        }
+        if (dimensionsBody.isNotEmpty()) {
+            body["dimensions"] = dimensionsBody
+        }
+        if (storedWCProductModel?.shippingClass != updatedProductModel.shippingClass) {
+            body["shipping_class"] = updatedProductModel.shippingClass
+        }
+        if (storedWCProductModel?.shortDescription != updatedProductModel.shortDescription) {
+            body["short_description"] = updatedProductModel.shortDescription
         }
 
         return body

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -465,9 +465,6 @@ class ProductRestClient(
             if (storedWCProductModel.backorders != updatedProductModel.backorders) {
                 body["backorders"] = updatedProductModel.backorders
             }
-            if (storedWCProductModel.backorders != updatedProductModel.backorders) {
-                body["backorders"] = updatedProductModel.backorders
-            }
         }
         if (storedWCProductModel.soldIndividually != updatedProductModel.soldIndividually) {
             body["sold_individually"] = updatedProductModel.soldIndividually

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -377,7 +377,10 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun updateProduct(payload: UpdateProductPayload) {
-        with(payload) { wcProductRestClient.updateProduct(site, product) }
+        with(payload) {
+            val storedProduct = getProductByRemoteId(site, product.remoteProductId)
+            wcProductRestClient.updateProduct(site, storedProduct, product)
+        }
     }
 
     private fun handleFetchSingleProductCompleted(payload: RemoteProductPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -92,6 +92,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         INVALID_REVIEW_ID,
         INVALID_IMAGE_ID,
         DUPLICATE_SKU,
+        EMPTY_REQUEST_BODY,
         GENERIC_ERROR;
 
         companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -91,6 +91,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         INVALID_PARAM,
         INVALID_REVIEW_ID,
         INVALID_IMAGE_ID,
+        DUPLICATE_SKU,
         GENERIC_ERROR;
 
         companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -92,7 +92,6 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         INVALID_REVIEW_ID,
         INVALID_IMAGE_ID,
         DUPLICATE_SKU,
-        EMPTY_REQUEST_BODY,
         GENERIC_ERROR;
 
         companion object {


### PR DESCRIPTION
Fixes #1435. This PR adds logic to update the following product fields to the API.

#### Changes
- Adds two columns/fields `dateOnSaleFrom` and `dateOnSaleTo` to `WCProductModel` to allow for scheduling product sales.
- Adds logic to update product only if updated product fields do not match the stored product fields. This is to allow the option for users to update empty product descriptions (should they choose to do so) and also, to ensure that we do not update product fields that do not contain any changes. 
- Testing the API, I found that we cannot update an existing SKU value from another product to the product we are trying to update. So added a new error type in `ProductErrorType` if user tries to update the SKU of the product by entering an existing value.
- Added enum classes for displaying product tax status options (`CoreProductTaxStatus`), product back order options (`CoreProductBackOrders`) and product stock status options (`CoreProductStockStatus`).
- Added a new page in the example app to test updating multiple product fields.

#### Testing
- Run tests in `MockedStack_WCProductsTest`, `WCProductStoreTest`.
- Since there is a migration script added to the PR, it would be good to verify if app can be updated to this PR without any issues.
- Testing in the example app:
  - Open the app, click on `Woo` (after login, of course) -> `Products` and select a site.
  - Click on `Update Product` button.
  - Enter a product ID.
  - Modify fields displayed in the UI and verify that only the fields updated in the UI are updated to the product.
  - Verify that an error is displayed in the example app when trying to update an existing SKU (from another product).

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/70407782-a1682000-1a6b-11ea-8a91-889185db078f.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/70407785-a3ca7a00-1a6b-11ea-87f0-56331a3d612d.png">

#### Notes 
- There is no option to test updating `tax_class` and `shipping_class` fields to a product. This is because we need to add a separate API endpoints to FluxC before testing this. Added issue [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1442) and here to address this separately. 