### PR TITLE
issue/1490-woo-product-sale-dates-gmt 

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 97
+        return 98
     }
 
     override fun getDbName(): String {
@@ -1055,6 +1055,10 @@ open class WellSqlConfig : DefaultWellConfig {
                             "DATE_CREATED TEXT,_id INTEGER PRIMARY KEY AUTOINCREMENT," +
                             "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
                             "UNIQUE(REMOTE_ID) ON CONFLICT REPLACE)")
+                }
+                97 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_FROM_GMT TEXT")
+                    db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_TO_GMT TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -43,8 +43,11 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var salePrice = ""
     @Column var onSale = false
     @Column var totalSales = 0
+
     @Column var dateOnSaleFrom = ""
     @Column var dateOnSaleTo = ""
+    @Column var dateOnSaleFromGmt = ""
+    @Column var dateOnSaleToGmt = ""
 
     @Column var virtual = false
     @Column var downloadable = false

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -40,8 +40,11 @@ class ProductApiResponse : Response {
     var manage_stock: String? = null
     var stock_quantity = 0
     var stock_status: String? = null
+
     var date_on_sale_from: String? = null
     var date_on_sale_to: String? = null
+    var date_on_sale_from_gmt: String? = null
+    var date_on_sale_to_gmt: String? = null
 
     var backorders: String? = null
     var backorders_allowed = false

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -630,8 +630,11 @@ class ProductRestClient(
 
             dateCreated = response.date_created ?: ""
             dateModified = response.date_modified ?: ""
+
             dateOnSaleFrom = response.date_on_sale_from ?: ""
             dateOnSaleTo = response.date_on_sale_to ?: ""
+            dateOnSaleFromGmt = response.date_on_sale_from_gmt ?: ""
+            dateOnSaleToGmt = response.date_on_sale_to_gmt ?: ""
 
             type = response.type ?: ""
             status = response.status ?: ""


### PR DESCRIPTION
Closes #1490 by adding the GMT versions of product sale dates. Before this is merged, I think we need to discuss how to name date variables because we're inconsistent. For example, the order model has `dateCreated` and `dateModified` fields which are UTC dates, whereas the product model has these same fields but they're _not_ UTC.

My vote is to append `Gmt` to the field names to make it explicit. I've started a thread on Slack to discuss this.