### PR TITLE
Fixes incorrect canLoadMore value for fetching post list

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -133,7 +133,7 @@ public class PostRestClient extends BaseWPComRestClient {
                                     .add(new PostListItem(postResponse.getRemotePostId(), postResponse.getModified(),
                                             postResponse.getStatus(), autoSaveModified));
                         }
-                        boolean canLoadMore = postListItems.size() == pageSize;
+                        boolean canLoadMore = response.getFound() > offset + postListItems.size();
                         FetchPostListResponsePayload responsePayload =
                                 new FetchPostListResponsePayload(listDescriptor, postListItems, loadedMore,
                                         canLoadMore, null);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -32,7 +32,8 @@ data class PostWPComRestResponse(
     @SerializedName("author") val author: Author? = null
 ) {
     data class PostsResponse(
-        @SerializedName("posts") val posts: List<PostWPComRestResponse>
+        @SerializedName("posts") val posts: List<PostWPComRestResponse>,
+        @SerializedName("found") val found: Int
     )
 
     data class PostThumbnail(


### PR DESCRIPTION
This PR changes how we figure out if there is more data to be loaded for posts. It utilizes the `found` property from the response, the offset parameter and retrieved post list size for an accurate result.