### PR TITLE
Fix #1565: Null check mOnParseErrorListener

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -326,7 +326,7 @@ public abstract class BaseRequest<T> extends Request<T> {
     @Override
     public final void deliverError(VolleyError volleyError) {
         AppLog.e(AppLog.T.API, "Volley error on " + getUrl(), volleyError);
-        if (volleyError instanceof ParseError) {
+        if (volleyError instanceof ParseError && mOnParseErrorListener != null) {
             OnUnexpectedError error = new OnUnexpectedError(volleyError, "API response parse error");
             error.addExtra(OnUnexpectedError.KEY_URL, getUrl());
             mOnParseErrorListener.onParseError(error);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -83,7 +83,6 @@ public abstract class BaseWPComRestClient {
     protected Request addUnauthedRequest(AccountSocialRequest request, boolean addLocaleParameter) {
         if (addLocaleParameter) {
             addLocaleToRequest(request);
-            request.setOnParseErrorListener(mOnParseErrorListener);
             request.setUserAgent(mUserAgent.getUserAgent());
         }
         return addRequest(request);
@@ -107,7 +106,6 @@ public abstract class BaseWPComRestClient {
 
     private WPComGsonRequest setRequestAuthParams(WPComGsonRequest request, boolean shouldAuth) {
         request.setOnAuthFailedListener(mOnAuthFailedListener);
-        request.setOnParseErrorListener(mOnParseErrorListener);
         request.setOnJetpackTunnelTimeoutListener(mOnJetpackTunnelTimeoutListener);
         request.setUserAgent(mUserAgent.getUserAgent());
         request.setAccessToken(shouldAuth ? mAccessToken.get() : null);
@@ -115,6 +113,7 @@ public abstract class BaseWPComRestClient {
     }
 
     private Request addRequest(BaseRequest request) {
+        request.setOnParseErrorListener(mOnParseErrorListener);
         if (request.shouldCache() && request.shouldForceUpdate()) {
             mRequestQueue.getCache().invalidate(request.mUri.toString(), true);
         }


### PR DESCRIPTION
Fix #1565 - Null check mOnParseErrorListener and use the request.setOnParseErrorListener right before  adding the request to the queue.

cc @bummytime 