### PR TITLE
Adds FETCH_POST_STATUS action

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -12,7 +12,6 @@ import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.UpdatePost;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
-import org.wordpress.android.fluxc.release.ReleaseStack_WCProductTest.TestEvent;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
@@ -689,7 +688,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(POST_STATUS_TO_TEST, uploadedPost.getStatus());
 
         // Fetch post status - The response will be tested in OnPostStatusFetched
-        fetchPostStatus();
+        fetchPostStatus(uploadedPost);
     }
 
     // Error handling tests
@@ -1208,10 +1207,10 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
-    private void fetchPostStatus() throws InterruptedException {
+    private void fetchPostStatus(PostModel post) throws InterruptedException {
         mNextEvent = TestEvents.POST_STATUS_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
-        mDispatcher.dispatch(PostActionBuilder.newFetchPostStatusAction(new RemotePostPayload(mPost, sSite)));
+        mDispatcher.dispatch(PostActionBuilder.newFetchPostStatusAction(new RemotePostPayload(post, sSite)));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PostAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.store.PostStore.FetchPostStatusResponsePayload;
 import org.wordpress.android.fluxc.store.PostStore.RemoteAutoSavePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.DeletedPostPayload;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostListPayload;
@@ -27,6 +28,8 @@ public enum PostAction implements IAction {
     @Action(payloadType = RemotePostPayload.class)
     FETCH_POST,
     @Action(payloadType = RemotePostPayload.class)
+    FETCH_POST_STATUS,
+    @Action(payloadType = RemotePostPayload.class)
     PUSH_POST,
     @Action(payloadType = RemotePostPayload.class)
     DELETE_POST,
@@ -44,6 +47,8 @@ public enum PostAction implements IAction {
     FETCHED_POSTS,
     @Action(payloadType = FetchPostResponsePayload.class)
     FETCHED_POST,
+    @Action(payloadType = FetchPostStatusResponsePayload.class)
+    FETCHED_POST_STATUS,
     @Action(payloadType = RemotePostPayload.class)
     PUSHED_POST,
     @Action(payloadType = DeletedPostPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -122,7 +122,6 @@ public class PostRestClient extends BaseWPComRestClient {
                 new WPComErrorListener() {
                     @Override
                     public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                        // Possible non-generic errors: 404 unknown_post (invalid post ID)
                         FetchPostStatusResponsePayload payload = new FetchPostStatusResponsePayload(post, site);
                         payload.error = new PostError(error.apiError, error.message);
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostStatusAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -116,7 +116,6 @@ public class PostRestClient extends BaseWPComRestClient {
                     public void onResponse(PostWPComRestResponse response) {
                         FetchPostStatusResponsePayload payload = new FetchPostStatusResponsePayload(post, site);
                         payload.remotePostStatus = response.getStatus();
-
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostStatusAction(payload));
                     }
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -114,9 +114,8 @@ public class PostRestClient extends BaseWPComRestClient {
                 new Listener<PostWPComRestResponse>() {
                     @Override
                     public void onResponse(PostWPComRestResponse response) {
-                        PostModel fetchedPost = postResponseToPostModel(response);
                         FetchPostStatusResponsePayload payload = new FetchPostStatusResponsePayload(post, site);
-                        payload.remotePostStatus = fetchedPost.getStatus();
+                        payload.remotePostStatus = response.getStatus();
 
                         mDispatcher.dispatch(PostActionBuilder.newFetchedPostStatusAction(payload));
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -105,19 +105,11 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    private List<Object> fetchPostParams(final PostModel post, final SiteModel site) {
-        List<Object> params = new ArrayList<>(4);
-        params.add(site.getSelfHostedSiteId());
-        params.add(site.getUsername());
-        params.add(site.getPassword());
-        params.add(post.getRemotePostId());
-        return params;
-    }
-
     public void fetchPostStatus(final PostModel post, final SiteModel site) {
         final String postStatusField = "post_status";
         List<Object> params = fetchPostParams(post, site);
-        params.add(postStatusField);
+        // If we only request the status, we get an empty response
+        params.add(Arrays.asList("post_id", postStatusField));
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POST, params,
                 new Listener<Object>() {
@@ -691,6 +683,15 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         if (fields != null && fields.size() > 0) {
             params.add(fields);
         }
+        return params;
+    }
+
+    private List<Object> fetchPostParams(final PostModel post, final SiteModel site) {
+        List<Object> params = new ArrayList<>(4);
+        params.add(site.getSelfHostedSiteId());
+        params.add(site.getUsername());
+        params.add(site.getPassword());
+        params.add(post.getRemotePostId());
         return params;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -115,25 +115,25 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
     }
 
     public void fetchPostStatus(final PostModel post, final SiteModel site) {
+        final String postStatusField = "post_status";
         List<Object> params = fetchPostParams(post, site);
-        params.add("post_status");
+        params.add(postStatusField);
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POST, params,
                 new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
+                        String remotePostStatus = null;
                         if (response instanceof Map) {
-                            PostModel postModel = postResponseObjectToPostModel((Map) response, site);
-                            FetchPostStatusResponsePayload payload;
-                            if (postModel != null) {
-                                payload = new FetchPostStatusResponsePayload(postModel, site);
-                            } else {
-                                payload = new FetchPostStatusResponsePayload(post, site);
-                                payload.error = new PostError(PostErrorType.INVALID_RESPONSE);
-                            }
-
-                            mDispatcher.dispatch(PostActionBuilder.newFetchedPostStatusAction(payload));
+                            remotePostStatus = MapUtils.getMapStr((Map) response, postStatusField);
                         }
+                        FetchPostStatusResponsePayload payload = new FetchPostStatusResponsePayload(post, site);
+                        if (remotePostStatus != null) {
+                            payload.remotePostStatus = remotePostStatus;
+                        } else {
+                            payload.error = new PostError(PostErrorType.INVALID_RESPONSE);
+                        }
+                        mDispatcher.dispatch(PostActionBuilder.newFetchedPostStatusAction(payload));
                     }
                 }, new BaseErrorListener() {
             @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -69,7 +69,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
     }
 
     public void fetchPost(final PostModel post, final SiteModel site, final PostAction origin) {
-        List<Object> params = fetchPostParams(post, site);
+        List<Object> params = createfetchPostParams(post, site);
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POST, params,
                 new Listener<Object>() {
@@ -107,7 +107,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchPostStatus(final PostModel post, final SiteModel site) {
         final String postStatusField = "post_status";
-        List<Object> params = fetchPostParams(post, site);
+        List<Object> params = createfetchPostParams(post, site);
         // If we only request the status, we get an empty response
         params.add(Arrays.asList("post_id", postStatusField));
 
@@ -628,7 +628,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         return params;
     }
 
-    private List<Object> fetchPostParams(final PostModel post, final SiteModel site) {
+    private List<Object> createfetchPostParams(final PostModel post, final SiteModel site) {
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -36,7 +36,6 @@ import org.wordpress.android.fluxc.model.list.ListOrder;
 import org.wordpress.android.fluxc.model.list.PostListDescriptor;
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForRestSite;
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForXmlRpcSite;
-import org.wordpress.android.fluxc.model.list.PostListOrderBy;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.model.revisions.Diff;
 import org.wordpress.android.fluxc.model.revisions.LocalDiffModel;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -328,6 +328,17 @@ public class PostStore extends Store {
         }
     }
 
+    public static class OnPostStatusFetched extends OnChanged<PostError> {
+        public PostModel post;
+        public String remotePostStatus;
+
+        OnPostStatusFetched(PostModel post, String remotePostStatus, PostError error) {
+            this.post = post;
+            this.remotePostStatus = remotePostStatus;
+            this.error = error;
+        }
+    }
+
     public enum PostDeleteActionType {
         TRASH,
         DELETE
@@ -616,6 +627,9 @@ public class PostStore extends Store {
                 break;
             case FETCHED_POST:
                 handleFetchSinglePostCompleted((FetchPostResponsePayload) action.getPayload());
+                break;
+            case FETCHED_POST_STATUS:
+                handleFetchPostStatusCompleted((FetchPostStatusResponsePayload) action.getPayload());
                 break;
             case PUSH_POST:
                 pushPost((RemotePostPayload) action.getPayload());
@@ -925,6 +939,10 @@ public class PostStore extends Store {
         } else {
             updatePost(payload.post, false);
         }
+    }
+
+    private void handleFetchPostStatusCompleted(FetchPostStatusResponsePayload payload) {
+        emitChange(new OnPostStatusFetched(payload.post, payload.remotePostStatus, payload.error));
     }
 
     private void handlePushPostCompleted(RemotePostPayload payload) {


### PR DESCRIPTION
This PR adds `FETCH_POST_STATUS` action which we will utilize to fix https://github.com/wordpress-mobile/WordPress-Android/issues/10951. The action is implemented for both REST and XML-RPC sites and both of them have connected tests.

@malinajirka Would you like me to open a separate PR for combining the errors in a single method in `PostXMLRPCClient`? I only introduced the method to be shared between `fetchPost` and `fetchPostStatus` but then realized we are doing the exact same error handling in every action, so I combined them all. I am happy to separate that into a new PR if you feel it'll help.