### PR TITLE
[Site Creation] Step 2: Remove site title and tagline in site creation

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -157,9 +157,9 @@ public class SitesFragment extends Fragment {
         mDispatcher.unregister(this);
     }
 
-    private void newSiteAction(String name, String title) {
+    private void newSiteAction(String name) {
         // Default language "en" (english)
-        NewSitePayload newSitePayload = new NewSitePayload(name, title, "en", SiteVisibility.PUBLIC, true);
+        NewSitePayload newSitePayload = new NewSitePayload(name, "en", SiteVisibility.PUBLIC, true);
         mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload));
     }
 
@@ -167,8 +167,8 @@ public class SitesFragment extends Fragment {
         FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
         DialogFragment newFragment = ThreeEditTextDialog.newInstance(new Listener() {
             @Override
-            public void onClick(String name, String title, String unused) {
-                newSiteAction(name, title);
+            public void onClick(String name, String unusedFirst, String unusedSecond) {
+                newSiteAction(name);
             }
         }, "Site Name", "Site Title", "Unused");
         newFragment.show(ft, "dialog");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -210,13 +210,12 @@ public class SiteRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void newSite(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
+    public void newSite(@NonNull String siteName, @NonNull String language,
                         @NonNull SiteVisibility visibility, @Nullable Long segmentId,
-                        @Nullable String tagLine, final boolean dryRun) {
+                        final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1_1();
         Map<String, Object> body = new HashMap<>();
         body.put("blog_name", siteName);
-        body.put("blog_title", siteTitle);
         body.put("lang_id", language);
         body.put("public", visibility.toString());
         body.put("validate", dryRun ? "1" : "0");
@@ -227,11 +226,6 @@ public class SiteRestClient extends BaseWPComRestClient {
         Map<String, Object> options = new HashMap<>();
         if (segmentId != null) {
             options.put("site_segment", segmentId);
-        }
-        if (tagLine != null) {
-            Map<String, Object> siteInformation = new HashMap<>();
-            siteInformation.put("site_tagline", tagLine);
-            options.put("site_information", siteInformation);
         }
         if (options.size() > 0) {
             body.put("options", options);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -211,7 +211,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void newSite(@NonNull String siteName, @NonNull String language,
-                        @NonNull SiteVisibility visibility, @Nullable Long segmentId,
+                        @NonNull SiteVisibility visibility,
                         final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1_1();
         Map<String, Object> body = new HashMap<>();
@@ -221,15 +221,6 @@ public class SiteRestClient extends BaseWPComRestClient {
         body.put("validate", dryRun ? "1" : "0");
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());
-
-        // Add site options if available
-        Map<String, Object> options = new HashMap<>();
-        if (segmentId != null) {
-            options.put("site_segment", segmentId);
-        }
-        if (options.size() > 0) {
-            body.put("options", options);
-        }
 
         WPComGsonRequest<NewSiteResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 NewSiteResponse.class,
@@ -498,7 +489,7 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void suggestDomains(@NonNull final String query, final Boolean onlyWordpressCom,
                                final Boolean includeWordpressCom, final Boolean includeDotBlogSubdomain,
-                               final Long segmentId, final int quantity, final boolean includeVendorDot,
+                               final int quantity, final boolean includeVendorDot,
                                final String tlds) {
         String url = WPCOMREST.domains.suggestions.getUrlV1_1();
         Map<String, String> params = new HashMap<>(4);
@@ -511,9 +502,6 @@ public class SiteRestClient extends BaseWPComRestClient {
         }
         if (includeDotBlogSubdomain != null) {
             params.put("include_dotblogsubdomain", String.valueOf(includeDotBlogSubdomain));
-        }
-        if (segmentId != null) {
-            params.put("segment_id", String.valueOf(segmentId));
         }
         if (tlds != null) {
             params.put("tlds", tlds);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -211,7 +211,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void newSite(@NonNull String siteName, @NonNull String language,
-                        @NonNull SiteVisibility visibility,
+                        @NonNull SiteVisibility visibility, @Nullable Long segmentId,
                         final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1_1();
         Map<String, Object> body = new HashMap<>();
@@ -221,6 +221,15 @@ public class SiteRestClient extends BaseWPComRestClient {
         body.put("validate", dryRun ? "1" : "0");
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());
+
+        // Add site options if available
+        Map<String, Object> options = new HashMap<>();
+        if (segmentId != null) {
+            options.put("site_segment", segmentId);
+        }
+        if (options.size() > 0) {
+            body.put("options", options);
+        }
 
         WPComGsonRequest<NewSiteResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 NewSiteResponse.class,
@@ -489,7 +498,7 @@ public class SiteRestClient extends BaseWPComRestClient {
 
     public void suggestDomains(@NonNull final String query, final Boolean onlyWordpressCom,
                                final Boolean includeWordpressCom, final Boolean includeDotBlogSubdomain,
-                               final int quantity, final boolean includeVendorDot,
+                               final Long segmentId, final int quantity, final boolean includeVendorDot,
                                final String tlds) {
         String url = WPCOMREST.domains.suggestions.getUrlV1_1();
         Map<String, String> params = new HashMap<>(4);
@@ -502,6 +511,9 @@ public class SiteRestClient extends BaseWPComRestClient {
         }
         if (includeDotBlogSubdomain != null) {
             params.put("include_dotblogsubdomain", String.valueOf(includeDotBlogSubdomain));
+        }
+        if (segmentId != null) {
+            params.put("segment_id", String.valueOf(segmentId));
         }
         if (tlds != null) {
             params.put("tlds", tlds);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -78,20 +78,13 @@ public class SiteStore extends Store {
         @NonNull public String siteName;
         @NonNull public String language;
         @NonNull public SiteVisibility visibility;
-        @Nullable public Long segmentId;
         @NonNull public boolean dryRun;
 
         public NewSitePayload(@NonNull String siteName, @NonNull String language,
                               @NonNull SiteVisibility visibility, boolean dryRun) {
-            this(siteName, language, visibility, null, dryRun);
-        }
-
-        public NewSitePayload(@NonNull String siteName, @NonNull String language,
-                              @NonNull SiteVisibility visibility, @Nullable Long segmentId, boolean dryRun) {
             this.siteName = siteName;
             this.language = language;
             this.visibility = visibility;
-            this.segmentId = segmentId;
             this.dryRun = dryRun;
         }
     }
@@ -1684,7 +1677,7 @@ public class SiteStore extends Store {
 
     private void createNewSite(NewSitePayload payload) {
         mSiteRestClient.newSite(payload.siteName, payload.language, payload.visibility,
-                payload.segmentId, payload.dryRun);
+                payload.dryRun);
     }
 
     private void handleCreateNewSiteCompleted(NewSiteResponsePayload payload) {
@@ -1876,7 +1869,7 @@ public class SiteStore extends Store {
 
     private void suggestDomains(SuggestDomainsPayload payload) {
         mSiteRestClient.suggestDomains(payload.query, payload.onlyWordpressCom, payload.includeWordpressCom,
-                payload.includeDotBlogSubdomain, payload.segmentId, payload.quantity, payload.includeVendorDot,
+                payload.includeDotBlogSubdomain, payload.quantity, payload.includeVendorDot,
                 payload.tlds);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -78,13 +78,20 @@ public class SiteStore extends Store {
         @NonNull public String siteName;
         @NonNull public String language;
         @NonNull public SiteVisibility visibility;
+        @Nullable public Long segmentId;
         @NonNull public boolean dryRun;
 
         public NewSitePayload(@NonNull String siteName, @NonNull String language,
                               @NonNull SiteVisibility visibility, boolean dryRun) {
+            this(siteName, language, visibility, null, dryRun);
+        }
+
+        public NewSitePayload(@NonNull String siteName, @NonNull String language,
+                              @NonNull SiteVisibility visibility, @Nullable Long segmentId, boolean dryRun) {
             this.siteName = siteName;
             this.language = language;
             this.visibility = visibility;
+            this.segmentId = segmentId;
             this.dryRun = dryRun;
         }
     }
@@ -1677,7 +1684,7 @@ public class SiteStore extends Store {
 
     private void createNewSite(NewSitePayload payload) {
         mSiteRestClient.newSite(payload.siteName, payload.language, payload.visibility,
-                payload.dryRun);
+                payload.segmentId, payload.dryRun);
     }
 
     private void handleCreateNewSiteCompleted(NewSiteResponsePayload payload) {
@@ -1869,7 +1876,7 @@ public class SiteStore extends Store {
 
     private void suggestDomains(SuggestDomainsPayload payload) {
         mSiteRestClient.suggestDomains(payload.query, payload.onlyWordpressCom, payload.includeWordpressCom,
-                payload.includeDotBlogSubdomain, payload.quantity, payload.includeVendorDot,
+                payload.includeDotBlogSubdomain, payload.segmentId, payload.quantity, payload.includeVendorDot,
                 payload.tlds);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -76,27 +76,22 @@ public class SiteStore extends Store {
     @SuppressWarnings("WeakerAccess")
     public static class NewSitePayload extends Payload<BaseNetworkError> {
         @NonNull public String siteName;
-        @NonNull public String siteTitle;
         @NonNull public String language;
         @NonNull public SiteVisibility visibility;
         @Nullable public Long segmentId;
-        @Nullable public String tagLine;
         @NonNull public boolean dryRun;
 
-        public NewSitePayload(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
+        public NewSitePayload(@NonNull String siteName, @NonNull String language,
                               @NonNull SiteVisibility visibility, boolean dryRun) {
-            this(siteName, siteTitle, language, visibility, null, null, dryRun);
+            this(siteName, language, visibility, null, dryRun);
         }
 
-        public NewSitePayload(@NonNull String siteName, @NonNull String siteTitle, @NonNull String language,
-                              @NonNull SiteVisibility visibility, @Nullable Long segmentId,
-                              @Nullable String tagLine, boolean dryRun) {
+        public NewSitePayload(@NonNull String siteName, @NonNull String language,
+                              @NonNull SiteVisibility visibility, @Nullable Long segmentId, boolean dryRun) {
             this.siteName = siteName;
-            this.siteTitle = siteTitle;
             this.language = language;
             this.visibility = visibility;
             this.segmentId = segmentId;
-            this.tagLine = tagLine;
             this.dryRun = dryRun;
         }
     }
@@ -1688,8 +1683,8 @@ public class SiteStore extends Store {
     }
 
     private void createNewSite(NewSitePayload payload) {
-        mSiteRestClient.newSite(payload.siteName, payload.siteTitle, payload.language, payload.visibility,
-                payload.segmentId, payload.tagLine, payload.dryRun);
+        mSiteRestClient.newSite(payload.siteName, payload.language, payload.visibility,
+                payload.segmentId, payload.dryRun);
     }
 
     private void handleCreateNewSiteCompleted(NewSiteResponsePayload payload) {


### PR DESCRIPTION
Since we are removing site info step in https://github.com/wordpress-mobile/WordPress-Android/pull/11440, we don't need to pass site title and tag line in the new site requests.

This PR removes

`blog_title: <site title>` and 
   ```
site_information: {
    site_tagline: <site tagline>
} 
```
params in the new site requests which were introduced as part of #1079.

I am creating this as a draft PR as wordpress-mobile/WordPress-Android#11421 is not merged yet. 