### PR TITLE
Removes unnecessary LIST_ITEMS_CHANGED action

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.store.ListStore.OnListChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChange
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged.CauseOfListChange.FIRST_PAGE_FETCHED
 import org.wordpress.android.fluxc.store.ListStore.OnListDataInvalidated
-import org.wordpress.android.fluxc.store.ListStore.OnListItemsChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
 
@@ -130,12 +129,6 @@ class PagedListWrapperTest {
     }
 
     @Test
-    fun `onListItemsChanged invokes invalidate property`() {
-        triggerOnListItemsChanged()
-        verify(mockInvalidate).invoke()
-    }
-
-    @Test
     fun `onListRequiresRefresh invokes refresh`() {
         triggerOnListRequiresRefresh()
         verify(mockRefresh).invoke()
@@ -181,18 +174,6 @@ class PagedListWrapperTest {
                 error = error
         )
         pagedListWrapper.onListChanged(event)
-    }
-
-    private fun triggerOnListItemsChanged(
-        error: ListError? = null
-    ) {
-        val pagedListWrapper = createPagedListWrapper()
-        whenever(mockListDescriptor.typeIdentifier).thenReturn(ListDescriptorTypeIdentifier(0))
-        val event = OnListItemsChanged(
-                type = mockListDescriptor.typeIdentifier,
-                error = error
-        )
-        pagedListWrapper.onListItemsChanged(event)
     }
 
     private fun triggerOnListRequiresRefresh() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -5,7 +5,6 @@ import org.wordpress.android.fluxc.annotations.ActionEnum
 import org.wordpress.android.fluxc.annotations.action.IAction
 import org.wordpress.android.fluxc.model.list.ListDescriptorTypeIdentifier
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
-import org.wordpress.android.fluxc.store.ListStore.ListItemsChangedPayload
 import org.wordpress.android.fluxc.store.ListStore.ListItemsRemovedPayload
 import org.wordpress.android.fluxc.store.ListStore.RemoveExpiredListsPayload
 
@@ -13,8 +12,6 @@ import org.wordpress.android.fluxc.store.ListStore.RemoveExpiredListsPayload
 enum class ListAction : IAction {
     @Action(payloadType = FetchedListItemsPayload::class)
     FETCHED_LIST_ITEMS,
-    @Action(payloadType = ListItemsChangedPayload::class)
-    LIST_ITEMS_CHANGED,
     @Action(payloadType = ListItemsRemovedPayload::class)
     LIST_ITEMS_REMOVED,
     @Action(payloadType = ListDescriptorTypeIdentifier::class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListDataInvalidated
-import org.wordpress.android.fluxc.store.ListStore.OnListItemsChanged
 import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
 import kotlin.coroutines.CoroutineContext
@@ -123,19 +122,6 @@ class PagedListWrapper<T>(
     @Suppress("unused")
     fun onListChanged(event: OnListChanged) {
         if (!event.listDescriptors.contains(listDescriptor)) {
-            return
-        }
-        invalidateData()
-    }
-
-    /**
-     * Handles the [OnListItemsChanged] `ListStore` event. It'll invalidate the data, so it can be reloaded. It'll also
-     * updates whether the list is empty or not.
-     */
-    @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @Suppress("unused")
-    fun onListItemsChanged(event: OnListItemsChanged) {
-        if (listDescriptor.typeIdentifier != event.type) {
             return
         }
         invalidateData()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -49,7 +49,6 @@ import org.wordpress.android.fluxc.persistence.PostSqlUtils;
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload;
 import org.wordpress.android.fluxc.store.ListStore.ListError;
 import org.wordpress.android.fluxc.store.ListStore.ListErrorType;
-import org.wordpress.android.fluxc.store.ListStore.ListItemsChangedPayload;
 import org.wordpress.android.fluxc.store.ListStore.ListItemsRemovedPayload;
 import org.wordpress.android.fluxc.utils.ObjectsUtils;
 import org.wordpress.android.util.AppLog;
@@ -952,8 +951,8 @@ public class PostStore extends Store {
         OnPostChanged onPostChanged = new OnPostChanged(causeOfChange, rowsAffected);
         emitChange(onPostChanged);
 
-        mDispatcher.dispatch(ListActionBuilder.newListItemsChangedAction(
-                new ListItemsChangedPayload(PostListDescriptor.calculateTypeIdentifier(post.getLocalSiteId()))));
+        mDispatcher.dispatch(ListActionBuilder.newListDataInvalidatedAction(
+                PostListDescriptor.calculateTypeIdentifier(post.getLocalSiteId())));
     }
 
     private void removePost(PostModel post) {


### PR DESCRIPTION
With the introduction of `LIST_DATA_INVALIDATED`, we no longer need `LIST_ITEMS_CHANGED ` since they perform the same action.

I created branches in [WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/tree/issue/update-fluxc-hash-for-list-items-changed-event-removal) and [WCAndroid](https://github.com/woocommerce/woocommerce-android/tree/issue/update-fluxc-hash-for-list-items-changed-event-removal) for the FluxC hash update and they both worked fine. I can open both PRs once this PR is merged in and I create a new tag for it.

_Since this affects both WPAndroid and WCAndroid and it's a tiny PR, it'd be good to get it reviewed by developers from each platform._