### PR TITLE
Fix failing test

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -395,7 +395,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         createNewComment();
 
         // Edit comment instance
-        mNewComment.setContent("Trying with 10,000 gigawatts");
+        mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
 
         // Create new Comment
         mNextEvent = TestEvents.COMMENT_CHANGED;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -280,7 +280,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         createNewComment();
 
         // Edit comment instance
-        mNewComment.setContent("Trying with: 20,000 gigawatts");
+        mNewComment.setContent("Trying with: " + (new Random()).nextFloat() * 10 + " gigawatts");
 
         // Create new Comment
         mNextEvent = TestEvents.COMMENT_CHANGED;


### PR DESCRIPTION
Fixed
`ReleaseStack_CommentTestXMLRPC`
`ReleaseStack_CommentTestWPCom`

The test was failing because I was using a static comment. Added a random number to the comment to ensure it is unique.