### PR TITLE
Clear Account & Token on Invalid Token

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -912,6 +912,9 @@ public class AccountStore extends Store {
     }
 
     private void handleAuthenticateError(AuthenticateErrorPayload payload) {
+        if (payload.error.type == AuthenticationErrorType.INVALID_TOKEN) {
+            clearAccountAndAccessToken();
+        }
         OnAuthenticationChanged event = new OnAuthenticationChanged();
         event.error = payload.error;
         emitChange(event);
@@ -1111,15 +1114,19 @@ public class AccountStore extends Store {
         mAccountRestClient.pushUsername(payload.username, payload.actionType);
     }
 
-    private void signOut() {
+    private void clearAccountAndAccessToken() {
         // Remove Account
         AccountSqlUtils.deleteAccount(mAccount);
         mAccount.init();
+        // Remove authentication token
+        mAccessToken.set(null);
+    }
+
+    private void signOut() {
+        clearAccountAndAccessToken();
         OnAccountChanged accountChanged = new OnAccountChanged();
         accountChanged.accountInfosChanged = true;
         emitChange(accountChanged);
-        // Remove authentication token
-        mAccessToken.set(null);
         emitChange(new OnAuthenticationChanged());
     }
 


### PR DESCRIPTION
Fixes #462 
## Findings
When the token is invalid, the account and access token isn't being cleared in the `AccountStore` but there was a `signOut` function that contained some of the logic to do so. 

## Solution
To replicate the signout behavior when the `invalid_token` event is published so once the client consumes it's known that all account data has been invalidated. 

## Testing
1. Use this [WP Android branch with the FluxC hash
](https://github.com/wordpress-mobile/WordPress-Android/pull/11048)
2. Sign in to the app and select a WP.com site. 
3. Go to  https://wordpress.com/me/security/connected-applications on the same profile signed in above and disconnect WordPress Android. 
4. Try to utilize functionality such as Account Settings and the app should log out. 
5. Log back in and the app won't redirect you to the login when it's successful. 

N.B 
1. When I use my Automattic email this error doesn't occur. I haven't finished investigating that as yet.
2. I didn't do any tests with a self-hosted site. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 