### PR TITLE
Woo/add shipping class by id api

### DIFF
--- a/example/src/androidTest/resources/wc-fetch-product-shipping-class-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-shipping-class-response-success.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "id": 34,
+    "name": "example1",
+    "slug": "example-1",
+    "description": "Testing shipping class",
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https:\/\/anitaastestwooshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/shipping_classes\/34"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https:\/\/anitaastestwooshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/shipping_classes"
+        }
+      ]
+    }
+  }
+}

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -103,6 +103,13 @@
             android:text="Fetch Product Review by ID"/>
 
         <Button
+            android:id="@+id/fetch_product_shipping_class"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Product Shipping class by ID"/>
+
+        <Button
             android:id="@+id/fetch_product_shipping_classes"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Config(manifest = Config.NONE)
@@ -190,6 +191,41 @@ class ProductSqlUtilsTest {
         val nonExistingSite = SiteModel().apply { id = 400 }
         val savedShippingClassList = ProductSqlUtils.getProductShippingClassListForSite(nonExistingSite.id)
         assertEquals(0, savedShippingClassList.size)
+    }
+
+    @Test
+    fun testGetProductShippingClassByRemoteShippingId() {
+        val shippingClass = ProductTestUtils.generateSampleProductShippingClass(
+                remoteId = 40, siteId = site.id
+        )
+
+        // Insert product shipping class list
+        val rowsAffected = ProductSqlUtils.insertOrUpdateProductShippingClass(shippingClass)
+        assertEquals(1, rowsAffected)
+
+        // Get shipping class for site and remoteId and verify
+        val savedShippingClassExists = ProductSqlUtils.getProductShippingClassByRemoteId(
+                shippingClass.remoteShippingClassId, site.id
+        )
+        assertEquals(shippingClass.remoteShippingClassId, savedShippingClassExists?.remoteShippingClassId)
+        assertEquals(shippingClass.name, savedShippingClassExists?.name)
+        assertEquals(shippingClass.description, savedShippingClassExists?.description)
+        assertEquals(shippingClass.slug, savedShippingClassExists?.slug)
+        assertEquals(shippingClass.localSiteId, savedShippingClassExists?.localSiteId)
+
+        // Get shipping class for a site that does not exist
+        val nonExistingSite = SiteModel().apply { id = 400 }
+        val savedShippingClass = ProductSqlUtils.getProductShippingClassByRemoteId(
+                25, nonExistingSite.id
+        )
+        assertNull(savedShippingClass)
+
+        // Get shipping class for a site that does not exist
+        val nonExistingRemoteId = 25L
+        val nonExistentShippingClass = ProductSqlUtils.getProductShippingClassByRemoteId(
+                nonExistingRemoteId, site.id
+        )
+        assertNull(nonExistentShippingClass)
     }
 
     @Test

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -11,10 +11,12 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPa
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
@@ -38,6 +40,8 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_VARIATIONS,
     @Action(payloadType = FetchProductShippingClassListPayload.class)
     FETCH_PRODUCT_SHIPPING_CLASS_LIST,
+    @Action(payloadType = FetchSingleProductShippingClassPayload.class)
+    FETCH_SINGLE_PRODUCT_SHIPPING_CLASS,
     @Action(payloadType = FetchProductReviewsPayload.class)
     FETCH_PRODUCT_REVIEWS,
     @Action(payloadType = FetchSingleProductReviewPayload.class)
