### PR TITLE
[Site Creation] Step 1: Remove vertical id in site creation

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -211,7 +211,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void newSite(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
-                        @NonNull SiteVisibility visibility, @Nullable String verticalId, @Nullable Long segmentId,
+                        @NonNull SiteVisibility visibility, @Nullable Long segmentId,
                         @Nullable String tagLine, final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1_1();
         Map<String, Object> body = new HashMap<>();
@@ -225,9 +225,6 @@ public class SiteRestClient extends BaseWPComRestClient {
 
         // Add site options if available
         Map<String, Object> options = new HashMap<>();
-        if (verticalId != null) {
-            options.put("site_vertical", verticalId);
-        }
         if (segmentId != null) {
             options.put("site_segment", segmentId);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -79,24 +79,22 @@ public class SiteStore extends Store {
         @NonNull public String siteTitle;
         @NonNull public String language;
         @NonNull public SiteVisibility visibility;
-        @Nullable public String verticalId;
         @Nullable public Long segmentId;
         @Nullable public String tagLine;
         @NonNull public boolean dryRun;
 
         public NewSitePayload(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
                               @NonNull SiteVisibility visibility, boolean dryRun) {
-            this(siteName, siteTitle, language, visibility, null, null, null, dryRun);
+            this(siteName, siteTitle, language, visibility, null, null, dryRun);
         }
 
         public NewSitePayload(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
-                              @NonNull SiteVisibility visibility, @Nullable String verticalId, @Nullable Long segmentId,
+                              @NonNull SiteVisibility visibility, @Nullable Long segmentId,
                               @Nullable String tagLine, boolean dryRun) {
             this.siteName = siteName;
             this.siteTitle = siteTitle;
             this.language = language;
             this.visibility = visibility;
-            this.verticalId = verticalId;
             this.segmentId = segmentId;
             this.tagLine = tagLine;
             this.dryRun = dryRun;
@@ -1691,7 +1689,7 @@ public class SiteStore extends Store {
 
     private void createNewSite(NewSitePayload payload) {
         mSiteRestClient.newSite(payload.siteName, payload.siteTitle, payload.language, payload.visibility,
-                payload.verticalId, payload.segmentId, payload.tagLine, payload.dryRun);
+                payload.segmentId, payload.tagLine, payload.dryRun);
     }
 
     private void handleCreateNewSiteCompleted(NewSiteResponsePayload payload) {


### PR DESCRIPTION
Since we are removing verticals step in https://github.com/wordpress-mobile/WordPress-Android/pull/11435, https://github.com/wordpress-mobile/WordPress-Android/pull/11437, we don't need to pass `verticalId` in the new site requests.

This PR removes `site_vertical` and `verticalId` options key-value pair in the new site requests which were introduced as part of https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1079.

I am creating this as a draft PR as wordpress-mobile/WordPress-Android#11421 is not merged yet. 