### PR TITLE
Add remotePostId to RemoteAutoSavePayload

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
@@ -11,5 +11,5 @@ sealed class CauseOfOnPostChanged {
     object RemoveAllPosts : CauseOfOnPostChanged()
     class RemovePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
     class UpdatePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
-    class RemoteAutoSavePost(val localPostId: Int) : CauseOfOnPostChanged()
+    class RemoteAutoSavePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -282,7 +282,7 @@ public class PostRestClient extends BaseWPComRestClient {
                     @Override
                     public void onResponse(PostRemoteAutoSaveModel response) {
                         RemoteAutoSavePostPayload payload =
-                                new RemoteAutoSavePostPayload(post.getId(), response, site);
+                                new RemoteAutoSavePostPayload(post.getId(), post.getRemotePostId(), response, site);
                         mDispatcher.dispatch(UploadActionBuilder.newRemoteAutoSavedPostAction(payload));
                     }
                 },
@@ -292,7 +292,7 @@ public class PostRestClient extends BaseWPComRestClient {
                         // Possible non-generic errors: 404 unknown_post (invalid post ID)
                         PostError postError = new PostError(error.apiError, error.message);
                         RemoteAutoSavePostPayload payload =
-                                new RemoteAutoSavePostPayload(post.getId(), postError);
+                                new RemoteAutoSavePostPayload(post.getId(), post.getRemotePostId(), postError);
                         mDispatcher.dispatch(UploadActionBuilder.newRemoteAutoSavedPostAction(payload));
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -235,17 +235,20 @@ public class PostStore extends Store {
     public static class RemoteAutoSavePostPayload extends Payload<PostError> {
         public PostRemoteAutoSaveModel autoSaveModel;
         public int localPostId;
+        public long remotePostId;
         public SiteModel site;
 
-        public RemoteAutoSavePostPayload(int localPostId, @NonNull PostRemoteAutoSaveModel autoSaveModel,
-                                         @NonNull SiteModel site) {
+        public RemoteAutoSavePostPayload(int localPostId, long remotePostId,
+                                         @NonNull PostRemoteAutoSaveModel autoSaveModel, @NonNull SiteModel site) {
             this.localPostId = localPostId;
+            this.remotePostId = remotePostId;
             this.autoSaveModel = autoSaveModel;
             this.site = site;
         }
 
-        public RemoteAutoSavePostPayload(int localPostId, @NonNull PostError error) {
+        public RemoteAutoSavePostPayload(int localPostId, long remotePostId, @NonNull PostError error) {
             this.localPostId = localPostId;
+            this.remotePostId = remotePostId;
             this.error = error;
         }
     }
@@ -1050,13 +1053,15 @@ public class PostStore extends Store {
                     PostErrorType.UNSUPPORTED_ACTION,
                     "Remote-auto-save not support on self-hosted sites."
             );
-            RemoteAutoSavePostPayload response = new RemoteAutoSavePostPayload(payload.post.getId(), postError);
+            RemoteAutoSavePostPayload response =
+                    new RemoteAutoSavePostPayload(payload.post.getId(), payload.post.getRemotePostId(), postError);
             mDispatcher.dispatch(UploadActionBuilder.newRemoteAutoSavedPostAction(response));
         }
     }
 
     private void handleRemoteAutoSavedPost(RemoteAutoSavePostPayload payload) {
-        CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.RemoteAutoSavePost(payload.localPostId);
+        CauseOfOnPostChanged causeOfChange =
+                new CauseOfOnPostChanged.RemoteAutoSavePost(payload.localPostId, payload.remotePostId);
         OnPostChanged onPostChanged;
 
         if (payload.isError()) {


### PR DESCRIPTION
Adds remotePostId to RemoteAutoSavePayload.

Changes will be tested in [WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/11477).