@@ -62,6 +66,8 @@ public enum WCProductAction implements IAction {
     FETCHED_PRODUCT_VARIATIONS,
     @Action(payloadType = RemoteProductShippingClassListPayload.class)
     FETCHED_PRODUCT_SHIPPING_CLASS_LIST,
+    @Action(payloadType = RemoteProductShippingClassPayload.class)
+    FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS,
     @Action(payloadType = FetchProductReviewsResponsePayload.class)
     FETCHED_PRODUCT_REVIEWS,
     @Action(payloadType = RemoteProductReviewPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -654,7 +654,7 @@ class ProductRestClient(
     private fun productShippingClassResponseToProductShippingClassModel(
         response: ProductShippingClassApiResponse,
         site: SiteModel
-    ) : WCProductShippingClassModel {
+    ): WCProductShippingClassModel {
         return WCProductShippingClassModel().apply {
             remoteShippingClassId = response.id
             localSiteId = site.id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload
@@ -56,6 +57,41 @@ class ProductRestClient(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    /**
+     * Makes a GET request to `/wp-json/wc/v3/products/shipping_classes/[remoteShippingClassId]`
+     * to fetch a single product shipping class
+     *
+     * Dispatches a WCProductAction.FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS action with the result
+     *
+     * @param [remoteShippingClassId] Unique server id of the shipping class to fetch
+     */
+    fun fetchSingleProductShippingClass(site: SiteModel, remoteShippingClassId: Long) {
+        val url = WOOCOMMERCE.products.shipping_classes.id(remoteShippingClassId).pathV3
+        val responseType = object : TypeToken<ProductShippingClassApiResponse>() {}.type
+        val params = emptyMap<String, String>()
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
+                { response: ProductShippingClassApiResponse? ->
+                    response?.let {
+                        val newModel = productShippingClassResponseToProductShippingClassModel(
+                                it, site
+                        ).apply { localSiteId = site.id }
+                        val payload = RemoteProductShippingClassPayload(newModel, site)
+                        dispatcher.dispatch(WCProductActionBuilder.newFetchedSingleProductShippingClassAction(payload))
+                    }
+                },
+                WPComErrorListener { networkError ->
+                    val productError = networkErrorToProductError(networkError)
+                    val payload = RemoteProductShippingClassPayload(
+                            productError,
+                            WCProductShippingClassModel().apply { this.remoteShippingClassId = remoteShippingClassId },
+                            site
+                    )
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchedSingleProductShippingClassAction(payload))
+                },
+                { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
     /**
      * Makes a GET request to `GET /wp-json/wc/v3/products/shipping_classes` to fetch
      * product shipping classes for a site
@@ -79,13 +115,7 @@ class ProductRestClient(
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<ProductShippingClassApiResponse>? ->
                     val shippingClassList = response?.map {
-                        WCProductShippingClassModel().apply {
-                            remoteShippingClassId = it.id
-                            localSiteId = site.id
-                            name = it.name ?: ""
-                            slug = it.slug ?: ""
-                            description = it.description ?: ""
-                        }
+                        productShippingClassResponseToProductShippingClassModel(it, site)
                     }.orEmpty()
 
                     val loadedMore = offset > 0
@@ -619,6 +649,19 @@ class ProductRestClient(
         }
 
         return body
+    }
+
+    private fun productShippingClassResponseToProductShippingClassModel(
+        response: ProductShippingClassApiResponse,
+        site: SiteModel
+    ) : WCProductShippingClassModel {
+        return WCProductShippingClassModel().apply {
+            remoteShippingClassId = response.id
+            localSiteId = site.id
+            name = response.name ?: ""
+            slug = response.slug ?: ""
+            description = response.description ?: ""
+        }
     }
 
     private fun productResponseToProductModel(response: ProductApiResponse): WCProductModel {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -304,9 +304,21 @@ object ProductSqlUtils {
     ): List<WCProductShippingClassModel> {
         return WellSql.select(WCProductShippingClassModel::class.java)
                 .where().beginGroup()
-                .equals(WCProductReviewModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(WCProductShippingClassModelTable.LOCAL_SITE_ID, localSiteId)
                 .endGroup().endWhere()
                 .asModel
+    }
+
+    fun getProductShippingClassByRemoteId(
+        remoteShippingClassId: Long,
+        localSiteId: Int
+    ): WCProductShippingClassModel? {
+        return WellSql.select(WCProductShippingClassModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductShippingClassModelTable.REMOTE_SHIPPING_CLASS_ID, remoteShippingClassId)
+                .equals(WCProductShippingClassModelTable.LOCAL_SITE_ID, localSiteId)
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
     }
 
     fun deleteProductShippingClassListForSite(site: SiteModel): Int {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -73,6 +73,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var offset: Int = 0
     ) : Payload<BaseNetworkError>()
 
+    class FetchSingleProductShippingClassPayload(
+        var site: SiteModel,
+        var remoteShippingClassId: Long
+    ) : Payload<BaseNetworkError>()
+
     class FetchProductReviewsPayload(
         var site: SiteModel,
         var offset: Int = 0,
@@ -235,6 +240,19 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             error: ProductError,
             site: SiteModel
         ) : this(site) {
+            this.error = error
+        }
+    }
+
+    class RemoteProductShippingClassPayload(
+        val productShippingClassModel: WCProductShippingClassModel,
+        val site: SiteModel
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            productShippingClassModel: WCProductShippingClassModel,
+            site: SiteModel
+        ) : this(productShippingClassModel, site) {
             this.error = error
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -360,6 +360,12 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             ProductSqlUtils.getProductShippingClassListForSite(site.id)
 
     /**
+     * returns the corresponding product shipping class from the database as a [WCProductShippingClassModel].
+     */
+    fun getShippingByRemoteId(site: SiteModel, remoteShippingClassId: Long): WCProductShippingClassModel? =
+            ProductSqlUtils.getProductShippingClassByRemoteId(remoteShippingClassId, site.id)
+
+    /**
      * returns a list of [WCProductModel] for the give [SiteModel] and [remoteProductIds]
      * if it exists in the database
      */

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -362,7 +362,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     /**
      * returns the corresponding product shipping class from the database as a [WCProductShippingClassModel].
      */
-    fun getShippingByRemoteId(site: SiteModel, remoteShippingClassId: Long): WCProductShippingClassModel? =
+    fun getShippingClassByRemoteId(site: SiteModel, remoteShippingClassId: Long): WCProductShippingClassModel? =
             ProductSqlUtils.getProductShippingClassByRemoteId(remoteShippingClassId, site.id)
 
     /**

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -9,6 +9,7 @@
 /products/<id>/variations/
 /products/
 /products/shipping_classes
+/products/shipping_classes/<id>/
 
 /products/reviews/
 /products/reviews/<id>/


### PR DESCRIPTION
Fixes #1528 . This PR adds a new endpoint to the `WCProductStore` to fetch a shipping class by it's `remoteShippingClassId`.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/78101373-f659e880-7404-11ea-91fa-d39c0f8bc0d6.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/78101397-0671c800-7405-11ea-9400-8cd660a2bfb3.png">

#### To test
- Run `MockedStack_WCProductsTest`, `ReleaseStack_WCProductTest` and `ProductSqlUtilsTest`.
- Open the example app and click on `Woo` -> `Products` -> `Select Site` -> `Fetch Product Shipping Class by ID` and enter a shipping class ID that exists for the site.
- Notice the shipping class name for that ID is displayed in the logs.
- Enter a shipping class id that does not exist for the site and notice that an error message is displayed in the logs.
