### PR TITLE
Issue/1562 password protected products

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -581,10 +581,10 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             }
         } else if (event.causeOfChange == WCProductAction.FETCH_PRODUCT_PASSWORD) {
             assertEquals(TestEvent.FETCHED_PRODUCT_PASSWORD, nextEvent)
-            assertEquals(event.password, updatedPassword)
+            assertEquals(updatedPassword, event.password)
         } else if (event.causeOfChange == WCProductAction.UPDATE_PRODUCT_PASSWORD) {
             assertEquals(TestEvent.UPDATED_PRODUCT_PASSWORD, nextEvent)
-            assertEquals(event.password, updatedPassword)
+            assertEquals(updatedPassword, event.password)
         }
 
         mCountDownLatch.countDown()

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -10,8 +10,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCProductAction
-import org.wordpress.android.fluxc.action.WCProductAction.FETCHED_PRODUCT_PASSWORD
-import org.wordpress.android.fluxc.action.WCProductAction.UPDATED_PRODUCT_PASSWORD
 import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
@@ -280,7 +278,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
     @Throws(InterruptedException::class)
     @Test
-    fun testUpdateAndFetchProductPassword() {
+    fun testUpdateProductPassword() {
         // first dispatch a request to update the password
         nextEvent = TestEvent.UPDATED_PRODUCT_PASSWORD
         mCountDownLatch = CountDownLatch(1)
@@ -296,7 +294,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
-        // then dispatch a request to fetch it so we can make it's the same we just updated to
+        // then dispatch a request to fetch it so we can make sure it's the same we just updated to
         nextEvent = TestEvent.FETCHED_PRODUCT_PASSWORD
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
@@ -582,10 +580,10 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
                 throw AssertionError("onProductPasswordChanged has unexpected error: ${it.type}, ${it.message}")
             }
         }
-        else if (event.causeOfChange == FETCHED_PRODUCT_PASSWORD) {
+        else if (event.causeOfChange == WCProductAction.FETCH_PRODUCT_PASSWORD) {
             assertEquals(TestEvent.FETCHED_PRODUCT_PASSWORD, nextEvent)
             assertEquals(event.password, updatedPassword)
-        } else if (event.causeOfChange == UPDATED_PRODUCT_PASSWORD) {
+        } else if (event.causeOfChange == WCProductAction.UPDATE_PRODUCT_PASSWORD) {
             assertEquals(TestEvent.UPDATED_PRODUCT_PASSWORD, nextEvent)
             assertEquals(event.password, updatedPassword)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -579,8 +579,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             event.error?.let {
                 throw AssertionError("onProductPasswordChanged has unexpected error: ${it.type}, ${it.message}")
             }
-        }
-        else if (event.causeOfChange == WCProductAction.FETCH_PRODUCT_PASSWORD) {
+        } else if (event.causeOfChange == WCProductAction.FETCH_PRODUCT_PASSWORD) {
             assertEquals(TestEvent.FETCHED_PRODUCT_PASSWORD, nextEvent)
             assertEquals(event.password, updatedPassword)
         } else if (event.causeOfChange == WCProductAction.UPDATE_PRODUCT_PASSWORD) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -279,7 +279,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     @Throws(InterruptedException::class)
     @Test
     fun testUpdateProductPassword() {
-        // first dispatch a request to update the password
+        // first dispatch a request to update the password - note that this will fail for private products
         nextEvent = TestEvent.UPDATED_PRODUCT_PASSWORD
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/FloatingLabelEditText.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/FloatingLabelEditText.kt
@@ -34,6 +34,8 @@ class FloatingLabelEditText@JvmOverloads constructor(ctx: Context, attrs: Attrib
         edit_text.post { edit_text.setText(text) }
     }
 
+    fun getText() = edit_text.text.toString()
+
     override fun setEnabled(isEnabled: Boolean) {
         edit_text.isEnabled = isEnabled
     }

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -414,10 +414,23 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:inputType="number"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/product_password"
+            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_button_text"
             app:textHint="Menu order" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_password"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_menu_order"
+            app:layout_constraintTop_toBottomOf="@+id/product_button_text"
+            app:textHint="Password" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -24,8 +24,10 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsP
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload;
 
@@ -58,6 +60,8 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_SKU_AVAILABILITY,
     @Action(payloadType = FetchProductPasswordPayload.class)
     FETCH_PRODUCT_PASSWORD,
+    @Action(payloadType = UpdateProductPasswordPayload.class)
+    UPDATE_PRODUCT_PASSWORD,
 
 
     // Remote responses
@@ -86,5 +90,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteProductSkuAvailabilityPayload.class)
     FETCHED_PRODUCT_SKU_AVAILABILITY,
     @Action(payloadType = RemoteProductPasswordPayload.class)
-    FETCHED_PRODUCT_PASSWORD
+    FETCHED_PRODUCT_PASSWORD,
+    @Action(payloadType = RemoteUpdatedProductPasswordPayload.class)
+    UPDATED_PRODUCT_PASSWORD,
 }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload;
