### PR TITLE
Bump Mockito version to 3.3.3

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -115,12 +115,12 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation 'org.robolectric:robolectric:3.6.1'
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation "androidx.arch.core:core-testing:$arch_core_version"
 
-    androidTestImplementation 'org.mockito:mockito-android:2.6.3'
+    androidTestImplementation 'org.mockito:mockito-android:3.3.3'
     androidTestImplementation 'org.apache.commons:commons-lang3:3.7'
     androidTestImplementation "androidx.arch.core:core-testing:$arch_core_version"
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"


### PR DESCRIPTION
This PR updates mockito library to the latest stable release. 