### PR TITLE
Issue/1547 product update always includes images

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -122,19 +122,21 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      */
     fun getImages(): ArrayList<WCProductImageModel> {
         val imageList = ArrayList<WCProductImageModel>()
-        try {
-            Gson().fromJson<JsonElement>(images, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
-                with(jsonElement.asJsonObject) {
-                    WCProductImageModel(this.getLong("id")).also {
-                        it.name = this.getString("name") ?: ""
-                        it.src = this.getString("src") ?: ""
-                        it.alt = this.getString("alt") ?: ""
-                        imageList.add(it)
+        if (!images.isEmpty()) {
+            try {
+                Gson().fromJson<JsonElement>(images, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+                    with(jsonElement.asJsonObject) {
+                        WCProductImageModel(this.getLong("id")).also {
+                            it.name = this.getString("name") ?: ""
+                            it.src = this.getString("src") ?: ""
+                            it.alt = this.getString("alt") ?: ""
+                            imageList.add(it)
+                        }
                     }
                 }
+            } catch (e: JsonParseException) {
+                AppLog.e(T.API, e)
             }
-        } catch (e: JsonParseException) {
-            AppLog.e(T.API, e)
         }
         return imageList
     }
@@ -261,5 +263,23 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             AppLog.e(T.API, e)
         }
         return triplets
+    }
+
+    /**
+     * Compares this product's images with the passed product's images, returns true only if both
+     * lists contain the same images in the same order
+     */
+    fun hasSameImages(updatedProduct: WCProductModel): Boolean {
+        val updatedImages = updatedProduct.getImages()
+        val thisImages = getImages()
+        if (thisImages.size != updatedImages.size) {
+            return false
+        }
+        for (i in thisImages.indices) {
+            if (thisImages[i].id != updatedImages[i].id) {
+                return false
+            }
+        }
+        return true
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -658,9 +658,10 @@ class ProductRestClient(
         if (storedWCProductModel.shortDescription != updatedProductModel.shortDescription) {
             body["short_description"] = updatedProductModel.shortDescription
         }
-        if (storedWCProductModel.images != updatedProductModel.images) {
+        if (!storedWCProductModel.hasSameImages(updatedProductModel)) {
+            val updatedImages = updatedProductModel.getImages()
             body["images"] = JsonArray().also {
-                for (image in updatedProductModel.getImages()) {
+                for (image in updatedImages) {
                     it.add(image.toJson())
                 }
             }


### PR DESCRIPTION
Fixes #1547 - when updating a product, it's list of images is now only passed if they've been changed.