### PR TITLE
Check for empty post formats values.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -83,6 +83,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesError;
 import org.wordpress.android.fluxc.store.SiteStore.UserRolesErrorType;
+import org.wordpress.android.fluxc.utils.SiteUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
@@ -369,17 +370,17 @@ public class SiteRestClient extends BaseWPComRestClient {
                 new Listener<PostFormatsResponse>() {
                     @Override
                     public void onResponse(PostFormatsResponse response) {
-                        List<PostFormatModel> postFormats = new ArrayList<>();
-                        if (response.formats != null) {
-                            for (String key : response.formats.keySet()) {
-                                PostFormatModel postFormat = new PostFormatModel();
-                                postFormat.setSlug(key);
-                                postFormat.setDisplayName(response.formats.get(key));
-                                postFormats.add(postFormat);
-                            }
+                        List<PostFormatModel> postFormats = SiteUtils.getValidPostFormatsOrNull(response.formats);
+
+                        if (postFormats != null) {
+                            mDispatcher.dispatch(SiteActionBuilder.newFetchedPostFormatsAction(new
+                                    FetchedPostFormatsPayload(site, postFormats)));
+                        } else {
+                            FetchedPostFormatsPayload payload = new FetchedPostFormatsPayload(site,
+                                    Collections.<PostFormatModel>emptyList());
+                            payload.error = new PostFormatsError(PostFormatsErrorType.INVALID_RESPONSE);
+                            mDispatcher.dispatch(SiteActionBuilder.newFetchedPostFormatsAction(payload));
                         }
-                        mDispatcher.dispatch(SiteActionBuilder.newFetchedPostFormatsAction(new
-                                FetchedPostFormatsPayload(site, postFormats)));
                     }
                 },
                 new WPComErrorListener() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.xmlrpc.site;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
@@ -23,6 +24,7 @@ import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCUtils;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.PostFormatsError;
 import org.wordpress.android.fluxc.store.SiteStore.PostFormatsErrorType;
+import org.wordpress.android.fluxc.utils.SiteUtils;
 import org.wordpress.android.util.MapUtils;
 
 import java.util.ArrayList;
@@ -303,22 +305,12 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         return oldModel;
     }
 
-    private List<PostFormatModel> responseToPostFormats(Object response, SiteModel site) {
+    private @Nullable List<PostFormatModel> responseToPostFormats(Object response, SiteModel site) {
         if (!(response instanceof Map)) {
             reportParseError(response, site.getXmlRpcUrl(), Map.class);
             return null;
         }
 
-        Map<?, ?> formatsMap = (Map<?, ?>) response;
-        List<PostFormatModel> res = new ArrayList<>();
-        for (Object key : formatsMap.keySet()) {
-            if (!(key instanceof String)) continue;
-            String skey = (String) key;
-            PostFormatModel postFormat = new PostFormatModel();
-            postFormat.setSlug(skey);
-            postFormat.setDisplayName(MapUtils.getMapStr(formatsMap, skey));
-            res.add(postFormat);
-        }
-        return res;
+        return SiteUtils.getValidPostFormatsOrNull((Map) response);
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -120,7 +120,6 @@ public class SiteUtils {
     public static @Nullable List<PostFormatModel> getValidPostFormatsOrNull(@Nullable Map<?, ?> formatsMap) {
         if (formatsMap == null) return null;
 
-        //Map<?, ?> formatsMap = (Map<?, ?>) formats;
         List<PostFormatModel> res = new ArrayList<>();
         for (Object key : formatsMap.keySet()) {
             if (!(key instanceof String)) continue;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -1,12 +1,18 @@
 package org.wordpress.android.fluxc.utils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
+import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.util.MapUtils;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 import static org.apache.commons.lang3.StringUtils.split;
@@ -104,5 +110,31 @@ public class SiteUtils {
         }
 
         return TimeZone.getTimeZone(timezoneNormalized);
+    }
+
+    /**
+     * Given a formatsMap returns a List<PostFormatModel> or null
+     * @param formatsMap the map of post formats
+     * @return List<PostFormatModel> or null
+     */
+    public static @Nullable List<PostFormatModel> getValidPostFormatsOrNull(@Nullable Map<?, ?> formatsMap) {
+        if (formatsMap == null) return null;
+
+        //Map<?, ?> formatsMap = (Map<?, ?>) formats;
+        List<PostFormatModel> res = new ArrayList<>();
+        for (Object key : formatsMap.keySet()) {
+            if (!(key instanceof String)) continue;
+            String skey = (String) key;
+            String sValue = MapUtils.getMapStr(formatsMap, skey);
+
+            if (sValue.isEmpty()) return null;
+
+            PostFormatModel postFormat = new PostFormatModel();
+            postFormat.setSlug(skey);
+            postFormat.setDisplayName(sValue);
+            res.add(postFormat);
+        }
+
+        return res.isEmpty() ? null : res;
     }
 }


### PR DESCRIPTION
Part of the solution to  wordpress-mobile/WordPress-Android#11662 .
Companion WPAndroid PR wordpress-mobile/WordPress-Android#11832 .

For both pure self-hosted and WPCOM API accessed sited we do not want the name (value) of a post format to be empty. If we detect a this condition we emit a `PostFormatsError` in `OnPostFormatsChanged` event.

## To test
Use the companion WPAndroid PR and follow the steps there for testing.

