### PR TITLE
Add API tests against bleeding edge WC Rest API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,12 +185,12 @@ workflows:
           num-flaky-test-attempts: 1
           post-slack-status: true
   nightly-api-tests:
-    #triggers:
-    #  - schedule:
-    #      cron: "0 2 * * *"
-    #      filters:
-    #        branches:
-    #          only:
-    #            - develop
+    triggers:
+      - schedule:
+          cron: "0 2 * * *"
+          filters:
+            branches:
+              only:
+                - develop
     jobs:
       - WooCommerce API Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,9 +151,7 @@ jobs:
             sleep 2m
       - run:
           name: API Tests
-          command: |
-            cd tests/api 
-            gradle test
+          command: ./gradlew --stacktrace -PtestsMaxHeapSize=1536m :tests:api:test
       - android/save-test-results
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,25 @@ jobs:
                 failure_message: '${SLACK_FAILURE_MESSAGE}'
                 success_message: '${SLACK_SUCCESS_MESSAGE}'
                 webhook: '${SLACK_STATUS_WEBHOOK}'
+  WooCommerce API Tests:
+    executor: 
+      name: android/default
+      api-version: "27"
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - copy-gradle-properties
+      - run:
+          name: Update Rest Plugin
+          command: |
+            wget API_TEST_SITE_URL
+            sleep 2m
+      - run:
+          name: API Tests
+          command: |
+            cd tests/api 
+            gradle test
+      - android/save-test-results
 
 workflows:
   fluxc:
@@ -167,3 +186,13 @@ workflows:
           timeout: 30m
           num-flaky-test-attempts: 1
           post-slack-status: true
+  nightly-api-tests:
+    triggers:
+      - schedule:
+          cron: "0 * * * *"
+          filters:
+            branches:
+              only:
+                - try/wc-api-tests
+    jobs:
+      - WooCommerce API Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,12 +187,12 @@ workflows:
           num-flaky-test-attempts: 1
           post-slack-status: true
   nightly-api-tests:
-    triggers:
-      - schedule:
-          cron: "0 * * * *"
-          filters:
-            branches:
-              only:
-                - try/wc-api-tests
+    #triggers:
+    #  - schedule:
+    #      cron: "0 2 * * *"
+    #      filters:
+    #        branches:
+    #          only:
+    #            - develop
     jobs:
       - WooCommerce API Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,9 @@ jobs:
           name: API Tests
           command: ./gradlew --stacktrace -PtestsMaxHeapSize=1536m :tests:api:test
       - android/save-test-results
+      - slack/status:
+          fail_only: 'true'
+          webhook: '${SLACK_WOO_WEBHOOK}'
 
 workflows:
   fluxc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - run:
           name: Update Rest Plugin
           command: |
-            wget API_TEST_SITE_URL
+            wget $API_TEST_SITE_URL
             sleep 2m
       - run:
           name: API Tests

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 include ':fluxc', ':fluxc-processor', ':fluxc-annotations', ':plugins:woocommerce'
 include ':example'
 include ':instaflux'
+include ':tests:api'

--- a/tests/api/build.gradle
+++ b/tests/api/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'java'
+dependencies {
+    testImplementation 'io.rest-assured:rest-assured:4.2.0' 
+    testImplementation 'junit:junit:4.13'
+    testCompile 'org.json:json:20190722'
+}
+
+test {
+  testLogging {
+    events "passed", "skipped", "failed", "standardOut", "standardError"
+  }
+}
+
+repositories {
+    google()
+    jcenter()
+}

--- a/tests/api/src/test/java/APITesting_WCGateway.java
+++ b/tests/api/src/test/java/APITesting_WCGateway.java
@@ -1,0 +1,61 @@
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.restassured.specification.RequestSpecification;
+import io.restassured.builder.RequestSpecBuilder;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.oauth2;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+public class APITesting_WCGateway {
+    private RequestSpecification mRequestSpec;
+
+    @Before
+    public void setup() {
+        Map<String, String> pathParams = new HashMap<String, String>();
+        pathParams.put("json", "true");
+        pathParams.put("locale", "en_US");
+        pathParams.put("status", "any");
+
+        RequestSpecBuilder requestBuilder = new RequestSpecBuilder().
+            setBaseUri("https://public-api.wordpress.com").
+            setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
+            addQueryParams(pathParams).
+            setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
+        this.mRequestSpec = requestBuilder.build();    
+    }
+
+    @Test
+    public void canGetAllPaymentGateways() {
+        given().
+            spec(this.mRequestSpec).
+            queryParam("path", "/wc/v4/payment_gateways").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(14),
+                "data.id", hasItems("paypal", "bacs", "stripe")
+            ); 
+    }
+
+    @Test
+    public void canGetSinglePaymentGateway() {
+        given().
+            spec(this.mRequestSpec).
+            queryParam("path", "/wc/v4/payment_gateways/stripe").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.id", equalTo("stripe"),
+                "data.title", equalTo("Credit Card (Stripe)")
+            ); 
+    }
+}

