### PR TITLE
Issue/1454 product variants pagination

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -260,6 +260,7 @@ class WooProductsFragment : Fragment() {
                     if (event.canLoadMore) {
                         pendingFetchSingleProductVariationOffset += event.rowsAffected
                         load_more_product_variations.visibility = View.VISIBLE
+                        load_more_product_variations.isEnabled = true
                     } else {
                         pendingFetchSingleProductVariationOffset = 0
                         load_more_product_variations.isEnabled = false

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -50,7 +50,9 @@ class WooProductsFragment : Fragment() {
     private var selectedPos: Int = -1
     private var selectedSite: SiteModel? = null
     private var pendingFetchSingleProductRemoteId: Long? = null
+
     private var pendingFetchSingleProductVariationRemoteId: Long? = null
+    private var pendingFetchSingleProductVariationOffset: Int = 0
 
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
@@ -119,6 +121,18 @@ class WooProductsFragment : Fragment() {
                         dispatcher.dispatch(WCProductActionBuilder.newFetchProductVariationsAction(payload))
                     } ?: prependToLog("No valid remoteProductId defined...doing nothing")
                 }
+            }
+        }
+
+        load_more_product_variations.setOnClickListener {
+            selectedSite?.let { site ->
+                pendingFetchSingleProductVariationRemoteId?.let { id ->
+                    prependToLog("Submitting offset request to fetch product variations by remoteProductID $id")
+                    val payload = FetchProductVariationsPayload(
+                            site, id, offset = pendingFetchSingleProductVariationOffset
+                    )
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchProductVariationsAction(payload))
+                } ?: prependToLog("No valid remoteProductId defined...doing nothing")
             }
         }
 
@@ -241,12 +255,14 @@ class WooProductsFragment : Fragment() {
                     prependToLog("Fetched ${event.rowsAffected} products")
                 }
                 FETCH_PRODUCT_VARIATIONS -> {
-                    pendingFetchSingleProductVariationRemoteId?.let { remoteId ->
-                        pendingFetchSingleProductVariationRemoteId = null
-                        val variations = wcProductStore.getVariationsForProduct(site, remoteId)
-                        variations.forEach { variant ->
-                            prependToLog("Variations: ${variant.remoteVariationId}")
-                        }
+                    prependToLog("Fetched ${event.rowsAffected} product variants. " +
+                            "More variants available ${event.canLoadMore}")
+                    if (event.canLoadMore) {
+                        pendingFetchSingleProductVariationOffset += event.rowsAffected
+                        load_more_product_variations.visibility = View.VISIBLE
+                    } else {
+                        pendingFetchSingleProductVariationOffset = 0
+                        load_more_product_variations.isEnabled = false
                     }
                 }
                 FETCH_PRODUCT_REVIEWS -> {

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -68,6 +68,13 @@
             android:text="Fetch Product Variations"/>
 
         <Button
+            android:id="@+id/load_more_product_variations"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:text="Load More Variations" />
+
+        <Button
             android:id="@+id/fetch_reviews_for_product"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -193,7 +193,8 @@ class ProductRestClient(
         val responseType = object : TypeToken<List<ProductVariationApiResponse>>() {}.type
         val params = mutableMapOf(
                 "per_page" to pageSize.toString(),
-                "offset" to offset.toString())
+                "offset" to offset.toString(),
+                "order" to "asc")
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<ProductVariationApiResponse>? ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -182,6 +182,14 @@ class ProductRestClient(
      * Dispatches a WCProductAction.FETCHED_PRODUCT_VARIATIONS action with the result
      *
      * @param [productId] Unique server id of the product
+     *
+     * Variations by default are sorted by `menu_order` with sorting order = desc.
+     * i.e. `orderby` = `menu_order` and `order` = `desc`
+     *
+     * We do not pass `orderby` field in the request here because the API does not support `orderby`
+     * with `menu_order` as value. But we still need to pass `order` field to the API request in order to
+     * preserve the sorting order when fetching multiple pages of variations.
+     *
      */
     fun fetchProductVariations(
         site: SiteModel,


### PR DESCRIPTION
Fixes #1454. This PR adds logic to support pagination when fetching product variations.

#### Changes
- Adds a default page size when fetching variations, which is 25.
- Adds an `offset` field to the API request when fetching variations.
- Adds a sort order to the API request, which is `asc`. This essentially sorts the variations by `menu_order` ASC.
- Adds a new button in the example app to test the pagination.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/70957305-b2341980-209b-11ea-9dce-0a3f5de72a1e.gif">

#### Testing
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Fetch product variations`.
- Verify that the variations are fetched correctly and the sorting order is maintained. i.e the variations are fetched by `menu_order` ascending..
- Click on `Lore more variations` and verify that the variations are fetched correctly.
  - If there is no more variation data found in the API response, the `Load more variations` button should be displayed.