### PR TITLE
Issue/1437 deleted products remain take2

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -133,6 +133,7 @@ class ProductRestClient(
                         val payload = RemoteProductListPayload(
                                 site,
                                 productModels,
+                                offset,
                                 loadedMore,
                                 canLoadMore
                         )
@@ -142,6 +143,7 @@ class ProductRestClient(
                                 site,
                                 searchQuery,
                                 productModels,
+                                offset,
                                 loadedMore,
                                 canLoadMore
                         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -113,7 +113,7 @@ class ProductRestClient(
         val responseType = object : TypeToken<List<ProductApiResponse>>() {}.type
         val params = mutableMapOf(
                 "per_page" to pageSize.toString(),
-                "orderBy" to orderBy,
+                "orderby" to orderBy,
                 "order" to sortOrder,
                 "offset" to offset.toString(),
                 "search" to (searchQuery ?: ""))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -400,6 +400,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         if (payload.isError) {
             onProductChanged = OnProductChanged(0).also { it.error = payload.error }
         } else {
+            // remove the existing products for this site if this is the first page of results, otherwise
+            // products deleted outside of the app will persist
+            if (!payload.loadedMore) {
+                ProductSqlUtils.deleteProductsForSite(payload.site)
+            }
             val rowsAffected = ProductSqlUtils.insertOrUpdateProducts(payload.products)
             onProductChanged = OnProductChanged(rowsAffected, canLoadMore = payload.canLoadMore)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -124,6 +124,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class RemoteProductListPayload(
         val site: SiteModel,
         val products: List<WCProductModel> = emptyList(),
+        var offset: Int = 0,
         var loadedMore: Boolean = false,
         var canLoadMore: Boolean = false
     ) : Payload<ProductError>() {
@@ -139,6 +140,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var site: SiteModel,
         var searchQuery: String,
         var products: List<WCProductModel> = emptyList(),
+        var offset: Int = 0,
         var loadedMore: Boolean = false,
         var canLoadMore: Boolean = false
     ) : Payload<ProductError>() {
@@ -402,7 +404,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         } else {
             // remove the existing products for this site if this is the first page of results, otherwise
             // products deleted outside of the app will persist
-            if (!payload.loadedMore) {
+            if (payload.offset == 0) {
                 ProductSqlUtils.deleteProductsForSite(payload.site)
             }
             val rowsAffected = ProductSqlUtils.insertOrUpdateProducts(payload.products)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType.GENERIC_ERROR
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Locale
@@ -28,7 +28,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     companion object {
         const val NUM_REVIEWS_PER_FETCH = 25
         const val DEFAULT_PRODUCT_PAGE_SIZE = 25
-        val DEFAULT_PRODUCT_SORTING = DATE_DESC
+        val DEFAULT_PRODUCT_SORTING = TITLE_ASC
     }
 
     class FetchSingleProductPayload(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType.GENERIC_ERROR
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Locale
@@ -28,7 +28,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     companion object {
         const val NUM_REVIEWS_PER_FETCH = 25
         const val DEFAULT_PRODUCT_PAGE_SIZE = 25
-        val DEFAULT_PRODUCT_SORTING = TITLE_ASC
+        val DEFAULT_PRODUCT_SORTING = DATE_DESC
     }
 
     class FetchSingleProductPayload(


### PR DESCRIPTION
Closes #1437 - when the product list is fetched without an offset, we now clear the db of existing products. This prevents products deleted outside of the app to continue to appear in the app.