### PR TITLE
Update Page RemoteLastModified if newer version exists in remote

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -936,7 +936,8 @@ public class PostStore extends Store {
                             // at this point we know there's a potential version conflict (the post has been modified
                             // both locally and on the remote), so flag the local version of the Post so the
                             // hosting app can inform the user and the user can decide and take action
-                            post.setRemoteLastModified(remotePostFromDb.getRemoteLastModified());
+                            remotePostFromDb.setRemoteLastModified(post.getLastModified());
+                            post = remotePostFromDb;
                         }
                     }
                     rowsAffected += mPostSqlUtils.insertOrUpdatePostKeepingLocalChanges(post);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -905,15 +905,48 @@ public class PostStore extends Store {
             }
 
             int rowsAffected = 0;
-            for (PostModel post : payload.posts.getPosts()) {
-                rowsAffected += mPostSqlUtils.insertOrUpdatePostKeepingLocalChanges(post);
+
+            ArrayList<Long> postIds;
+            Map<Long, PostModel> posts = new HashMap<>();
+
+            // only do database fetch if this is a page which means there could be a conflict.
+            if (payload.isPages) {
+                postIds = new ArrayList<>(payload.posts.getPosts().size());
+                SiteModel site = payload.site;
+
+                for (PostModel item : payload.posts.getPosts()) {
+                    postIds.add(item.getRemotePostId());
+                }
+                posts = getPostsByRemotePostIds(postIds, site);
             }
 
+            for (PostModel post : payload.posts.getPosts()) {
+                if (payload.isPages) {
+                    PostModel remotePostFromDb = posts.get(post.getRemotePostId());
+                    if (remotePostFromDb != null) {
+                        // Check if the post's last modified date or status have changed.
+                        // We need to check status separately because when a scheduled post is published, its
+                        // modified date
+                        // will not be updated.
+                        boolean isPostChanged =
+                                !post.getLastModified().equals(remotePostFromDb.getLastModified())
+                                || !post.getStatus().equals(remotePostFromDb.getStatus());
+
+                        if (isPostChanged) {
+                            // at this point we know there's a potential version conflict (the post has been modified
+                            // both locally and on the remote), so flag the local version of the Post so the
+                            // hosting app can inform the user and the user can decide and take action
+                            post.setRemoteLastModified(remotePostFromDb.getRemoteLastModified());
+                        }
+                    }
+                    rowsAffected += mPostSqlUtils.insertOrUpdatePostKeepingLocalChanges(post);
+                }
+            }
             onPostChanged = new OnPostChanged(causeOfChange, rowsAffected, payload.canLoadMore);
         }
-
         emitChange(onPostChanged);
     }
+
 
     private void handleFetchSinglePostCompleted(FetchPostResponsePayload payload) {
         if (payload.origin == PostAction.PUSH_POST) {


### PR DESCRIPTION
## Findings
The goal of this PR is to add the conflict resolution functionality to the Pages List components. i.e when the `PageStore`/`PostStore` is used to fetches related to pages it should mark local posts that have changes with the last modified date of a remote posts that have been updated.

## Solution
The first solution was to add this to the `handleFetchPostsCompleted` of the `PostStore` since it's used to update `Pages` when a fetch occurs on the `Pages List`. The solution in place should work, however, the logic for conflict resolution, autosave currently lives in `handleFetchedPostList` and it would be best if it could be shared to make maintenance easier and reduce the complexity of the solution. 

`handleFetchedPostList` is called when `handleFetchPostList` is triggered to get the posts from the server and within the params of the request there is the ability to fetch pages but this is currently set to false. 

https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ca5bc4e5fab893d3e616669e5ce45d01300ecb45/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java#L140

1. So this functionality could be reused in some way once that parameter is exposed with a `FETCH_PAGE_LIST` action. 

What I didn't quite get while looking at this is how this could be leveraged in a way without causing any clashes and unnecessary API calls because the ways how posts and the post list items are fetched within the `Post List` are different from the `Page List`. It might not be as complex but it was an interesting problem to solve.

2. The logic within `handleFetchedPostList` could be extracted into another function so that it can be shared between this `List` based one and `FetchPosts`