### PR TITLE
Don't remove "p" and "br" tags when uploading local drafts on self hosted sites

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -109,6 +109,31 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     @Test
+    public void testUploadNewPostWithGutenbergContent() throws InterruptedException {
+        String postContent = "<!-- wp:paragraph -->\n"
+                             + "<p>Paragraph 1</p>\n"
+                             + "<!-- /wp:paragraph -->";
+        // Instantiate new post
+        createNewPost();
+        mPost.setTitle("Gutenberg content");
+        mPost.setContent(postContent);
+
+        // Upload new post to site
+        uploadPost(mPost);
+
+        PostModel uploadedPostBeforeFetch = mPostStore.getPostByLocalPostId(mPost.getId());
+        // Make sure the uploaded post content is the same as the one we uploaded
+        assertEquals(postContent, uploadedPostBeforeFetch.getContent());
+
+        // Fetch the uploaded post from the server
+        fetchPost(mPost);
+
+        PostModel uploadedPostAfterFetch = mPostStore.getPostByLocalPostId(mPost.getId());
+        // Make sure the uploaded post content is the same as the one we uploaded
+        assertEquals(postContent, uploadedPostAfterFetch.getContent());
+    }
+
+    @Test
     public void testEditRemotePost() throws InterruptedException {
         createNewPost();
         setupPostAttributes();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -507,11 +507,6 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         String content = post.getContent();
 
-        // get rid of the p and br tags that the editor adds.
-        if (post.isLocalDraft()) {
-            content = content.replace("<p>", "").replace("</p>", "\n").replace("<br>", "");
-        }
-
         // gets rid of the weird character android inserts after images
         content = content.replaceAll("\uFFFC", "");
 


### PR DESCRIPTION
This fixes https://github.com/wordpress-mobile/WordPress-Android/issues/11030 and https://github.com/wordpress-mobile/gutenberg-mobile/issues/1728

I tried to find the origin of this code and I think it was imported from the old network code when we created FluxC. 

I guess we wanted to clean things up from the legacy editors before pushing things to the site. This doesn't make sense to have this on the network side. If we have an editor that creates unwanted `<p>` or `<br>` tags, we should do this when we get the post content from the editor and not here when we upload the post.

To test:
- Checkout e8adbc22bc3a7eb72b098a812a2f38c3b93c4b72 (contains the new test but not the fix) and run the test `ReleaseStack_PostTestXMLRPC.testUploadNewPostWithGutenbergContent`. Test will fail. 
```sh
./gradlew cAT -Pandroid.testInstrumentationRunnerArguments.class=org.wordpress.android.fluxc.release.ReleaseStack_PostTestXMLRPC\#testUploadNewPostWithGutenbergContent
```
- Checkout this branch and run the same test. Test will succeed.
```sh
./gradlew cAT -Pandroid.testInstrumentationRunnerArguments.class=org.wordpress.android.fluxc.release.ReleaseStack_PostTestXMLRPC\#testUploadNewPostWithGutenbergContent
```
