### PR TITLE
Issue/1549 woo enable reviews and purchase note

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -412,6 +412,12 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         val updatedProductSlug = "product-slug"
         productModel.slug = updatedProductSlug
 
+        val updatedProductReviewsAllowed = true
+        productModel.reviewsAllowed = updatedProductReviewsAllowed
+
+        val updateProductPurchaseNote = "Test purchase note"
+        productModel.purchaseNote = updateProductPurchaseNote
+
         nextEvent = TestEvent.UPDATED_PRODUCT
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
@@ -428,6 +434,8 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         assertEquals(updatedProductVisibility, updatedProduct?.catalogVisibility)
         assertEquals(updatedProductFeatured, updatedProduct?.featured)
         assertEquals(updatedProductSlug, updatedProduct?.slug)
+        assertEquals(updatedProductReviewsAllowed, updatedProduct?.reviewsAllowed)
+        assertEquals(updateProductPurchaseNote, updatedProduct?.purchaseNote)
     }
 
     /**

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -284,6 +284,8 @@ class WooUpdateProductFragment : Fragment() {
                 product_status.text = it.status
                 product_slug.setText(it.slug)
                 product_is_featured.isChecked = it.featured
+                product_reviews_allowed.isChecked = it.reviewsAllowed
+                product_purchase_note.setText(it.purchaseNote)
             } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -201,6 +201,12 @@ class WooUpdateProductFragment : Fragment() {
             selectedProductModel?.featured = isChecked
         }
 
+        product_reviews_allowed.setOnCheckedChangeListener { _, isChecked ->
+            selectedProductModel?.reviewsAllowed = isChecked
+        }
+
+        product_purchase_note.onTextChanged { selectedProductModel?.purchaseNote = it }
+
         product_slug.onTextChanged { selectedProductModel?.slug = it }
 
         savedInstanceState?.let { bundle ->

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -355,8 +355,34 @@
             android:layout_marginTop="12dp"
             android:enabled="false"
             android:text="Featured"
+            app:layout_constraintEnd_toStartOf="@+id/product_reviews_allowed"
+            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/manageStockContainer" />
+
+        <CheckBox
+            android:id="@+id/product_reviews_allowed"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:enabled="false"
+            android:text="Reviews allowed"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_is_featured"
+            app:layout_constraintTop_toBottomOf="@+id/manageStockContainer" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_purchase_note"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:enabled="false"
+            android:inputType="number"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_reviews_allowed"
+            app:textHint="Purchase note" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -666,7 +666,12 @@ class ProductRestClient(
                 }
             }
         }
-
+        if (storedWCProductModel.reviewsAllowed != updatedProductModel.reviewsAllowed) {
+            body["reviews_allowed"] = updatedProductModel.reviewsAllowed
+        }
+        if (storedWCProductModel.purchaseNote != updatedProductModel.purchaseNote) {
+            body["purchase_note"] = updatedProductModel.purchaseNote
+        }
         return body
     }
 


### PR DESCRIPTION
Closes #1549 - adds `reviews_allowed` and `purchase_note` when updating a product. These two fields have also been added to the update product test and update product fragment.