### PR TITLE
Update to use application/xml instead of text/xml for content type

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
@@ -13,7 +13,7 @@ import java.io.UnsupportedEncodingException;
 
 public class DiscoveryRequest extends BaseRequest<String> {
     private static final String PROTOCOL_CHARSET = "utf-8";
-    private static final String PROTOCOL_CONTENT_TYPE = String.format("text/xml; charset=%s", PROTOCOL_CHARSET);
+    private static final String PROTOCOL_CONTENT_TYPE = String.format("application/xml; charset=%s", PROTOCOL_CHARSET);
 
     private final Listener<String> mListener;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.xmlrpc;
 
+import android.util.Log;
 import android.util.Xml;
 
 import androidx.annotation.NonNull;
@@ -34,7 +35,7 @@ import java.util.List;
 // TODO: Would be great to use generics / return POJO or model direclty (see GSON code?)
 public class XMLRPCRequest extends BaseRequest<Object> {
     private static final String PROTOCOL_CHARSET = "utf-8";
-    private static final String PROTOCOL_CONTENT_TYPE = String.format("text/xml; charset=%s", PROTOCOL_CHARSET);
+    private static final String PROTOCOL_CONTENT_TYPE = String.format("application/xml; charset=%s", PROTOCOL_CHARSET);
 
     private final Listener<? super Object[]> mListener;
     private final XMLRPC mMethod;
@@ -44,6 +45,9 @@ public class XMLRPCRequest extends BaseRequest<Object> {
     public XMLRPCRequest(String url, XMLRPC method, List<Object> params, Listener<? super Object[]> listener,
                          BaseErrorListener errorListener) {
         super(Method.POST, url, errorListener);
+
+        Log.d("AMANDA-TEST", "XMLRPCRequest: ");
+
         mListener = listener;
         mMethod = method;
         // First params are always username/password


### PR DESCRIPTION
Fixes #1480 by replacing `text/xml` with `application/xml` as the `Content-Type` for `DiscoveryRequest` and `XMLRPCRequest` requests. Tested in the example app and there doesn't appear to be any issues with this change, but it'd be good to test this against the WordPress app as well. 

Created a test branch in `wordpress-android` called `fluxc/application-text-content-type` for testing with WordPress as well 👍 