### PR TITLE
Pass the last day of the week as end date when fetching revenue stats api

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -641,7 +641,7 @@ class WCStatsStore @Inject constructor(
 
     private fun fetchRevenueStats(payload: FetchRevenueStatsPayload) {
         val startDate = getStartDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.startDate)
-        val endDate = getEndDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.startDate)
+        val endDate = getEndDateForRevenueStatsGranularity(payload.site, payload.granularity)
         val perPage = getRandomPageIntForRevenueStats(payload.forced)
         wcOrderStatsClient.fetchRevenueStats(
                 payload.site,
@@ -675,23 +675,18 @@ class WCStatsStore @Inject constructor(
     }
 
     /**
-     * Given a [endDate], formats the date based on the site's timezone in format yyyy-MM-dd'T'hh:mm:ss
-     * If the endDate date is empty, fetches the date based on the [granularity]
+     * Formats the date based on the site's timezone in format yyyy-MM-dd'T'hh:mm:ss
+     * based on the [granularity] and [site]
      */
     private fun getEndDateForRevenueStatsGranularity(
         site: SiteModel,
-        granularity: StatsGranularity,
-        endDate: String?
+        granularity: StatsGranularity
     ): String {
-        return if (endDate.isNullOrEmpty()) {
-            when (granularity) {
-                StatsGranularity.DAYS -> DateUtils.getEndDateForSite(site)
-                StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
-                StatsGranularity.MONTHS -> DateUtils.getEndDateForSite(site)
-                StatsGranularity.YEARS -> DateUtils.getEndDateForSite(site)
-            }
-        } else {
-            DateUtils.getEndDateForSite(site)
+        return when (granularity) {
+            StatsGranularity.DAYS -> DateUtils.getEndDateForSite(site)
+            StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
+            StatsGranularity.MONTHS -> DateUtils.getEndDateForSite(site)
+            StatsGranularity.YEARS -> DateUtils.getEndDateForSite(site)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -675,8 +675,8 @@ class WCStatsStore @Inject constructor(
     }
 
     /**
-     * Formats the date based on the site's timezone in format yyyy-MM-dd'T'hh:mm:ss
-     * based on the [granularity] and [site]
+     * Returns the appropriate end date for the [site] and [granularity] provided,
+     * to use for fetching revenue stats.
      */
     private fun getEndDateForRevenueStatsGranularity(
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -686,7 +686,7 @@ class WCStatsStore @Inject constructor(
         return if (endDate.isNullOrEmpty()) {
             when (granularity) {
                 StatsGranularity.DAYS -> DateUtils.getEndDateForSite(site)
-                StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekBySite(site)
+                StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
                 StatsGranularity.MONTHS -> DateUtils.getEndDateForSite(site)
                 StatsGranularity.YEARS -> DateUtils.getEndDateForSite(site)
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -641,7 +641,7 @@ class WCStatsStore @Inject constructor(
 
     private fun fetchRevenueStats(payload: FetchRevenueStatsPayload) {
         val startDate = getStartDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.startDate)
-        val endDate = DateUtils.getEndDateForSite(payload.site)
+        val endDate = getEndDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.startDate)
         val perPage = getRandomPageIntForRevenueStats(payload.forced)
         wcOrderStatsClient.fetchRevenueStats(
                 payload.site,
@@ -671,6 +671,27 @@ class WCStatsStore @Inject constructor(
             }
         } else {
             DateUtils.getStartDateForSite(site, startDate)
+        }
+    }
+
+    /**
+     * Given a [endDate], formats the date based on the site's timezone in format yyyy-MM-dd'T'hh:mm:ss
+     * If the endDate date is empty, fetches the date based on the [granularity]
+     */
+    private fun getEndDateForRevenueStatsGranularity(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        endDate: String?
+    ): String {
+        return if (endDate.isNullOrEmpty()) {
+            when (granularity) {
+                StatsGranularity.DAYS -> DateUtils.getEndDateForSite(site)
+                StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekBySite(site)
+                StatsGranularity.MONTHS -> DateUtils.getEndDateForSite(site)
+                StatsGranularity.YEARS -> DateUtils.getEndDateForSite(site)
+            }
+        } else {
+            DateUtils.getEndDateForSite(site)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -314,11 +314,11 @@ object DateUtils {
         return formatDate(DATE_TIME_FORMAT_START, cal.time)
     }
 
-    fun getLastDayOfCurrentWeekBySite(site: SiteModel): String {
+    fun getLastDayOfCurrentWeekForSite(site: SiteModel): String {
         val cal = Calendar.getInstance(Locale.ROOT)
         cal.time = getCurrentDateFromSite(site)
         cal.set(Calendar.DAY_OF_WEEK, cal.getActualMaximum(Calendar.DAY_OF_WEEK))
-        return formatDate(DATE_TIME_FORMAT_START, cal.time)
+        return formatDate(DATE_TIME_FORMAT_END, cal.time)
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -314,6 +314,13 @@ object DateUtils {
         return formatDate(DATE_TIME_FORMAT_START, cal.time)
     }
 
+    fun getLastDayOfCurrentWeekBySite(site: SiteModel): String {
+        val cal = Calendar.getInstance(Locale.ROOT)
+        cal.time = getCurrentDateFromSite(site)
+        cal.set(Calendar.DAY_OF_WEEK, cal.getActualMaximum(Calendar.DAY_OF_WEEK))
+        return formatDate(DATE_TIME_FORMAT_START, cal.time)
+    }
+
     /**
      * Given a [SiteModel] instance, returns a [Date] instance for the current date
      *


### PR DESCRIPTION
Fixes #1463 - This PR adds the option to pass the end of the week date as the end date, when fetching revenue stats from the `/wc/v4/reports/revenue/stats` endpoint.

#### To Test
- Click on `Woo` -> `Revenue Stats` -> `Select Site` -> `Fetch Current week revenue stats`.
- Verify that the end date for the weekly stats is the future date for the end of the week instead of the current date. i.e. for this week end date should be `28-12-2019`.


<img width="300" src="https://user-images.githubusercontent.com/22608780/71457445-00e06280-27c4-11ea-9953-c06d95d81633.png">
