### PR TITLE
Woo/fetch product tax class

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
+import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
 
 @Module
 internal abstract class FragmentsModule {
@@ -83,6 +84,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooGatewaysFragmentInjector(): WooGatewaysFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooTaxFragmentInjector(): WooTaxFragment
 
     @ContributesAndroidInjector
     abstract fun provideSiteSelectorDialogInjector(): SiteSelectorDialog

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
+import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
@@ -104,6 +105,12 @@ class WooCommerceFragment : Fragment() {
         gateways.setOnClickListener {
             getFirstWCSite()?.let {
                 replaceFragment(WooGatewaysFragment())
+            } ?: showNoWCSitesToast()
+        }
+
+        taxes.setOnClickListener {
+            getFirstWCSite()?.let {
+                replaceFragment(WooTaxFragment())
             } ?: showNoWCSitesToast()
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.fluxc.example.ui.taxes
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_taxes.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WCTaxStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class WooTaxFragment : Fragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var wcTaxStore: WCTaxStore
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    private var selectedPos: Int = -1
+    private var selectedSite: SiteModel? = null
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_woo_taxes, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        taxes_select_site.setOnClickListener {
+            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                override fun onSiteSelected(site: SiteModel, pos: Int) {
+                    selectedSite = site
+                    selectedPos = pos
+                    toggleSiteDependentButtons(true)
+                    taxes_selected_site.text = site.name ?: site.displayName
+                }
+            })
+        }
+
+        fetch_tax_class.setOnClickListener {
+            selectedSite?.let { site ->
+                prependToLog("Submitting request to fetch tax classes for site ${site.id}")
+                GlobalScope.launch(Dispatchers.Main) {
+                    supervisorScope {
+                        try {
+                            val response = withContext(Dispatchers.Default) {
+                                wcTaxStore.fetchTaxClassList(site)
+                            }
+                            response.error?.let {
+                                prependToLog("${it.type}: ${it.message}")
+                            }
+                            response.model?.let {
+                                prependToLog("Site has ${it.size} tax classes")
+                            }
+                        } catch (e: Exception) {
+                            prependToLog("Error: ${e.message}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
+        fragmentManager?.let { fm ->
+            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
+            dialog.show(fm, "StoreSelectorDialog")
+        }
+    }
+
+    private fun toggleSiteDependentButtons(enabled: Boolean) {
+        for (i in 0 until buttonContainer.childCount) {
+            val child = buttonContainer.getChildAt(i)
+            if (child is Button) {
+                child.isEnabled = enabled
+            }
+        }
+    }
+}

--- a/example/src/main/res/layout/fragment_woo_taxes.xml
+++ b/example/src/main/res/layout/fragment_woo_taxes.xml
@@ -1,0 +1,49 @@
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:text="Perform actions on a selected site:"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/taxes_select_site"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Select Site"/>
+
+            <TextView
+                android:id="@+id/taxes_selected_site"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingLeft="10dp"
+                android:paddingStart="10dp"
+                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+                android:textColor="@android:color/holo_blue_bright"/>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/fetch_tax_class"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Tax Classes"/>
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -75,5 +75,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Gateways"/>
+
+                <Button
+                    android:id="@+id/taxes"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Taxes"/>
         </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/TaxTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/TaxTestUtils.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.wc.taxes
+
+import org.wordpress.android.fluxc.model.taxes.WCTaxClassModel
+
+object TaxTestUtils {
+    fun generateSampleTaxClass(
+        name: String = "",
+        slug: String = "",
+        siteId: Int = 6
+    ): WCTaxClassModel {
+        return WCTaxClassModel().apply {
+            localSiteId = siteId
+            this.name = name
+            this.slug = slug
+        }
+    }
+
+    fun generateTaxClassList(siteId: Int = 6, slug: String = "slug"): List<WCTaxClassModel> {
+        with(ArrayList<WCTaxClassModel>()) {
+            add(generateSampleTaxClass(siteId = siteId, slug = slug.plus(1)))
+            add(generateSampleTaxClass(siteId = siteId, slug = slug.plus(2)))
+            add(generateSampleTaxClass(siteId = siteId, slug = slug.plus(3)))
+            add(generateSampleTaxClass(siteId = siteId, slug = slug.plus(4)))
+            add(generateSampleTaxClass(siteId = siteId, slug = slug.plus(5)))
+            return this
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/TaxTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/TaxTestUtils.kt
@@ -1,9 +1,10 @@
 package org.wordpress.android.fluxc.wc.taxes
 
 import org.wordpress.android.fluxc.model.taxes.WCTaxClassModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient.TaxClassApiResponse
 
 object TaxTestUtils {
-    fun generateSampleTaxClass(
+    private fun generateSampleTaxClass(
         name: String = "",
         slug: String = "",
         siteId: Int = 6
@@ -24,5 +25,10 @@ object TaxTestUtils {
             add(generateSampleTaxClass(siteId = siteId, slug = slug.plus(5)))
             return this
         }
+    }
+
+    fun generateSampleTaxClassApiResponse(): List<TaxClassApiResponse> {
+        return listOf(TaxClassApiResponse("example1", "example1"),
+                TaxClassApiResponse("example2", "example2"))
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/WCTaxSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/WCTaxSqlUtilsTest.kt
@@ -1,0 +1,134 @@
+package org.wordpress.android.fluxc.wc.taxes
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.taxes.WCTaxClassModel
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.persistence.WCTaxSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCTaxSqlUtilsTest {
+    val site = SiteModel().apply {
+        email = "test@example.org"
+        name = "Test Site"
+        siteId = 24
+    }
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(SiteModel::class.java, WCTaxClassModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE)
+        WellSql.init(config)
+        config.reset()
+
+        // Insert the site into the db so it's available later for tax classes
+        SiteSqlUtils.insertOrUpdateSite(site)
+    }
+
+    @Test
+    fun testInsertOrUpdateTaxClassForSite() {
+        val taxClass = TaxTestUtils.generateTaxClassList(site.id)[0]
+        assertNotNull(taxClass)
+
+        // Test inserting a tax class
+        var rowsAffected = WCTaxSqlUtils.insertOrUpdateTaxClass(taxClass)
+        assertEquals(1, rowsAffected)
+        var savedTaxClassList = WCTaxSqlUtils.getTaxClassesForSite(site.id)
+        assertEquals(savedTaxClassList.size, 1)
+        assertEquals(savedTaxClassList[0].localSiteId, taxClass.localSiteId)
+        assertEquals(savedTaxClassList[0].name, taxClass.name)
+        assertEquals(savedTaxClassList[0].slug, taxClass.slug)
+
+        // Test updating the same product shipping class
+        taxClass.apply {
+            name = "Test tax class"
+        }
+        rowsAffected = WCTaxSqlUtils.insertOrUpdateTaxClass(taxClass)
+        assertEquals(1, rowsAffected)
+        savedTaxClassList = WCTaxSqlUtils.getTaxClassesForSite(site.id)
+        assertEquals(savedTaxClassList.size, 1)
+        assertEquals(savedTaxClassList[0].localSiteId, taxClass.localSiteId)
+        assertEquals(savedTaxClassList[0].name, taxClass.name)
+        assertEquals(savedTaxClassList[0].slug, taxClass.slug)
+    }
+
+    @Test
+    fun testInsertOrUpdateProductTaxClassList() {
+        val taxClassList = TaxTestUtils.generateTaxClassList(site.id)
+        assertTrue(taxClassList.isNotEmpty())
+
+        // Insert product shipping class list
+        val rowsAffected = WCTaxSqlUtils.insertOrUpdateTaxClasses(taxClassList)
+        assertEquals(taxClassList.size, rowsAffected)
+    }
+
+    @Test
+    fun testGetTaxClassListForSite() {
+        val taxClassList = TaxTestUtils.generateTaxClassList(site.id)
+        assertTrue(taxClassList.isNotEmpty())
+
+        // Insert product shipping class list
+        val rowsAffected = WCTaxSqlUtils.insertOrUpdateTaxClasses(taxClassList)
+        assertEquals(taxClassList.size, rowsAffected)
+
+        // Get tax class list for site and verify
+        val savedTaxClassListExists = WCTaxSqlUtils.getTaxClassesForSite(site.id)
+        assertEquals(taxClassList.size, savedTaxClassListExists.size)
+
+        // Get tax class list for a site that does not exist
+        val nonExistingSite = SiteModel().apply { id = 400 }
+        val savedTaxClassList = WCTaxSqlUtils.getTaxClassesForSite(nonExistingSite.id)
+        assertEquals(0, savedTaxClassList.size)
+    }
+
+    @Test
+    fun testDeleteTaxClassListForSite() {
+        val taxClassList = TaxTestUtils.generateTaxClassList(site.id)
+
+        var rowsAffected = WCTaxSqlUtils.insertOrUpdateTaxClasses(taxClassList)
+        assertEquals(taxClassList.size, rowsAffected)
+
+        // Verify tax class list inserted
+        var savedTaxClassList = WCTaxSqlUtils.getTaxClassesForSite(site.id)
+        assertEquals(taxClassList.size, savedTaxClassList.size)
+
+        // Delete tax class list for site and verify
+        rowsAffected = WCTaxSqlUtils.deleteTaxClassesForSite(site)
+        assertEquals(taxClassList.size, rowsAffected)
+        savedTaxClassList = WCTaxSqlUtils.getTaxClassesForSite(site.id)
+        assertEquals(0, savedTaxClassList.size)
+    }
+
+    @Test
+    fun testDeleteSiteDeletesProductShippingClassList() {
+        val taxClassList = TaxTestUtils.generateTaxClassList(site.id)
+        assertTrue(taxClassList.isNotEmpty())
+
+        val rowsAffected = WCTaxSqlUtils.insertOrUpdateTaxClasses(taxClassList)
+        assertEquals(taxClassList.size, rowsAffected)
+
+        // Verify tax class list inserted
+        var savedTaxClassList = WCTaxSqlUtils.getTaxClassesForSite(site.id)
+        assertEquals(taxClassList.size, savedTaxClassList.size)
+
+        // Delete site and verify tac class list  deleted via foreign key constraint
+        SiteSqlUtils.deleteSite(site)
+        savedTaxClassList = WCTaxSqlUtils.getTaxClassesForSite(site.id)
+        assertEquals(0, savedTaxClassList.size)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/WCTaxStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/WCTaxStoreTest.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.fluxc.wc.taxes
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.yarolegovich.wellsql.WellSql
+import kotlinx.coroutines.Dispatchers
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.assertj.core.api.Assertions.assertThat
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.taxes.WCTaxClassMapper
+import org.wordpress.android.fluxc.model.taxes.WCTaxClassModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.store.WCTaxStore
+import org.wordpress.android.fluxc.test
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCTaxStoreTest {
+    private val restClient = mock<WCTaxRestClient>()
+    private val site = SiteModel().apply { id = 321 }
+    private val errorSite = SiteModel().apply { id = 123 }
+    private val mapper = WCTaxClassMapper()
+    private lateinit var store: WCTaxStore
+
+    private val sampleTaxClassList = TaxTestUtils.generateSampleTaxClassApiResponse()
+    private val error = WooError(INVALID_RESPONSE, NETWORK_ERROR, "Invalid site ID")
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(SiteModel::class.java, WCTaxClassModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE
+        )
+        WellSql.init(config)
+        config.reset()
+
+        store = WCTaxStore(
+                restClient,
+                Dispatchers.Unconfined,
+                mapper
+        )
+
+        // Insert the site into the db so it's available later when fetching tax classes
+        SiteSqlUtils.insertOrUpdateSite(site)
+    }
+
+    @Test
+    fun `fetch tax class list for site`() = test {
+        val result = fetchTaxClassListForSite()
+
+        assertThat(result.model?.size).isEqualTo(sampleTaxClassList.size)
+        assertThat(result.model?.first()?.name).isEqualTo(mapper.map(sampleTaxClassList.first()).name)
+        assertThat(result.model?.first()?.slug).isEqualTo(mapper.map(sampleTaxClassList.first()).slug)
+
+        val invalidRequestResult = store.fetchTaxClassList(errorSite)
+        assertThat(invalidRequestResult.model).isNull()
+        assertThat(invalidRequestResult.error).isEqualTo(error)
+    }
+
+    @Test
+    fun `get stored tax class list for site`() = test {
+        fetchTaxClassListForSite()
+
+        val storedTaxClassList = store.getShippingClassListForSite(site)
+
+        assertThat(storedTaxClassList.size).isEqualTo(2)
+        assertThat(storedTaxClassList.first().name).isEqualTo(mapper.map(sampleTaxClassList.first()).name)
+        assertThat(storedTaxClassList.first().slug).isEqualTo(mapper.map(sampleTaxClassList.first()).slug)
+
+        val invalidRequestResult = store.getShippingClassListForSite(errorSite)
+        assertThat(invalidRequestResult.size).isEqualTo(0)
+    }
+
+    private suspend fun fetchTaxClassListForSite(): WooResult<List<WCTaxClassModel>> {
+        val fetchTaxClassListPayload = WooPayload(sampleTaxClassList.toTypedArray())
+        whenever(restClient.fetchTaxClassList(site)).thenReturn(fetchTaxClassListPayload)
+        whenever(restClient.fetchTaxClassList(errorSite)).thenReturn(WooPayload(error))
+        return store.fetchTaxClassList(site)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 94
+        return 95
     }
 
     override fun getDbName(): String {
@@ -1023,6 +1023,18 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 93 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD MENU_ORDER INTEGER")
+                }
+                94 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL(
+                            "CREATE TABLE WCTaxClassModel(" +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "NAME TEXT NOT NULL," +
+                                    "SLUG TEXT NOT NULL," +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
+                                    "UNIQUE (LOCAL_SITE_ID) " +
+                                    "ON CONFLICT REPLACE)"
+                    )
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1032,7 +1032,7 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "SLUG TEXT NOT NULL," +
                                     "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
                                     "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
-                                    "UNIQUE (LOCAL_SITE_ID) " +
+                                    "UNIQUE (SLUG, LOCAL_SITE_ID) " +
                                     "ON CONFLICT REPLACE)"
                     )
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/taxes/WCTaxClassMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/taxes/WCTaxClassMapper.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.model.taxes
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient.TaxClassApiResponse
+import javax.inject.Inject
+
+class WCTaxClassMapper
+@Inject constructor() {
+    fun map(response: TaxClassApiResponse): WCTaxClassModel {
+        return WCTaxClassModel().apply {
+            name = response.name ?: ""
+            slug = response.slug ?: ""
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/taxes/WCTaxClassModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/taxes/WCTaxClassModel.kt
@@ -10,12 +10,12 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 @RawConstraints(
         "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
-        "UNIQUE (LOCAL_SITE_ID) ON CONFLICT REPLACE"
+        "UNIQUE (SLUG, LOCAL_SITE_ID) ON CONFLICT REPLACE"
 )
 data class WCTaxClassModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var localSiteId = 0
     @Column var name = ""
-    @Column var slug = ""
+    @Column var slug = ""   // The unique identifier for the tax class on the server
 
     override fun getId() = id
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/taxes/WCTaxClassModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/taxes/WCTaxClassModel.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.model.taxes
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+@RawConstraints(
+        "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+        "UNIQUE (LOCAL_SITE_ID) ON CONFLICT REPLACE"
+)
+data class WCTaxClassModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var name = ""
+    @Column var slug = ""
+
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/taxes/WCTaxClassModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/taxes/WCTaxClassModel.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 data class WCTaxClassModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var localSiteId = 0
     @Column var name = ""
-    @Column var slug = ""   // The unique identifier for the tax class on the server
+    @Column var slug = "" // The unique identifier for the tax class on the server
 
     override fun getId() = id
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -81,6 +82,17 @@ class ReleaseWCNetworkModule {
         token: AccessToken,
         userAgent: UserAgent
     ) = GatewayRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideTaxRestClient(
+        appContext: Context,
+        requestBuilder: JetpackTunnelGsonRequestBuilder,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = WCTaxRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
 
     @Singleton
     @Provides

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/taxes/WCTaxRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/taxes/WCTaxRestClient.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Singleton
+
+@Singleton
+class WCTaxRestClient
+constructor(
+    dispatcher: Dispatcher,
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
+    appContext: Context?,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchTaxClassList(
+        site: SiteModel
+    ): WooPayload<Array<TaxClassApiResponse>> {
+        val url = WOOCOMMERCE.taxes.classes.pathV3
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                emptyMap(),
+                Array<TaxClassApiResponse>::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
+    data class TaxClassApiResponse(
+        val name: String? = null,
+        val slug: String? = null
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCTaxSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCTaxSqlUtils.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.WCTaxClassModelTable
+import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.taxes.WCTaxClassModel
+
+object WCTaxSqlUtils {
+    fun getTaxClassesForSite(
+        localSiteId: Int
+    ): List<WCTaxClassModel> {
+        return WellSql.select(WCTaxClassModel::class.java)
+                .where()
+                .equals(WCTaxClassModelTable.LOCAL_SITE_ID, localSiteId)
+                .endWhere()
+                .asModel
+    }
+
+    fun deleteTaxClassesForSite(site: SiteModel): Int {
+        return WellSql.delete(WCTaxClassModel::class.java)
+                .where()
+                .equals(WCTaxClassModelTable.LOCAL_SITE_ID, site.id)
+                .or()
+                .equals(WCTaxClassModelTable.LOCAL_SITE_ID, 0) // Should never happen, but sanity cleanup
+                .endWhere().execute()
+    }
+
+    fun insertOrUpdateTaxClasses(taxClassList: List<WCTaxClassModel>): Int {
+        var rowsAffected = 0
+        taxClassList.forEach {
+            rowsAffected += insertOrUpdateTaxClass(it)
+        }
+        return rowsAffected
+    }
+
+    fun insertOrUpdateTaxClass(taxClass: WCTaxClassModel): Int {
+        val result = WellSql.select(WCTaxClassModel::class.java)
+                .where().beginGroup()
+                .equals(WCTaxClassModelTable.ID, taxClass.id)
+                .or()
+                .beginGroup()
+                .equals(WCTaxClassModelTable.LOCAL_SITE_ID, taxClass.localSiteId)
+                .equals(WCTaxClassModelTable.SLUG, taxClass.slug)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+
+        return if (result == null) {
+            // Insert
+            WellSql.insert(taxClass).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            val oldId = result.id
+            WellSql.update(WCTaxClassModel::class.java).whereId(oldId)
+                    .put(taxClass, UpdateAllExceptId(WCTaxClassModel::class.java)).execute()
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCTaxStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCTaxStore.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.fluxc.store
+
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.taxes.WCTaxClassMapper
+import org.wordpress.android.fluxc.model.taxes.WCTaxClassModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient
+import org.wordpress.android.fluxc.persistence.WCTaxSqlUtils
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+
+@Singleton
+class WCTaxStore @Inject constructor(
+    private val restClient: WCTaxRestClient,
+    private val coroutineContext: CoroutineContext,
+    private val mapper: WCTaxClassMapper
+) {
+    /**
+     * returns a list of tax classes for a specific site in the database
+     */
+    fun getShippingClassListForSite(site: SiteModel): List<WCTaxClassModel> =
+            WCTaxSqlUtils.getTaxClassesForSite(site.id)
+
+    suspend fun fetchTaxClassList(site: SiteModel): WooResult<List<WCTaxClassModel>> {
+        return withContext(coroutineContext) {
+            val response = restClient.fetchTaxClassList(site)
+            return@withContext when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+                response.result != null -> {
+                    val taxClassModels = response.result.map {
+                        mapper.map(it).apply { localSiteId = site.id }
+                    }
+
+                    WCTaxSqlUtils.insertOrUpdateTaxClasses(taxClassModels)
+                    WooResult(taxClassModels)
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCTaxStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCTaxStore.kt
@@ -38,6 +38,8 @@ class WCTaxStore @Inject constructor(
                         mapper.map(it).apply { localSiteId = site.id }
                     }
 
+                    // delete existing tax classes for site before adding incoming entries
+                    WCTaxSqlUtils.deleteTaxClassesForSite(site)
                     WCTaxSqlUtils.insertOrUpdateTaxClasses(taxClassModels)
                     WooResult(taxClassModels)
                 }

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -23,3 +23,6 @@
 
 /payment_gateways
 /payment_gateways/<gateway_id>#String
+
+/taxes
+/taxes/classes/


### PR DESCRIPTION
Fixes part 2 of #1442 by adding support to fetch tax_class list for a site. 

#### Changes
- I thought it would be nice to use coroutines for this implementation 😄
- Adds new endpoint `/wc/v3/taxes/classes`.  Since this is a new implementation, added all subsequent logic under the `taxes` package.
- Added new `WCTaxClassModel` model class and a migration script to create table.
- Added new classes, stores and mapper classes to fetch, store, update, delete tax class list for a site.
- Added unit tests.
- Added a new page to the example app to fetch tax class list for a site.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/71085261-1f8b9b80-21bd-11ea-9cd2-2483b445d48e.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/71085265-21555f00-21bd-11ea-81fd-7170bb01d96b.png"> 

#### Testing
- Since this PR adds a migration script, it would be nice to test updating the app.
- Run `WCTaxStoreTest` and `WCTaxSqlUtilsTest`.
- In the example app, click on `Woo` -> `Taxes` -> `Select Site` -> `Fetch Tax classes` and verify that the tax class list for the site is fetched successfully.
   - Try adding a new tax class to the site and verify it is displayed in the app.
   - Try deleting tax class from the site and verify it is updated in the app.
  - Try fetching tax classes for multiple test sites and verify the correct tax class list is displayed.
