### PR TITLE
Fix geolocation disappearance from app on save 

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -52,6 +52,8 @@ import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostListItem;
 import org.wordpress.android.fluxc.store.PostStore.RemoteAutoSavePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
@@ -433,11 +435,15 @@ public class PostRestClient extends BaseWPComRestClient {
                 for (PostMetaData metaData : metaDataList) {
                     String key = metaData.getKey();
                     if (key != null && metaData.getValue() != null) {
-                        if (key.equals("geo_longitude")) {
-                            post.setLongitude(Double.parseDouble(metaData.getValue()));
-                        }
-                        if (key.equals("geo_latitude")) {
-                            post.setLatitude(Double.parseDouble(metaData.getValue()));
+                        try {
+                            if (key.equals("geo_longitude")) {
+                                post.setLongitude(Double.parseDouble(metaData.getValue()));
+                            }
+                            if (key.equals("geo_latitude")) {
+                                post.setLatitude(Double.parseDouble(metaData.getValue()));
+                            }
+                        } catch (NumberFormatException nfe) {
+                            AppLog.w(T.POSTS, "Geo location found in wrong format in the post metadata.");
                         }
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErro
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostMeta.PostData.PostAutoSave;
+import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostMetaData;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostsResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsResponse.DiffResponse;
@@ -426,6 +427,21 @@ public class PostRestClient extends BaseWPComRestClient {
         if (from.getGeo() != null) {
             post.setLatitude(from.getGeo().latitude);
             post.setLongitude(from.getGeo().longitude);
+        } else {
+            List<PostMetaData> metaDataList = from.getMetadata();
+            if (metaDataList != null) {
+                for (PostMetaData metaData : metaDataList) {
+                    String key = metaData.getKey();
+                    if (key != null && metaData.getValue() != null) {
+                        if (key.equals("geo_longitude")) {
+                            post.setLongitude(Double.parseDouble(metaData.getValue()));
+                        }
+                        if (key.equals("geo_latitude")) {
+                            post.setLatitude(Double.parseDouble(metaData.getValue()));
+                        }
+                    }
+                }
+            }
         }
 
         if (from.getCategories() != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -29,6 +29,7 @@ data class PostWPComRestResponse(
     @SerializedName("categories") val categories: Map<String, TermWPComRestResponse>? = null,
     @SerializedName("capabilities") val capabilities: Capabilities? = null,
     @SerializedName("meta") val meta: PostMeta? = null,
+    @SerializedName("metadata") val metadata: List<PostMetaData>? = null,
     @SerializedName("author") val author: Author? = null
 ) {
     data class PostsResponse(
@@ -63,6 +64,12 @@ data class PostWPComRestResponse(
             )
         }
     }
+
+    data class PostMetaData(
+        @SerializedName("id") var id: Long = 0,
+        @SerializedName("key") var key: String? = null,
+        @SerializedName("value") var value: String? = null
+    )
 
     fun getPostAutoSave(): PostAutoSave? {
         return meta?.data?.autoSave


### PR DESCRIPTION
This PR sets post latitude, longitude from the `metadata` param if post `geo` param is null to fix https://github.com/wordpress-mobile/WordPress-Android/issues/7626


### To Test
0. Use commit hash from this PR for `fluxCVersion` in [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android), build and install the app on device.
1. Create a new post in the mobile app on a Jetpack site.
2. Go to post settings and set the location for that post.
3. Save the post as a draft.
4. When you get back to post settings, the geolocation data should be displayed.

![location](https://user-images.githubusercontent.com/1405144/81150994-2ebd8b00-8f9e-11ea-985e-7db36f7d894c.gif)



