### PR TITLE
Issue/1559 woo add button text

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -212,6 +212,8 @@ class WooUpdateProductFragment : Fragment() {
 
         product_external_url.onTextChanged { selectedProductModel?.externalUrl = it }
 
+        product_button_text.onTextChanged { selectedProductModel?.buttonText = it }
+
         product_menu_order.onTextChanged { selectedProductModel?.menuOrder = StringUtils.stringToInt(it) }
 
         savedInstanceState?.let { bundle ->
@@ -293,6 +295,7 @@ class WooUpdateProductFragment : Fragment() {
                 product_purchase_note.setText(it.purchaseNote)
                 product_menu_order.setText(it.menuOrder.toString())
                 product_external_url.setText(it.externalUrl)
+                product_button_text.setText(it.buttonText)
             } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
     }

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -397,6 +397,18 @@
             app:textHint="External url (external products only)" />
 
         <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_button_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:enabled="false"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_external_url"
+            app:textHint="Button text (external products only)" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_menu_order"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -404,7 +416,7 @@
             android:inputType="number"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_external_url"
+            app:layout_constraintTop_toBottomOf="@+id/product_button_text"
             app:textHint="Menu order" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1074,7 +1074,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE WCProductModel ADD MENU_ORDER INTEGER")
                 }
                 102 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCProductModel ADD BUTTON_TEXT INTEGER")
+                    db.execSQL("ALTER TABLE WCProductModel ADD BUTTON_TEXT STRING")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 102
+        return 103
     }
 
     override fun getDbName(): String {
@@ -1072,6 +1072,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 101 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD MENU_ORDER INTEGER")
+                }
+                102 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD BUTTON_TEXT INTEGER")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -54,7 +54,9 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var downloadLimit = 0
     @Column var downloadExpiry = 0
     @Column var soldIndividually = false
+
     @Column var externalUrl = ""
+    @Column var buttonText = ""
 
     @Column var taxStatus = "" // taxable, shipping, none
     @Column var taxClass = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -32,7 +32,9 @@ class ProductApiResponse : Response {
     var downloadable = false
     var download_limit = 0
     var download_expiry = 0
+
     var external_url: String? = null
+    val button_text: String? = null
 
     var tax_status: String? = null
     var tax_class: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -727,7 +727,9 @@ class ProductRestClient(
             downloadable = response.downloadable
             downloadLimit = response.download_limit
             downloadExpiry = response.download_expiry
+
             externalUrl = response.external_url ?: ""
+            buttonText = response.button_text ?: ""
 
             taxStatus = response.tax_status ?: ""
             taxClass = response.tax_class ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -604,6 +604,9 @@ class ProductRestClient(
         if (storedWCProductModel.externalUrl != updatedProductModel.externalUrl) {
             body["external_url"] = updatedProductModel.externalUrl
         }
+        if (storedWCProductModel.buttonText != updatedProductModel.buttonText) {
+            body["button_text"] = updatedProductModel.buttonText
+        }
 
         // only allowed to change the following params if manageStock is enabled
         if (updatedProductModel.manageStock) {


### PR DESCRIPTION
Closes #1559 - adds `button_text` to the product model, product table, product update request, and product update fragment.