### PR TITLE
delete product variations from local db before updating incoming variants

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -434,6 +434,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         if (payload.isError) {
             onProductChanged = OnProductChanged(0).also { it.error = payload.error }
         } else {
+            // delete product variations for site before inserting the incoming variations
+            ProductSqlUtils.deleteVariationsForProduct(payload.site, payload.remoteProductId)
             val rowsAffected = ProductSqlUtils.insertOrUpdateProductVariations(payload.variations)
             onProductChanged = OnProductChanged(rowsAffected)
         }


### PR DESCRIPTION
Fixes #1452 - when the product variant list is fetched we now clear the db of existing product variations. This prevents variants deleted outside of the app to continue to appear in the app.

#### Testing steps
- In the example app, click on `Woo` -> `Products` -> `Select Site` -> `Fetch product variations`.
- Notice the variation count fetched in the app for the product.
- For the same product, go to `wp-admin` and delete some variations.
- Follow step 1 again and verify that the number of variations in the web matches the variations in the app.
- For the same product, go to `wp-admin` and add some more variations to the product.
- Follow step 1 again and verify that the number of variations in the web matches the variations in the app.


