### PR TITLE
Issue/1535 filter products

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
+import org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
@@ -75,6 +76,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooUpdateProductFragmentInjector(): WooUpdateProductFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooProductFiltersFragmentInjector(): WooProductFiltersFragment
 
     @ContributesAndroidInjector
     abstract fun provideWooOrdersFragmentInjector(): WooOrdersFragment

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductFiltersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductFiltersFragment.kt
@@ -1,0 +1,156 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_product_filters.*
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.ARG_LIST_SELECTED_ITEM
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.LIST_SELECTOR_REQUEST_CODE
+import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STATUS
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STOCK_STATUS
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.TYPE
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.io.Serializable
+import javax.inject.Inject
+
+class WooProductFiltersFragment : Fragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    private var selectedSiteId: Int = -1
+    private var filterOptions: MutableMap<ProductFilterOption, String>? = null
+    companion object {
+        const val ARG_SELECTED_SITE_ID = "ARG_SELECTED_SITE_ID"
+        const val ARG_SELECTED_FILTER_OPTIONS = "ARG_SELECTED_FILTER_OPTIONS"
+
+        const val LIST_RESULT_CODE_STOCK_STATUS = 101
+        const val LIST_RESULT_CODE_PRODUCT_TYPE = 102
+        const val LIST_RESULT_CODE_PRODUCT_STATUS = 103
+
+        @JvmStatic
+        fun newInstance(selectedSitePosition: Int): WooProductFiltersFragment {
+            return WooProductFiltersFragment().apply {
+                this.selectedSiteId = selectedSitePosition
+            }
+        }
+    }
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dispatcher.register(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        dispatcher.unregister(this)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(layout.fragment_woo_product_filters, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        savedInstanceState?.let { bundle -> selectedSiteId = bundle.getInt(ARG_SELECTED_SITE_ID) }
+        filterOptions = savedInstanceState?.getSerializable(ARG_SELECTED_FILTER_OPTIONS)
+                as? MutableMap<ProductFilterOption, String> ?: mutableMapOf()
+
+        filter_stock_status.setOnClickListener {
+            showListSelectorDialog(
+                    CoreProductStockStatus.values().map { it.value }.toList(),
+                    LIST_RESULT_CODE_STOCK_STATUS, filterOptions?.get(STOCK_STATUS)
+            )
+        }
+
+        filter_by_status.setOnClickListener {
+            showListSelectorDialog(
+                    CoreProductStatus.values().map { it.value }.toList(),
+                    LIST_RESULT_CODE_PRODUCT_STATUS, filterOptions?.get(STATUS)
+            )
+        }
+
+        filter_by_type.setOnClickListener {
+            showListSelectorDialog(
+                    CoreProductType.values().map { it.value }.toList(),
+                    LIST_RESULT_CODE_PRODUCT_TYPE, filterOptions?.get(TYPE)
+            )
+        }
+
+        filter_products.setOnClickListener {
+            getWCSite()?.let { site ->
+                val payload = FetchProductsPayload(site, filterOptions = filterOptions)
+                dispatcher.dispatch(WCProductActionBuilder.newFetchProductsAction(payload))
+            } ?: prependToLog("No valid siteId defined...doing nothing")
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(ARG_SELECTED_SITE_ID, selectedSiteId)
+        outState.putSerializable(ARG_SELECTED_FILTER_OPTIONS, filterOptions as? Serializable)
+    }
+
+    private fun getWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(selectedSiteId)
+
+    private fun showListSelectorDialog(listItems: List<String>, resultCode: Int, selectedItem: String? = null) {
+        fragmentManager?.let { fm ->
+            val dialog = ListSelectorDialog.newInstance(
+                    this, listItems, resultCode, selectedItem
+            )
+            dialog.show(fm, "ListSelectorDialog")
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == LIST_SELECTOR_REQUEST_CODE) {
+            val selectedItem = data?.getStringExtra(ARG_LIST_SELECTED_ITEM)
+            when (resultCode) {
+                LIST_RESULT_CODE_PRODUCT_TYPE -> {
+                    selectedItem?.let { filterOptions?.put(TYPE, it) }
+                }
+                LIST_RESULT_CODE_STOCK_STATUS -> {
+                    selectedItem?.let { filterOptions?.put(STOCK_STATUS, it) }
+                }
+                LIST_RESULT_CODE_PRODUCT_STATUS -> {
+                    selectedItem?.let { filterOptions?.put(STATUS, it) }
+                }
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductChanged(event: OnProductChanged) {
+        if (event.isError) {
+            prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
+            return
+        }
+
+        if (event.causeOfChange == FETCH_PRODUCTS) {
+            prependToLog("Fetched ${event.rowsAffected} products")
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -117,6 +117,10 @@ class WooProductsFragment : Fragment() {
             }
         }
 
+        fetch_products_with_filters.setOnClickListener {
+            replaceFragment(WooProductFiltersFragment.newInstance(selectedPos))
+        }
+
         search_products.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(

--- a/example/src/main/res/layout/fragment_woo_product_filters.xml
+++ b/example/src/main/res/layout/fragment_woo_product_filters.xml
@@ -1,0 +1,42 @@
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <Button
+            android:id="@+id/filter_stock_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Filter by Stock Status"/>
+
+        <Button
+            android:id="@+id/filter_by_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Filter by Status" />
+
+        <Button
+            android:id="@+id/filter_by_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Filter by Product Type" />
+
+
+        <Button
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin"
+            android:layout_marginTop="@dimen/activity_vertical_margin"
+            android:id="@+id/filter_products"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Filter Products" />
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -61,6 +61,13 @@
             android:text="Fetch Products"/>
 
         <Button
+            android:id="@+id/fetch_products_with_filters"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Products with Filters"/>
+
+        <Button
             android:id="@+id/search_products"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -5,6 +5,7 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductReviewApiResponse
 
 object ProductTestUtils {
@@ -13,7 +14,9 @@ object ProductTestUtils {
         type: String = "simple",
         name: String = "",
         virtual: Boolean = false,
-        siteId: Int = 6
+        siteId: Int = 6,
+        stockStatus: String = CoreProductStockStatus.IN_STOCK.value,
+        status: String = "publish"
     ): WCProductModel {
         return WCProductModel().apply {
             remoteProductId = remoteId
@@ -21,6 +24,8 @@ object ProductTestUtils {
             this.type = type
             this.name = name
             this.virtual = virtual
+            this.stockStatus = stockStatus
+            this.status = status
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -127,5 +128,57 @@ class WCProductStoreTest {
 
         // verify if product with non existent sku returns false
         assertFalse(ProductSqlUtils.getProductExistsBySku(site, "woooo"))
+    }
+
+    @Test
+    fun testGetProductsByFilterOptions() {
+        val filterOptions = mapOf<ProductFilterOption, String>(
+                ProductFilterOption.TYPE to "simple",
+                ProductFilterOption.STOCK_STATUS to "instock",
+                ProductFilterOption.STATUS to "publish"
+        )
+        val product1 = ProductTestUtils.generateSampleProduct(3)
+        val product2 = ProductTestUtils.generateSampleProduct(
+                31, type = "variable", status = "draft"
+        )
+        val product3 = ProductTestUtils.generateSampleProduct(
+                42, stockStatus = "onbackorder", status = "pending"
+                )
+
+        ProductSqlUtils.insertOrUpdateProduct(product1)
+        ProductSqlUtils.insertOrUpdateProduct(product2)
+        ProductSqlUtils.insertOrUpdateProduct(product3)
+
+        val site = SiteModel().apply { id = product1.localSiteId }
+        val products = productStore.getProductsByFilterOptions(site, filterOptions)
+        assertEquals(1, products.size)
+
+        // insert products with the same product options but for a different site
+        val differentSiteProduct1 = ProductTestUtils.generateSampleProduct(10, siteId = 10)
+        val differentSiteProduct2 = ProductTestUtils.generateSampleProduct(
+                11, siteId = 10, type = "variable", status = "draft"
+        )
+        val differentSiteProduct3 = ProductTestUtils.generateSampleProduct(
+                12, siteId = 10, stockStatus = "onbackorder", status = "pending"
+        )
+
+        ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct1)
+        ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct2)
+        ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct3)
+
+        // verify that the products for the first site is still 1
+        assertEquals(1, productStore.getProductsByFilterOptions(site, filterOptions).size)
+
+        // verify that the products for the second site is 3
+        val site2 = SiteModel().apply { id = differentSiteProduct1.localSiteId }
+        val filterOptions2 = mapOf(ProductFilterOption.STATUS to "draft")
+        val differentSiteProducts = productStore.getProductsByFilterOptions(site2, filterOptions2)
+        assertEquals(1, differentSiteProducts.size)
+        assertEquals(differentSiteProduct2.status, differentSiteProducts[0].status)
+
+        val filterOptions3 = mapOf(ProductFilterOption.STOCK_STATUS to "onbackorder")
+        val differentProductFilters = productStore.getProductsByFilterOptions(site2, filterOptions3)
+        assertEquals(1, differentProductFilters.size)
+        assertEquals(differentSiteProduct3.stockStatus, differentProductFilters[0].stockStatus)
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStatus.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+enum class CoreProductStatus(val value: String) {
+    DRAFT("draft"),
+    PENDING("pending"),
+    PRIVATE("private"),
+    PUBLISH("publish");
+
+    companion object {
+        private val valueMap = values().associateBy(CoreProductStatus::value)
+
+        /**
+         * Convert the base value into the associated CoreProductStatus object
+         */
+        fun fromValue(value: String) = valueMap[value]
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductType.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductType.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+enum class CoreProductType(val value: String) {
+    SIMPLE("simple"),
+    GROUPED("grouped"),
+    EXTERNAL("external"),
+    VARIABLE("variable");
+
+    companion object {
+        private val valueMap = values().associateBy(CoreProductType::value)
+
+        /**
+         * Convert the base value into the associated CoreProductType object
+         */
+        fun fromValue(value: String) = valueMap[value]
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUC
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.ProductError
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
@@ -180,7 +181,8 @@ class ProductRestClient(
         offset: Int = 0,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         searchQuery: String? = null,
-        remoteProductIds: List<Long>? = null
+        remoteProductIds: List<Long>? = null,
+        filterOptions: Map<ProductFilterOption, String>? = null
     ) {
         // orderby (string) Options: date, id, include, title and slug. Default is date.
         val orderBy = when (sortType) {
@@ -202,6 +204,10 @@ class ProductRestClient(
                 "search" to (searchQuery ?: ""))
         remoteProductIds?.let { ids ->
             params.put("include", ids.map { it }.joinToString())
+        }
+
+        filterOptions?.let { filters ->
+            filters.map { params.put(it.key.toString(), it.value) }
         }
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -381,6 +381,17 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getProductsByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): List<WCProductModel> =
             ProductSqlUtils.getProductsByRemoteIds(site, remoteProductIds)
 
+    /**
+     * returns a list of [WCProductModel] for the give [SiteModel] and [filterOptions]
+     * if it exists in the database
+     */
+    fun getProductsByFilterOptions(
+        site: SiteModel,
+        filterOptions: Map<ProductFilterOption, String>,
+        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING
+    ): List<WCProductModel> =
+            ProductSqlUtils.getProductsByFilterOptions(site, filterOptions, sortType)
+
     fun getProductsForSite(site: SiteModel, sortType: ProductSorting = DEFAULT_PRODUCT_SORTING) =
             ProductSqlUtils.getProductsForSite(site, sortType)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -34,6 +34,14 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         val DEFAULT_PRODUCT_SORTING = DATE_DESC
     }
 
+    /**
+     * Defines the filter options currently supported in the app
+     */
+    enum class ProductFilterOption {
+        STOCK_STATUS, STATUS, TYPE;
+        override fun toString() = name.toLowerCase()
+    }
+
     class FetchProductSkuAvailabilityPayload(
         var site: SiteModel,
         var sku: String

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -57,7 +57,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         var offset: Int = 0,
         var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
-        var remoteProductIds: List<Long>? = null
+        var remoteProductIds: List<Long>? = null,
+        var filterOptions: Map<ProductFilterOption, String>? = null
     ) : Payload<BaseNetworkError>()
 
     class SearchProductsPayload(
@@ -474,7 +475,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     private fun fetchProducts(payload: FetchProductsPayload) {
         with(payload) {
-            wcProductRestClient.fetchProducts(site, pageSize, offset, sorting, remoteProductIds = remoteProductIds)
+            wcProductRestClient.fetchProducts(
+                    site, pageSize, offset, sorting,
+                    remoteProductIds = remoteProductIds,
+                    filterOptions = filterOptions
+                    )
         }
     }
 


### PR DESCRIPTION
Fixes #1535 by adding option to filter products. Product filter options currently supported are: product status, product type and stock status.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/78993862-5c104800-7b5c-11ea-8917-c5d0839ae1cd.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/78993878-616d9280-7b5c-11ea-9d94-8b0f9cea25e1.png" width="300"/>

#### To test
- Run `ProductSqlUtilsTest`
- Run `WCProductStoreTest`
- Run the example app, click on `Woo` -> `Products` - `Fetch products with filters` and select filters and click on `Filter Products`.
- Verify that the products fetched match the filters on the web.