### PR TITLE
Issue/1537 woo product sorting

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
+import java.util.Locale
 
 object ProductSqlUtils {
     fun insertOrUpdateProduct(product: WCProductModel): Int {
@@ -102,12 +103,15 @@ object ProductSqlUtils {
             TITLE_ASC, TITLE_DESC -> WCProductModelTable.NAME
             DATE_ASC, DATE_DESC -> WCProductModelTable.DATE_CREATED
         }
-        return WellSql.select(WCProductModel::class.java)
+        val products = WellSql.select(WCProductModel::class.java)
                 .where()
                 .equals(WCProductModelTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
                 .orderBy(sortField, sortOrder)
                 .asModel
+        // WellSQL uses case-sensitive sorting but we need case-insensitive
+        products.sortBy { it.name.toLowerCase(Locale.getDefault()) }
+        return products
     }
 
     fun deleteProductsForSite(site: SiteModel): Int {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -109,8 +109,14 @@ object ProductSqlUtils {
                 .endWhere()
                 .orderBy(sortField, sortOrder)
                 .asModel
+
         // WellSQL uses case-sensitive sorting but we need case-insensitive
-        products.sortBy { it.name.toLowerCase(Locale.getDefault()) }
+        if (sortType == TITLE_ASC) {
+            products.sortBy { it.name.toLowerCase(Locale.getDefault()) }
+        } else if (sortType == TITLE_DESC) {
+            products.sortByDescending { it.name.toLowerCase(Locale.getDefault()) }
+        }
+
         return products
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -283,6 +283,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     // OnChanged events
     class OnProductChanged(
         var rowsAffected: Int,
+        var remoteProductId: Long = 0L, // only set for fetching a single product
         var canLoadMore: Boolean = false
     ) : OnChanged<ProductError>() {
         var causeOfChange: WCProductAction? = null
@@ -516,7 +517,9 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             onProductChanged = OnProductChanged(0).also { it.error = payload.error }
         } else {
             val rowsAffected = ProductSqlUtils.insertOrUpdateProduct(payload.product)
-            onProductChanged = OnProductChanged(rowsAffected)
+            onProductChanged = OnProductChanged(rowsAffected).also {
+                it.remoteProductId = payload.product.remoteProductId
+            }
         }
 
         onProductChanged.causeOfChange = WCProductAction.FETCH_SINGLE_PRODUCT

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -514,7 +514,10 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         val onProductChanged: OnProductChanged
 
         if (payload.isError) {
-            onProductChanged = OnProductChanged(0).also { it.error = payload.error }
+            onProductChanged = OnProductChanged(0).also {
+                it.error = payload.error
+                it.remoteProductId = payload.product.remoteProductId
+            }
         } else {
             val rowsAffected = ProductSqlUtils.insertOrUpdateProduct(payload.product)
             onProductChanged = OnProductChanged(rowsAffected).also {


### PR DESCRIPTION
Fixes #1537 - the product list is now sorted in case-insensitive order. I tried to get WellSQL to support `COLLATE NOCASE` but didn't have any luck, and adding `COLLATE NOCASE` to the table creation didn't work, so I opted to simply sort the products after retrieving them from the database.

**Note:** #1540 should be merged before this one. 