### PR TITLE
Fix slug not set on self hosted sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -563,6 +563,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         }
 
         contentStruct.put("post_excerpt", post.getExcerpt());
+        contentStruct.put("post_name", post.getSlug());
         contentStruct.put("post_status", post.getStatus());
 
         // Geolocation

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -454,6 +454,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         post.setCustomFields(jsonCustomFieldsArray.toString());
 
         post.setExcerpt(MapUtils.getMapStr(postMap, "post_excerpt"));
+        post.setSlug(MapUtils.getMapStr(postMap, "post_name"));
 
         post.setPassword(MapUtils.getMapStr(postMap, "post_password"));
         post.setStatus(MapUtils.getMapStr(postMap, "post_status"));


### PR DESCRIPTION
This PR tries to fix [#11040](https://github.com/wordpress-mobile/WordPress-Android/issues/11040) to set slug on self-hosted sites. 

### To Test
- Open a published post on a self-hosted site
- Open Post settings
- Set a slug
- Click on Update
- Open the post again and notice the slug is present

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1405144/72872653-e0002400-3d13-11ea-89f0-c461c39a6a0d.gif)

