### PR TITLE
Updates paging library to 2.1.2

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     api 'com.android.volley:volley:1.1.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-text:1.1'
-    api "androidx.paging:paging-runtime:2.1.0"
+    api "androidx.paging:paging-runtime:2.1.2"
 
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/WordPress-Android/issues/11792 and https://github.com/woocommerce/woocommerce-android/issues/1782, I wanted to update the paging library dependency to the latest version in case it's helpful. I also looked into disabling the placeholder as a workaround as mentioned in [its tracker](https://issuetracker.google.com/issues/135628748) but I don't think we should do that, at least not yet. Disabling the placeholders will impact the user experience greatly, especially on WPAndroid post list and the number of crashes we have _right now_ doesn't warrant that, I don't think. It's been a while since it's reported to Google, so hopefully we'll have a fix soon.

It's interesting that the crash in WPAndroid only started happening in the latest beta. I couldn't find anything in the WPAndroid changes that might cause this. I am not really sure what to do about it, but I thought I'd share in case it's helpful as a future reference.