### PR TITLE
Woo/v4 stats crash fix

### DIFF
--- a/example/src/androidTest/resources/wc-revenue-stats-response-empty.json
+++ b/example/src/androidTest/resources/wc-revenue-stats-response-empty.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "totals": [],
+    "intervals": []
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -1,13 +1,14 @@
 package org.wordpress.android.fluxc.model
 
 import com.google.gson.Gson
+import com.google.gson.JsonParser
+import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
-import com.google.gson.annotations.SerializedName
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
@@ -57,9 +58,24 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
 
     /**
      * Deserializes the JSON contained in [data] into a Total object.
+     * The [total] param by default is a map which is parsed into [Total].
+     *
+     * There are some instances where the [total] param can be an empty list
+     * https://github.com/woocommerce/woocommerce-android/issues/2154
+     *
+     * To address this issue, we check if the [total] param is a JsonArray
+     * and return a null response, if that's the case.
      */
     fun getTotal(): Total? {
-        val responseType = object : TypeToken<Total>() {}.type
-        return gson.fromJson(total, responseType) as? Total
+        val jsonElement = JsonParser().parse(total)
+        return if (jsonElement.isJsonArray) {
+            if (jsonElement.asJsonArray.size() > 0) {
+                val responseType = object : TypeToken<Total>() {}.type
+                gson.fromJson(jsonElement.asJsonArray[0], responseType) as? Total
+            } else null
+        } else {
+            val responseType = object : TypeToken<Total>() {}.type
+            gson.fromJson(total, responseType) as? Total
+        }
     }
 }


### PR DESCRIPTION
Fixes woocommerce/woocommerce-android#2154. I was not able to reproduce the crash but this PR ensures that we check if the `total` param is a json array when fetching the total. 

As mentioned in [this issue](https://github.com/woocommerce/woocommerce-android/issues/2154), this crash only happened on the days when the daylight savings time change was taking place. It happens because the start date query param sent to the API is greater than the end date and this returns an empty API response leading to this crash.

#### To test
- Run `MockedStack_WCStatsTest` 
- Smoke test the revenue stats api in the example app by clicking on `Woo`-> `Revenue Stats`.
- Verify that the correct dates are being passed to the API for `Current day`, `Current week`, `Current month` and `Current year`.