--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -1,0 +1,316 @@
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.builder.RequestSpecBuilder;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.oauth2;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+public class APITesting_WCOrder {
+    private RequestSpecification requestSpec;
+    private String ORDER_FIELDS = "id,number,status,currency,date_created_gmt,total,total_tax,shipping_total," +
+            "payment_method,payment_method_title,prices_include_tax,customer_note,discount_total," +
+            "coupon_lines,refunds,billing,shipping,line_items,date_paid_gmt,shipping_lines";
+    private String TRACKING_FIELDS = "tracking_id,tracking_number,tracking_link,tracking_provider,date_shipped";
+
+    @Before
+    public void setup() {
+        Map<String, String> pathParams = new HashMap<String, String>();
+        pathParams.put("json", "true");
+        pathParams.put("locale", "en_US");
+        pathParams.put("status", "any");
+
+        RequestSpecBuilder requestBuilder = new RequestSpecBuilder().
+            setBaseUri("https://public-api.wordpress.com").
+            setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
+            addQueryParams(pathParams).
+            setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
+        this.requestSpec = requestBuilder.build();    
+    }
+
+    @Test
+    public void canGetAllOrders() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&_fields=" + ORDER_FIELDS).
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(50));
+    }
+
+    @Test
+    public void canGetOrderListSummary() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&status=failed&_fields=id,"
+                + "date_created_gmt,date_modified_gmt").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(10));
+    }
+
+    @Test
+    public void canGetOrdersByID() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders&per_page=50&include=625,628,618").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(3),
+                "data.find { it.id == 618 }.status", equalTo("processing"),
+                "data.find { it.id == 625 }.status", equalTo("failed")
+            );
+    }
+
+    @Test
+    public void canGetOrderStatusOptions() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/reports/orders/totals").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(7));
+    }
+
+    @Test
+    public void canSearchOrders() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&status=failed&search=belt&_fields=" + ORDER_FIELDS).
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(3),
+                "data.id", hasItems(620, 282, 185)
+            );
+    }
+
+    @Test
+    public void canGetSingleOrder() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders/609&_fields=" + ORDER_FIELDS).
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.id", equalTo(609),
+                "data.status", equalTo("completed")
+            );
+    }
+
+    @Test
+    public void canGetOrderCount() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/reports/orders/totals&status=processing").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.find { it.slug == 'processing' }.total", equalTo(12));
+    }
+
+    @Test
+    public void canGetHasOrders() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders&per_page=1&offset=0&status=processing").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(1),
+                "data[0].status", equalTo("processing")
+            );
+    }
+
+    @Test
+    public void canUpdateOrderStatus() {
+        String path = "/wc/v4/orders/607/";
+        String method = "put";
+
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("status", "processing");
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("path", path);
+        jsonObj.put("body", jsonBody.toString());
+        jsonObj.put("json", "true");
+        jsonObj.put("method", method);
+
+        // Set Status to processing.
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200);
+
+        // Get Status.
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            body(jsonObj.toString()).
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.status", equalTo("processing"));
+
+        // Set status to completed
+        jsonBody.put("status", "completed");
+        jsonObj.put("body", jsonBody.toString());
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200).
+            body("data.status", equalTo("completed"));
+    }
+
+    @Test
+    public void canGetOrderNotes() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders/591/notes").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(2),
+                "data.find { it.id == 1173 }.note", equalTo("Order status changed from Processing to Completed.")
+            );
+    }
+
+    @Test
+    public void canAddOrderNote() {
+        String path = "/wc/v4/orders/565/notes";
+        String method = "post";
+
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("note", "Adding note to an order test");
+        jsonBody.put("customer_note", false);
+        jsonBody.put("added_by_user", true);
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("path", path);
+        jsonObj.put("body", jsonBody.toString());
+        jsonObj.put("json", "true");
+        jsonObj.put("method", method);
+
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200);
+    }
+
+    @Test
+    public void canGetOrderShipmentTrackings() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders/635/shipment-trackings&_fields=" + TRACKING_FIELDS).
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(1),
+                "data[0].tracking_number", equalTo("324567890234567")
+            );
+    }
+
+    @Test
+    public void canGetOrderShipmentProviders() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/orders/635/shipment-trackings/providers").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.'United States (US)'.USPS", 
+                equalTo("https://tools.usps.com/go/TrackConfirmAction_input?qtc_tLabels1=%number%")
+            );
+    }
+
+    @Test
+    public void canAddAndDeleteShipmentTracking() {
+        String path = "/wc/v4/orders/634/shipment-trackings";
+        String method = "post";
+
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("tracking_provider", "USPS");
+        jsonBody.put("tracking_number", "987654321987654321");
+        jsonBody.put("date_shipped", "2020-04-05");
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("path", path);
+        jsonObj.put("body", jsonBody.toString());
+        jsonObj.put("json", "true");
+        jsonObj.put("method", method);
+
+        // Add tracking number
+        String tracking = given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200).
+        extract().
+            path("data.tracking_id");
+        
+        // Delete tracking number    
+        method = "delete";
+        path = "/wc/v4/orders/634/shipment-trackings/" + tracking + "&_method=" + method;
+        jsonObj.put("path", path);
+        jsonObj.remove("method");
+        jsonObj.remove("body");
+
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            body(jsonObj.toString()).
+        when().
+            log().
+            all().
+            post().peek().
+        then().
+            statusCode(200);
+    }
+}

