### PR TITLE
Synchronize insertOrUpdatePost

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -39,7 +39,7 @@ public class PostSqlUtils {
     public PostSqlUtils() {
     }
 
-    public int insertOrUpdatePost(PostModel post, boolean overwriteLocalChanges) {
+    public synchronized int insertOrUpdatePost(PostModel post, boolean overwriteLocalChanges) {
         if (post == null) {
             return 0;
         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1524

I explored the code and went through all the paths that can lead to this bug. The only explanation I came up with is that `insertOrUpdatePost` is performed by several threads at the same time. Consider the following scenario
1. FetchPages is invoked 3 times in a row.
1. Thread 1 [checks the db for PageA](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/851f9429cbe12e6f9f3d55b3efe49f8ceb383a52/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java#L54) but doesn't find it. 
2. Thread 2 checks the db for PageA but doesn't find it.
3. Thread 1 inserts the PageA into the database because [`postResult.isEmpty()`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/851f9429cbe12e6f9f3d55b3efe49f8ceb383a52/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java#L65)
3. Thread 2 inserts the PageA into the database because [`postResult.isEmpty()`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/851f9429cbe12e6f9f3d55b3efe49f8ceb383a52/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java#L65)
4. Thread 3 checks the database for PageA and finds two instances.
5. It wants to delete one of the instances, but [this code](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/851f9429cbe12e6f9f3d55b3efe49f8ceb383a52/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java#L80) assumes two instances of the same post can be in the db only when we are pushing changes (we are comparing localIds but when we fetch a post/page the response from the server doesn't have a local id) -> the code deletes both instances of the page/post.
6. Boom

I came to this conclusion and after that I decided to try to replicate it. It was actually pretty simple - I just invoked fetchpages 50times in a row and the app crashes every time. I created a testing branch in WPAndroid where you can easily test it before and after the fix.

WPAndroid before the fix: ff12d4d6b41a67758ee5659938e4d50660e797fc
WPAndroid after the fix: 48631f6bcd8a12c77fbe3c89c89c4ea169b7da59


I decided to simply synchronize the method as it seems like the most straighforward solution and I believe the method should be synchronized. 

To Test
1. Check out ff12d4d6b41a67758ee5659938e4d50660e797fc in WPAndroid
2. Open PageList and notice the app crashes. If it doesn't crash, go back to MySite and open the page list again.
3. Checkout 48631f6bcd8a12c77fbe3c89c89c4ea169b7da59
4. Open PageList and notice the app doesn't crash
5. Repeat step 4 several times to verify it works

Note: Notice that with the fix the page list sometimes displays an empty view. This imho isn't related to the fix and this issue has been there for a long time. I think I understand what's causing it, but I'm not sure how to easily fix it.
We delete all the pages from the db [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/75050e8e588c95ea5ba836194ece8aa0011b8472/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java#L900). However, if the UI reloads the pages from the db before they are re-insterted, the db will return an empty set. The solution is to put [this](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/75050e8e588c95ea5ba836194ece8aa0011b8472/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java#L900), [this](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/851f9429cbe12e6f9f3d55b3efe49f8ceb383a52/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java#L54) and [this](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/851f9429cbe12e6f9f3d55b3efe49f8ceb383a52/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java#L65) into a single db transaction. I gave it a try but wasn't able to do achieve it. Do you by any chance have any suggestions how to do it?