### PR TITLE
Reduce artificial network delay to .5s for mocked tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
@@ -26,6 +26,7 @@ import javax.inject.Singleton
 class ResponseMockingInterceptor : Interceptor {
     companion object {
         private val SUBSTITUTION_DEFAULT = { string: String -> string }
+        private const val NETWORK_DELAY_MS = 500L
     }
 
     /**
@@ -96,7 +97,7 @@ class ResponseMockingInterceptor : Interceptor {
         val request = chain.request()
 
         // Give some time to create a realistic network event
-        TestUtils.waitFor(1000)
+        TestUtils.waitFor(NETWORK_DELAY_MS)
 
         lastRequest = request
         lastRequestUrl = request.url().toString()


### PR DESCRIPTION
Closes #1497. Each (mocked) network request for the mocked tests has an artificial `1000ms` wait to simulate a real network response (allow events to fire, state to be updated, and so on).

~#1462 should be merged first and the base branch of this PR updated.~

`500ms` seems enough to keep everything running smoothly, and knocks off about 1 minute when running the full mocked test suite on my device (from ~2m22s to ~1m24s).

We might be able to go a bit lower, but not by much for now due to [requirements of the media cancellation tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1462#discussion_r381036211).