### PR TITLE
Issue/1539 woo add productid to event

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -435,6 +435,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         when (event.causeOfChange) {
             WCProductAction.FETCH_SINGLE_PRODUCT -> {
                 assertEquals(TestEvent.FETCHED_SINGLE_PRODUCT, nextEvent)
+                assertEquals(event.remoteProductId, productModel.remoteProductId)
                 mCountDownLatch.countDown()
             }
             WCProductAction.FETCH_PRODUCTS -> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -283,6 +283,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     // OnChanged events
     class OnProductChanged(
         var rowsAffected: Int,
+        var remoteProductId: Long = 0L, // only set for fetching a single product
         var canLoadMore: Boolean = false
     ) : OnChanged<ProductError>() {
         var causeOfChange: WCProductAction? = null
@@ -516,7 +517,9 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             onProductChanged = OnProductChanged(0).also { it.error = payload.error }
         } else {
             val rowsAffected = ProductSqlUtils.insertOrUpdateProduct(payload.product)
-            onProductChanged = OnProductChanged(rowsAffected)
+            onProductChanged = OnProductChanged(rowsAffected).also {
+                it.remoteProductId = payload.product.remoteProductId
+            }
         }
 
         onProductChanged.causeOfChange = WCProductAction.FETCH_SINGLE_PRODUCT

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -514,7 +514,10 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         val onProductChanged: OnProductChanged
 
         if (payload.isError) {
-            onProductChanged = OnProductChanged(0).also { it.error = payload.error }
+            onProductChanged = OnProductChanged(0).also {
+                it.error = payload.error
+                it.remoteProductId = payload.product.remoteProductId
+            }
         } else {
             val rowsAffected = ProductSqlUtils.insertOrUpdateProduct(payload.product)
             onProductChanged = OnProductChanged(rowsAffected).also {


### PR DESCRIPTION
Closes #1539 - adds `remoteProductId` to the `OnProductChanged` event when fetching a single product. This is required for [this WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/2232) in order to ensure the fetched product is the same one being displayed in order detail.