### PR TITLE
Pass full error for use by Gutenberg

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release
 
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.example.BuildConfig
@@ -28,7 +29,17 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
         val params = mapOf("context" to "view")
         val response = runBlocking { reactNativeStore.performWPAPIRequest(url, params) }
 
-        val failureMessage = "Call failed with error: ${(response as? Error)?.error}"
-        assertTrue(failureMessage, response is Success)
+        val assertionMessage = "Call failed with error: ${(response as? Error)?.error}"
+        assertTrue(assertionMessage, response is Success)
+    }
+
+    @Test
+    fun testWPAPICallOnSelfHosted_fails() {
+        val url = BuildConfig.TEST_WPORG_URL_SH_WPAPI_SIMPLE + "/wp-json/wp/v2/an-invalid-extension/"
+        val response = runBlocking { reactNativeStore.performWPAPIRequest(url, emptyMap()) }
+
+        val assertionMessage = "Call should have failed with a 404, instead response was $response"
+        val actualStatusCode = (response as? Error)?.error?.volleyError?.networkResponse?.statusCode
+        assertEquals(assertionMessage, actualStatusCode, 404)
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release
 
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
@@ -25,5 +26,15 @@ class ReleaseStack_ReactNativeWPComRequestTest : ReleaseStack_WPComBase() {
 
         val failureMessage = "Call failed with error: ${(response as? Error)?.error}"
         assertTrue(failureMessage, response is Success)
+    }
+
+    @Test
+    fun testWpComCall_fails() {
+        val url = "https://public-api.wordpress.com/wp/v2/sites/${siteFromDb.siteId}/an-invalid-extension"
+        val response = runBlocking { reactNativeStore.performWPComRequest(url, emptyMap()) }
+
+        val assertionMessage = "Call should have failed with a 404, instead response was $response"
+        val actualStatusCode = (response as? Error)?.error?.volleyError?.networkResponse?.statusCode
+        Assert.assertEquals(assertionMessage, actualStatusCode, 404)
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
@@ -64,7 +64,7 @@ class ReactNativeFragment : Fragment() {
                     prependToLog("$callType call succeeded")
                     AppLog.i(AppLog.T.API, "$callType call result: ${response.result}")
                 }
-                is Error -> prependToLog("$callType call failed: ${response.error}")
+                is Error -> prependToLog("$callType call failed: ${response.error.volleyError?.message}")
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.store
 import com.google.gson.JsonElement
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.reactnative.ReactNativeWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.reactnative.ReactNativeWPComRestClient
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
@@ -37,21 +36,5 @@ class ReactNativeStore
 
 sealed class ReactNativeFetchResponse {
     class Success(val result: JsonElement) : ReactNativeFetchResponse()
-    class Error(networkError: BaseNetworkError) : ReactNativeFetchResponse() {
-        val error: String
-
-        init {
-            val volleyError = networkError.volleyError?.message
-            val wpComError = (networkError as? WPComGsonNetworkError)?.apiError
-            val baseError = networkError.message
-            val errorType = networkError.type?.toString()
-            error = when {
-                volleyError?.isNotBlank() == true -> volleyError
-                wpComError?.isNotBlank() == true -> wpComError
-                baseError?.isNotBlank() == true -> baseError
-                errorType?.isNotBlank() == true -> errorType
-                else -> "Unknown ${networkError.javaClass.simpleName} Error"
-            }
-        }
-    }
+    class Error(val error: BaseNetworkError) : ReactNativeFetchResponse()
 }


### PR DESCRIPTION
Previously, we were only passing a human-readable error string to Gutenberg in the case of errors. Gutenberg now needs access to additional error information though, so this PR updates the React Native request handling to return the full error object. That way any parsing of the error that needs to be done for Gutenberg can be kept out of FluxC and instead handled closer to Gutenberg.