### PR TITLE
Woo: Only include the `search` query param when fetching orders if it's being used

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -126,12 +126,14 @@ class OrderRestClient(
         val url = WOOCOMMERCE.orders.pathV3
         val responseType = object : TypeToken<List<OrderSummaryApiResponse>>() {}.type
         val networkPageSize = listDescriptor.config.networkPageSize
-        val params = mapOf(
+        val params = mutableMapOf(
                 "per_page" to networkPageSize.toString(),
                 "offset" to offset.toString(),
                 "status" to statusFilter,
-                "_fields" to "id,date_created_gmt,date_modified_gmt",
-                "search" to listDescriptor.searchQuery.orEmpty())
+                "_fields" to "id,date_created_gmt,date_modified_gmt")
+        listDescriptor.searchQuery.takeUnless { it.isNullOrEmpty() }?.let {
+            params.put("search", it)
+        }
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, listDescriptor.site.siteId, params, responseType,
                 { response: List<OrderSummaryApiResponse>? ->
                     val orderSummaries = response?.map {


### PR DESCRIPTION
Fixes the issue described in this ticket: https://github.com/woocommerce/woocommerce-android/issues/1841 by only including the `search` query param if the argument is not empty. 

## To Test
- Open the order list test (Woo -> Orders -> Fetch Order List)
- Use Stethos to verify the search param is not including in the API request
- Enter a search term and verify search still works. 