### PR TITLE
Issue/7626 location from metadata with json syntax fix

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -437,10 +437,16 @@ public class PostRestClient extends BaseWPComRestClient {
                     if (key != null && metaData.getValue() != null) {
                         try {
                             if (key.equals("geo_longitude")) {
-                                post.setLongitude(Double.parseDouble(metaData.getValue()));
+                                Object metaDataValue = metaData.getValue();
+                                if (metaDataValue instanceof String) {
+                                    post.setLongitude(Double.parseDouble(metaDataValue.toString()));
+                                }
                             }
                             if (key.equals("geo_latitude")) {
-                                post.setLatitude(Double.parseDouble(metaData.getValue()));
+                                Object metaDataValue = metaData.getValue();
+                                if (metaDataValue instanceof String) {
+                                    post.setLatitude(Double.parseDouble(metaDataValue.toString()));
+                                }
                             }
                         } catch (NumberFormatException nfe) {
                             AppLog.w(T.POSTS, "Geo location found in wrong format in the post metadata.");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErro
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostMeta.PostData.PostAutoSave;
+import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostMetaData;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostsResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.revisions.RevisionsResponse.DiffResponse;
@@ -51,6 +52,8 @@ import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostListItem;
 import org.wordpress.android.fluxc.store.PostStore.RemoteAutoSavePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
@@ -426,6 +429,25 @@ public class PostRestClient extends BaseWPComRestClient {
         if (from.getGeo() != null) {
             post.setLatitude(from.getGeo().latitude);
             post.setLongitude(from.getGeo().longitude);
+        } else {
+            List<PostMetaData> metaDataList = from.getMetadata();
+            if (metaDataList != null) {
+                for (PostMetaData metaData : metaDataList) {
+                    String key = metaData.getKey();
+                    if (key != null && metaData.getValue() != null) {
+                        try {
+                            if (key.equals("geo_longitude")) {
+                                post.setLongitude(Double.parseDouble(metaData.getValue()));
+                            }
+                            if (key.equals("geo_latitude")) {
+                                post.setLatitude(Double.parseDouble(metaData.getValue()));
+                            }
+                        } catch (NumberFormatException nfe) {
+                            AppLog.w(T.POSTS, "Geo location found in wrong format in the post metadata.");
+                        }
+                    }
+                }
+            }
         }
 
         if (from.getCategories() != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -29,6 +29,7 @@ data class PostWPComRestResponse(
     @SerializedName("categories") val categories: Map<String, TermWPComRestResponse>? = null,
     @SerializedName("capabilities") val capabilities: Capabilities? = null,
     @SerializedName("meta") val meta: PostMeta? = null,
+    @SerializedName("metadata") val metadata: List<PostMetaData>? = null,
     @SerializedName("author") val author: Author? = null
 ) {
     data class PostsResponse(
@@ -63,6 +64,12 @@ data class PostWPComRestResponse(
             )
         }
     }
+
+    data class PostMetaData(
+        @SerializedName("id") var id: Long = 0,
+        @SerializedName("key") var key: String? = null,
+        @SerializedName("value") var value: String? = null
+    )
 
     fun getPostAutoSave(): PostAutoSave? {
         return meta?.data?.autoSave

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -1,8 +1,18 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.post
 
+import com.google.gson.Gson
+import com.google.gson.TypeAdapter
+import com.google.gson.TypeAdapterFactory
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken.BEGIN_ARRAY
+import com.google.gson.stream.JsonToken.BEGIN_OBJECT
+import com.google.gson.stream.JsonWriter
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse.PostMeta.PostData.PostAutoSave
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse
+import java.io.IOException
 
 data class PostWPComRestResponse(
     @SerializedName("ID") val remotePostId: Long = 0,
@@ -29,7 +39,7 @@ data class PostWPComRestResponse(
     @SerializedName("categories") val categories: Map<String, TermWPComRestResponse>? = null,
     @SerializedName("capabilities") val capabilities: Capabilities? = null,
     @SerializedName("meta") val meta: PostMeta? = null,
-    @SerializedName("metadata") val metadata: List<PostMetaData>? = null,
+    @SerializedName("metadata") @JsonAdapter(MetaDataAdapterFactory::class) val metadata: List<PostMetaData>? = null,
     @SerializedName("author") val author: Author? = null
 ) {
     data class PostsResponse(
@@ -79,4 +89,42 @@ data class PostWPComRestResponse(
         @SerializedName("ID") val id: Long = 0,
         @SerializedName("name") val name: String?
     )
+
+    @Suppress("UNCHECKED_CAST")
+    class MetaDataAdapterFactory : TypeAdapterFactory {
+        override fun <T> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T> {
+            return MetaDataAdapter(gson) as TypeAdapter<T>
+        }
+    }
+
+    class MetaDataAdapter(private val gson: Gson) : TypeAdapter<List<PostMetaData>>() {
+        @Throws(IOException::class)
+        override
+        fun read(jsonReader: JsonReader): List<PostMetaData> {
+            val metaDataList = arrayListOf<PostMetaData>()
+
+            when (jsonReader.peek()) {
+                BEGIN_ARRAY -> {
+                    jsonReader.beginArray()
+                    while (jsonReader.hasNext()) {
+                        if (BEGIN_OBJECT == jsonReader.peek()) {
+                            val type = object : TypeToken<PostMetaData>() {}.type
+                            metaDataList.add(gson.fromJson(jsonReader, type))
+                        } else {
+                            jsonReader.skipValue()
+                        }
+                    }
+                    jsonReader.endArray()
+                }
+                else -> {
+                    jsonReader.skipValue()
+                }
+            }
+
+            return metaDataList
+        }
+
+        override fun write(out: JsonWriter?, value: List<PostMetaData>) { // Do Nothing
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -125,10 +125,8 @@ data class PostWPComRestResponse(
                                 when (ex) {
                                     is JsonSyntaxException,
                                     is JsonIOException -> {
-                                        AppLog.w(POSTS, "Error in post metadata json conversion.")
+                                        AppLog.w(POSTS, "Error in post metadata json conversion: " + ex.message)
                                         jsonReader.skipValue()
-                                    }
-                                    else -> {
                                     }
                                 }
                             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -78,7 +78,7 @@ data class PostWPComRestResponse(
     data class PostMetaData(
         @SerializedName("id") var id: Long = 0,
         @SerializedName("key") var key: String? = null,
-        @SerializedName("value") var value: String? = null
+        @SerializedName("value") var value: Any? = null
     )
 
     fun getPostAutoSave(): PostAutoSave? {


### PR DESCRIPTION
This PR fixes json syntax error in post metadata parsing noticed in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1576 and resubmits changes introduced in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1573.

Tested for different formats:

```
{"metadata”:[{“id”:”5”,”key”:”geo_latitude”,”value”:”28.6139391”}]}
{"metadata”:[false]}, 
{"metadata":false},
{"metadata":[{"id":"15","key":"switch_like_status","value":[0]}]}
```