### PR TITLE
Added missing product type to CoreProductType

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductType.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductType.kt
@@ -4,7 +4,8 @@ enum class CoreProductType(val value: String) {
     SIMPLE("simple"),
     GROUPED("grouped"),
     EXTERNAL("external"),
-    VARIABLE("variable");
+    VARIABLE("variable"),
+    VARIATION("variation");
 
     companion object {
         private val valueMap = values().associateBy(CoreProductType::value)


### PR DESCRIPTION
As part of the woocommerce/woocommerce-android#2217 issue, we need to update the `CoreProductType` to include `VARIATION` as a product type. This tiny PR fixes that. 