### PR TITLE
Add bold type to formattable range types

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
@@ -12,6 +12,28 @@ import kotlin.test.assertEquals
 class FormattableContentMapperTest {
     private lateinit var formattableContentMapper: FormattableContentMapper
     private val url = "https://www.wordpress.com"
+    private val notificationSubjectResponse = "{\n" +
+            "      \"text\": \"You've received 20 likes on My Site\",\n" +
+            "      \"ranges\": [\n" +
+            "        {\n" +
+            "          \"type\": \"b\",\n" +
+            "          \"indices\": [\n" +
+            "            16,\n" +
+            "            18\n" +
+            "          ]\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"type\": \"site\",\n" +
+            "          \"indices\": [\n" +
+            "            28,\n" +
+            "            35\n" +
+            "          ],\n" +
+            "          \"url\": \"http://mysite.wordpress.com\",\n" +
+            "          \"id\": 123\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }"
+
     private val notificationBodyResponse: String = "{\n" +
             "          \"text\": \"This site was created by Author\",\n" +
             "          \"ranges\": [\n" +
@@ -96,7 +118,24 @@ class FormattableContentMapperTest {
     }
 
     @Test
-    fun mapsNotificationToRichFormattableContent() {
+    fun mapsNotificationSubjectToRichFormattableContent() {
+        val formattableContent = formattableContentMapper.mapToFormattableContent(notificationSubjectResponse)
+        assertEquals("You've received 20 likes on My Site", formattableContent.text)
+        assertEquals(2, formattableContent.ranges!!.size)
+        with(formattableContent.ranges!![0]) {
+            assertEquals(FormattableRangeType.B, this.rangeType())
+            assertEquals(listOf(16, 18), this.indices)
+        }
+        with(formattableContent.ranges!![1]) {
+            assertEquals(FormattableRangeType.SITE, this.rangeType())
+            assertEquals(123, this.id)
+            assertEquals("http://mysite.wordpress.com", this.url)
+            assertEquals(listOf(28, 35), this.indices)
+        }
+    }
+
+    @Test
+    fun mapsNotificationBodyToRichFormattableContent() {
         val formattableContent = formattableContentMapper.mapToFormattableContent(notificationBodyResponse)
         assertEquals("This site was created by Author", formattableContent.text)
         assertEquals(1, formattableContent.ranges!!.size)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -99,6 +99,7 @@ enum class FormattableRangeType {
     LIKE,
     MATCH,
     MEDIA,
+    B,
     UNKNOWN;
 
     companion object {
@@ -116,6 +117,7 @@ enum class FormattableRangeType {
                 "like" -> LIKE
                 "match" -> MATCH
                 "media" -> MEDIA
+                "b" -> B
                 else -> UNKNOWN
             }
         }


### PR DESCRIPTION
Related [WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/11382).

This PR adds the bold type to the list of supported formattable range types. 

This allows us to parse and show up-to-date definitions for bold text in notifications, such as the likes count (e.g. "You've received **5** likes on **Example Blog**").

Internal reference: `pauD4L-z9-p2#comment-567`