### PR TITLE
Issue/1487 product sku verification optimize

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -18,6 +18,8 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
@@ -106,5 +108,24 @@ class WCProductStoreTest {
             // Other fields should not be altered by the update
             assertEquals(productModel.name, this?.name)
         }
+    }
+
+    @Test
+    fun testVerifySkuExistsLocally() {
+        val sku = "woo-cap"
+        val productModel = ProductTestUtils.generateSampleProduct(42).apply {
+            name = "test product"
+            description = "test description"
+            this.sku = sku
+        }
+        val site = SiteModel().apply { id = productModel.localSiteId }
+        ProductSqlUtils.insertOrUpdateProduct(productModel)
+
+        // verify if product with sku: woo-cap exists in local cache
+        val skuAvailable = ProductSqlUtils.getProductExistsBySku(site, sku)
+        assertTrue(skuAvailable)
+
+        // verify if product with non existent sku returns false
+        assertFalse(ProductSqlUtils.getProductExistsBySku(site, "woooo"))
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -239,7 +239,7 @@ class ProductRestClient(
     ) {
         val url = WOOCOMMERCE.products.pathV3
         val responseType = object : TypeToken<List<ProductApiResponse>>() {}.type
-        val params = mutableMapOf("sku" to sku)
+        val params = mutableMapOf("sku" to sku, "_fields" to "sku")
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<ProductApiResponse>? ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -81,6 +81,15 @@ object ProductSqlUtils {
                 .exists()
     }
 
+    fun getProductExistsBySku(site: SiteModel, sku: String): Boolean {
+        return WellSql.select(WCProductModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductModelTable.SKU, sku)
+                .equals(WCProductModelTable.LOCAL_SITE_ID, site.id)
+                .endGroup().endWhere()
+                .exists()
+    }
+
     fun getProductsForSite(
         site: SiteModel,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -324,6 +324,12 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             ProductSqlUtils.geProductExistsByRemoteId(site, remoteProductId)
 
     /**
+     * returns true if the product exists with this [sku] in the database
+     */
+    fun geProductExistsBySku(site: SiteModel, sku: String) =
+            ProductSqlUtils.getProductExistsBySku(site, sku)
+
+    /**
      * returns a list of variations for a specific product in the database
      */
     fun getVariationsForProduct(site: SiteModel, remoteProductId: Long): List<WCProductVariationModel> =


### PR DESCRIPTION
Fixes #1487 by adding the option to check if a given SKU exists for a site in the local db. This PR also adds the `_fields` param to the `/wc/v3/products/%26_method=get&sku=` endpoint to reduce the response size.

#### Testing
- In the example app, click on `Woo` -> `Products` -> `Select site` -> `Fetch SKU Availability`. Using Stethos, verify that the response returned only contains the `sku` field.
- Run `WCProductStoreTest` 