### PR TITLE
Issue/1552 woo add permalink and menu order

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.OnProductUpdated
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.DateUtils
+import org.wordpress.android.util.StringUtils
 import java.util.Calendar
 import javax.inject.Inject
 
@@ -209,6 +210,10 @@ class WooUpdateProductFragment : Fragment() {
 
         product_slug.onTextChanged { selectedProductModel?.slug = it }
 
+        product_menu_order.onTextChanged { selectedProductModel?.menuOrder = StringUtils.stringToInt(it) }
+
+        product_permalink.onTextChanged { selectedProductModel?.permalink = it }
+
         savedInstanceState?.let { bundle ->
             selectedRemoteProductId = bundle.getLong(ARG_SELECTED_PRODUCT_ID)
             selectedSitePosition = bundle.getInt(ARG_SELECTED_SITE_POS)
@@ -286,6 +291,8 @@ class WooUpdateProductFragment : Fragment() {
                 product_is_featured.isChecked = it.featured
                 product_reviews_allowed.isChecked = it.reviewsAllowed
                 product_purchase_note.setText(it.purchaseNote)
+                product_menu_order.setText(it.menuOrder.toString())
+                product_permalink.setText(it.permalink)
             } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
     }

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -378,11 +378,33 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:enabled="false"
-            android:inputType="number"
+            android:inputType="text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_reviews_allowed"
             app:textHint="Purchase note" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_menu_order"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="number"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_purchase_note"
+            app:textHint="Menu order" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_permalink"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_menu_order"
+            app:textHint="Permalink" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 101
+        return 102
     }
 
     override fun getDbName(): String {
@@ -1069,6 +1069,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 100 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD IS_WPCOM_ATOMIC BOOLEAN")
                     db.execSQL("ALTER TABLE SiteModel ADD IS_COMING_SOON BOOLEAN")
+                }
+                101 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD MENU_ORDER INTEGER")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -78,6 +78,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
 
     @Column var parentId = 0
     @Column var purchaseNote = ""
+    @Column var menuOrder = 0
 
     @Column var categories = "" // array of categories
     @Column var tags = "" // array of tags

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -64,6 +64,7 @@ class ProductApiResponse : Response {
     var rating_count = 0
 
     var parent_id = 0
+    val menu_order = 0
     var purchase_note: String? = null
 
     var categories: JsonElement? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -672,6 +672,12 @@ class ProductRestClient(
         if (storedWCProductModel.purchaseNote != updatedProductModel.purchaseNote) {
             body["purchase_note"] = updatedProductModel.purchaseNote
         }
+        if (storedWCProductModel.menuOrder != updatedProductModel.menuOrder) {
+            body["menu_order"] = updatedProductModel.menuOrder
+        }
+        if (storedWCProductModel.permalink != updatedProductModel.permalink) {
+            body["permalink"] = updatedProductModel.permalink
+        }
         return body
     }
 
@@ -750,6 +756,7 @@ class ProductRestClient(
             ratingCount = response.rating_count
 
             parentId = response.parent_id
+            menuOrder = response.menu_order
             purchaseNote = response.purchase_note ?: ""
 
             categories = response.categories?.toString() ?: ""


### PR DESCRIPTION
Closes #1552 - adds `permalink` and `menu_order` when updating a product, as well as adds `menuOrder` to the product model. These two fields have also been added to the update product test and update product fragment.

