### PR TITLE
Woo: Lower max orders to fetch in batch from 25 to 15

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -36,7 +36,7 @@ import javax.inject.Singleton
 class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrderRestClient: OrderRestClient) :
         Store(dispatcher) {
     companion object {
-        const val NUM_ORDERS_PER_FETCH = 25
+        const val NUM_ORDERS_PER_FETCH = 15
         const val DEFAULT_ORDER_STATUS = "any"
     }
 


### PR DESCRIPTION
Lowered the maximum number of orders to fetch in batch from 25 to 15. The reason this limit is being lowered is to avoid possibly hitting the arbitrary max URI size set by hosts (HTTP 414 Error). This size differs from host to host, but generally you want to keep the length below 2k characters. This will ensure we are well below that limit for stores with really long order numbers. See `p91TBi-2re-p2` for additional background.

## To Test
In the Example app:
1. Navigate to Woo -> Orders -> Fetch Order List
2. Verify orders load
3. Scroll to test load more
4. Test search and filtering