### PR TITLE
Added logic to use dateOnSaleFromGmt instead of using dateOnSaleFrom

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -157,14 +157,14 @@ class WooUpdateProductFragment : Fragment() {
         product_from_date.setOnClickListener {
             showDatePickerDialog(product_from_date.text.toString(), OnDateSetListener { _, year, month, dayOfMonth ->
                 product_from_date.text = DateUtils.getFormattedDateString(year, month, dayOfMonth)
-                selectedProductModel?.dateOnSaleFrom = product_from_date.text.toString()
+                selectedProductModel?.dateOnSaleFromGmt = product_from_date.text.toString()
             })
         }
 
         product_to_date.setOnClickListener {
             showDatePickerDialog(product_to_date.text.toString(), OnDateSetListener { _, year, month, dayOfMonth ->
                 product_to_date.text = DateUtils.getFormattedDateString(year, month, dayOfMonth)
-                selectedProductModel?.dateOnSaleTo = product_to_date.text.toString()
+                selectedProductModel?.dateOnSaleToGmt = product_to_date.text.toString()
             })
         }
 
@@ -231,8 +231,8 @@ class WooUpdateProductFragment : Fragment() {
                 product_weight.setText(it.weight)
                 product_tax_status.text = it.taxStatus
                 product_sold_individually.isChecked = it.soldIndividually
-                product_from_date.text = it.dateOnSaleFrom.split('T')[0]
-                product_to_date.text = it.dateOnSaleTo.split('T')[0]
+                product_from_date.text = it.dateOnSaleFromGmt.split('T')[0]
+                product_to_date.text = it.dateOnSaleToGmt.split('T')[0]
                 product_manage_stock.isChecked = it.manageStock
                 product_stock_status.text = it.stockStatus
                 product_back_orders.text = it.backorders

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -582,11 +582,11 @@ class ProductRestClient(
         if (storedWCProductModel.salePrice != updatedProductModel.salePrice) {
             body["sale_price"] = updatedProductModel.salePrice
         }
-        if (storedWCProductModel.dateOnSaleFrom != updatedProductModel.dateOnSaleFrom) {
-            body["date_on_sale_from"] = updatedProductModel.dateOnSaleFrom
+        if (storedWCProductModel.dateOnSaleFromGmt != updatedProductModel.dateOnSaleFromGmt) {
+            body["date_on_sale_from_gmt"] = updatedProductModel.dateOnSaleFromGmt
         }
-        if (storedWCProductModel.dateOnSaleTo != updatedProductModel.dateOnSaleTo) {
-            body["date_on_sale_to"] = updatedProductModel.dateOnSaleTo
+        if (storedWCProductModel.dateOnSaleToGmt != updatedProductModel.dateOnSaleToGmt) {
+            body["date_on_sale_to_gmt"] = updatedProductModel.dateOnSaleToGmt
         }
         if (storedWCProductModel.taxStatus != updatedProductModel.taxStatus) {
             body["tax_status"] = updatedProductModel.taxStatus


### PR DESCRIPTION
This tine PR fixes #1494 by using the `dateOnSaleFromGmt` and `dateOnSaleToGmt` instead of `dateOnSaleFrom` and `dateOnSaleTo`.

#### To test
- Click on `Woo` -> `Products` -> `Select Site` -> `Update Product`.
- Choose a date for `Start Date` and `End date` under `Scheduling Sale` section.
- Using Stethos, ensure that `dateOnSaleFromGmt` and `dateOnSaleToGmt` is passed to the API request.