### PR TITLE
Introduces PostSummary for post list sectioning

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
@@ -306,8 +306,8 @@ class PostStoreTest {
         // Assert
         verify(postSqlUtils).insertOrUpdatePostSummaries(argThat {
             this.first().let {
-                it.status == post.status && it.remoteId == post.remotePostId && it.localSiteId == post.localSiteId
-                        && it.dateCreated == post.dateCreated
+                it.status == post.status && it.remoteId == post.remotePostId && it.localSiteId == post.localSiteId &&
+                        it.dateCreated == post.dateCreated
             }
         })
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
@@ -319,6 +319,7 @@ class PostStoreTest {
         post: PostModel,
         status: String = post.status,
         lastModified: String = post.lastModified,
-        autoSaveModified: String? = post.autoSaveModified
-    ) = PostListItem(post.remotePostId, lastModified, status, autoSaveModified)
+        autoSaveModified: String? = post.autoSaveModified,
+        dateCreated: String? = null
+    ) = PostListItem(post.remotePostId, lastModified, status, autoSaveModified, dateCreated)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
@@ -3,12 +3,17 @@ package org.wordpress.android.fluxc.model
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.post.PostStatus
 
 data class PostSummary(val remoteId: Long, val localSiteId: Int, val status: PostStatus)
 
 @Table
+@RawConstraints(
+        "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+        "UNIQUE(REMOTE_ID) ON CONFLICT REPLACE"
+)
 class PostSummaryModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var remoteId: Long? = null
     @Column var localSiteId: Int? = null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.post.PostStatus