@@ -13,6 +14,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayloa
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload;
@@ -54,6 +56,9 @@ public enum WCProductAction implements IAction {
     UPDATE_PRODUCT,
     @Action(payloadType = FetchProductSkuAvailabilityPayload.class)
     FETCH_PRODUCT_SKU_AVAILABILITY,
+    @Action(payloadType = FetchProductPasswordPayload.class)
+    FETCH_PRODUCT_PASSWORD,
+
 
     // Remote responses
     @Action(payloadType = RemoteProductPayload.class)
@@ -79,5 +84,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteUpdateProductPayload.class)
     UPDATED_PRODUCT,
     @Action(payloadType = RemoteProductSkuAvailabilityPayload.class)
-    FETCHED_PRODUCT_SKU_AVAILABILITY
+    FETCHED_PRODUCT_SKU_AVAILABILITY,
+    @Action(payloadType = RemoteProductPasswordPayload.class)
+    FETCHED_PRODUCT_PASSWORD
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -325,9 +325,8 @@ class ProductRestClient(
      */
     fun updateProductPassword(site: SiteModel, remoteProductId: Long, password: String) {
         val url = WPCOMREST.sites.site(site.siteId).posts.post(remoteProductId).urlV1_2
-
-        val body = HashMap<String, Any>()
-        body["password"] = password
+        val body = listOfNotNull(
+                "password" to password).toMap()
 
         val request = WPComGsonRequest.buildPostRequest(url,
                 body,
@@ -341,6 +340,8 @@ class ProductRestClient(
             payload.error = networkErrorToProductError(networkError)
             dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductPasswordAction(payload))
         }
+        request.addQueryParameter("context", "edit")
+        request.addQueryParameter("fields", "password")
         add(request)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -302,9 +302,7 @@ class ProductRestClient(
      */
     fun fetchProductPassword(site: SiteModel, remoteProductId: Long) {
         val url = WPCOMREST.sites.site(site.siteId).posts.post(remoteProductId).urlV1_1
-
-        val params: MutableMap<String, String> = HashMap()
-        params["fields"] = "pasword"
+        val params = mutableMapOf("fields" to "password")
 
         val request = WPComGsonRequest.buildGetRequest(url,
                 params,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
@@ -22,6 +23,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErro
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
 import org.wordpress.android.fluxc.network.utils.getString
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_PAGE_SIZE
@@ -38,6 +40,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload
@@ -291,6 +294,31 @@ class ProductRestClient(
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductSkuAvailabilityAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
+    /**
+     * Makes a WP.COM GET request to `/sites/$site/posts/$post_ID` to fetch just the password for a product
+     */
+    fun fetchProductPassword(site: SiteModel, remoteProductId: Long) {
+        val url = WPCOMREST.sites.site(site.siteId).posts.post(remoteProductId).urlV1_1
+
+        val params: MutableMap<String, String> = HashMap()
+        params["fields"] = "pasword"
+
+        val request = WPComGsonRequest.buildGetRequest(url,
+                params,
+                PostWPComRestResponse::class.java,
+                { response ->
+                    val password = response.password
+                    val payload = RemoteProductPasswordPayload(remoteProductId, site, password)
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchedProductPasswordAction(payload))
+                }
+        ) { networkError ->
+            val payload = RemoteProductPasswordPayload(remoteProductId, site, "")
+            payload.error = networkErrorToProductError(networkError)
+            dispatcher.dispatch(WCProductActionBuilder.newFetchedProductPasswordAction(payload))
+        }
         add(request)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -354,7 +354,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     class OnProductPasswordChanged(
         var remoteProductId: Long,
-        var password: String
+        var password: String?
     )  : OnChanged<ProductError>() {
         var causeOfChange: WCProductAction? = null
     }
@@ -473,7 +473,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
                 fetchProductShippingClass(action.payload as FetchSingleProductShippingClassPayload)
             WCProductAction.FETCH_PRODUCT_SHIPPING_CLASS_LIST ->
                 fetchProductShippingClasses(action.payload as FetchProductShippingClassListPayload)
-            WCProductAction.FETCHED_PRODUCT_PASSWORD ->
+            WCProductAction.FETCH_PRODUCT_PASSWORD ->
                 fetchProductPassword(action.payload as FetchProductPasswordPayload)
 
             // remote responses
@@ -501,6 +501,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
                 handleFetchProductShippingClassesCompleted(action.payload as RemoteProductShippingClassListPayload)
             WCProductAction.FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS ->
                 handleFetchProductShippingClassCompleted(action.payload as RemoteProductShippingClassPayload)
+            WCProductAction.FETCHED_PRODUCT_PASSWORD ->
+                handleFetchProductPasswordCompleted(action.payload as RemoteProductPasswordPayload)
         }
     }
 
@@ -649,6 +651,15 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         }
         onProductShippingClassesChanged.causeOfChange = WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS
         emitChange(onProductShippingClassesChanged)
+    }
+
+    private fun handleFetchProductPasswordCompleted(payload: RemoteProductPasswordPayload) {
+        val onProductPasswordChanged = if (payload.isError) {
+            OnProductPasswordChanged(payload.remoteProductId, null).also { it.error = payload.error }
+        } else {
+            OnProductPasswordChanged(payload.remoteProductId, payload.password)
+        }
+        emitChange(onProductPasswordChanged)
     }
 
     private fun handleFetchProductVariationsCompleted(payload: RemoteProductVariationsPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -100,6 +100,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var remoteReviewId: Long
     ) : Payload<BaseNetworkError>()
 
+    class FetchProductPasswordPayload(
+        var site: SiteModel,
+        var remoteProductId: Long
+    ) : Payload<BaseNetworkError>()
+
     class UpdateProductReviewStatusPayload(
         var site: SiteModel,
         var remoteReviewId: Long,
@@ -163,6 +168,21 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             product: WCProductModel,
             site: SiteModel
         ) : this(product, site) {
+            this.error = error
+        }
+    }
+
+    class RemoteProductPasswordPayload(
+        val remoteProductId: Long,
+        val site: SiteModel,
+        val password: String?
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            remoteProductId: Long,
+            site: SiteModel,
+            password: String?
+        ) : this(remoteProductId, site, password) {
             this.error = error
         }
     }
