### PR TITLE
Add a setOnlyIfEmpty option to the DesignateMobileEditorForAllSites payload

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -332,12 +332,12 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void designateMobileEditorForAllSites(final String mobileEditorName) {
+    public void designateMobileEditorForAllSites(final String mobileEditorName, final boolean setOnlyIfEmpty) {
         Map<String, Object> params = new HashMap<>();
         String url = WPCOMV2.me.gutenberg.getUrl();
         params.put("editor", mobileEditorName);
         params.put("platform", "mobile");
-        params.put("set_only_if_empty", "true");
+        params.put("set_only_if_empty", String.valueOf(setOnlyIfEmpty));
 
         add(WPComGsonRequest
                 .buildPostRequest(url, params, Map.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -337,7 +337,12 @@ public class SiteRestClient extends BaseWPComRestClient {
         String url = WPCOMV2.me.gutenberg.getUrl();
         params.put("editor", mobileEditorName);
         params.put("platform", "mobile");
-        params.put("set_only_if_empty", String.valueOf(setOnlyIfEmpty));
+        if (setOnlyIfEmpty) {
+            params.put("set_only_if_empty", "true");
+        }
+        // Else, omit the "set_only_if_empty" parameters.
+        // There is an issue in the API implementation. It only checks
+        // for "set_only_if_empty" presence but don't check for its value.
 
         add(WPComGsonRequest
                 .buildPostRequest(url, params, Map.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -115,9 +115,16 @@ public class SiteStore extends Store {
 
     public static class DesignateMobileEditorForAllSitesPayload extends Payload<SiteEditorsError> {
         public String editor;
+        public boolean setOnlyIfEmpty;
 
         public DesignateMobileEditorForAllSitesPayload(@NonNull String editorName) {
             this.editor = editorName;
+            this.setOnlyIfEmpty = true;
+        }
+
+        public DesignateMobileEditorForAllSitesPayload(@NonNull String editorName, boolean setOnlyIfEmpty) {
+            this.editor = editorName;
+            this.setOnlyIfEmpty = setOnlyIfEmpty;
         }
     }
 
@@ -1754,7 +1761,7 @@ public class SiteStore extends Store {
         }
 
         if (wpcomPostRequestRequired) {
-            mSiteRestClient.designateMobileEditorForAllSites(payload.editor);
+            mSiteRestClient.designateMobileEditorForAllSites(payload.editor, payload.setOnlyIfEmpty);
             event.isNetworkResponse = false;
         } else {
             event.isNetworkResponse = true;


### PR DESCRIPTION
Make sure to replace "CHANGEME" by an actual Bearer token.


To test:

- Open a user report card, on at least one site, turn `mobile-editor` to `aztec`.
- Run one of the following command.
- Refresh the user report card. Check the `mobile-editor` setting on that site.

3 commands, one is not working as expected (the second one):

- `set_only_if_empty: true`, this won't change the `mobile-editor` setting unless it's "empty" (ie. unset or null).
    ```sh
    curl 'https://public-api.wordpress.com/wpcom/v2/me/gutenberg/' -H 'Authorization: Bearer CHANGEME' -H 'Content-Type: application/json; charset=utf-8' --data '{"editor":"gutenberg","set_only_if_empty":"true","platform":"mobile"}'
    ```

- `set_only_if_empty: false`, this should change the `mobile-editor` whatever current value is, but this doesn't work.
    ```sh
    curl 'https://public-api.wordpress.com/wpcom/v2/me/gutenberg/' -H 'Authorization: Bearer CHANGEME' -H 'Content-Type: application/json; charset=utf-8' --data '{"editor":"gutenberg","set_only_if_empty":"false","platform":"mobile"}'
    ```

- Omit `set_only_if_empty` - This will change the `mobile-editor` value whatever current value is.
    ```sh
    curl 'https://public-api.wordpress.com/wpcom/v2/me/gutenberg/' -H 'Authorization: Bearer CHANGEME' -H 'Content-Type: application/json; charset=utf-8' --data '{"editor":"gutenberg","platform":"mobile"}'
    ```