--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -16,11 +16,11 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 
 public class APITesting_WCOrder {
-    private RequestSpecification requestSpec;
-    private String ORDER_FIELDS = "id,number,status,currency,date_created_gmt,total,total_tax,shipping_total," +
-            "payment_method,payment_method_title,prices_include_tax,customer_note,discount_total," +
-            "coupon_lines,refunds,billing,shipping,line_items,date_paid_gmt,shipping_lines";
-    private String TRACKING_FIELDS = "tracking_id,tracking_number,tracking_link,tracking_provider,date_shipped";
+    private RequestSpecification mRequestSpec;
+    private String mOrderFields = "id,number,status,currency,date_created_gmt,total,total_tax,shipping_total,"
+            + "payment_method,payment_method_title,prices_include_tax,customer_note,discount_total,"
+            + "coupon_lines,refunds,billing,shipping,line_items,date_paid_gmt,shipping_lines";
+    private String mTrackingFields = "tracking_id,tracking_number,tracking_link,tracking_provider,date_shipped";
 
     @Before
     public void setup() {
@@ -34,14 +34,14 @@ public class APITesting_WCOrder {
             setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
             addQueryParams(pathParams).
             setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
-        this.requestSpec = requestBuilder.build();    
+        this.mRequestSpec = requestBuilder.build();
     }
 
     @Test
     public void canGetAllOrders() {
         given().
-            spec(this.requestSpec).
-            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&_fields=" + ORDER_FIELDS).
+            spec(this.mRequestSpec).
+            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&_fields=" + mOrderFields).
         when().
             get().
         then().
@@ -52,7 +52,7 @@ public class APITesting_WCOrder {
     @Test
     public void canGetOrderListSummary() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/orders&per_page=50&offset=0&status=failed&_fields=id,"
                 + "date_created_gmt,date_modified_gmt").
         when().
@@ -65,7 +65,7 @@ public class APITesting_WCOrder {
     @Test
     public void canGetOrdersByID() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/orders&per_page=50&include=625,628,618").
         when().
             get().
@@ -80,7 +80,7 @@ public class APITesting_WCOrder {
     @Test
     public void canGetOrderStatusOptions() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/reports/orders/totals").
         when().
             get().
@@ -92,8 +92,8 @@ public class APITesting_WCOrder {
     @Test
     public void canSearchOrders() {
         given().
-            spec(this.requestSpec).
-            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&status=failed&search=belt&_fields=" + ORDER_FIELDS).
+            spec(this.mRequestSpec).
+            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&status=failed&search=belt&_fields=" + mOrderFields).
         when().
             get().
         then().
@@ -106,8 +106,8 @@ public class APITesting_WCOrder {
     @Test
     public void canGetSingleOrder() {
         given().
-            spec(this.requestSpec).
-            queryParam("path", "/wc/v4/orders/609&_fields=" + ORDER_FIELDS).
+            spec(this.mRequestSpec).
+                queryParam("path", "/wc/v4/orders/609&_fields=" + mOrderFields).
         when().
             get().
         then().
@@ -120,7 +120,7 @@ public class APITesting_WCOrder {
     @Test
     public void canGetOrderCount() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/reports/orders/totals&status=processing").
         when().
             get().
@@ -132,7 +132,7 @@ public class APITesting_WCOrder {
     @Test
     public void canGetHasOrders() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/orders&per_page=1&offset=0&status=processing").
         when().
             get().
@@ -158,7 +158,7 @@ public class APITesting_WCOrder {
 
         // Set Status to processing.
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             queryParam("_method", method).
@@ -170,7 +170,7 @@ public class APITesting_WCOrder {
 
         // Get Status.
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             body(jsonObj.toString()).
@@ -184,7 +184,7 @@ public class APITesting_WCOrder {
         jsonBody.put("status", "completed");
         jsonObj.put("body", jsonBody.toString());
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             queryParam("_method", method).
@@ -199,7 +199,7 @@ public class APITesting_WCOrder {
     @Test
     public void canGetOrderNotes() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/orders/591/notes").
         when().
             get().
@@ -226,7 +226,7 @@ public class APITesting_WCOrder {
         jsonObj.put("method", method);
 
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             queryParam("_method", method).
@@ -240,8 +240,8 @@ public class APITesting_WCOrder {
     @Test
     public void canGetOrderShipmentTrackings() {
         given().
-            spec(this.requestSpec).
-            queryParam("path", "/wc/v4/orders/635/shipment-trackings&_fields=" + TRACKING_FIELDS).
+            spec(this.mRequestSpec).
+            queryParam("path", "/wc/v4/orders/635/shipment-trackings&_fields=" + mTrackingFields).
         when().
             get().
         then().
@@ -254,7 +254,7 @@ public class APITesting_WCOrder {
     @Test
     public void canGetOrderShipmentProviders() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/orders/635/shipment-trackings/providers").
         when().
             get().
@@ -282,7 +282,7 @@ public class APITesting_WCOrder {
 
         // Add tracking number
         String tracking = given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             queryParam("_method", method).
@@ -302,7 +302,7 @@ public class APITesting_WCOrder {
         jsonObj.remove("body");
 
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             body(jsonObj.toString()).

--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -307,9 +307,7 @@ public class APITesting_WCOrder {
             queryParam("path", path).
             body(jsonObj.toString()).
         when().
-            log().
-            all().
-            post().peek().
+            post().
         then().
             statusCode(200);
     }

--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -296,7 +296,7 @@ public class APITesting_WCOrder {
 
         // Delete tracking number
         method = "delete";
-        path = "/wc/v3/orders/634/shipment-trackings/" + tracking + "&_method=" + method;
+        path = path + '/' + tracking + "&_method=" + method;
         jsonObj.put("path", path);
         jsonObj.remove("method");
         jsonObj.remove("body");

--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -81,7 +81,7 @@ public class APITesting_WCOrder {
     public void canGetOrderStatusOptions() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/reports/orders/totals").
+            queryParam("path", "/wc/v3/reports/orders/totals").
         when().
             get().
         then().
@@ -121,7 +121,7 @@ public class APITesting_WCOrder {
     public void canGetOrderCount() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/reports/orders/totals&status=processing").
+            queryParam("path", "/wc/v3/reports/orders/totals&status=processing").
         when().
             get().
         then().
@@ -241,7 +241,7 @@ public class APITesting_WCOrder {
     public void canGetOrderShipmentTrackings() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders/635/shipment-trackings&_fields=" + mTrackingFields).
+            queryParam("path", "/wc/v3/orders/635/shipment-trackings&_fields=" + mTrackingFields).
         when().
             get().
         then().
@@ -255,19 +255,19 @@ public class APITesting_WCOrder {
     public void canGetOrderShipmentProviders() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders/635/shipment-trackings/providers").
+            queryParam("path", "/wc/v3/orders/635/shipment-trackings/providers").
         when().
             get().
         then().
             statusCode(200).
-            body("data.'United States (US)'.USPS", 
+            body("data.'United States (US)'.USPS",
                 equalTo("https://tools.usps.com/go/TrackConfirmAction_input?qtc_tLabels1=%number%")
             );
     }
 
     @Test
     public void canAddAndDeleteShipmentTracking() {
-        String path = "/wc/v4/orders/634/shipment-trackings";
+        String path = "/wc/v3/orders/634/shipment-trackings";
         String method = "post";
 
         JSONObject jsonBody = new JSONObject();
@@ -293,10 +293,10 @@ public class APITesting_WCOrder {
             statusCode(200).
         extract().
             path("data.tracking_id");
-        
-        // Delete tracking number    
+
+        // Delete tracking number
         method = "delete";
-        path = "/wc/v4/orders/634/shipment-trackings/" + tracking + "&_method=" + method;
+        path = "/wc/v3/orders/634/shipment-trackings/" + tracking + "&_method=" + method;
         jsonObj.put("path", path);
         jsonObj.remove("method");
         jsonObj.remove("body");

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -106,6 +106,18 @@ public class APITesting_WCProduct {
                  "data.name", hasItems("hats", "shirts")
             );
     }
+    
+    @Test
+    public void canGetProductShippingClassbyID() {
+        given().
+            spec(this.mRequestSpec).
+            queryParam("path", "/wc/v4/products/shipping_classes/35").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.name", equalTo("hats"));
+    }
 
     @Test
     public void canGetProductReviews() {

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -303,4 +303,66 @@ public class APITesting_WCProduct {
             statusCode(200).
             body("data.images", hasSize(4));
     }
+
+    @Test
+    public void canUpdateProduct() {
+        String path = "/wc/v4/products/19";
+        String method = "put";
+
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("regular_price", "90");
+        jsonBody.put("name", "Sunglasses");
+        jsonBody.put("weight", "0");
+        jsonBody.put("slug", "sunglasses");
+        jsonBody.put("short_description", "Sunglasses you will love");
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("body", jsonBody.toString());
+        jsonObj.put("path", path);
+        jsonObj.put("method", method);
+        jsonObj.put("json", "true"); 
+
+        // Reset Product
+        given().
+            spec(this.mRequestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            body("data.id", equalTo(19),
+                "data.regular_price", equalTo("90"),
+                "data.name", equalTo("Sunglasses"),
+                "data.weight", equalTo("0"),
+                "data.slug", equalTo("sunglasses"),
+                "data.short_description", equalTo("Sunglasses you will love")
+            );
+
+        // Update Product
+        jsonBody = new JSONObject();
+        jsonBody.put("regular_price", "120");
+        jsonBody.put("name", "HOT Sunglasses");
+        jsonBody.put("weight", "12");
+        jsonBody.put("slug", "hot-sunglasses");
+        jsonBody.put("short_description", "Really hot sunglasses");
+        jsonObj.put("body", jsonBody.toString());
+
+        given().
+            spec(this.mRequestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200).
+            body("data.id", equalTo(19),
+                "data.regular_price", equalTo("120"),
+                "data.name", equalTo("HOT Sunglasses"),
+                "data.weight", equalTo("12"),
+                "data.slug", equalTo("hot-sunglasses"),
+                "data.short_description", equalTo("Really hot sunglasses")
+            );
+    }
 }

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -1,0 +1,294 @@
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.builder.RequestSpecBuilder;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.oauth2;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+public class APITesting_WCProduct {
+    private RequestSpecification requestSpec;
+
+    @Before
+    public void setup() {
+        Map<String, String> pathParams = new HashMap<String, String>();
+        pathParams.put("json", "true");
+        pathParams.put("locale", "en_US");
+        pathParams.put("status", "any");
+
+        RequestSpecBuilder requestBuilder = new RequestSpecBuilder().
+            setBaseUri("https://public-api.wordpress.com").
+            setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
+            addQueryParams(pathParams).
+            setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
+        this.requestSpec = requestBuilder.build();    
+    }
+
+    @Test
+    public void canGetAllProducts() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/products&per_page=50&offset=0").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(18));
+    }
+
+    @Test
+    public void canGetSingleProduct() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/products/12").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.name", equalTo("V-Neck T-Shirt"),
+                 "data.categories.name", hasItems("Tshirts"),
+                 "data.tags.name", hasItems("shirts"),
+                 "data.images.name", hasItems("vneck-tee-2.jpg"),
+                 "data.attributes.name", hasItems("Color", "Size"),
+                 "data.attributes.find { it.name == 'Size' }.options", hasItems("Large", "Medium", "Small"),
+                 "data.attributes.find { it.name == 'Color' }.options", hasItems("Blue", "Green", "Red"),
+                 "data.variations", hasSize(3)    
+            );
+    }
+
+    @Test
+    public void canGetProductVariations() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/products/12/variations").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(3),
+                 "data.id", hasItems(28, 27, 26)
+            );
+    }
+
+    @Test
+    public void canGetProductSkuAvailability() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/products/&_fields=sku&sku=woo-belt").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(1)
+            );
+    }
+
+    @Test
+    public void canGetProductShippingClasses() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/products/shipping_classes").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(2),
+                 "data.name", hasItems("hats", "shirts")
+            );
+    }
+
+    @Test
+    public void canGetProductReviews() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/products/reviews").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.findAll { it.reviewer == 'WooTester' }", hasSize(2),
+                 "data.status", hasItems("approved")
+            );
+    }
+
+    @Test
+    public void canGetSingleProductReview() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/products/reviews/1088").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.rating", equalTo(3),
+                 "data.product_id", equalTo(33),
+                 "data.reviewer", equalTo("JoeTester")
+            );
+    }
+
+    @Test
+    public void canUpdateProductReviewStatus() {
+        String path = "/wc/v4/products/reviews/1088/";
+        String method = "put";
+
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("status", "approved");
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("path", path);
+        jsonObj.put("body", jsonBody.toString());
+        jsonObj.put("json", "true");
+        jsonObj.put("method", method);
+
+        // Set Status to approved.
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200);
+
+        // Get Status.
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            body(jsonObj.toString()).
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.status", equalTo("approved"));
+
+        // Set status to hold
+        jsonBody.put("status", "hold");
+        jsonObj.put("body", jsonBody.toString());
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200).
+            body("data.status", equalTo("hold"));
+    }
+   
+    @Test
+    public void canUpdateProductImages() {
+        String path = "/wc/v4/products/13";
+        String method = "put";
+
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("images", new JSONArray());
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("body", jsonBody.toString());
+        jsonObj.put("path", path);
+        jsonObj.put("method", method);
+        jsonObj.put("json", "true"); 
+
+        // Set Images to none.
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200);
+
+        // Make sure there are no images now.
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            body(jsonObj.toString()).
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.images", hasSize(0));
+
+        // Add images back on
+        JSONArray jsonImagesArray = new JSONArray();
+        JSONObject jsonImage = new JSONObject();
+        jsonImage.put("id", 40);
+        jsonImage.put("date_created", "2020-02-18T20:45:45");
+        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");    
+        jsonImage.put("date_modified", "2020-02-18T20:45:45");  
+        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");  
+        jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
+            + "/uploads/2020/02/hoodie-2.jpg");  
+        jsonImage.put("name", "hoodie-2.jpg");
+        jsonImage.put("alt", "");
+        jsonImagesArray.put(0, jsonImage);
+
+        jsonImage = new JSONObject();
+        jsonImage.put("id", 41);
+        jsonImage.put("date_created", "2020-02-18T20:45:45");
+        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");    
+        jsonImage.put("date_modified", "2020-02-18T20:45:45");  
+        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");  
+        jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
+            + "/uploads/2020/02/hoodie-blue-1.jpg");  
+        jsonImage.put("name", "hoodie-blue-1.jpg");
+        jsonImage.put("alt", "");
+        jsonImagesArray.put(1, jsonImage);
+
+        jsonImage = new JSONObject();
+        jsonImage.put("id", 42);
+        jsonImage.put("date_created", "2020-02-18T20:45:45");
+        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");    
+        jsonImage.put("date_modified", "2020-02-18T20:45:45");  
+        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");  
+        jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
+            + "/uploads/2020/02/hoodie-green-1.jpg");  
+        jsonImage.put("name", "hoodie-green-1.jpg");
+        jsonImage.put("alt", "");
+        jsonImagesArray.put(2, jsonImage);
+
+        jsonImage = new JSONObject();
+        jsonImage.put("id", 43);
+        jsonImage.put("date_created", "2020-02-18T20:45:45");
+        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");    
+        jsonImage.put("date_modified", "2020-02-18T20:45:45");  
+        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");  
+        jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
+            + "/uploads/2020/02/hoodie-with-logo-2.jpg");  
+        jsonImage.put("name", "hoodie-with-logo-2.jpg");
+        jsonImage.put("alt", "");
+        jsonImagesArray.put(3, jsonImage);
+
+        jsonBody.put("images", jsonImagesArray);
+        jsonObj.put("body", jsonBody.toString());
+
+        given().
+            spec(this.requestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200).
+            body("data.images", hasSize(4));
+    }
+}

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 
 public class APITesting_WCProduct {
-    private RequestSpecification requestSpec;
+    private RequestSpecification mRequestSpec;
 
     @Before
     public void setup() {
@@ -31,13 +31,13 @@ public class APITesting_WCProduct {
             setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
             addQueryParams(pathParams).
             setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
-        this.requestSpec = requestBuilder.build();    
+        this.mRequestSpec = requestBuilder.build();    
     }
 
     @Test
     public void canGetAllProducts() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/products&per_page=50&offset=0").
         when().
             get().
@@ -49,7 +49,7 @@ public class APITesting_WCProduct {
     @Test
     public void canGetSingleProduct() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/products/12").
         when().
             get().
@@ -69,7 +69,7 @@ public class APITesting_WCProduct {
     @Test
     public void canGetProductVariations() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/products/12/variations").
         when().
             get().
@@ -83,7 +83,7 @@ public class APITesting_WCProduct {
     @Test
     public void canGetProductSkuAvailability() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/products/&_fields=sku&sku=woo-belt").
         when().
             get().
@@ -96,7 +96,7 @@ public class APITesting_WCProduct {
     @Test
     public void canGetProductShippingClasses() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/products/shipping_classes").
         when().
             get().
@@ -110,7 +110,7 @@ public class APITesting_WCProduct {
     @Test
     public void canGetProductReviews() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/products/reviews").
         when().
             get().
@@ -124,7 +124,7 @@ public class APITesting_WCProduct {
     @Test
     public void canGetSingleProductReview() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/products/reviews/1088").
         when().
             get().
@@ -151,7 +151,7 @@ public class APITesting_WCProduct {
 
         // Set Status to approved.
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             queryParam("_method", method).
@@ -163,7 +163,7 @@ public class APITesting_WCProduct {
 
         // Get Status.
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             body(jsonObj.toString()).
@@ -177,7 +177,7 @@ public class APITesting_WCProduct {
         jsonBody.put("status", "hold");
         jsonObj.put("body", jsonBody.toString());
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             queryParam("_method", method).
@@ -204,7 +204,7 @@ public class APITesting_WCProduct {
 
         // Set Images to none.
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             queryParam("_method", method).
@@ -216,7 +216,7 @@ public class APITesting_WCProduct {
 
         // Make sure there are no images now.
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             body(jsonObj.toString()).
@@ -280,7 +280,7 @@ public class APITesting_WCProduct {
         jsonObj.put("body", jsonBody.toString());
 
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             header("Content-Type", ContentType.JSON).
             queryParam("path", path).
             queryParam("_method", method).

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -31,7 +31,7 @@ public class APITesting_WCProduct {
             setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
             addQueryParams(pathParams).
             setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
-        this.mRequestSpec = requestBuilder.build();    
+        this.mRequestSpec = requestBuilder.build();
     }
 
     @Test
@@ -62,7 +62,7 @@ public class APITesting_WCProduct {
                  "data.attributes.name", hasItems("Color", "Size"),
                  "data.attributes.find { it.name == 'Size' }.options", hasItems("Large", "Medium", "Small"),
                  "data.attributes.find { it.name == 'Color' }.options", hasItems("Blue", "Green", "Red"),
-                 "data.variations", hasSize(3)    
+                 "data.variations", hasSize(3)
             );
     }
 
@@ -106,7 +106,7 @@ public class APITesting_WCProduct {
                  "data.name", hasItems("hats", "shirts")
             );
     }
-    
+
     @Test
     public void canGetProductShippingClassbyID() {
         given().
@@ -150,7 +150,7 @@ public class APITesting_WCProduct {
 
     @Test
     public void canUpdateProductReviewStatus() {
-        String path = "/wc/v4/products/reviews/1088/";
+        String path = "/wc/v3/products/reviews/1088/";
         String method = "put";
 
         JSONObject jsonBody = new JSONObject();
@@ -200,7 +200,7 @@ public class APITesting_WCProduct {
             statusCode(200).
             body("data.status", equalTo("hold"));
     }
-   
+
     @Test
     public void canUpdateProductImages() {
         String path = "/wc/v4/products/13";
@@ -212,7 +212,7 @@ public class APITesting_WCProduct {
         jsonObj.put("body", jsonBody.toString());
         jsonObj.put("path", path);
         jsonObj.put("method", method);
-        jsonObj.put("json", "true"); 
+        jsonObj.put("json", "true");
 
         // Set Images to none.
         given().
@@ -243,11 +243,11 @@ public class APITesting_WCProduct {
         JSONObject jsonImage = new JSONObject();
         jsonImage.put("id", 40);
         jsonImage.put("date_created", "2020-02-18T20:45:45");
-        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");    
-        jsonImage.put("date_modified", "2020-02-18T20:45:45");  
-        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");  
+        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");
+        jsonImage.put("date_modified", "2020-02-18T20:45:45");
+        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");
         jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
-            + "/uploads/2020/02/hoodie-2.jpg");  
+            + "/uploads/2020/02/hoodie-2.jpg");
         jsonImage.put("name", "hoodie-2.jpg");
         jsonImage.put("alt", "");
         jsonImagesArray.put(0, jsonImage);
@@ -255,11 +255,11 @@ public class APITesting_WCProduct {
         jsonImage = new JSONObject();
         jsonImage.put("id", 41);
         jsonImage.put("date_created", "2020-02-18T20:45:45");
-        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");    
-        jsonImage.put("date_modified", "2020-02-18T20:45:45");  
-        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");  
+        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");
+        jsonImage.put("date_modified", "2020-02-18T20:45:45");
+        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");
         jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
-            + "/uploads/2020/02/hoodie-blue-1.jpg");  
+            + "/uploads/2020/02/hoodie-blue-1.jpg");
         jsonImage.put("name", "hoodie-blue-1.jpg");
         jsonImage.put("alt", "");
         jsonImagesArray.put(1, jsonImage);
@@ -267,11 +267,11 @@ public class APITesting_WCProduct {
         jsonImage = new JSONObject();
         jsonImage.put("id", 42);
         jsonImage.put("date_created", "2020-02-18T20:45:45");
-        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");    
-        jsonImage.put("date_modified", "2020-02-18T20:45:45");  
-        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");  
+        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");
+        jsonImage.put("date_modified", "2020-02-18T20:45:45");
+        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");
         jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
-            + "/uploads/2020/02/hoodie-green-1.jpg");  
+            + "/uploads/2020/02/hoodie-green-1.jpg");
         jsonImage.put("name", "hoodie-green-1.jpg");
         jsonImage.put("alt", "");
         jsonImagesArray.put(2, jsonImage);
@@ -279,11 +279,11 @@ public class APITesting_WCProduct {
         jsonImage = new JSONObject();
         jsonImage.put("id", 43);
         jsonImage.put("date_created", "2020-02-18T20:45:45");
-        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");    
-        jsonImage.put("date_modified", "2020-02-18T20:45:45");  
-        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");  
+        jsonImage.put("date_created_gmt", "2020-02-18T20:45:45");
+        jsonImage.put("date_modified", "2020-02-18T20:45:45");
+        jsonImage.put("date_modified_gmt", "2020-02-18T20:45:45");
         jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
-            + "/uploads/2020/02/hoodie-with-logo-2.jpg");  
+            + "/uploads/2020/02/hoodie-with-logo-2.jpg");
         jsonImage.put("name", "hoodie-with-logo-2.jpg");
         jsonImage.put("alt", "");
         jsonImagesArray.put(3, jsonImage);
@@ -319,7 +319,7 @@ public class APITesting_WCProduct {
         jsonObj.put("body", jsonBody.toString());
         jsonObj.put("path", path);
         jsonObj.put("method", method);
-        jsonObj.put("json", "true"); 
+        jsonObj.put("json", "true");
 
         // Reset Product
         given().

--- a/tests/api/src/test/java/APITesting_WCRefund.java
+++ b/tests/api/src/test/java/APITesting_WCRefund.java
@@ -1,0 +1,120 @@
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.builder.RequestSpecBuilder;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.oauth2;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+public class APITesting_WCRefund {
+    private RequestSpecification mRequestSpec;
+
+    @Before
+    public void setup() {
+        Map<String, String> pathParams = new HashMap<String, String>();
+        pathParams.put("json", "true");
+        pathParams.put("locale", "en_US");
+        pathParams.put("status", "any");
+
+        RequestSpecBuilder requestBuilder = new RequestSpecBuilder().
+            setBaseUri("https://public-api.wordpress.com").
+            setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
+            addQueryParams(pathParams).
+            setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
+        this.mRequestSpec = requestBuilder.build();
+    }
+
+    @Test
+    public void canGetAllRefunds() {
+        given().
+            spec(this.mRequestSpec).
+            queryParam("path", "/wc/v4/orders/161/refunds").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(1),
+                "data.id", hasItems(638)
+            );
+    }
+
+    @Test
+    public void canGetSingleRefund() {
+        given().
+            spec(this.mRequestSpec).
+            queryParam("path", "/wc/v4/orders/161/refunds/638").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.amount", equalTo("118.00"));
+    }
+
+    @Test
+    public void canCreateRefund() {
+        String path = "/wc/v4/orders/156/refunds";
+        // Get previous refund
+        Integer id = given().
+            spec(this.mRequestSpec).
+            queryParam("path", path).
+        when().
+            get().
+        then().
+            statusCode(200).
+        extract().
+            path("data[0].id");
+        
+        // Delete previous refund    
+        String method = "delete";        
+        JSONObject jsonObj = new JSONObject();      
+        jsonObj.put("json", "true");
+        jsonObj.put("method", method);
+
+        if (id != null) {
+            path = path + "/" + Integer.toString(id) + "&_method=" + method;
+            jsonObj.put("path", path); 
+            given().
+                spec(this.mRequestSpec).
+                header("Content-Type", ContentType.JSON).
+                queryParam("path", path).
+                body(jsonObj.toString()).
+            when().
+                post().
+            then().
+               statusCode(200);
+        }
+
+        // Add new refund
+        method = "post";
+        path = "/wc/v3/orders/156/refunds";
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("reason", "API testing");
+        jsonBody.put("amount", "142.00");
+        jsonBody.put("api_refund", false);
+        jsonBody.put("restock_items", false);
+
+        jsonObj.put("body", jsonBody.toString());
+        jsonObj.put("method", method);
+        jsonObj.put("path", path);
+
+        given().
+            spec(this.mRequestSpec).
+            header("Content-Type", ContentType.JSON).
+            queryParam("path", path).
+            queryParam("_method", method).
+            body(jsonObj.toString()).
+        when().
+            post().
+        then().
+            statusCode(200);
+    }
+}

--- a/tests/api/src/test/java/APITesting_WCRefund.java
+++ b/tests/api/src/test/java/APITesting_WCRefund.java
@@ -95,7 +95,7 @@ public class APITesting_WCRefund {
 
         // Add new refund
         method = "post";
-        path = "/wc/v3/orders/156/refunds";
+        path = "/wc/v4/orders/156/refunds";
         JSONObject jsonBody = new JSONObject();
         jsonBody.put("reason", "API testing");
         jsonBody.put("amount", "142.00");

--- a/tests/api/src/test/java/APITesting_WCRefund.java
+++ b/tests/api/src/test/java/APITesting_WCRefund.java
@@ -61,7 +61,7 @@ public class APITesting_WCRefund {
 
     @Test
     public void canCreateRefund() {
-        String path = "/wc/v4/orders/156/refunds";
+        String path = "/wc/v3/orders/156/refunds";
         // Get previous refund
         Integer id = given().
             spec(this.mRequestSpec).
@@ -72,16 +72,16 @@ public class APITesting_WCRefund {
             statusCode(200).
         extract().
             path("data[0].id");
-        
-        // Delete previous refund    
-        String method = "delete";        
-        JSONObject jsonObj = new JSONObject();      
+
+        // Delete previous refund
+        String method = "delete";
+        JSONObject jsonObj = new JSONObject();
         jsonObj.put("json", "true");
         jsonObj.put("method", method);
 
         if (id != null) {
             path = path + "/" + Integer.toString(id) + "&_method=" + method;
-            jsonObj.put("path", path); 
+            jsonObj.put("path", path);
             given().
                 spec(this.mRequestSpec).
                 header("Content-Type", ContentType.JSON).
@@ -95,7 +95,7 @@ public class APITesting_WCRefund {
 
         // Add new refund
         method = "post";
-        path = "/wc/v4/orders/156/refunds";
+        path = "/wc/v3/orders/156/refunds";
         JSONObject jsonBody = new JSONObject();
         jsonBody.put("reason", "API testing");
         jsonBody.put("amount", "142.00");

--- a/tests/api/src/test/java/APITesting_WCSettings.java
+++ b/tests/api/src/test/java/APITesting_WCSettings.java
@@ -1,0 +1,61 @@
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.restassured.specification.RequestSpecification;
+import io.restassured.builder.RequestSpecBuilder;
+
+//import com.google.gson.Gson;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.oauth2;
+import static org.hamcrest.Matchers.hasItems;
+
+public class APITesting_WCSettings {
+    private RequestSpecification requestSpec;
+
+    @Before
+    public void setup() {
+        Map<String, String> pathParams = new HashMap<String, String>();
+        pathParams.put("json", "true");
+        pathParams.put("locale", "en_US");
+        pathParams.put("status", "any");
+
+        RequestSpecBuilder requestBuilder = new RequestSpecBuilder().
+            setBaseUri("https://public-api.wordpress.com").
+            setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
+            addQueryParams(pathParams).
+            setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
+        this.requestSpec = requestBuilder.build();    
+    }
+
+    @Test
+    public void canGetGeneralSettings() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/settings/general").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.id", hasItems("woocommerce_currency", "woocommerce_currency_pos", 
+                "woocommerce_price_thousand_sep", "woocommerce_price_decimal_sep",
+                "woocommerce_price_num_decimals", "woocommerce_default_country")
+            );
+    }
+
+    @Test
+    public void canGetProductSettings() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/settings/products").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data.id", hasItems("woocommerce_weight_unit", "woocommerce_dimension_unit")
+            );
+    }
+}

--- a/tests/api/src/test/java/APITesting_WCSettings.java
+++ b/tests/api/src/test/java/APITesting_WCSettings.java
@@ -14,7 +14,7 @@ import static io.restassured.RestAssured.oauth2;
 import static org.hamcrest.Matchers.hasItems;
 
 public class APITesting_WCSettings {
-    private RequestSpecification requestSpec;
+    private RequestSpecification mRequestSpec;
 
     @Before
     public void setup() {
@@ -28,13 +28,13 @@ public class APITesting_WCSettings {
             setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
             addQueryParams(pathParams).
             setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
-        this.requestSpec = requestBuilder.build();    
+        this.mRequestSpec = requestBuilder.build();    
     }
 
     @Test
     public void canGetGeneralSettings() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/settings/general").
         when().
             get().
@@ -49,7 +49,7 @@ public class APITesting_WCSettings {
     @Test
     public void canGetProductSettings() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/settings/products").
         when().
             get().

--- a/tests/api/src/test/java/APITesting_WCTax.java
+++ b/tests/api/src/test/java/APITesting_WCTax.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 
 public class APITesting_WCTax {
-    private RequestSpecification requestSpec;
+    private RequestSpecification mRequestSpec;
 
     @Before
     public void setup() {
@@ -29,13 +29,13 @@ public class APITesting_WCTax {
             setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
             addQueryParams(pathParams).
             setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
-        this.requestSpec = requestBuilder.build();    
+        this.mRequestSpec = requestBuilder.build();    
     }
 
     @Test
     public void canGetTaxClasses() {
         given().
-            spec(this.requestSpec).
+            spec(this.mRequestSpec).
             queryParam("path", "/wc/v4/taxes/classes").
         when().
             get().

--- a/tests/api/src/test/java/APITesting_WCTax.java
+++ b/tests/api/src/test/java/APITesting_WCTax.java
@@ -1,0 +1,48 @@
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.restassured.specification.RequestSpecification;
+import io.restassured.builder.RequestSpecBuilder;
+
+//import com.google.gson.Gson;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.oauth2;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+public class APITesting_WCTax {
+    private RequestSpecification requestSpec;
+
+    @Before
+    public void setup() {
+        Map<String, String> pathParams = new HashMap<String, String>();
+        pathParams.put("json", "true");
+        pathParams.put("locale", "en_US");
+        pathParams.put("status", "any");
+
+        RequestSpecBuilder requestBuilder = new RequestSpecBuilder().
+            setBaseUri("https://public-api.wordpress.com").
+            setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/").
+            addQueryParams(pathParams).
+            setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
+        this.requestSpec = requestBuilder.build();    
+    }
+
+    @Test
+    public void canGetTaxClasses() {
+        given().
+            spec(this.requestSpec).
+            queryParam("path", "/wc/v4/taxes/classes").
+        when().
+            get().
+        then().
+            statusCode(200).
+            body("data", hasSize(3),
+                "data.slug", hasItems("standard", "reduced-rate", "zero-rate")
+            );
+    }
+}


### PR DESCRIPTION
This PR adds in 27 new API tests that run against a site that is using the latest development version of the `woocommerce-rest-api`.

The tests will run daily by scheduled job that is configured in CircleCI config. The use Rest Assured to handle the calls and validation.

I think I hit every api call that is used in this project that hits the wc endpoints, but if you see any that I missed, please let me know.
