### PR TITLE
Fixes SiteRestClient.checkDomainAvailability comment to refer to the correct API version

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -693,7 +693,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     /**
-     * Performs an HTTP GET call to v1.1 /domains/$domainName/is-available/ endpoint. Upon receiving a response
+     * Performs an HTTP GET call to v1.3 /domains/$domainName/is-available/ endpoint. Upon receiving a response
      * (success or error) a {@link SiteAction#CHECKED_DOMAIN_AVAILABILITY} action is dispatched with a
      * payload of type {@link DomainAvailabilityResponsePayload}.
      *


### PR DESCRIPTION
Even though we are using the v1.3 for `SiteRestClient.checkDomainAvailability` [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java#L703), the comment said v1.1. It probably wasn't updated after a change or something.