### PR TITLE
Woo/fetch product shipping class

### DIFF
--- a/example/src/androidTest/resources/wc-fetch-product-shipping-classes-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-shipping-classes-response-success.json
@@ -1,0 +1,32 @@
+{
+  "data": [{
+    "id": 34,
+    "name": "example1",
+    "slug": "example-1",
+    "description": "Testing shipping class",
+    "count": 1,
+    "_links": {
+      "self": [{
+        "href": "https:\/\/anitaastestwooshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/shipping_classes\/34"
+      }],
+      "collection": [{
+        "href": "https:\/\/anitaastestwooshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/shipping_classes"
+      }]
+    }
+  },
+    {
+      "id": 35,
+      "name": "example2",
+      "slug": "example-2",
+      "description": "Testing shipping class part 2",
+      "count": 3,
+      "_links": {
+        "self": [{
+          "href": "https:\/\/anitaastestwooshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/shipping_classes\/34"
+        }],
+        "collection": [{
+          "href": "https:\/\/anitaastestwooshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/shipping_classes"
+        }]
+      }
+    }]
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -29,12 +29,14 @@ import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductImagesChanged
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClassesChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductsSearched
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
@@ -162,6 +164,14 @@ class WooProductsFragment : Fragment() {
             }
         }
 
