### PR TITLE
Add URL to CommentModel

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -395,7 +395,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         createNewComment();
 
         // Edit comment instance
-        mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
+        mNewComment.setContent("Trying with 10,000 gigawatts");
 
         // Create new Comment
         mNextEvent = TestEvents.COMMENT_CHANGED;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -389,6 +389,27 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
+    public void testCommentResponseContainsURL() throws InterruptedException {
+        // New Comment
+        createNewComment();
+
+        // Edit comment instance
+        mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
+
+        // Create new Comment
+        mNextEvent = TestEvents.COMMENT_CHANGED;
+        RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, mFirstPost, mNewComment);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Check the new comment response contains URL
+        CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment.getUrl());
+    }
+
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onCommentChanged(OnCommentChanged event) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -274,6 +274,26 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertEquals(null, comment);
     }
 
+    @Test
+    public void testCommentResponseContainsURL() throws InterruptedException {
+        // New Comment
+        createNewComment();
+
+        // Edit comment instance
+        mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
+
+        // Create new Comment
+        mNextEvent = TestEvents.COMMENT_CHANGED;
+        RemoteCreateCommentPayload payload = new RemoteCreateCommentPayload(sSite, mPosts.get(0), mNewComment);
+        mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(CommentActionBuilder.newCreateNewCommentAction(payload));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Check the new comment response contains URL
+        CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment.getUrl());
+    }
+
     // OnChanged Events
 
     @SuppressWarnings("unused")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -280,7 +280,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         createNewComment();
 
         // Edit comment instance
-        mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
+        mNewComment.setContent("Trying with: 20,000 gigawatts");
 
         // Create new Comment
         mNextEvent = TestEvents.COMMENT_CHANGED;

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -76,6 +76,15 @@ public class CommentsFragment extends Fragment {
                 likeOrUnlikeFirstComment();
             }
         });
+        view.findViewById(R.id.show_link_address).setOnClickListener(new OnClickListener() {
+            @Override public void onClick(View v) {
+                if (getFirstComment() == null) {
+                    ToastUtils.showToast(getActivity(), "Fetch comments first");
+                    return;
+                }
+                showLinkAddress();
+            }
+        });
         return view;
     }
 
@@ -122,6 +131,12 @@ public class CommentsFragment extends Fragment {
         mDispatcher.dispatch(CommentActionBuilder.newLikeCommentAction(
                 new CommentStore.RemoteLikeCommentPayload(getFirstSite(), getFirstComment(),
                         !getFirstComment().getILike())));
+    }
+
+    private void showLinkAddress() {
+        CommentModel commentModel = getFirstComment();
+        ToastUtils.showToast(getActivity(), commentModel.getUrl());
+        prependToLog("Comment link address " + commentModel.getUrl());
     }
 
     @SuppressWarnings("unused")

--- a/example/src/main/res/layout/fragment_comments.xml
+++ b/example/src/main/res/layout/fragment_comments.xml
@@ -23,4 +23,10 @@
         android:layout_height="wrap_content"
         android:text="Like/Unlike first comment" />
 
+    <Button
+        android:id="@+id/show_link_address"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Show link address" />
+
 </LinearLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
