### PR TITLE
Issue/1450 product variants sorting

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -243,6 +243,9 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         with(dbVariations.first()) {
             assertEquals(this.remoteProductId, remoteProductId)
             assertEquals(this.localSiteId, siteModel.id)
+
+            // verify that the variant with the first menu order is fetched first
+            assertEquals(this.menuOrder, 1)
         }
     }
 

--- a/example/src/androidTest/resources/wc-fetch-product-variations-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-variations-response-success.json
@@ -50,7 +50,7 @@
       "id": 181,
       "image": null,
       "manage_stock": false,
-      "menu_order": 0,
+      "menu_order": 3,
       "meta_data": [
         {
           "id": 1348,
@@ -134,7 +134,7 @@
         "src": "https://example.com/wp-content/uploads/2019/03/profile-rockem-sockem.png?fit=300%2C225&ssl=1"
       },
       "manage_stock": false,
-      "menu_order": 0,
+      "menu_order": 1,
       "meta_data": [
         {
           "id": 1312,
@@ -218,7 +218,7 @@
         "src": "https://example.com/wp-content/uploads/2019/03/profile-rockem-sockem.png?fit=300%2C225&ssl=1"
       },
       "manage_stock": false,
-      "menu_order": 0,
+      "menu_order": 2,
       "meta_data": [
         {
           "id": 1276,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -50,6 +50,7 @@ class WooProductsFragment : Fragment() {
     private var selectedPos: Int = -1
     private var selectedSite: SiteModel? = null
     private var pendingFetchSingleProductRemoteId: Long? = null
+    private var pendingFetchSingleProductVariationRemoteId: Long? = null
 
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
@@ -111,8 +112,8 @@ class WooProductsFragment : Fragment() {
                         activity,
                         "Enter the remoteProductId of product to fetch variations:"
                 ) { editText ->
-                    val remoteProductId = editText.text.toString().toLongOrNull()
-                    remoteProductId?.let { id ->
+                    pendingFetchSingleProductVariationRemoteId = editText.text.toString().toLongOrNull()
+                    pendingFetchSingleProductVariationRemoteId?.let { id ->
                         prependToLog("Submitting request to fetch product variations by remoteProductID $id")
                         val payload = FetchProductVariationsPayload(site, id)
                         dispatcher.dispatch(WCProductActionBuilder.newFetchProductVariationsAction(payload))
@@ -240,7 +241,13 @@ class WooProductsFragment : Fragment() {
                     prependToLog("Fetched ${event.rowsAffected} products")
                 }
                 FETCH_PRODUCT_VARIATIONS -> {
-                    prependToLog("Fetched ${event.rowsAffected} product variations")
+                    pendingFetchSingleProductVariationRemoteId?.let { remoteId ->
+                        pendingFetchSingleProductVariationRemoteId = null
+                        val variations = wcProductStore.getVariationsForProduct(site, remoteId)
+                        variations.forEach { variant ->
+                            prependToLog("Variations: ${variant.remoteVariationId}")
+                        }
+                    }
                 }
                 FETCH_PRODUCT_REVIEWS -> {
                     prependToLog("Fetched ${event.rowsAffected} product reviews")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 93
+        return 94
     }
 
     override fun getDbName(): String {
@@ -1020,6 +1020,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 92 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_FROM TEXT")
                     db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_TO TEXT")
+                }
+                93 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD MENU_ORDER INTEGER")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -46,6 +46,8 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     @Column var width = ""
     @Column var height = ""
 
+    @Column var menuOrder = 0
+
     @Column var attributes = ""
 
     override fun getId() = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -625,6 +625,7 @@ class ProductRestClient(
             attributes = response.attributes?.toString() ?: ""
 
             weight = response.weight ?: ""
+            menuOrder = response.menu_order
 
             response.dimensions?.asJsonObject?.let { json ->
                 length = json.getString("length") ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -30,6 +30,8 @@ class ProductVariationApiResponse : Response {
     var image: JsonElement? = null
 
     var weight: String? = null
+    val menu_order: Int = 0
+
     var dimensions: JsonElement? = null
     var attributes: JsonElement? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -148,7 +148,7 @@ object ProductSqlUtils {
                 .equals(WCProductVariationModelTable.REMOTE_PRODUCT_ID, remoteProductId)
                 .equals(WCProductVariationModelTable.LOCAL_SITE_ID, site.id)
                 .endGroup().endWhere()
-                .orderBy(WCProductVariationModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
+                .orderBy(WCProductVariationModelTable.MENU_ORDER, SelectQuery.ORDER_ASCENDING)
                 .asModel
     }
 


### PR DESCRIPTION
Fixes #1450. This PR adds logic to sort the product variants using the `menu_order` field from the GET product variations API response.

#### Changes
- Adds a new column to `WCProductVariationModel` to store `menu_order` field.
- Adds logic to sort the list of `WCProductVariationModel` using `menu_order` when fetching product variations from the local db.

#### Testing
- Run `ReleaseStack_WCProductTest` and verify that all tests pass.
- Since there is a migration script running, it would be good to test app update. 
- Open the example app. Click on `Woo` -> `Products` -> Select site -> `Fetch product variations`. Verify that the ids are sorted according to the `menu_order` and that it matches the sorting in `wp-admin`.