### PR TITLE
Issue/1474 verify sku exists

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload
@@ -213,6 +214,40 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RemoteSearchProductsPayload
         assertNotNull(payload.error)
         assertEquals(payload.searchQuery, searchQuery)
+    }
+
+    @Test
+    fun testFetchProductSkuAvailabilitySuccess() {
+        interceptor.respondWith("wc-fetch-products-response-success.json")
+        productRestClient.fetchProductSkuAvailability(siteModel, "woo-hoodie123456")
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCProductAction.FETCHED_PRODUCT_SKU_AVAILABILITY, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteProductSkuAvailabilityPayload
+        with(payload) {
+            assertNull(error)
+            assertEquals(siteModel, site)
+            assertFalse(available)
+        }
+    }
+
+    @Test
+    fun testFetchProductSkuAvailabilityError() {
+        interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
+        productRestClient.fetchProductSkuAvailability(siteModel, "woo-hoodie")
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCProductAction.FETCHED_PRODUCT_SKU_AVAILABILITY, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteProductSkuAvailabilityPayload
+        with(payload) {
+            assertNotNull(error)
+            assertNotNull(sku)
+            assertTrue(available)
+        }
     }
 
     @Test

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
@@ -37,6 +38,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReview
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductImagesChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClassesChanged
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductSkuAvailabilityChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductsSearched
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
@@ -89,6 +91,18 @@ class WooProductsFragment : Fragment() {
                         val payload = FetchSingleProductPayload(site, id)
                         dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
                     } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
+                }
+            }
+        }
+
+        fetch_product_sku_availability.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter a product SKU:"
+                ) { editText ->
+                    val payload = FetchProductSkuAvailabilityPayload(site, editText.text.toString())
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchProductSkuAvailabilityAction(payload))
                 }
             }
         }
@@ -309,6 +323,16 @@ class WooProductsFragment : Fragment() {
             prependToLog("Error searching products - error: " + event.error.type)
         } else {
             prependToLog("Found ${event.searchResults.size} products matching ${event.searchQuery}")
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductSkuAvailabilityChanged(event: OnProductSkuAvailabilityChanged) {
+        if (event.isError) {
+            prependToLog("Error searching product sku availability - error: " + event.error.type)
+        } else {
+            prependToLog("Sku ${event.sku} available for site ${selectedSite?.name}: ${event.available}")
         }
     }
 

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -47,6 +47,13 @@
             android:text="Fetch Single Product"/>
 
         <Button
+            android:id="@+id/fetch_product_sku_availability"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch SKU Availability"/>
+
+        <Button
             android:id="@+id/fetch_products"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
@@ -14,6 +15,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
@@ -46,6 +48,8 @@ public enum WCProductAction implements IAction {
     UPDATE_PRODUCT_IMAGES,
     @Action(payloadType = UpdateProductPayload.class)
     UPDATE_PRODUCT,
+    @Action(payloadType = FetchProductSkuAvailabilityPayload.class)
+    FETCH_PRODUCT_SKU_AVAILABILITY,
 
     // Remote responses
     @Action(payloadType = RemoteProductPayload.class)
@@ -67,5 +71,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteUpdateProductImagesPayload.class)
     UPDATED_PRODUCT_IMAGES,
     @Action(payloadType = RemoteUpdateProductPayload.class)
-    UPDATED_PRODUCT
+    UPDATED_PRODUCT,
+    @Action(payloadType = RemoteProductSkuAvailabilityPayload.class)
+    FETCHED_PRODUCT_SKU_AVAILABILITY
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -34,6 +34,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         val DEFAULT_PRODUCT_SORTING = DATE_DESC
     }
 
+    class FetchProductSkuAvailabilityPayload(
+        var site: SiteModel,
+        var sku: String
+    ) : Payload<BaseNetworkError>()
+
     class FetchSingleProductPayload(
         var site: SiteModel,
         var remoteProductId: Long
@@ -118,6 +123,19 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         TITLE_DESC,
         DATE_ASC,
         DATE_DESC
+    }
+
+    class RemoteProductSkuAvailabilityPayload(
+        val site: SiteModel,
+        val available: Boolean = false
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel,
+            available: Boolean
+        ) : this(site, available) {
+            this.error = error
+        }
     }
 
     class RemoteProductPayload(


### PR DESCRIPTION
Fixes #1474. This PR adds new endpoint to check if a SKU is available for a site.

#### Changes
- Adds new action classes: `FetchProductSkuAvailabilityPayload` and `RemoteProductSkuAvailabilityPayload` for verifying sku availability.
- Adds new methods to `WCProductStore` and `ProductRestClient` to check sku availability.
- Adds new button in the example app to test the changes.

#### Screenshot
<img width="300" src="https://user-images.githubusercontent.com/22608780/72163063-1c18b800-33e9-11ea-869e-f71121975f3b.png"> 

#### Testing
- Run `MockedStack_WCProductsTest`.
- In the example app, click on `Woo` -> `Products` -> `Select Site` -> `Fetch SKU availability`. Verify that the SKU availability is set to `false` if you enter a product sku that is already available for a site and vice versa.