@@ -332,6 +352,13 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var causeOfChange: WCProductAction? = null
     }
 
+    class OnProductPasswordChanged(
+        var remoteProductId: Long,
+        var password: String
+    )  : OnChanged<ProductError>() {
+        var causeOfChange: WCProductAction? = null
+    }
+
     class OnProductUpdated(
         var rowsAffected: Int,
         var remoteProductId: Long
@@ -446,6 +473,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
                 fetchProductShippingClass(action.payload as FetchSingleProductShippingClassPayload)
             WCProductAction.FETCH_PRODUCT_SHIPPING_CLASS_LIST ->
                 fetchProductShippingClasses(action.payload as FetchProductShippingClassListPayload)
+            WCProductAction.FETCHED_PRODUCT_PASSWORD ->
+                fetchProductPassword(action.payload as FetchProductPasswordPayload)
 
             // remote responses
             WCProductAction.FETCHED_SINGLE_PRODUCT ->
@@ -517,6 +546,10 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     private fun fetchSingleProductReview(payload: FetchSingleProductReviewPayload) {
         with(payload) { wcProductRestClient.fetchProductReviewById(site, remoteReviewId) }
+    }
+
+    private fun fetchProductPassword(payload: FetchProductPasswordPayload) {
+        with(payload) { wcProductRestClient.fetchProductPassword(site, remoteProductId) }
     }
 
     private fun updateProductReviewStatus(payload: UpdateProductReviewStatusPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -376,7 +376,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class OnProductPasswordChanged(
         var remoteProductId: Long,
         var password: String?
-    )  : OnChanged<ProductError>() {
+    ) : OnChanged<ProductError>() {
         var causeOfChange: WCProductAction? = null
     }
 
@@ -580,7 +580,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun updateProductPassword(payload: UpdateProductPasswordPayload) {
-        with(payload) { wcProductRestClient.updateProductPassword(site, remoteProductId, password)}
+        with(payload) { wcProductRestClient.updateProductPassword(site, remoteProductId, password) }
     }
 
     private fun updateProductReviewStatus(payload: UpdateProductReviewStatusPayload) {


### PR DESCRIPTION
Closes #1562 - adds the ability to set a password for a product via the WP.com API. Tests are included.