### PR TITLE
Modified method name when fetching tax class list from db

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/WCTaxStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/taxes/WCTaxStoreTest.kt
@@ -76,13 +76,13 @@ class WCTaxStoreTest {
     fun `get stored tax class list for site`() = test {
         fetchTaxClassListForSite()
 
-        val storedTaxClassList = store.getShippingClassListForSite(site)
+        val storedTaxClassList = store.getTaxClassListForSite(site)
 
         assertThat(storedTaxClassList.size).isEqualTo(2)
         assertThat(storedTaxClassList.first().name).isEqualTo(mapper.map(sampleTaxClassList.first()).name)
         assertThat(storedTaxClassList.first().slug).isEqualTo(mapper.map(sampleTaxClassList.first()).slug)
 
-        val invalidRequestResult = store.getShippingClassListForSite(errorSite)
+        val invalidRequestResult = store.getTaxClassListForSite(errorSite)
         assertThat(invalidRequestResult.size).isEqualTo(0)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCTaxStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCTaxStore.kt
@@ -23,7 +23,7 @@ class WCTaxStore @Inject constructor(
     /**
      * returns a list of tax classes for a specific site in the database
      */
-    fun getShippingClassListForSite(site: SiteModel): List<WCTaxClassModel> =
+    fun getTaxClassListForSite(site: SiteModel): List<WCTaxClassModel> =
             WCTaxSqlUtils.getTaxClassesForSite(site.id)
 
     suspend fun fetchTaxClassList(site: SiteModel): WooResult<List<WCTaxClassModel>> {


### PR DESCRIPTION
Fixes #1498. This tine PR just changes the method name when fetching tax class list from `getShippingClassListForSite` to `getTaxClassListForSite`.  