### PR TITLE
Issue/1457 shipping class pagination

### DIFF
--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -103,6 +103,13 @@
             android:text="Fetch Product Shipping classes"/>
 
         <Button
+            android:id="@+id/load_more_product_shipping_classes"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:text="Load More Shipping classes" />
+
+        <Button
             android:id="@+id/update_product_images"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -72,8 +72,8 @@ class ProductRestClient(
         val responseType = object : TypeToken<List<ProductShippingClassApiResponse>>() {}.type
         val params = mutableMapOf(
                 "per_page" to pageSize.toString(),
-                "offset" to offset.toString(),
-                "order" to "asc")
+                "offset" to offset.toString()
+        )
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<ProductShippingClassApiResponse>? ->


### PR DESCRIPTION
Fixes #1457. This PR adds logic to support pagination when fetching product shipping classes.

#### Changes
- Adds a default page size when fetching shipping class list, which is 25.
- Adds an `offset` field to the API request when fetching shipping classes.
- Adds a new button in the example app to test the pagination.
- The default sort order is by name ASC 

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/71575659-ca804b80-2b13-11ea-8a0d-d42b615875ab.png">

#### Testing
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Fetch product shipping classes`.
- Verify that the shipping class list is fetched correctly.
- Click on `Lore more shipping classes` and verify that the shipping classes are fetched correctly.
  - If there is no more variation data found in the API response, the `Load more shipping classes` button should be displayed but disabled.