+        fetch_product_shipping_classes.setOnClickListener {
+            selectedSite?.let { site ->
+                prependToLog("Submitting request to fetch product shipping classes for site ${site.id}")
+                val payload = FetchProductShippingClassListPayload(site)
+                dispatcher.dispatch(WCProductActionBuilder.newFetchProductShippingClassListAction(payload))
+            }
+        }
+
         update_product_images.setOnClickListener {
             showSingleLineDialog(
                     activity,
@@ -280,6 +290,16 @@ class WooProductsFragment : Fragment() {
             prependToLog("Error updating product images - error: " + event.error.type)
         } else {
             prependToLog("Product images updated")
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductShippingClassesChanged(event: OnProductShippingClassesChanged) {
+        if (event.isError) {
+            prependToLog("Error fetching product shipping classes - error: " + event.error.type)
+        } else {
+            prependToLog("Fetched ${event.rowsAffected} product shipping classes")
         }
     }
 

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -89,6 +89,13 @@
             android:text="Fetch Product Review by ID"/>
 
         <Button
+            android:id="@+id/fetch_product_shipping_classes"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Product Shipping classes"/>
+
+        <Button
             android:id="@+id/update_product_images"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
+import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductReviewApiResponse
 
 object ProductTestUtils {
@@ -20,6 +21,33 @@ object ProductTestUtils {
             this.type = type
             this.name = name
             this.virtual = virtual
+        }
+    }
+
+    fun generateSampleProductShippingClass(
+        remoteId: Long = 1L,
+        name: String = "",
+        slug: String = "",
+        description: String = "",
+        siteId: Int = 6
+    ): WCProductShippingClassModel {
+        return WCProductShippingClassModel().apply {
+            remoteShippingClassId = remoteId
+            localSiteId = siteId
+            this.name = name
+            this.slug = slug
+            this.description = description
+        }
+    }
+
+    fun generateProductList(siteId: Int = 6): List<WCProductShippingClassModel> {
+        with(ArrayList<WCProductShippingClassModel>()) {
+            add(generateSampleProductShippingClass(1, siteId = siteId))
+            add(generateSampleProductShippingClass(2, siteId = siteId))
+            add(generateSampleProductShippingClass(3, siteId = siteId))
+            add(generateSampleProductShippingClass(4, siteId = siteId))
+            add(generateSampleProductShippingClass(5, siteId = siteId))
+            return this
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 93
+        return 94
     }
 
     override fun getDbName(): String {
@@ -1020,6 +1020,20 @@ open class WellSqlConfig : DefaultWellConfig {
                 92 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_FROM TEXT")
                     db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_TO TEXT")
+                }
+                93 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL(
+                            "CREATE TABLE WCProductShippingClassModel(" +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "REMOTE_SHIPPING_CLASS_ID INTEGER," +
+                                    "NAME TEXT NOT NULL," +
+                                    "SLUG TEXT NOT NULL," +
+                                    "DESCRIPTION TEXT NOT NULL," +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
+                                    "UNIQUE (REMOTE_SHIPPING_CLASS_ID, LOCAL_SITE_ID) " +
+                                    "ON CONFLICT REPLACE)"
+                    )
                 }
             }
         }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload;
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
@@ -12,6 +13,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReview
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
@@ -32,6 +34,8 @@ public enum WCProductAction implements IAction {
     SEARCH_PRODUCTS,
     @Action(payloadType = FetchProductVariationsPayload.class)
     FETCH_PRODUCT_VARIATIONS,
+    @Action(payloadType = FetchProductShippingClassListPayload.class)
+    FETCH_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = FetchProductReviewsPayload.class)
     FETCH_PRODUCT_REVIEWS,
     @Action(payloadType = FetchSingleProductReviewPayload.class)
@@ -52,6 +56,8 @@ public enum WCProductAction implements IAction {
     SEARCHED_PRODUCTS,
     @Action(payloadType = RemoteProductVariationsPayload.class)
     FETCHED_PRODUCT_VARIATIONS,
+    @Action(payloadType = RemoteProductShippingClassListPayload.class)
+    FETCHED_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = FetchProductReviewsResponsePayload.class)
     FETCHED_PRODUCT_REVIEWS,
     @Action(payloadType = RemoteProductReviewPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductShippingClassModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductShippingClassModel.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+@RawConstraints(
+        "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+        "UNIQUE (REMOTE_SHIPPING_CLASS_ID, LOCAL_SITE_ID) ON CONFLICT REPLACE"
+)
+class WCProductShippingClassModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var remoteShippingClassId = 0L // The unique identifier for this shipping class on the server
+    @Column var name = ""
+    @Column var slug = ""
+    @Column var description = ""
+
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
+import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
@@ -36,6 +37,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DES
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload
@@ -51,6 +53,42 @@ class ProductRestClient(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    /**
+     * Makes a GET request to `GET /wp-json/wc/v3/products/shipping_classes` to fetch
+     * prodict shipping classes for a site
+     *
+     * Dispatches a WCProductAction.FETCHED_PRODUCT_SHIPPING_CLASS_LIST action with the result
+     *
+     * @param [site] The site to fetch product shipping class list for
+     */
+    fun fetchProductShippingClassList(site: SiteModel) {
+        val url = WOOCOMMERCE.products.shipping_classes.pathV3
+        val responseType = object : TypeToken<List<ProductShippingClassApiResponse>>() {}.type
+        val params = emptyMap<String, String>()
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
+                { response: List<ProductShippingClassApiResponse>? ->
+                    val shippingClassList = response?.map {
+                        WCProductShippingClassModel().apply {
+                            remoteShippingClassId = it.id
+                            localSiteId = site.id
+                            name = it.name ?: ""
+                            slug = it.slug ?: ""
+                            description = it.description ?: ""
+                        }
+                    }.orEmpty()
+
+                    val payload = RemoteProductShippingClassListPayload(site, shippingClassList)
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchedProductShippingClassListAction(payload))
+                },
+                WPComErrorListener { networkError ->
+                    val productError = networkErrorToProductError(networkError)
+                    val payload = RemoteProductShippingClassListPayload(productError, site)
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchedProductShippingClassListAction(payload))
+                },
+                { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
     /**
      * Makes a GET request to `/wp-json/wc/v3/products/[remoteProductId]` to fetch a single product
      *

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -55,12 +55,13 @@ class ProductRestClient(
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     /**
      * Makes a GET request to `GET /wp-json/wc/v3/products/shipping_classes` to fetch
-     * prodict shipping classes for a site
+     * product shipping classes for a site
      *
      * Dispatches a WCProductAction.FETCHED_PRODUCT_SHIPPING_CLASS_LIST action with the result
      *
      * @param [site] The site to fetch product shipping class list for
      */
+    // TODO: add pagination support in another PR
     fun fetchProductShippingClassList(site: SiteModel) {
         val url = WOOCOMMERCE.products.shipping_classes.pathV3
         val responseType = object : TypeToken<List<ProductShippingClassApiResponse>>() {}.type

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductShippingClassApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductShippingClassApiResponse.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import org.wordpress.android.fluxc.network.Response
+
+@Suppress("PropertyName")
+class ProductShippingClassApiResponse : Response {
+    var id: Long = 0L
+
+    var name: String? = null
+    var slug: String? = null
+    var description: String? = null
+
+    var count = 0
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
+import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
@@ -55,6 +56,10 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class FetchProductVariationsPayload(
         var site: SiteModel,
         var remoteProductId: Long
+    ) : Payload<BaseNetworkError>()
+
+    class FetchProductShippingClassListPayload(
+        var site: SiteModel
     ) : Payload<BaseNetworkError>()
 
     class FetchProductReviewsPayload(
@@ -186,6 +191,18 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             site: SiteModel,
             remoteProductId: Long
         ) : this(site, remoteProductId) {
+            this.error = error
+        }
+    }
+
+    class RemoteProductShippingClassListPayload(
+        val site: SiteModel,
+        val shippingClassList: List<WCProductShippingClassModel> = emptyList()
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel
+        ) : this(site) {
             this.error = error
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -472,7 +472,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             ProductSqlUtils.deleteProductShippingClassListForSite(payload.site)
 
             val rowsAffected = ProductSqlUtils.insertOrUpdateProductShippingClassList(payload.shippingClassList)
-            OnProductChanged(rowsAffected)
+            OnProductShippingClassesChanged(rowsAffected)
         }
         emitChange(onProductShippingClassesChanged)
     }

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -8,6 +8,7 @@
 /products/<id>/
 /products/<id>/variations/
 /products/
+/products/shipping_classes
 
 /products/reviews/
 /products/reviews/<id>/


### PR DESCRIPTION
Fixes Part 1 of #1442 by adding support to fetch `shipping_class` list for a site.

#### Changes
- Adds new endpoint `/wc/v3/products/shipping_classes`. Since this is part of the products feature, added all subsequent logic under the products package, even though the `shipping_classes` are not product, but site, specific.
- Added new `WCProductAction` and payload classes.
- Added new `WCProductShippinClassModel` model class and a migration script to create table.
- Added methods to `WCProductRestClient`, `WCProductStore` and `ProductSqlUtils` to fetch, store, update, delete shipping class list for a site. 
- Added mocked, release and unit tests.
- Added a new button to the example app to fetch shipping class list for a site.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/70959445-515c0f80-20a2-11ea-90bb-98c3cf4436bd.png">

#### Testing
- Since this PR adds a migration script, it would be nice to test updating the app.
- Run `MockedStack_WCProductsTest`, `ReleaseStack_WCProductTest` and `ProductSqlUtilsTest`.
- In the example app, click on `Woo` -> `Products` -> `Select Site` -> `Fetch Product shipping classes` and verify that the shipping class list for the site is fetched successfully.