@@ -234,6 +235,21 @@ public class CommentStoreUnitTest {
         commentModel.setRemoteCommentId(remoteId);
         commentModel.setStatus(status.toString());
         commentModel.setDatePublished(DateTimeUtils.iso8601FromTimestamp(new Random().nextInt()));
+        commentModel.setUrl("https://www.wordpress.com");
         CommentSqlUtils.insertOrUpdateComment(commentModel);
+    }
+
+    @Test
+    public void testGetCommentsIncludeURL() {
+        SiteModel siteModel = new SiteModel();
+        siteModel.setId(21);
+
+        insertTestComments(siteModel);
+
+        List<CommentModel> queriedComments = CommentSqlUtils.getCommentsForSite(siteModel, SelectQuery.ORDER_ASCENDING,
+                CommentStatus.APPROVED, CommentStatus.SPAM, CommentStatus.UNAPPROVED);
+        for (CommentModel commentModel : queriedComments) {
+            assertNotNull(commentModel.getUrl());
+        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
@@ -34,6 +34,7 @@ public class CommentModel extends Payload<BaseNetworkError> implements Identifia
     @Column private String mStatus;
     @Column private String mDatePublished;
     @Column private String mContent;
+    @Column private String mUrl;
 
     // WPCOM only
     @Column private boolean mILike; // current user likes this comment
@@ -158,5 +159,13 @@ public class CommentModel extends Payload<BaseNetworkError> implements Identifia
 
     public void setILike(boolean iLike) {
         mILike = iLike;
+    }
+
+    public String getUrl() {
+        return mUrl;
+    }
+
+    public void setUrl(String url) {
+        mUrl = url;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -280,6 +280,7 @@ public class CommentRestClient extends BaseWPComRestClient {
         comment.setDatePublished(response.date);
         comment.setContent(response.content);
         comment.setILike(response.i_like);
+        comment.setUrl(response.URL);
 
         if (response.author != null) {
             comment.setAuthorUrl(response.author.URL);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentWPComRestResponse.java
@@ -30,4 +30,5 @@ public class CommentWPComRestResponse {
     public String status;
     public String content;
     public boolean i_like;
+    public String URL;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -335,6 +335,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         comment.setDatePublished(DateTimeUtils.iso8601UTCFromDate(datePublished));
         comment.setContent(XMLRPCUtils.safeGetMapValue(commentMap, "content", ""));
         comment.setRemoteParentCommentId(XMLRPCUtils.safeGetMapValue(commentMap, "parent", 0L));
+        comment.setUrl(XMLRPCUtils.safeGetMapValue(commentMap, "URL", ""));
 
         // Author
         comment.setAuthorUrl(XMLRPCUtils.safeGetMapValue(commentMap, "author_url", ""));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -335,7 +335,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         comment.setDatePublished(DateTimeUtils.iso8601UTCFromDate(datePublished));
         comment.setContent(XMLRPCUtils.safeGetMapValue(commentMap, "content", ""));
         comment.setRemoteParentCommentId(XMLRPCUtils.safeGetMapValue(commentMap, "parent", 0L));
-        comment.setUrl(XMLRPCUtils.safeGetMapValue(commentMap, "URL", ""));
+        comment.setUrl(XMLRPCUtils.safeGetMapValue(commentMap, "link", ""));
 
         // Author
         comment.setAuthorUrl(XMLRPCUtils.safeGetMapValue(commentMap, "author_url", ""));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1070,7 +1070,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE SiteModel ADD IS_WPCOM_ATOMIC BOOLEAN")
                     db.execSQL("ALTER TABLE SiteModel ADD IS_COMING_SOON BOOLEAN")
                 }
-                102 -> migrate(version) {
+                101 -> migrate(version) {
                     db.execSQL("ALTER TABLE CommentModel ADD URL TEXT")
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 101
+        return 102
     }
 
     override fun getDbName(): String {
@@ -1069,6 +1069,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 100 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD IS_WPCOM_ATOMIC BOOLEAN")
                     db.execSQL("ALTER TABLE SiteModel ADD IS_COMING_SOON BOOLEAN")
+                }
+                102 -> migrate(version) {
+                    db.execSQL("ALTER TABLE CommentModel ADD URL TEXT")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -286,6 +286,7 @@ public class CommentStore extends Store {
         comment.setAuthorName("");
         comment.setAuthorEmail("");
         comment.setAuthorUrl("");
+        comment.setUrl("");
         // Insert in the DB
         comment = CommentSqlUtils.insertCommentForResult(comment);
 


### PR DESCRIPTION
This PR supports [#8319](https://github.com/wordpress-mobile/WordPress-Android/issues/8319) by adding URL to the CommentModel and updating the CommentRestClient and CommentXMLRPCClient  with the associated URL property.

Testing
- Unit test:  `CommentStoreUnitTest` was updated with the new column and all its tests passed.
- Instrumented Tests : Added new tests to `ReleaseStack_CommentTestWPCom` and `ReleaseStack_CommentTestXMLRPC`  to verify that the api layer still functions accurately and returns the URL. All tests passed. 
-  Example app tests: Updated  `CommentsFragment` to show/log the comment URL.
-  Tested in WPAndroid using hashed version of this branch and received URL in the response.