### PR TITLE
Woo/update product stock status fix

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/ListSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/ListSelectorDialog.kt
@@ -15,15 +15,22 @@ class ListSelectorDialog : DialogFragment() {
         const val ARG_LIST_ITEMS = "ARG_LIST_ITEMS"
         const val ARG_RESULT_CODE = "ARG_RESULT_CODE"
         @JvmStatic
-        fun newInstance(fragment: Fragment, listItems: List<String>, resultCode: Int) = ListSelectorDialog().apply {
+        fun newInstance(
+            fragment: Fragment,
+            listItems: List<String>,
+            resultCode: Int,
+            selectedListItem: String?
+        ) = ListSelectorDialog().apply {
             setTargetFragment(fragment, LIST_SELECTOR_REQUEST_CODE)
             this.resultCode = resultCode
             this.listItems = listItems
+            this.selectedListItem = selectedListItem
         }
     }
 
     var resultCode: Int = -1
     var listItems: List<String>? = null
+    var selectedListItem: String? = null
 
     override fun onResume() {
         super.onResume()
@@ -34,12 +41,13 @@ class ListSelectorDialog : DialogFragment() {
         savedInstanceState?.let {
             listItems = it.getStringArrayList(ARG_LIST_ITEMS)
             resultCode = it.getInt(ARG_RESULT_CODE)
+            selectedListItem = it.getString(ARG_LIST_SELECTED_ITEM)
         }
 
         return activity?.let {
             val builder = AlertDialog.Builder(it)
             builder.setTitle("Select a list item")
-                    .setSingleChoiceItems(listItems?.toTypedArray(), 0) { dialog, which ->
+                    .setSingleChoiceItems(listItems?.toTypedArray(), getListIndex()) { dialog, which ->
                         val intent = activity?.intent
                         intent?.putExtra(ARG_LIST_SELECTED_ITEM, listItems?.get(which))
                         targetFragment?.onActivityResult(LIST_SELECTOR_REQUEST_CODE, resultCode, intent)
@@ -49,9 +57,14 @@ class ListSelectorDialog : DialogFragment() {
         } ?: throw IllegalStateException("Activity cannot be null")
     }
 
+    private fun getListIndex(): Int {
+        return listItems?.indexOfFirst { it == selectedListItem } ?: 0
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putStringArrayList(ARG_LIST_ITEMS, listItems as ArrayList<String>?)
         outState.putInt(ARG_RESULT_CODE, resultCode)
+        outState.putString(ARG_LIST_SELECTED_ITEM, selectedListItem)
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -136,21 +136,21 @@ class WooUpdateProductFragment : Fragment() {
         product_tax_status.setOnClickListener {
             showListSelectorDialog(
                     CoreProductTaxStatus.values().map { it.value }.toList(),
-                    LIST_RESULT_CODE_TAX_STATUS
+                    LIST_RESULT_CODE_TAX_STATUS, selectedProductModel?.taxStatus
             )
         }
 
         product_stock_status.setOnClickListener {
             showListSelectorDialog(
                     CoreProductStockStatus.values().map { it.value }.toList(),
-                    LIST_RESULT_CODE_STOCK_STATUS
+                    LIST_RESULT_CODE_STOCK_STATUS, selectedProductModel?.stockStatus
             )
         }
 
         product_back_orders.setOnClickListener {
             showListSelectorDialog(
                     CoreProductBackOrders.values().map { it.value }.toList(),
-                    LIST_RESULT_CODE_BACK_ORDERS
+                    LIST_RESULT_CODE_BACK_ORDERS, selectedProductModel?.backorders
             )
         }
 
@@ -242,9 +242,11 @@ class WooUpdateProductFragment : Fragment() {
         } ?: prependToLog("No valid site found...doing nothing")
     }
 
-    private fun showListSelectorDialog(listItems: List<String>, resultCode: Int) {
+    private fun showListSelectorDialog(listItems: List<String>, resultCode: Int, selectedItem: String?) {
         fragmentManager?.let { fm ->
-            val dialog = ListSelectorDialog.newInstance(this, listItems, resultCode)
+            val dialog = ListSelectorDialog.newInstance(
+                    this, listItems, resultCode, selectedItem
+            )
             dialog.show(fm, "ListSelectorDialog")
         }
     }

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -254,6 +254,18 @@
             app:layout_constraintStart_toEndOf="@+id/product_from_date"
             app:layout_constraintTop_toBottomOf="@+id/product_schedule_sale" />
 
+        <Button
+            android:id="@+id/product_stock_status"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Stock Status"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_from_date"/>
+
         <Switch
             android:id="@+id/product_manage_stock"
             android:layout_width="match_parent"
@@ -261,7 +273,7 @@
             android:enabled="false"
             android:text="Manage Stock"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_from_date" />
+            app:layout_constraintTop_toBottomOf="@+id/product_stock_status" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/manageStockContainer"
@@ -271,16 +283,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_manage_stock">
 
-            <Button
-                android:id="@+id/product_stock_status"
-                style="?android:attr/spinnerStyle"
+            <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+                android:id="@+id/product_stock_quantity"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
                 android:enabled="false"
-                android:text="Stock Status"
-                app:layout_constraintEnd_toStartOf="@+id/product_back_orders"
+                app:textHint="Stock quantity"
+                android:inputType="number"
                 app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintEnd_toStartOf="@+id/product_back_orders"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
@@ -294,19 +305,8 @@
                 android:text="Allow Back Orders"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toEndOf="@+id/product_stock_status"
+                app:layout_constraintStart_toEndOf="@+id/product_stock_quantity"
                 app:layout_constraintTop_toTopOf="parent" />
-
-            <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
-                android:id="@+id/product_stock_quantity"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:enabled="false"
-                app:textHint="Stock quantity"
-                android:inputType="number"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_stock_status" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -531,15 +531,15 @@ class ProductRestClient(
 
         // only allowed to change the following params if manageStock is enabled
         if (updatedProductModel.manageStock) {
-            if (storedWCProductModel.stockStatus != updatedProductModel.stockStatus) {
-                body["stock_status"] = updatedProductModel.stockStatus
-            }
             if (storedWCProductModel.stockQuantity != updatedProductModel.stockQuantity) {
                 body["stock_quantity"] = updatedProductModel.stockQuantity
             }
             if (storedWCProductModel.backorders != updatedProductModel.backorders) {
                 body["backorders"] = updatedProductModel.backorders
             }
+        }
+        if (storedWCProductModel.stockStatus != updatedProductModel.stockStatus) {
+            body["stock_status"] = updatedProductModel.stockStatus
         }
         if (storedWCProductModel.soldIndividually != updatedProductModel.soldIndividually) {
             body["sold_individually"] = updatedProductModel.soldIndividually


### PR DESCRIPTION
Fixes #1472 . This PR adds the option to update `stock_status` of a product without enabling `manage_stock` option.

#### Notes
The stock_status cannot be changed manually for variable products. `stock_status` will be updated automatically for variable products based on `stock_quantity` and `backOrdersAllowed`.
So if `stock_quantity` = 0 and if `backOrdersAllowed` = true, then `stock_status` = `onbackorder`.
If `stock_quantity` = 0 and if `backOrdersAllowed` = false, then `stock_status` = `outofstock`.

#### Testing
- In the example app, click on `Woo` -> `Products` -> `Select Site` and select a site.
- Click on `Update Product` and enter a product Id.
- Verify that you are able to update `stock_status` of the product without switching on `manage_stock` option.