+
+data class PostSummary(val remoteId: Long, val localSiteId: Int, val status: PostStatus)
+
+@Table
+class PostSummaryModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var remoteId: Long? = null
+    @Column var localSiteId: Int? = null
+    @Column var status: String? = null
+
+    override fun getId(): Int = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    companion object {
+        @JvmStatic
+        fun newInstance(site: SiteModel, remoteId: Long, postStatus: String?): PostSummaryModel {
+            return PostSummaryModel().apply {
+                this.localSiteId = site.id
+                this.remoteId = remoteId
+                this.status = postStatus
+            }
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
@@ -54,15 +54,10 @@ class PostSummaryModel(@PrimaryKey @Column private var id: Int = 0) : Identifiab
         this.id = id
     }
 
-    companion object {
-        @JvmStatic
-        fun newInstance(site: SiteModel, remoteId: Long, postStatus: String?, dateCreated: String?): PostSummaryModel {
-            return PostSummaryModel().apply {
-                this.localSiteId = site.id
-                this.remoteId = remoteId
-                this.status = postStatus
-                this.dateCreated = dateCreated
-            }
-        }
+    constructor(site: SiteModel, remoteId: Long, postStatus: String?, dateCreated: String?): this() {
+        this.localSiteId = site.id
+        this.remoteId = remoteId
+        this.status = postStatus
+        this.dateCreated = dateCreated
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
@@ -15,7 +15,7 @@ data class PostSummary(val remoteId: Long, val localSiteId: Int, val status: Pos
             return PostSummary(
                     postSummaryModel.remoteId!!,
                     postSummaryModel.localSiteId!!,
-                    PostStatus.(postSummaryModel.status)
+                    PostStatus.fromPostSummary(postSummaryModel)
             )
         }
     }
@@ -30,6 +30,7 @@ class PostSummaryModel(@PrimaryKey @Column private var id: Int = 0) : Identifiab
     @Column var remoteId: Long? = null
     @Column var localSiteId: Int? = null
     @Column var status: String? = null
+    @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
 
     override fun getId(): Int = id
 
@@ -39,11 +40,12 @@ class PostSummaryModel(@PrimaryKey @Column private var id: Int = 0) : Identifiab
 
     companion object {
         @JvmStatic
-        fun newInstance(site: SiteModel, remoteId: Long, postStatus: String?): PostSummaryModel {
+        fun newInstance(site: SiteModel, remoteId: Long, postStatus: String?, dateCreated: String?): PostSummaryModel {
             return PostSummaryModel().apply {
                 this.localSiteId = site.id
                 this.remoteId = remoteId
                 this.status = postStatus
+                this.dateCreated = dateCreated
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
@@ -7,6 +7,22 @@ import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.post.PostStatus
 
+/**
+ * When we fetch the post list, we don't fetch the whole model and only keep the ids of posts in ListStore's
+ * ListItemModelTable. However, some fields such as `status` and `dateCreated` are necessary to be able to section the
+ * list properly.
+ *
+ * `PostSummaryModel` is a pattern we can utilize in situations like this. It works as a look up table where records
+ * in its table are updated each time posts are fetched. This way the information necessary for a list to work is
+ * always available, but we still don't need to fetch & update the whole model on each fetch.
+ *
+ * // TODO: We can add a link to the wiki for ListStore when that's available.
+ * See `ListStore` components for more details.
+ */
+
+/**
+ * Immutable version of PostSummaryModel that should be used by the clients.
+ */
 data class PostSummary(val remoteId: Long, val localSiteId: Int, val status: PostStatus) {
     companion object {
         @JvmStatic

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
@@ -54,7 +54,7 @@ class PostSummaryModel(@PrimaryKey @Column private var id: Int = 0) : Identifiab
         this.id = id
     }
 
-    constructor(site: SiteModel, remoteId: Long, postStatus: String?, dateCreated: String?): this() {
+    constructor(site: SiteModel, remoteId: Long, postStatus: String?, dateCreated: String?) : this() {
         this.localSiteId = site.id
         this.remoteId = remoteId
         this.status = postStatus

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostSummaryModel.kt
@@ -7,7 +7,19 @@ import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.post.PostStatus
 
-data class PostSummary(val remoteId: Long, val localSiteId: Int, val status: PostStatus)
+data class PostSummary(val remoteId: Long, val localSiteId: Int, val status: PostStatus) {
+    companion object {
+        @JvmStatic
+        fun fromPostSummaryModel(postSummaryModel: PostSummaryModel): PostSummary {
+            // Both remoteId and localSiteId should never be null, so it's worth crashing here to catch the bug
+            return PostSummary(
+                    postSummaryModel.remoteId!!,
+                    postSummaryModel.localSiteId!!,
+                    PostStatus.(postSummaryModel.status)
+            )
+        }
+    }
+}
 
 @Table
 @RawConstraints(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model.post;
 
 import org.wordpress.android.fluxc.model.PostImmutableModel;
+import org.wordpress.android.fluxc.model.PostSummaryModel;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.Date;
@@ -61,10 +62,17 @@ public enum PostStatus {
     }
 
     public static synchronized PostStatus fromPost(PostImmutableModel post) {
-        String value = post.getStatus();
+        return fromStringAndDateIso8601(post.getStatus(), post.getDateCreated());
+    }
+
+    public static synchronized PostStatus fromPostSummary(PostSummaryModel postSummaryModel) {
+        return fromStringAndDateIso8601(postSummaryModel.getStatus(), postSummaryModel.getDateCreated());
+    }
+
+    private static synchronized PostStatus fromStringAndDateIso8601(String value, String dateCreatedIso8601) {
         long dateCreatedGMT = 0;
 
-        Date dateCreated = DateTimeUtils.dateUTCFromIso8601(post.getDateCreated());
+        Date dateCreated = DateTimeUtils.dateUTCFromIso8601(dateCreatedIso8601);
         if (dateCreated != null) {
             dateCreatedGMT = dateCreated.getTime();
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -108,7 +108,7 @@ public class PostRestClient extends BaseWPComRestClient {
         String url = WPCOMREST.sites.site(listDescriptor.getSite().getSiteId()).posts.getUrlV1_1();
 
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
-        String fields = TextUtils.join(",", Arrays.asList("ID", "modified", "status", "meta"));
+        String fields = TextUtils.join(",", Arrays.asList("ID", "modified", "status", "meta", "date"));
         Map<String, String> params =
                 createFetchPostListParameters(false, offset, pageSize, listDescriptor.getStatusList(),
                         listDescriptor.getAuthor(), fields, listDescriptor.getOrder().getValue(),
@@ -133,7 +133,7 @@ public class PostRestClient extends BaseWPComRestClient {
                             }
                             postListItems
                                     .add(new PostListItem(postResponse.getRemotePostId(), postResponse.getModified(),
-                                            postResponse.getStatus(), autoSaveModified));
+                                            postResponse.getStatus(), autoSaveModified, postResponse.getDate()));
                         }
                         boolean canLoadMore = response.getFound() > offset + postListItems.size();
                         FetchPostListResponsePayload responsePayload =

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.UploadActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.PostModel;
-import org.wordpress.android.fluxc.model.PostSummaryModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.list.AuthorFilter;
@@ -125,7 +124,6 @@ public class PostRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(PostsResponse response) {
                         List<PostListItem> postListItems = new ArrayList<>(response.getPosts().size());
-                        List<PostSummaryModel> postSummaryModelList = new ArrayList<>(response.getPosts().size());
                         for (PostWPComRestResponse postResponse : response.getPosts()) {
                             String autoSaveModified = null;
                             if (postResponse.getPostAutoSave() != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.UploadActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.PostSummaryModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.list.AuthorFilter;
@@ -124,6 +125,7 @@ public class PostRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(PostsResponse response) {
                         List<PostListItem> postListItems = new ArrayList<>(response.getPosts().size());
+                        List<PostSummaryModel> postSummaryModelList = new ArrayList<>(response.getPosts().size());
                         for (PostWPComRestResponse postResponse : response.getPosts()) {
                             String autoSaveModified = null;
                             if (postResponse.getPostAutoSave() != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -122,7 +122,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchPostList(final PostListDescriptorForXmlRpcSite listDescriptor, final long offset) {
         SiteModel site = listDescriptor.getSite();
-        List<String> fields = Arrays.asList("post_id", "post_modified_gmt", "post_status");
+        List<String> fields = Arrays.asList("post_id", "post_modified_gmt", "post_date_gmt", "post_status");
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
         List<Object> params =
                 createFetchPostListParameters(site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(), false,
@@ -346,8 +346,11 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             String postStatus = MapUtils.getMapStr(postMap, "post_status");
             Date lastModifiedGmt = MapUtils.getMapDate(postMap, "post_modified_gmt");
             String lastModifiedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(lastModifiedGmt);
+            Date dateCreatedGmt = MapUtils.getMapDate(postMap, "post_date_gmt");
+            String dateCreatedAsIso8601 = DateTimeUtils.iso8601UTCFromDate(dateCreatedGmt);
 
-            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus, null));
+            postListItems.add(new PostListItem(Long.parseLong(postID), lastModifiedAsIso8601, postStatus, null,
+                    dateCreatedAsIso8601));
         }
         return postListItems;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -409,6 +409,9 @@ public class PostSqlUtils {
     }
 
     public List<PostSummaryModel> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
+        if (site == null || remotePostIds == null || remotePostIds.isEmpty()) {
+            return Collections.emptyList();
+        }
         return WellSql.select(PostSummaryModel.class)
                       .where()
                       .equals(PostSummaryModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import com.wellsql.generated.LocalDiffModelTable;
 import com.wellsql.generated.LocalRevisionModelTable;
 import com.wellsql.generated.PostModelTable;
+import com.wellsql.generated.PostSummaryModelTable;
 import com.yarolegovich.wellsql.ConditionClauseBuilder;
 import com.yarolegovich.wellsql.SelectQuery;
 import com.yarolegovich.wellsql.SelectQuery.Order;
@@ -19,6 +20,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.PostSummaryModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.revisions.LocalDiffModel;
 import org.wordpress.android.fluxc.model.revisions.LocalRevisionModel;
@@ -399,5 +401,26 @@ public class PostSqlUtils {
             localPostIds.add(new LocalId(post.getId()));
         }
         return localPostIds;
+    }
+
+    public void insertPostSummaries(List<PostSummaryModel> postSummaryModelList) {
+        WellSql.insert(postSummaryModelList).asSingleTransaction(true).execute();
+    }
+
+    public List<PostSummaryModel> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
+        return WellSql.select(PostSummaryModel.class)
+                      .where()
+                      .equals(PostSummaryModelTable.LOCAL_SITE_ID, site.getId())
+                      .isIn(PostSummaryModelTable.REMOTE_ID, remotePostIds)
+                      .endWhere()
+                      .getAsModel();
+    }
+
+    public void deletePostSummaries(SiteModel site) {
+        WellSql.delete(PostSummaryModel.class)
+               .where()
+               .equals(PostSummaryModelTable.LOCAL_SITE_ID, site.getId())
+               .endWhere()
+               .execute()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -410,8 +410,8 @@ public class PostSqlUtils {
         WellSql.insert(postSummaryModelList).asSingleTransaction(true).execute();
     }
 
-    public List<PostSummaryModel> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
-        if (site == null || remotePostIds == null || remotePostIds.isEmpty()) {
+    public List<PostSummaryModel> getPostSummaries(@NonNull SiteModel site, @NonNull List<Long> remotePostIds) {
+        if (remotePostIds.isEmpty()) {
             return Collections.emptyList();
         }
         List<PostSummaryModel> postSummaryModelList = WellSql.select(PostSummaryModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -403,7 +403,8 @@ public class PostSqlUtils {
         return localPostIds;
     }
 
-    public void insertPostSummaries(List<PostSummaryModel> postSummaryModelList) {
+    public void insertOrUpdatePostSummaries(List<PostSummaryModel> postSummaryModelList) {
+        // The "unique(remote_id) on conflict replace" constraint will take care of updating on insert
         WellSql.insert(postSummaryModelList).asSingleTransaction(true).execute();
     }
 
@@ -414,13 +415,5 @@ public class PostSqlUtils {
                       .isIn(PostSummaryModelTable.REMOTE_ID, remotePostIds)
                       .endWhere()
                       .getAsModel();
-    }
-
-    public void deletePostSummaries(SiteModel site) {
-        WellSql.delete(PostSummaryModel.class)
-               .where()
-               .equals(PostSummaryModelTable.LOCAL_SITE_ID, site.getId())
-               .endWhere()
-               .execute()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1052,7 +1052,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 96 -> migrate(version) {
                     db.execSQL("CREATE TABLE PostSummaryModel (REMOTE_ID INTEGER,LOCAL_SITE_ID INTEGER,STATUS TEXT," +
-                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "DATE_CREATED TEXT,_id INTEGER PRIMARY KEY AUTOINCREMENT," +
                             "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
                             "UNIQUE(REMOTE_ID) ON CONFLICT REPLACE)")
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 96
+        return 97
     }
 
     override fun getDbName(): String {
@@ -1049,6 +1049,10 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "UNIQUE (SLUG, LOCAL_SITE_ID) " +
                                     "ON CONFLICT REPLACE)"
                     )
+                }
+                96 -> migrate(version) {
+                    db.execSQL("CREATE TABLE PostSummaryModel (REMOTE_ID INTEGER,LOCAL_SITE_ID INTEGER,STATUS TEXT," +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT)" )
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1052,7 +1052,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 96 -> migrate(version) {
                     db.execSQL("CREATE TABLE PostSummaryModel (REMOTE_ID INTEGER,LOCAL_SITE_ID INTEGER,STATUS TEXT," +
-                            "_id INTEGER PRIMARY KEY AUTOINCREMENT)" )
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
+                            "UNIQUE(REMOTE_ID) ON CONFLICT REPLACE)")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1074,14 +1074,13 @@ public class PostStore extends Store {
     private void updatePostSummaries(SiteModel site, List<PostListItem> postListItems) {
         List<PostSummaryModel> postSummaryModelList = new ArrayList<>(postListItems.size());
         for (PostListItem item : postListItems) {
-            postSummaryModelList.add(PostSummaryModel.newInstance(site, item.remotePostId, item.status);
+            postSummaryModelList.add(PostSummaryModel.newInstance(site, item.remotePostId, item.status));
         }
-        mPostSqlUtils.insertPostSummaries(postSummaryModelList);
+        mPostSqlUtils.insertOrUpdatePostSummaries(postSummaryModelList);
     }
 
-    // TODO: Do we need to purge the PostSummaryModelTable, if so when is the best time to do that?
-
-    public List<PostSummary> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
-        mPostSqlUtils.getPostSummaries(site, remotePostIds);
+    // TODO: Return PostSummary instead
+    public List<PostSummaryModel> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
+        return mPostSqlUtils.getPostSummaries(site, remotePostIds);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -93,12 +93,15 @@ public class PostStore extends Store {
         public String lastModified;
         public String status;
         public String autoSaveModified;
+        public String dateCreated;
 
-        public PostListItem(Long remotePostId, String lastModified, String status, String autoSaveModified) {
+        public PostListItem(Long remotePostId, String lastModified, String status, String autoSaveModified,
+                            String dateCreated) {
             this.remotePostId = remotePostId;
             this.lastModified = lastModified;
             this.status = status;
             this.autoSaveModified = autoSaveModified;
+            this.dateCreated = dateCreated;
         }
     }
 
@@ -1074,7 +1077,8 @@ public class PostStore extends Store {
     private void updatePostSummaries(SiteModel site, List<PostListItem> postListItems) {
         List<PostSummaryModel> postSummaryModelList = new ArrayList<>(postListItems.size());
         for (PostListItem item : postListItems) {
-            postSummaryModelList.add(PostSummaryModel.newInstance(site, item.remotePostId, item.status));
+            postSummaryModelList
+                    .add(PostSummaryModel.newInstance(site, item.remotePostId, item.status, item.dateCreated));
         }
         mPostSqlUtils.insertOrUpdatePostSummaries(postSummaryModelList);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -28,6 +28,8 @@ import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.RemoveAllPosts;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.PostSummary;
+import org.wordpress.android.fluxc.model.PostSummaryModel;
 import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.list.ListOrder;
@@ -754,6 +756,8 @@ public class PostStore extends Store {
             }
         }
 
+        updatePostSummaries(payload.listDescriptor.getSite(), payload.postListItems);
+
         FetchedListItemsPayload fetchedListItemsPayload =
                 new FetchedListItemsPayload(payload.listDescriptor, postIds,
                         payload.loadedMore, payload.canLoadMore, fetchedListItemsError);
@@ -1061,5 +1065,23 @@ public class PostStore extends Store {
 
     public void deleteLocalRevisionOfAPostOrPage(PostModel post) {
         mPostSqlUtils.deleteLocalRevisionAndDiffsOfAPostOrPage(post);
+    }
+
+    /**
+     * Since we only fetch the ids of a post while fetching the post list, new need to keep a small table in the
+     * DB to be able to check post statuses for sectioning.
+     */
+    private void updatePostSummaries(SiteModel site, List<PostListItem> postListItems) {
+        List<PostSummaryModel> postSummaryModelList = new ArrayList<>(postListItems.size());
+        for (PostListItem item : postListItems) {
+            postSummaryModelList.add(PostSummaryModel.newInstance(site, item.remotePostId, item.status);
+        }
+        mPostSqlUtils.insertPostSummaries(postSummaryModelList);
+    }
+
+    // TODO: Do we need to purge the PostSummaryModelTable, if so when is the best time to do that?
+
+    public List<PostSummary> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
+        mPostSqlUtils.getPostSummaries(site, remotePostIds);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1079,8 +1079,12 @@ public class PostStore extends Store {
         mPostSqlUtils.insertOrUpdatePostSummaries(postSummaryModelList);
     }
 
-    // TODO: Return PostSummary instead
-    public List<PostSummaryModel> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
-        return mPostSqlUtils.getPostSummaries(site, remotePostIds);
+    public List<PostSummary> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
+        List<PostSummaryModel> postSummaryModelList = mPostSqlUtils.getPostSummaries(site, remotePostIds);
+        List<PostSummary> postSummaryList = new ArrayList<>(postSummaryModelList.size());
+        for (PostSummaryModel postSummaryModel : postSummaryModelList) {
+            postSummaryList.add(PostSummary.fromPostSummaryModel(postSummaryModel));
+        }
+        return postSummaryList;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1071,14 +1071,14 @@ public class PostStore extends Store {
     }
 
     /**
-     * Since we only fetch the ids of a post while fetching the post list, new need to keep a small table in the
+     * Since we only fetch the ids of a post while fetching the post list, we need to keep a small table in the
      * DB to be able to check post statuses for sectioning.
      */
     private void updatePostSummaries(SiteModel site, List<PostListItem> postListItems) {
         List<PostSummaryModel> postSummaryModelList = new ArrayList<>(postListItems.size());
         for (PostListItem item : postListItems) {
             postSummaryModelList
-                    .add(PostSummaryModel.newInstance(site, item.remotePostId, item.status, item.dateCreated));
+                    .add(new PostSummaryModel(site, item.remotePostId, item.status, item.dateCreated));
         }
         mPostSqlUtils.insertOrUpdatePostSummaries(postSummaryModelList);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1083,7 +1083,7 @@ public class PostStore extends Store {
         mPostSqlUtils.insertOrUpdatePostSummaries(postSummaryModelList);
     }
 
-    public List<PostSummary> getPostSummaries(SiteModel site, List<Long> remotePostIds) {
+    public List<PostSummary> getPostSummaries(@NonNull SiteModel site, @NonNull List<Long> remotePostIds) {
         List<PostSummaryModel> postSummaryModelList = mPostSqlUtils.getPostSummaries(site, remotePostIds);
         List<PostSummary> postSummaryList = new ArrayList<>(postSummaryModelList.size());
         for (PostSummaryModel postSummaryModel : postSummaryModelList) {


### PR DESCRIPTION
This PR introduces a new `PostSummary` model that is updated each time the post list is fetched from remote. Since we only keep the ids of posts in `ListItemModel` to be used in lists, we are unable to section as it requires the `status` property. We might have it for some of them if we already fetched the actual model, but we need to guarantee that all of them are available for a feature like sectioning to work properly.

When I first worked on `ListStore`, I explored various ways to achieve sectioning and out of all of them, I think this has the best trade-offs. So, at the time, I made some adjustments to the public interfaces of `ListStore` to make using this pattern very easy.

The PR itself is very straightforward. We just fetch an extra field `dateCreated` while fetching the post list, because we need that for figuring out the status. 😬 We then insert or update the records in the `PostSummaryModelTable` for all the posts that were fetched. This guarantees that if multiple lists refer to the same item, they'll use the exact same information which wouldn't be the case if for example we used a solution where we kept the status in the `ListItemModelTable`. (I also don't really like generic fields that might only be used by some features but not others)

We don't purge the `PostSummaryModelTable` at any time which means there might be some stray records that are never used. However, it's really hard to find a case where that would matter significantly. We do clear all the records for a site when the site is removed, so that alone should be enough imo.

Finally, this time around I opted to introduce an immutable version of the `PostSummaryModel` as `PostSummary`. I wanted to do this in many features I worked on before but didn't go ahead with it for consistency. I am regretting that decision now because I strongly believe the DB models and the models that are consumed by clients should be different (preferably immutable) especially since our DB models are structured in a very specific way to work with `WellSql`. I did leave a comment about that and also about why `PostSummary` exists in the first place.