### PR TITLE
Fixing CI related to PR #1460.

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ManageInsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ManageInsightsTestJetpack.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
+import org.wordpress.android.fluxc.store.DEFAULT_INSIGHTS
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
@@ -64,21 +65,21 @@ class ReleaseStack_ManageInsightsTestJetpack : ReleaseStack_Base() {
 
         val emptyStats = runBlocking { statsStore.getAddedInsights(site) }
 
-        // Starts with 5 default blocks
-        assertEquals(emptyStats.size, 4)
+        // Starts with default blocks (those in DEFAULT_INSIGHTS)
+        assertEquals(emptyStats.size, DEFAULT_INSIGHTS.size)
         if (!emptyStats.contains(InsightType.FOLLOWERS)) {
             runBlocking { statsStore.addType(site, InsightType.FOLLOWERS) }
         }
 
         val statsWithFollowers = runBlocking { statsStore.getAddedInsights(site) }
 
-        assertEquals(statsWithFollowers.size, 5)
+        assertEquals(statsWithFollowers.size, DEFAULT_INSIGHTS.size + 1)
 
         runBlocking { statsStore.removeType(site, FOLLOWERS) }
 
         val statsWithoutFollowers = runBlocking { statsStore.getAddedInsights(site) }
 
-        assertEquals(statsWithoutFollowers.size, 4)
+        assertEquals(statsWithoutFollowers.size, DEFAULT_INSIGHTS.size)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ManageInsightsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ManageInsightsTestJetpack.kt
@@ -65,20 +65,20 @@ class ReleaseStack_ManageInsightsTestJetpack : ReleaseStack_Base() {
         val emptyStats = runBlocking { statsStore.getAddedInsights(site) }
 
         // Starts with 5 default blocks
-        assertEquals(emptyStats.size, 5)
+        assertEquals(emptyStats.size, 4)
         if (!emptyStats.contains(InsightType.FOLLOWERS)) {
             runBlocking { statsStore.addType(site, InsightType.FOLLOWERS) }
         }
 
         val statsWithFollowers = runBlocking { statsStore.getAddedInsights(site) }
 
-        assertEquals(statsWithFollowers.size, 6)
+        assertEquals(statsWithFollowers.size, 5)
 
         runBlocking { statsStore.removeType(site, FOLLOWERS) }
 
         val statsWithoutFollowers = runBlocking { statsStore.getAddedInsights(site) }
 
-        assertEquals(statsWithoutFollowers.size, 5)
+        assertEquals(statsWithoutFollowers.size, 4)
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue with test 

`ReleaseStack_ManageInsightsTestJetpack > testAddAndRemoveInsights` 

after we changed the `DEFAULT_INSIGHTS` list in [1460 PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1460/files)

This PR aligns the expected number of elements in the list due to the above mentioned modification.

Everyone can review this and 1 reviewer is enough. (thanks @aforcier for pinging on this 🙇‍♂️)

### To test
Run the ReleaseStack_ManageInsightsTestJetpack tests (I've done it locally) and check it passes.

### Note
Do not know why tbh (and possibly I'm just missing something obvious 🤷‍♂️), but rerunning the workflow from Circle CI console yesterday I got the CI suite passed, this is why I did not dig into (my bad) and supposed it had been a flaky test/timing. Leaving this as a note in case someone with more knowledge than me on this can have some thoughts eventually.
