### PR TITLE
Open classes for testing

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
@@ -10,7 +10,8 @@ import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
-class CoroutineEngine
+// The class is open for testing
+open class CoroutineEngine
 @Inject constructor(private val coroutineContext: CoroutineContext, private val appLog: AppLogWrapper) {
     suspend fun <RESULT_TYPE> withDefaultContext(
         tag: AppLog.T,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -29,7 +29,7 @@ import javax.inject.Singleton
 import kotlin.math.absoluteValue
 
 @Singleton
-class WooCommerceStore @Inject constructor(
+open class WooCommerceStore @Inject constructor(
     private val appContext: Context,
     dispatcher: Dispatcher,
     private val wcCoreRestClient: WooCommerceRestClient

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -131,7 +131,7 @@ open class WooCommerceStore @Inject constructor(
     /**
      * Given a [SiteModel], returns its WooCommerce product settings, or null if no settings are stored for this site.
      */
-    fun getProductSettings(site: SiteModel): WCProductSettingsModel? =
+    open fun getProductSettings(site: SiteModel): WCProductSettingsModel? =
             WCProductSettingsSqlUtils.getProductSettingsForSite(site)
 
     /**


### PR DESCRIPTION
This PR opens a couple of classes for mocking because the usual approach used in unit tests does not work for instrumentation tests.