### PR TITLE
Woo v4 Stats: Change gross_revenue to total_sales to match changes to wc-admin

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -436,7 +436,7 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
             val total = getTotal()
             assertNotNull(total)
             assertEquals(11, total?.ordersCount)
-            assertEquals(301.99, total?.grossRevenue)
+            assertEquals(301.99, total?.totalSales)
         }
     }
 

--- a/example/src/androidTest/resources/wc-revenue-stats-response-success.json
+++ b/example/src/androidTest/resources/wc-revenue-stats-response-success.json
@@ -3,7 +3,7 @@
     "totals": {
       "orders_count": 11,
       "num_items_sold": 14,
-      "gross_revenue": 301.99,
+      "total_sales": 301.99,
       "coupons": 18,
       "coupons_count": 1,
       "refunds": 0,
@@ -23,7 +23,7 @@
         "subtotals": {
           "orders_count": 2,
           "num_items_sold": 2,
-          "gross_revenue": 2,
+          "total_sales": 2,
           "coupons": 18,
           "coupons_count": 1,
           "refunds": 0,
@@ -42,7 +42,7 @@
         "subtotals": {
           "orders_count": 7,
           "num_items_sold": 8,
-          "gross_revenue": 200.99,
+          "total_sales": 200.99,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -61,7 +61,7 @@
         "subtotals": {
           "orders_count": 0,
           "num_items_sold": 0,
-          "gross_revenue": 0,
+          "total_sales": 0,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -80,7 +80,7 @@
         "subtotals": {
           "orders_count": 0,
           "num_items_sold": 0,
-          "gross_revenue": 0,
+          "total_sales": 0,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -99,7 +99,7 @@
         "subtotals": {
           "orders_count": 1,
           "num_items_sold": 3,
-          "gross_revenue": 81,
+          "total_sales": 81,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -118,7 +118,7 @@
         "subtotals": {
           "orders_count": 0,
           "num_items_sold": 0,
-          "gross_revenue": 0,
+          "total_sales": 0,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -137,7 +137,7 @@
         "subtotals": {
           "orders_count": 1,
           "num_items_sold": 1,
-          "gross_revenue": 18,
+          "total_sales": 18,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -177,7 +177,7 @@ class WooRevenueStatsFragment : Fragment() {
                         event.startDate!!,
                         event.endDate!!)
                 wcRevenueStatsModel?.let {
-                    val revenueSum = it.getTotal()?.grossRevenue
+                    val revenueSum = it.getTotal()?.totalSales
                     prependToLog("Fetched stats with total " + revenueSum + " for granularity " +
                             event.granularity.toString().toLowerCase() + " from " + site.name +
                             " between " + event.startDate + " and " + event.endDate)

--- a/example/src/test/resources/wc/revenue-stats-data.json
+++ b/example/src/test/resources/wc/revenue-stats-data.json
@@ -8,7 +8,7 @@
         "subtotals": {
           "orders_count": 0,
           "num_items_sold": 0,
-          "gross_revenue": 0,
+          "total_sales": 0,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -27,7 +27,7 @@
         "subtotals": {
           "orders_count": 0,
           "num_items_sold": 0,
-          "gross_revenue": 0,
+          "total_sales": 0,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -46,7 +46,7 @@
         "subtotals": {
           "orders_count": 1,
           "num_items_sold": 3,
-          "gross_revenue": 81,
+          "total_sales": 81,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -65,7 +65,7 @@
         "subtotals": {
           "orders_count": 0,
           "num_items_sold": 0,
-          "gross_revenue": 0,
+          "total_sales": 0,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -84,7 +84,7 @@
         "subtotals": {
           "orders_count": 0,
           "num_items_sold": 0,
-          "gross_revenue": 0,
+          "total_sales": 0,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -103,7 +103,7 @@
         "subtotals": {
           "orders_count": 7,
           "num_items_sold": 8,
-          "gross_revenue": 200.99,
+          "total_sales": 200.99,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,
@@ -122,7 +122,7 @@
         "subtotals": {
           "orders_count": 2,
           "num_items_sold": 2,
-          "gross_revenue": 2,
+          "total_sales": 2,
           "coupons": 18,
           "coupons_count": 1,
           "refunds": 0,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -52,7 +52,7 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
         @SerializedName("orders_count")
         val ordersCount: Int? = null
         @SerializedName("total_sales")
-        val grossRevenue: Double? = null
+        val totalSales: Double? = null
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -36,8 +36,8 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
     class SubTotal {
         @SerializedName("orders_count")
         val ordersCount: Long? = null
-        @SerializedName("gross_revenue")
-        val grossRevenue: Double? = null
+        @SerializedName("total_sales")
+        val totalSales: Double? = null
     }
 
     /**
@@ -51,7 +51,7 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
     class Total {
         @SerializedName("orders_count")
         val ordersCount: Int? = null
-        @SerializedName("gross_revenue")
+        @SerializedName("total_sales")
         val grossRevenue: Double? = null
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -751,7 +751,7 @@ class WCStatsStore @Inject constructor(
     ): Map<String, Double> {
         val rawStats = getRawRevenueStats(site, granularity, startDate, endDate)
         return rawStats?.getIntervalList()?.map {
-            it.interval!! to it.subtotals?.grossRevenue!!
+            it.interval!! to it.subtotals?.totalSales!!
         }?.toMap() ?: mapOf()
     }
 


### PR DESCRIPTION
This field was changed in wc-admin v0.23. We only support the very latest version of the v4 Revenue Stats API since this is a beta feature so anyone running a store with the wc-admin plugin less than v0.22 will not see the gross sales total.

## TO TEST
On a store running the older version of wc-admin:
1. Run the example app
2. WOO -> REVENUE STATS
3. Select a site and then run FETCH CURRENT REVENUE STATS (FORCED)
4. The output in the log will say the total is null.
5. Update the wc-admin plugin to the latest version (currently 0.23.1)
6. Redo steps 1 - 3
7. The output should now show a total.
