### PR TITLE
Pass the last day of the month and year as end date when fetching revenue stats

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -685,8 +685,8 @@ class WCStatsStore @Inject constructor(
         return when (granularity) {
             StatsGranularity.DAYS -> DateUtils.getEndDateForSite(site)
             StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
-            StatsGranularity.MONTHS -> DateUtils.getEndDateForSite(site)
-            StatsGranularity.YEARS -> DateUtils.getEndDateForSite(site)
+            StatsGranularity.MONTHS -> DateUtils.getLastDayOfCurrentMonthForSite(site)
+            StatsGranularity.YEARS -> DateUtils.getLastDayOfCurrentYearForSite(site)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -321,6 +321,20 @@ object DateUtils {
         return formatDate(DATE_TIME_FORMAT_END, cal.time)
     }
 
+    fun getLastDayOfCurrentMonthForSite(site: SiteModel): String {
+        val cal = Calendar.getInstance(Locale.ROOT)
+        cal.time = getCurrentDateFromSite(site)
+        cal.set(Calendar.DAY_OF_MONTH, cal.getActualMaximum(Calendar.DAY_OF_MONTH))
+        return formatDate(DATE_TIME_FORMAT_END, cal.time)
+    }
+
+    fun getLastDayOfCurrentYearForSite(site: SiteModel): String {
+        val cal = Calendar.getInstance(Locale.ROOT)
+        cal.time = getCurrentDateFromSite(site)
+        cal.set(Calendar.DAY_OF_YEAR, cal.getActualMaximum(Calendar.DAY_OF_YEAR))
+        return formatDate(DATE_TIME_FORMAT_END, cal.time)
+    }
+
     /**
      * Given a [SiteModel] instance, returns a [Date] instance for the current date
      *


### PR DESCRIPTION
Fixes #1469 - This PR adds the option to pass the end of the month and end of the year as the end date, when fetching revenue stats from the `/wc/v4/reports/revenue/stats endpoint`.

#### To Test
- Click on `Woo` -> `Revenue Stats` -> `Select Site` -> `Fetch Current month revenue stats`.
- Verify that the end date for the month stats is the future date for the end of the month instead of the current date. i.e. for this month end date should be `31-01-2020T23:59:59`.
- Click on `Woo` -> `Revenue Stats` -> `Select Site` -> `Fetch Current year revenue stats`.
- Verify that the end date for the month stats is the future date for the end of the year instead of the current date. i.e. for this year end date should be `31-12-2020T23:59:59`.

<img width="300" src="https://user-images.githubusercontent.com/22608780/71861690-39b1fd00-311d-11ea-83dd-a572346291ac.png">
