### PR TITLE
Use Site directly instead of Site Store in test

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
@@ -20,7 +20,7 @@ class ReleaseStack_ReactNativeWPComRequestTest : ReleaseStack_WPComBase() {
 
     @Test
     fun testWpComCall() {
-        val url = "https://public-api.wordpress.com/wp/v2/sites/${siteFromDb.siteId}/media"
+        val url = "https://public-api.wordpress.com/wp/v2/sites/${sSite.siteId}/media"
         val params = mapOf("context" to "edit")
         val response = runBlocking { reactNativeStore.performWPComRequest(url, params) }
 
@@ -30,7 +30,7 @@ class ReleaseStack_ReactNativeWPComRequestTest : ReleaseStack_WPComBase() {
 
     @Test
     fun testWpComCall_fails() {
-        val url = "https://public-api.wordpress.com/wp/v2/sites/${siteFromDb.siteId}/an-invalid-extension"
+        val url = "https://public-api.wordpress.com/wp/v2/sites/${sSite.siteId}/an-invalid-extension"
         val response = runBlocking { reactNativeStore.performWPComRequest(url, emptyMap()) }
 
         val assertionMessage = "Call should have failed with a 404, instead response was $response"


### PR DESCRIPTION
### Summary

Uses the site directly instead of getting the site id from the Site Store.

This is a fix for a broken test merged in #1459 .  The tests passed when run individually, but failed when the entire class was run.

### To Test

Verfiy that the `ReleaseStack_ReactNativeWPComRequestTest` tests pass, i.e.:

```
./gradlew cAT -Pandroid.testInstrumentationRunnerArguments.class=org.wordpress.android.fluxc.release.ReleaseStack_ReactNativeWPComRequestTest
```