### PR TITLE
Migrate multiple media upload and cancellation tests to mocked network

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -22,6 +22,7 @@ public interface MockedNetworkAppComponent {
     void inject(MockedStack_AccountTest object);
     void inject(MockedStack_CacheTest object);
     void inject(MockedStack_JetpackTunnelTest object);
+    void inject(MockedStack_MediaTest object);
     void inject(MockedStack_NotificationTest object);
     void inject(MockedStack_PluginTest object);
     void inject(MockedStack_SiteTest object);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -62,7 +62,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
         nextEvent = TestEvents.NONE
     }
 
-    @Test @Throws(InterruptedException::class)
+    @Test
     fun testCancelImageUpload() {
         interceptor.respondWithSticky("media-upload-response-success.json")
 
@@ -103,7 +103,6 @@ class MockedStack_MediaTest : MockedStack_Base() {
     }
 
     @Test
-    @Throws(InterruptedException::class)
     fun testUploadMultipleImages() {
         // Upload media to guarantee media exists
         uploadedIds.clear()
@@ -135,7 +134,6 @@ class MockedStack_MediaTest : MockedStack_Base() {
     }
 
     @Test
-    @Throws(InterruptedException::class)
     fun testUploadMultipleImagesAndCancel() {
         // Upload media to guarantee media exists
         uploadedIds.clear()
@@ -171,7 +169,6 @@ class MockedStack_MediaTest : MockedStack_Base() {
     }
 
     @Test
-    @Throws(InterruptedException::class)
     fun testUploadMultipleImagesAndCancelWithoutDeleting() {
         // Upload media to guarantee media exists
         uploadedIds.clear()
@@ -270,7 +267,6 @@ class MockedStack_MediaTest : MockedStack_Base() {
         }
     }
 
-    @Throws(InterruptedException::class)
     private fun uploadMultipleMedia(
         mediaList: List<MediaModel>,
         howManyFirstToCancel: Int = 0,

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -291,7 +291,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
 
         if (howManyFirstToCancel > 0 && howManyFirstToCancel <= mediaList.size) {
             // Wait a bit and issue the cancel command
-            TestUtils.waitFor(500)
+            TestUtils.waitFor(300)
 
             // We'e only cancelling the first n=howManyFirstToCancel uploads
             for (i in 0 until howManyFirstToCancel) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -142,7 +142,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
         howManyFirstToCancel: Int = 0,
         delete: Boolean = false
     ) {
-        interceptor.respondWith("media-upload-response-success.json")
+        interceptor.respondWithSticky("media-upload-response-success.json")
         countDownLatch = CountDownLatch(mediaList.size)
         for (media in mediaList) {
             // Don't strip location, as all media are the same file and we end up with concurrent read/writes

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -2,14 +2,25 @@ package org.wordpress.android.fluxc.mocked
 
 import android.annotation.SuppressLint
 import org.greenrobot.eventbus.Subscribe
+import org.junit.Assert
+import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.TestUtils
+import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
+import org.wordpress.android.fluxc.store.MediaStore.UploadMediaPayload
+import org.wordpress.android.fluxc.utils.MediaUtils
+import org.wordpress.android.util.AppLog
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlin.properties.Delegates.notNull
 
 @SuppressLint("UseSparseArrays")
 class MockedStack_MediaTest : MockedStack_Base() {
@@ -21,6 +32,9 @@ class MockedStack_MediaTest : MockedStack_Base() {
     private var nextEvent: TestEvents? = null
     private var countDownLatch: CountDownLatch by notNull()
 
+    private val uploadedIds: MutableList<Long> = mutableListOf()
+    private val uploadedMediaModels: MutableMap<Int, MediaModel> = mutableMapOf()
+
     private val testSite: SiteModel
         get() {
             val site = SiteModel()
@@ -31,7 +45,8 @@ class MockedStack_MediaTest : MockedStack_Base() {
         }
 
     private enum class TestEvents {
-        NONE
+        NONE,
+        UPLOADED_MULTIPLE_MEDIA
     }
 
     @Throws(Exception::class)
@@ -43,12 +58,64 @@ class MockedStack_MediaTest : MockedStack_Base() {
         nextEvent = TestEvents.NONE
     }
 
+    @Test
+    @Throws(InterruptedException::class)
+    fun testUploadMultipleImages() {
+        // Upload media to guarantee media exists
+        uploadedIds.clear()
+        nextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA
+
+        uploadedMediaModels.clear()
+        // Here we use the newMediaModel() with id builder, as we need it to identify uploads
+        for (i in 1..5) {
+            addMediaModelToUploadArray("Test media $i")
+        }
+
+        // Upload media, dispatching all at once (not waiting for each to finish)
+        uploadMultipleMedia(uploadedMediaModels.values.toList())
+
+        // Verify all have been uploaded
+        Assert.assertEquals(uploadedMediaModels.size, uploadedIds.size)
+        Assert.assertEquals(
+                uploadedMediaModels.size,
+                mediaStore.getSiteMediaWithState(testSite, MediaUploadState.UPLOADED).size
+        )
+
+        // Verify they exist in the MediaStore
+        val iterator = uploadedMediaModels.values.iterator()
+        while (iterator.hasNext()) {
+            iterator.next().let { uploadedMediaModel ->
+                Assert.assertNotNull(mediaStore.getSiteMediaWithId(testSite, uploadedMediaModel.mediaId))
+            }
+        }
+    }
+
     @Suppress("unused")
     @Subscribe
     fun onMediaUploaded(event: OnMediaUploaded) {
         if (event.isError) {
             throw AssertionError("Unexpected error occurred with type: " + event.error.type)
         }
+        if (event.canceled) {
+            throw AssertionError("Unexpected cancellation for media: " + event.media.id)
+        } else if (event.completed) {
+            if (nextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA) {
+                uploadedIds.add(event.media.mediaId)
+                // Update our own map object with the new media id
+                val media = uploadedMediaModels[event.media.id]?.apply {
+                    mediaId = event.media.mediaId
+                } ?: AppLog.e(AppLog.T.MEDIA, "MediaModel not found: " + event.media.id)
+                Assert.assertNotNull(media)
+            } else {
+                throw AssertionError("Unexpected completion for media: " + event.media.id)
+            }
+            countDownLatch.countDown()
+        }
+    }
+
+    private fun addMediaModelToUploadArray(title: String) {
+        val mediaModel = newMediaModel(title, sampleImagePath, MediaUtils.MIME_TYPE_IMAGE)
+        uploadedMediaModels[mediaModel.id] = mediaModel
     }
 
     private fun newMediaModel(testTitle: String, mediaPath: String, mimeType: String): MediaModel {
@@ -67,5 +134,34 @@ class MockedStack_MediaTest : MockedStack_Base() {
             alt = testAlt
             localSiteId = testSite.id
         }
+    }
+
+    @Throws(InterruptedException::class)
+    private fun uploadMultipleMedia(
+        mediaList: List<MediaModel>,
+        howManyFirstToCancel: Int = 0,
+        delete: Boolean = false
+    ) {
+        interceptor.respondWith("media-upload-response-success.json")
+        countDownLatch = CountDownLatch(mediaList.size)
+        for (media in mediaList) {
+            // Don't strip location, as all media are the same file and we end up with concurrent read/writes
+            val payload = UploadMediaPayload(testSite, media, false)
+            dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
+        }
+
+        if (howManyFirstToCancel > 0 && howManyFirstToCancel <= mediaList.size) {
+            // Wait a bit and issue the cancel command
+            TestUtils.waitFor(1000)
+
+            // We'e only cancelling the first n=howManyFirstToCancel uploads
+            for (i in 0 until howManyFirstToCancel) {
+                val media = mediaList[i]
+                val payload = CancelMediaPayload(testSite, media, delete)
+                dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload))
+            }
+        }
+
+        Assert.assertTrue(countDownLatch.await(TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.fluxc.mocked
+
+import android.annotation.SuppressLint
+import org.greenrobot.eventbus.Subscribe
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
+import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
+import java.util.concurrent.CountDownLatch
+import javax.inject.Inject
+
+@SuppressLint("UseSparseArrays")
+class MockedStack_MediaTest : MockedStack_Base() {
+    @Inject lateinit var dispatcher: Dispatcher
+    @Inject lateinit var mediaStore: MediaStore
+
+    @Inject lateinit var interceptor: ResponseMockingInterceptor
+
+    private var nextEvent: TestEvents? = null
+    private var countDownLatch: CountDownLatch by notNull()
+
+    private val testSite: SiteModel
+        get() {
+            val site = SiteModel()
+            site.id = 5
+            site.setIsWPCom(true)
+            site.siteId = 6426253
+            return site
+        }
+
+    private enum class TestEvents {
+        NONE
+    }
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mMockedNetworkAppComponent.inject(this)
+
+        dispatcher.register(this)
+        nextEvent = TestEvents.NONE
+    }
+
+    @Suppress("unused")
+    @Subscribe
+    fun onMediaUploaded(event: OnMediaUploaded) {
+        if (event.isError) {
+            throw AssertionError("Unexpected error occurred with type: " + event.error.type)
+        }
+    }
+
+    private fun newMediaModel(testTitle: String, mediaPath: String, mimeType: String): MediaModel {
+        val testDescription = "Test Description"
+        val testCaption = "Test Caption"
+        val testAlt = "Test Alt"
+
+        return mediaStore.instantiateMediaModel().apply {
+            filePath = mediaPath
+            fileExtension = mediaPath.substring(mediaPath.lastIndexOf(".") + 1)
+            this.mimeType = mimeType + fileExtension
+            fileName = mediaPath.substring(mediaPath.lastIndexOf("/"))
+            title = testTitle
+            description = testDescription
+            caption = testCaption
+            alt = testAlt
+            localSiteId = testSite.id
+        }
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -235,7 +235,12 @@ class MockedStack_MediaTest : MockedStack_Base() {
         howManyFirstToCancel: Int = 0,
         delete: Boolean = false
     ) {
-        interceptor.respondWithSticky("media-upload-response-success.json")
+        interceptor.respondWithSticky("media-upload-response-success.json") {
+            // To imitate a real set of media upload requests as much as possible, each one should return a unique
+            // remote media id. This also makes sure the MediaModel table doesn't treat these as duplicate entries and
+            // deletes them, failing the test.
+            string: String -> string.replace("9999", Thread.currentThread().id.toString())
+        }
         countDownLatch = CountDownLatch(mediaList.size)
         for (media in mediaList) {
             // Don't strip location, as all media are the same file and we end up with concurrent read/writes

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -245,7 +245,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
 
         if (howManyFirstToCancel > 0 && howManyFirstToCancel <= mediaList.size) {
             // Wait a bit and issue the cancel command
-            TestUtils.waitFor(1000)
+            TestUtils.waitFor(500)
 
             // We'e only cancelling the first n=howManyFirstToCancel uploads
             for (i in 0 until howManyFirstToCancel) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
@@ -14,6 +14,7 @@ import okio.Okio
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor.InterceptorMode.ONE_TIME
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor.InterceptorMode.STICKY
+import org.wordpress.android.fluxc.module.ResponseMockingInterceptor.InterceptorMode.STICKY_SUBSTITUTION
 import java.io.BufferedReader
 import java.io.ByteArrayInputStream
 import java.io.IOException
@@ -23,16 +24,22 @@ import javax.inject.Singleton
 
 @Singleton
 class ResponseMockingInterceptor : Interceptor {
+    companion object {
+        private val SUBSTITUTION_DEFAULT = { string: String -> string }
+    }
+
     /**
      * ONE_TIME: Use the last response provided for the next request handled, and then clear it.
      * STICKY: Keep using the last response provided for all requests, until a new response is provided.
+     * STICKY_SUBSTITUTION: Like STICKY, but also run a transformation function on the response.
      */
-    enum class InterceptorMode { ONE_TIME, STICKY }
+    enum class InterceptorMode { ONE_TIME, STICKY, STICKY_SUBSTITUTION }
 
     private var nextResponseJson: String? = null
     private var nextResponseCode: Int = 200
 
     private var mode: InterceptorMode = ONE_TIME
+    private var transformStickyResponse = SUBSTITUTION_DEFAULT
 
     private val gson by lazy { Gson() }
 
@@ -55,12 +62,16 @@ class ResponseMockingInterceptor : Interceptor {
         nextResponseJson = getStringFromResourceFile(jsonResponseFileName)
         nextResponseCode = 200
         mode = ONE_TIME
+        transformStickyResponse = SUBSTITUTION_DEFAULT
     }
 
-    fun respondWithSticky(jsonResponseFileName: String) {
+    fun respondWithSticky(jsonResponseFileName: String, transformResponse: ((String) -> String)? = null) {
         nextResponseJson = getStringFromResourceFile(jsonResponseFileName)
         nextResponseCode = 200
-        mode = STICKY
+        transformResponse?.let {
+            transformStickyResponse = it
+        }
+        mode = if (transformResponse == null) STICKY else STICKY_SUBSTITUTION
     }
 
     @JvmOverloads
@@ -92,7 +103,11 @@ class ResponseMockingInterceptor : Interceptor {
 
         nextResponseJson?.let {
             // Will be a successful response if nextResponseCode is 200, otherwise an error response
-            val response = buildResponse(request, it, nextResponseCode)
+            val response = if (mode == STICKY_SUBSTITUTION) {
+                buildResponse(request, transformStickyResponse(it), nextResponseCode)
+            } else {
+                buildResponse(request, it, nextResponseCode)
+            }
 
             if (mode == ONE_TIME) {
                 // Clean up for the next call

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -31,7 +31,6 @@ import org.wordpress.android.util.AppLog;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -295,44 +294,6 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
         MediaModel canceledMedia = mMediaStore.getMediaWithLocalId(testMedia.getId());
         assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
-    }
-
-    @Test
-    public void testUploadMultipleImages() throws InterruptedException {
-        // upload media to guarantee media exists
-        mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA;
-
-        mUploadedMediaModels = new HashMap<>();
-        // here we use the newMediaModel() with id builder, as we need it to identify uploads
-        addMediaModelToUploadArray("Test media 1");
-        addMediaModelToUploadArray("Test media 2");
-        addMediaModelToUploadArray("Test media 3");
-        addMediaModelToUploadArray("Test media 4");
-        addMediaModelToUploadArray("Test media 5");
-
-        // upload media, dispatching all at a time (not waiting for each to finish)
-        uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()));
-
-        // verify all have been uploaded
-        assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
-        assertEquals(mUploadedMediaModels.size(),
-                mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
-
-        // verify they exist in the MediaStore
-        Iterator<MediaModel> iterator = mUploadedMediaModels.values().iterator();
-        while (iterator.hasNext()) {
-            MediaModel media = iterator.next();
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, media.getMediaId()));
-        }
-
-        // delete test images (bear in mind this is done sequentially)
-        iterator = mUploadedMediaModels.values().iterator();
-        while (iterator.hasNext()) {
-            MediaModel media = iterator.next();
-            mNextEvent = TestEvents.DELETED_MEDIA;
-            deleteMedia(media);
-        }
     }
 
     @Test
@@ -647,10 +608,6 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    private void uploadMultipleMedia(List<MediaModel> mediaList) throws InterruptedException {
-        uploadMultipleMedia(mediaList, 0, false);
     }
 
     private void uploadMultipleMedia(List<MediaModel> mediaList, int howManyFirstToCancel, boolean delete)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -14,10 +14,8 @@ import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.StockMediaModel;
 import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
@@ -47,7 +45,6 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
 
     private enum TestEvents {
         NONE,
-        CANCELED_MEDIA,
         DELETED_MEDIA,
         FETCHED_MEDIA_LIST,
         FETCHED_MEDIA_IMAGE_LIST,
@@ -251,45 +248,6 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     }
 
     @Test
-    public void testCancelImageUpload() throws InterruptedException {
-        // First, try canceling an image with the default behavior (canceled image is deleted from the store)
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.CANCELED_MEDIA;
-        UploadMediaPayload payload = new UploadMediaPayload(sSite, testMedia, true);
-        mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-
-        // Wait a bit and issue the cancel command
-        TestUtils.waitFor(1000);
-
-        CancelMediaPayload cancelPayload = new CancelMediaPayload(sSite, testMedia);
-        mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        assertEquals(0, mMediaStore.getSiteMediaCount(sSite));
-
-        // Now, try canceling with delete=false (canceled image should be marked as failed and kept in the store)
-        testMedia = newMediaModel(getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
-        mCountDownLatch = new CountDownLatch(1);
-        mNextEvent = TestEvents.CANCELED_MEDIA;
-        payload = new UploadMediaPayload(sSite, testMedia, true);
-        mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-
-        // Wait a bit and issue the cancel command
-        TestUtils.waitFor(1000);
-
-        cancelPayload = new CancelMediaPayload(sSite, testMedia, false);
-        mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload));
-
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-
-        assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
-        MediaModel canceledMedia = mMediaStore.getMediaWithLocalId(testMedia.getId());
-        assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
-    }
-
-    @Test
     public void testUploadVideo() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleVideoPath(), MediaUtils.MIME_TYPE_VIDEO);
@@ -338,13 +296,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        if (event.canceled) {
-            if (mNextEvent == TestEvents.CANCELED_MEDIA) {
-                mCountDownLatch.countDown();
-            } else {
-                throw new AssertionError("Unexpected cancellation for media: " + event.media.getId());
-            }
-        } else if (event.completed) {
+        if (event.completed) {
             if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
                 mLastUploadedId = event.media.getMediaId();
             } else {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -28,9 +28,7 @@ import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.util.AppLog;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -62,8 +60,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         PUSHED_MEDIA,
         REMOVED_MEDIA,
         UPLOADED_MEDIA,
-        UPLOADED_MULTIPLE_MEDIA, // these don't exist in FluxC, but are an artifact to wait for all uploads to finish
-        UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL, // same as above
         NULL_ERROR,
         MALFORMED_ERROR,
         NOT_FOUND_ERROR
@@ -71,9 +67,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     private TestEvents mNextEvent;
     private long mLastUploadedId = -1L;
-
-    private List<Long> mUploadedIds = new ArrayList<>();
-    private Map<Integer, MediaModel> mUploadedMediaModels = new HashMap<>();
 
     @Override
     public void setUp() throws Exception {
@@ -308,96 +301,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     @Test
-    public void testUploadMultipleImagesAndCancel() throws InterruptedException {
-        // upload media to guarantee media exists
-        mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL;
-
-        mUploadedMediaModels = new HashMap<>();
-        // here we use the newMediaModel() with id builder, as we need it to identify uploads
-        addMediaModelToUploadArray("Test media 1");
-        addMediaModelToUploadArray("Test media 2");
-        addMediaModelToUploadArray("Test media 3");
-        addMediaModelToUploadArray("Test media 4");
-        addMediaModelToUploadArray("Test media 5");
-
-        // use this variable to test cancelling 1, 2, 3, 4 or all 5 uploads
-        int amountToCancel = 4;
-
-        // upload media, dispatching all at a time (not waiting for each to finish)
-        // also cancel (and delete) the first n=`amountToCancel` media uploads
-        uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()), amountToCancel, true);
-
-        // verify how many have been uploaded
-        assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
-
-        // verify each one of the remaining, non-cancelled uploads exist in the MediaStore
-        for (long mediaId : mUploadedIds) {
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
-        }
-
-        // Only completed uploads should exist in the store
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteImageCount(sSite));
-        // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
-
-        // delete test images (bear in mind this is done sequentially)
-        mNextEvent = TestEvents.DELETED_MEDIA;
-        for (MediaModel media : mUploadedMediaModels.values()) {
-            // delete only successfully uploaded test images
-            if (mUploadedIds.contains(media.getMediaId())) {
-                deleteMedia(media);
-            }
-        }
-    }
-
-    @Test
-    public void testUploadMultipleImagesAndCancelWithoutDeleting() throws InterruptedException {
-        // upload media to guarantee media exists
-        mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL;
-
-        mUploadedMediaModels = new HashMap<>();
-        // here we use the newMediaModel() with id builder, as we need it to identify uploads
-        addMediaModelToUploadArray("Test media 1");
-        addMediaModelToUploadArray("Test media 2");
-        addMediaModelToUploadArray("Test media 3");
-        addMediaModelToUploadArray("Test media 4");
-        addMediaModelToUploadArray("Test media 5");
-
-        // use this variable to test cancelling 1, 2, 3, 4 or all 5 uploads
-        int amountToCancel = 4;
-
-        // upload media, dispatching all at a time (not waiting for each to finish)
-        // also cancel (without deleting) the first n=`amountToCancel` media uploads
-        uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()), amountToCancel, false);
-
-        // verify how many have been uploaded
-        assertEquals(mUploadedMediaModels.size() - amountToCancel, mUploadedIds.size());
-
-        // verify each one of the remaining, non-cancelled uploads exist in the MediaStore
-        for (long mediaId : mUploadedIds) {
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, mediaId));
-        }
-
-        // All the original uploads should exist in the store, whether cancelled or not
-        assertEquals(mUploadedMediaModels.size(), mMediaStore.getSiteMediaCount(sSite));
-        // The number of uploaded media in the store should match our records of how many were not cancelled
-        assertEquals(mUploadedIds.size(), mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
-        // All cancelled media should have a FAILED state
-        assertEquals(amountToCancel, mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.FAILED).size());
-
-        // delete test images (bear in mind this is done sequentially)
-        mNextEvent = TestEvents.DELETED_MEDIA;
-        for (MediaModel media : mUploadedMediaModels.values()) {
-            // delete only successfully uploaded test images
-            if (mUploadedIds.contains(media.getMediaId())) {
-                deleteMedia(media);
-            }
-        }
-    }
-
-    @Test
     public void testUploadVideo() throws InterruptedException {
         // upload media to guarantee media exists
         MediaModel testMedia = newMediaModel(getSampleVideoPath(), MediaUtils.MIME_TYPE_VIDEO);
@@ -489,34 +392,13 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
         if (event.canceled) {
-            if (mNextEvent == TestEvents.CANCELED_MEDIA
-                    || mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL) {
+            if (mNextEvent == TestEvents.CANCELED_MEDIA) {
                 mCountDownLatch.countDown();
             } else {
                 throw new AssertionError("Unexpected cancellation for media: " + event.media.getId());
             }
         } else if (event.completed) {
-            if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA_WITH_CANCEL) {
-                mUploadedIds.add(event.media.getMediaId());
-                // now update our own map object with the new media id
-                MediaModel media = mUploadedMediaModels.get(event.media.getId());
-                if (media != null) {
-                    media.setMediaId(event.media.getMediaId());
-                } else {
-                    AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
-                }
-                assertNotNull(media);
-            } else if (mNextEvent == TestEvents.UPLOADED_MULTIPLE_MEDIA) {
-                mUploadedIds.add(event.media.getMediaId());
-                // now update our own map object with the new media id
-                MediaModel media = mUploadedMediaModels.get(event.media.getId());
-                if (media != null) {
-                    media.setMediaId(event.media.getMediaId());
-                } else {
-                    AppLog.e(AppLog.T.MEDIA, "mediamodel not found: " + event.media.getId());
-                }
-                assertNotNull(media);
-            } else if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
+            if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
                 mLastUploadedId = event.media.getMediaId();
             } else {
                 throw new AssertionError("Unexpected completion for media: " + event.media.getId());
@@ -566,11 +448,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 || mNextEvent == TestEvents.FETCHED_MEDIA_IMAGE_LIST;
         assertTrue(isMediaListEvent);
         mCountDownLatch.countDown();
-    }
-
-    private void addMediaModelToUploadArray(String title) {
-        MediaModel mediaModel = newMediaModel(title, getSampleImagePath(), MediaUtils.MIME_TYPE_IMAGE);
-        mUploadedMediaModels.put(mediaModel.getId(), mediaModel);
     }
 
     private MediaModel newMediaModel(String mediaPath, String mimeType) {
@@ -631,30 +508,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    private void uploadMultipleMedia(List<MediaModel> mediaList, int howManyFirstToCancel, boolean delete)
-            throws InterruptedException {
-        mCountDownLatch = new CountDownLatch(mediaList.size());
-        for (MediaModel media : mediaList) {
-            // Don't strip location, as all media are the same file and we end up with concurrent read/writes
-            UploadMediaPayload payload = new UploadMediaPayload(sSite, media, false);
-            mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-        }
-
-        if (howManyFirstToCancel > 0 && howManyFirstToCancel <= mediaList.size()) {
-            // wait a bit and issue the cancel command
-            TestUtils.waitFor(1000);
-
-            // we'e only cancelling the first n=howManyFirstToCancel uploads
-            for (int i = 0; i < howManyFirstToCancel; i++) {
-                MediaModel media = mediaList.get(i);
-                CancelMediaPayload payload = new CancelMediaPayload(sSite, media, delete);
-                mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
-            }
-        }
-
-        assertTrue(mCountDownLatch.await(TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     private void deleteMedia(MediaModel media) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -29,7 +29,6 @@ import org.wordpress.android.util.AppLog;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -306,44 +305,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(1, mMediaStore.getSiteMediaCount(sSite));
         MediaModel canceledMedia = mMediaStore.getMediaWithLocalId(testMedia.getId());
         assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.getUploadState());
-    }
-
-    @Test
-    public void testUploadMultipleImages() throws InterruptedException {
-        // upload media to guarantee media exists
-        mUploadedIds = new ArrayList<>();
-        mNextEvent = TestEvents.UPLOADED_MULTIPLE_MEDIA;
-
-        mUploadedMediaModels = new HashMap<>();
-        // here we use the newMediaModel() with id builder, as we need it to identify uploads
-        addMediaModelToUploadArray("Test media 1");
-        addMediaModelToUploadArray("Test media 2");
-        addMediaModelToUploadArray("Test media 3");
-        addMediaModelToUploadArray("Test media 4");
-        addMediaModelToUploadArray("Test media 5");
-
-        // upload media, dispatching all at a time (not waiting for each to finish)
-        uploadMultipleMedia(new ArrayList<>(mUploadedMediaModels.values()));
-
-        // verify all have been uploaded
-        assertEquals(mUploadedMediaModels.size(), mUploadedIds.size());
-        assertEquals(mUploadedMediaModels.size(),
-                mMediaStore.getSiteMediaWithState(sSite, MediaUploadState.UPLOADED).size());
-
-        // verify they exist in the MediaStore
-        Iterator<MediaModel> iterator = mUploadedMediaModels.values().iterator();
-        while (iterator.hasNext()) {
-            MediaModel media = iterator.next();
-            assertNotNull(mMediaStore.getSiteMediaWithId(sSite, media.getMediaId()));
-        }
-
-        // delete test images (bear in mind this is done sequentially)
-        mNextEvent = TestEvents.DELETED_MEDIA;
-        iterator = mUploadedMediaModels.values().iterator();
-        while (iterator.hasNext()) {
-            MediaModel media = iterator.next();
-            deleteMedia(media);
-        }
     }
 
     @Test
@@ -670,10 +631,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-
-    private void uploadMultipleMedia(List<MediaModel> mediaList) throws InterruptedException {
-        uploadMultipleMedia(mediaList, 0, false);
     }
 
     private void uploadMultipleMedia(List<MediaModel> mediaList, int howManyFirstToCancel, boolean delete)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
@@ -304,6 +304,11 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
         assertEquals(0, mUploadStore.getPendingPosts().size());
         assertEquals(0, mUploadStore.getAllRegisteredPosts().size());
         assertNull(getPostUploadModelForPostModel(uploadedPost));
+
+        // Delete test image
+        testMedia.setMediaId(mLastUploadedId);
+        mNextEvent = TestEvents.DELETED_MEDIA;
+        deleteMedia(testMedia);
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Converts several live media tests (the ones testing media upload cancellation and multiple concurrent media uploads) to mocked network tests.

This will likely fix #564 since I think all the tests involved will be turned into mocks in the end.

The main reason for doing this is that I noticed our test sites have a huge amount of uploaded media (the WP.com test site ran out of storage recently). I tracked down the cause to these kinds of tests: the cancellation doesn't always go through before the media actually completes, and the uploaded media are left on the server because the tests don't know to delete them.

Making these tests mocked seems like a good solution, as we have other live tests testing actual media upload behavior - the tests I migrated in this PR are mostly testing FluxC behavior and generally make sense as mocked tests.

#### A few extra benefits
* A couple of these tests flake on occasion; possibly due to network hiccups, possibly a concurrency issue. Moving them to the mocked stack should resolve these issues (or make them more common/easier to resolve).
* As the tests were also duplicated between WP.com and XML-RPC; this should speed up the live test runs by a bit.

### TODO:
* [x] The method for giving each mock media upload response a unique remote id could be better; right now it relies on the `RequestQueue` having a thread pool size greater than or equal to 5 (the number of concurrent media uploads in the tests). Probably a `ConcurrentHashMap` or the like prepopulated with unique values should do the trick.
* [x] There is at least one test in `ReleaseStack_UploadTest` also not consistently clearing uploaded media - I'd like to migrate those too.

To test:
1. Run the mocked test suite, make sure it passes
2. Log in to the test sites used in `ReleaseStack_MediaTestWPCom` and`ReleaseStack_MediaTestXMLRPC`
3. Run those two test classes, and make sure no new media were uploaded to the test sites at the end of the tesst run
4. Repeat step 3 for `ReleaseStack_UploadTest` (this one's WPCom only, same test site as `ReleaseStack_MediaTestWPCom`)