### PR TITLE
Issue/1556 fetch shipping labels for order

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
+import org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
@@ -91,6 +92,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooTaxFragmentInjector(): WooTaxFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooShippingLabelFragmentInjector(): WooShippingLabelFragment
 
     @ContributesAndroidInjector
     abstract fun provideSiteSelectorDialogInjector(): SiteSelectorDialog

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
+import org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
@@ -111,6 +112,12 @@ class WooCommerceFragment : Fragment() {
         taxes.setOnClickListener {
             getFirstWCSite()?.let {
                 replaceFragment(WooTaxFragment())
+            } ?: showNoWCSitesToast()
+        }
+
+        shipping_labels.setOnClickListener {
+            getFirstWCSite()?.let {
+                replaceFragment(WooShippingLabelFragment())
             } ?: showNoWCSitesToast()
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -9,8 +9,8 @@ import android.widget.Button
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_shippinglabels.*
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
@@ -30,6 +30,8 @@ class WooShippingLabelFragment : Fragment() {
 
     private var selectedPos: Int = -1
     private var selectedSite: SiteModel? = null
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
@@ -58,7 +60,7 @@ class WooShippingLabelFragment : Fragment() {
                 showSingleLineDialog(activity, "Enter the order ID:") { orderEditText ->
                     val orderId = orderEditText.text.toString().toLong()
                     prependToLog("Submitting request to fetch shipping labels for order $orderId")
-                    GlobalScope.launch(Dispatchers.Main) {
+                    coroutineScope.launch {
                         try {
                             val response = withContext(Dispatchers.Default) {
                                 wcShippingLabelStore.fetchShippingLabelsForOrder(site, orderId)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -1,0 +1,96 @@
+package org.wordpress.android.fluxc.example.ui.shippinglabels
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_shippinglabels.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WCShippingLabelStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class WooShippingLabelFragment : Fragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+    @Inject internal lateinit var wcShippingLabelStore: WCShippingLabelStore
+
+    private var selectedPos: Int = -1
+    private var selectedSite: SiteModel? = null
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_woo_shippinglabels, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        shipping_labels_select_site.setOnClickListener {
+            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                override fun onSiteSelected(site: SiteModel, pos: Int) {
+                    selectedSite = site
+                    selectedPos = pos
+                    toggleSiteDependentButtons(true)
+                    shipping_labels_selected_site.text = site.name ?: site.displayName
+                }
+            })
+        }
+
+        fetch_shipping_labels.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(activity, "Enter the order ID:") { orderEditText ->
+                    val orderId = orderEditText.text.toString().toLong()
+                    prependToLog("Submitting request to fetch shipping labels for order $orderId")
+                    GlobalScope.launch(Dispatchers.Main) {
+                        try {
+                            val response = withContext(Dispatchers.Default) {
+                                wcShippingLabelStore.fetchShippingLabelsForOrder(site, orderId)
+                            }
+                            response.error?.let {
+                                prependToLog("${it.type}: ${it.message}")
+                            }
+                            response.model?.let {
+                                prependToLog("Order $orderId has ${it.size} shipping labels")
+                            }
+                        } catch (e: Exception) {
+                            prependToLog("Error: ${e.message}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
+        fragmentManager?.let { fm ->
+            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
+            dialog.show(fm, "StoreSelectorDialog")
+        }
+    }
+
+    private fun toggleSiteDependentButtons(enabled: Boolean) {
+        for (i in 0 until buttonContainer.childCount) {
+            val child = buttonContainer.getChildAt(i)
+            if (child is Button) {
+                child.isEnabled = enabled
+            }
+        }
+    }
+}

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -1,0 +1,49 @@
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:text="Perform actions on a selected site:"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/shipping_labels_select_site"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Select Site"/>
+
+            <TextView
+                android:id="@+id/shipping_labels_selected_site"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingLeft="10dp"
+                android:paddingStart="10dp"
+                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+                android:textColor="@android:color/holo_blue_bright"/>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/fetch_shipping_labels"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Shipping Labels"/>
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -81,5 +81,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Taxes"/>
+
+                <Button
+                    android:id="@+id/shipping_labels"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Shipping Labels"/>
         </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
@@ -1,0 +1,126 @@
+package org.wordpress.android.fluxc.wc.shippinglabels
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.persistence.WCShippingLabelSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCShippingLabelSqlUtilsTest {
+    val site = SiteModel().apply {
+        email = "test@example.org"
+        name = "Test Site"
+        siteId = 24
+    }
+
+    private val orderId = 25L
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(SiteModel::class.java, WCShippingLabelModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE)
+        WellSql.init(config)
+        config.reset()
+
+        // Insert the site into the db so it's available later for shipping labels
+        SiteSqlUtils.insertOrUpdateSite(site)
+    }
+
+    @Test
+    fun testInsertOrUpdateShippingLabelForOrder() {
+        val shippingLabel = WCShippingLabelTestUtils.generateShippingLabelList(site.id, orderId)[0]
+        assertNotNull(shippingLabel)
+
+        // Test inserting a shipping label for an order
+        var rowsAffected = WCShippingLabelSqlUtils.insertOrUpdateShippingLabel(shippingLabel)
+        assertEquals(1, rowsAffected)
+        var savedShippingLabels = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
+        assertEquals(savedShippingLabels.size, 1)
+        assertEquals(savedShippingLabels[0].localSiteId, shippingLabel.localSiteId)
+        assertEquals(savedShippingLabels[0].localOrderId, shippingLabel.localOrderId)
+        assertEquals(savedShippingLabels[0].remoteShippingLabelId, shippingLabel.remoteShippingLabelId)
+        assertEquals(savedShippingLabels[0].serviceName, shippingLabel.serviceName)
+
+        // Test updating the same shipping label
+        shippingLabel.apply {
+            serviceName = "Test service name"
+        }
+        rowsAffected = WCShippingLabelSqlUtils.insertOrUpdateShippingLabel(shippingLabel)
+        assertEquals(1, rowsAffected)
+        savedShippingLabels = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
+        assertEquals(savedShippingLabels.size, 1)
+        assertEquals(savedShippingLabels[0].localSiteId, shippingLabel.localSiteId)
+        assertEquals(savedShippingLabels[0].localOrderId, shippingLabel.localOrderId)
+        assertEquals(savedShippingLabels[0].remoteShippingLabelId, shippingLabel.remoteShippingLabelId)
+        assertEquals(savedShippingLabels[0].serviceName, shippingLabel.serviceName)
+    }
+
+    @Test
+    fun testInsertOrUpdateShippingLabelListForOrder() {
+        val shippingLabels = WCShippingLabelTestUtils.generateShippingLabelList(site.id, orderId)
+        assertNotNull(shippingLabels)
+
+        // Insert shipping label list
+        val rowsAffected = WCShippingLabelSqlUtils.insertOrUpdateShippingLabels(shippingLabels)
+        assertEquals(shippingLabels.size, rowsAffected)
+    }
+
+    @Test
+    fun testGetShippingLabelsForOrder() {
+        val shippingLabels = WCShippingLabelTestUtils.generateShippingLabelList(site.id, orderId)
+        assertTrue(shippingLabels.isNotEmpty())
+
+        // Insert shipping label list
+        val rowsAffected = WCShippingLabelSqlUtils.insertOrUpdateShippingLabels(shippingLabels)
+        assertEquals(shippingLabels.size, rowsAffected)
+
+        // Get shipping label list for site and order and verify
+        val savedShippingLabelListExists = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
+        assertEquals(shippingLabels.size, savedShippingLabelListExists.size)
+
+        // Get shipping label list for a site that does not exist
+        val nonExistingSite = SiteModel().apply { id = 400 }
+        val savedShippingLabelList = WCShippingLabelSqlUtils.getShippingClassesForOrder(nonExistingSite.id, orderId)
+        assertEquals(0, savedShippingLabelList.size)
+
+        // Get shipping label list for an order that does not exist
+        val nonExistingOrderId = 45L
+        val nonExistentOrderShippingLabelList =
+                WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, nonExistingOrderId)
+        assertEquals(0, nonExistentOrderShippingLabelList.size)
+    }
+
+    @Test
+    fun testDeleteShippingLabelListForOrder() {
+        val shippingLabels = WCShippingLabelTestUtils.generateShippingLabelList(site.id, orderId)
+
+        var rowsAffected = WCShippingLabelSqlUtils.insertOrUpdateShippingLabels(shippingLabels)
+        assertEquals(shippingLabels.size, rowsAffected)
+
+        // Verify shipping label list inserted
+        var savedShippingLabelList = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
+        assertEquals(shippingLabels.size, savedShippingLabelList.size)
+
+        // Delete shipping label list for order and verify
+        rowsAffected = WCShippingLabelSqlUtils.deleteShippingLabelsForOrder(orderId)
+        assertEquals(shippingLabels.size, rowsAffected)
+        savedShippingLabelList = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
+        assertEquals(0, savedShippingLabelList.size)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -28,7 +28,7 @@ import org.wordpress.android.fluxc.tools.initCoroutineEngine
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
-class WCTaxStoreTest {
+class WCShippingLabelStoreTest {
     private val restClient = mock<ShippingLabelRestClient>()
     private val orderId = 25L
     private val site = SiteModel().apply { id = 321 }
@@ -68,7 +68,8 @@ class WCTaxStoreTest {
         assertThat(result.model?.size).isEqualTo(shippingLabelModels.size)
         assertThat(result.model?.first()?.localOrderId).isEqualTo(shippingLabelModels.first().localOrderId)
         assertThat(result.model?.first()?.localSiteId).isEqualTo(shippingLabelModels.first().localSiteId)
-        assertThat(result.model?.first()?.remoteShippingLabelId).isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
+        assertThat(result.model?.first()?.remoteShippingLabelId)
+                .isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
         assertThat(result.model?.first()?.carrierId).isEqualTo(shippingLabelModels.first().carrierId)
         assertThat(result.model?.first()?.packageName).isEqualTo(shippingLabelModels.first().packageName)
         assertThat(result.model?.first()?.refundableAmount).isEqualTo(shippingLabelModels.first().refundableAmount)
@@ -90,7 +91,8 @@ class WCTaxStoreTest {
         assertThat(storedTaxClassList.size).isEqualTo(shippingLabelModels.size)
         assertThat(storedTaxClassList.first().localOrderId).isEqualTo(shippingLabelModels.first().localOrderId)
         assertThat(storedTaxClassList.first().localSiteId).isEqualTo(shippingLabelModels.first().localSiteId)
-        assertThat(storedTaxClassList.first().remoteShippingLabelId).isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
+        assertThat(storedTaxClassList.first().remoteShippingLabelId)
+                .isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
         assertThat(storedTaxClassList.first().carrierId).isEqualTo(shippingLabelModels.first().carrierId)
         assertThat(storedTaxClassList.first().packageName).isEqualTo(shippingLabelModels.first().packageName)
         assertThat(storedTaxClassList.first().refundableAmount).isEqualTo(shippingLabelModels.first().refundableAmount)
@@ -108,4 +110,3 @@ class WCTaxStoreTest {
         return store.fetchShippingLabelsForOrder(site, orderId)
     }
 }
-

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -1,0 +1,111 @@
+package org.wordpress.android.fluxc.wc.shippinglabels
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.yarolegovich.wellsql.WellSql
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelMapper
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.store.WCShippingLabelStore
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCTaxStoreTest {
+    private val restClient = mock<ShippingLabelRestClient>()
+    private val orderId = 25L
+    private val site = SiteModel().apply { id = 321 }
+    private val errorSite = SiteModel().apply { id = 123 }
+    private val mapper = WCShippingLabelMapper()
+    private lateinit var store: WCShippingLabelStore
+
+    private val sampleShippingLabelApiResponse = WCShippingLabelTestUtils.generateSampleShippingLabelApiResponse()
+    private val error = WooError(INVALID_RESPONSE, NETWORK_ERROR, "Invalid site ID")
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(SiteModel::class.java, WCShippingLabelModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE
+        )
+        WellSql.init(config)
+        config.reset()
+
+        store = WCShippingLabelStore(
+                restClient,
+                initCoroutineEngine(),
+                mapper
+        )
+
+        // Insert the site into the db so it's available later when testing shipping labels
+        SiteSqlUtils.insertOrUpdateSite(site)
+    }
+
+    @Test
+    fun `fetch shipping labels for order`() = test {
+        val result = fetchShippingLabelsForOrder()
+        val shippingLabelModels = mapper.map(sampleShippingLabelApiResponse!!, site)
+
+        assertThat(result.model?.size).isEqualTo(shippingLabelModels.size)
+        assertThat(result.model?.first()?.localOrderId).isEqualTo(shippingLabelModels.first().localOrderId)
+        assertThat(result.model?.first()?.localSiteId).isEqualTo(shippingLabelModels.first().localSiteId)
+        assertThat(result.model?.first()?.remoteShippingLabelId).isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
+        assertThat(result.model?.first()?.carrierId).isEqualTo(shippingLabelModels.first().carrierId)
+        assertThat(result.model?.first()?.packageName).isEqualTo(shippingLabelModels.first().packageName)
+        assertThat(result.model?.first()?.refundableAmount).isEqualTo(shippingLabelModels.first().refundableAmount)
+        assertThat(result.model?.first()?.rate).isEqualTo(shippingLabelModels.first().rate)
+        assertThat(result.model?.first()?.paperSize).isEqualTo(shippingLabelModels.first().paperSize)
+
+        val invalidRequestResult = store.fetchShippingLabelsForOrder(errorSite, orderId)
+        assertThat(invalidRequestResult.model).isNull()
+        assertThat(invalidRequestResult.error).isEqualTo(error)
+    }
+
+    @Test
+    fun `get stored shipping labels for order`() = test {
+        fetchShippingLabelsForOrder()
+
+        val storedTaxClassList = store.getShippingLabelsForOrder(site, orderId)
+
+        val shippingLabelModels = mapper.map(sampleShippingLabelApiResponse!!, site)
+        assertThat(storedTaxClassList.size).isEqualTo(shippingLabelModels.size)
+        assertThat(storedTaxClassList.first().localOrderId).isEqualTo(shippingLabelModels.first().localOrderId)
+        assertThat(storedTaxClassList.first().localSiteId).isEqualTo(shippingLabelModels.first().localSiteId)
+        assertThat(storedTaxClassList.first().remoteShippingLabelId).isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
+        assertThat(storedTaxClassList.first().carrierId).isEqualTo(shippingLabelModels.first().carrierId)
+        assertThat(storedTaxClassList.first().packageName).isEqualTo(shippingLabelModels.first().packageName)
+        assertThat(storedTaxClassList.first().refundableAmount).isEqualTo(shippingLabelModels.first().refundableAmount)
+        assertThat(storedTaxClassList.first().rate).isEqualTo(shippingLabelModels.first().rate)
+        assertThat(storedTaxClassList.first().paperSize).isEqualTo(shippingLabelModels.first().paperSize)
+
+        val invalidRequestResult = store.getShippingLabelsForOrder(errorSite, orderId)
+        assertThat(invalidRequestResult.size).isEqualTo(0)
+    }
+
+    private suspend fun fetchShippingLabelsForOrder(): WooResult<List<WCShippingLabelModel>> {
+        val fetchTaxClassListPayload = WooPayload(sampleShippingLabelApiResponse)
+        whenever(restClient.fetchShippingLabelsForOrder(orderId, site)).thenReturn(fetchTaxClassListPayload)
+        whenever(restClient.fetchShippingLabelsForOrder(orderId, errorSite)).thenReturn(WooPayload(error))
+        return store.fetchShippingLabelsForOrder(site, orderId)
+    }
+}
+

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.fluxc.wc.shippinglabels
+
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
+
+object WCShippingLabelTestUtils {
+    private fun generateSampleShippingLabel(
+        remoteId: Long,
+        orderId: Long = 12,
+        siteId: Int = 6,
+        carrierId: String = "",
+        serviceName: String = "",
+        status: String = "",
+        packageName: String = "",
+        rate: Float = 0F,
+        refundableAmount: Float = 0F,
+        currency: String = "",
+        paperSize: String = ""
+    ): WCShippingLabelModel {
+        return WCShippingLabelModel().apply {
+            localSiteId = siteId
+            localOrderId = orderId
+            remoteShippingLabelId = remoteId
+            this.carrierId = carrierId
+            this.serviceName = serviceName
+            this.packageName = packageName
+            this.status = status
+            this.rate = rate
+            this.refundableAmount = refundableAmount
+            this.currency = currency
+            this.paperSize = paperSize
+        }
+    }
+
+    fun generateShippingLabelList(
+        siteId: Int = 6,
+        orderId: Long = 12,
+        remoteShippingLabelId: Long = 0
+    ): List<WCShippingLabelModel> {
+        with(ArrayList<WCShippingLabelModel>()) {
+            add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 1))
+            add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 2))
+            add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 3))
+            add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 4))
+            add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 5))
+            return this
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -1,20 +1,24 @@
 package org.wordpress.android.fluxc.wc.shippinglabels
 
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
 
 object WCShippingLabelTestUtils {
     private fun generateSampleShippingLabel(
         remoteId: Long,
         orderId: Long = 12,
         siteId: Int = 6,
-        carrierId: String = "",
-        serviceName: String = "",
-        status: String = "",
-        packageName: String = "",
-        rate: Float = 0F,
-        refundableAmount: Float = 0F,
-        currency: String = "",
-        paperSize: String = ""
+        carrierId: String = "usps",
+        serviceName: String = "USPS - Priority Mail",
+        status: String = "PURCHASED",
+        packageName: String = "Small Flat Rate Box",
+        rate: Float = 7.65F,
+        refundableAmount: Float = 7.65F,
+        currency: String = "USD",
+        paperSize: String = "label"
     ): WCShippingLabelModel {
         return WCShippingLabelModel().apply {
             localSiteId = siteId
@@ -44,5 +48,11 @@ object WCShippingLabelTestUtils {
             add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 5))
             return this
         }
+    }
+
+    fun generateSampleShippingLabelApiResponse(): ShippingLabelApiResponse? {
+        val json = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/shipping-labels.json")
+        val responseType = object : TypeToken<ShippingLabelApiResponse>() {}.type
+        return Gson().fromJson(json, responseType) as? ShippingLabelApiResponse
     }
 }

--- a/example/src/test/resources/wc/shipping-labels.json
+++ b/example/src/test/resources/wc/shipping-labels.json
@@ -1,0 +1,170 @@
+{
+  "orderId": 25,
+  "paperSize": "label",
+  "formData": {
+    "is_packed": true,
+    "selected_packages": {
+      "default_box": {
+        "id": "default_box",
+        "box_id": "not_selected",
+        "height": 0,
+        "length": 0,
+        "weight": 0,
+        "width": 0,
+        "items": [{
+          "height": 0,
+          "product_id": 61,
+          "length": 0,
+          "quantity": 1,
+          "weight": 0,
+          "width": 0,
+          "name": "woo-polo - Polo",
+          "url": "https:\/\/awootestshop.mystagingwebsite.com\/wp-admin\/post.php?post=61&action=edit",
+          "value": 20
+        }, {
+          "height": 0,
+          "product_id": 39,
+          "length": 0,
+          "quantity": 1,
+          "weight": 0,
+          "width": 0,
+          "name": "woo-sunglasses - Sunglasses",
+          "url": "https:\/\/awootestshop.mystagingwebsite.com\/wp-admin\/post.php?post=39&action=edit",
+          "value": 90
+        }, {
+          "height": 0,
+          "product_id": 35,
+          "length": 0,
+          "quantity": 1,
+          "weight": 0,
+          "width": 0,
+          "name": "woo-tshirt - T-Shirt",
+          "url": "https:\/\/awootestshop.mystagingwebsite.com\/wp-admin\/post.php?post=35&action=edit",
+          "value": 18
+        }]
+      }
+    },
+    "origin": {
+      "company": "awootestshop.mystagingwebsite.com",
+      "name": "Anitaa Murthy",
+      "phone": "",
+      "country": "US",
+      "state": "CA",
+      "address": "60 29TH ST # 343",
+      "address_2": "",
+      "city": "SAN FRANCISCO",
+      "postcode": "94110-4929"
+    },
+    "destination": {
+      "company": "",
+      "address_2": "",
+      "city": "SAN FRANCISCO",
+      "state": "CA",
+      "postcode": "94110-4929",
+      "country": "US",
+      "phone": "41535032",
+      "name": "Anitaa OrderTesting29",
+      "address": "60 29TH ST # 343"
+    },
+    "origin_normalized": true,
+    "destination_normalized": true,
+    "rates": {
+      "selected": {}
+    },
+    "order_id": 1427
+  },
+  "labelsData": [{
+    "label_id": 1,
+    "tracking": "9405500205309038753691",
+    "refundable_amount": 7.65,
+    "created": 1589295659638,
+    "carrier_id": "usps",
+    "service_name": "USPS - Priority Mail",
+    "status": "PURCHASED",
+    "package_name": "Small Flat Rate Box",
+    "product_names": ["Polo", "T-Shirt"],
+    "receipt_item_id": 24212914,
+    "created_date": 1589295663000,
+    "main_receipt_id": 19680344,
+    "rate": 7.65,
+    "currency": "USD",
+    "expiry_date": 1604847662000,
+    "label_cached": 1589295666000
+  }, {
+    "label_id": 2,
+    "tracking": "9405500205309038753691",
+    "refundable_amount": 7.65,
+    "created": 1589295659638,
+    "carrier_id": "usps",
+    "service_name": "USPS - Priority Mail",
+    "status": "PURCHASED",
+    "package_name": "Small Flat Rate Box",
+    "product_names": ["Polo", "T-Shirt"],
+    "receipt_item_id": 24212914,
+    "created_date": 1589295663000,
+    "main_receipt_id": 19680344,
+    "rate": 7.65,
+    "currency": "USD",
+    "expiry_date": 1604847662000,
+    "label_cached": 1589295666000
+  }, {
+    "label_id": 3,
+    "tracking": "9405500205309038753691",
+    "refundable_amount": 7.65,
+    "created": 1589295659638,
+    "carrier_id": "usps",
+    "service_name": "USPS - Priority Mail",
+    "status": "PURCHASED",
+    "package_name": "Small Flat Rate Box",
+    "product_names": ["Polo", "T-Shirt"],
+    "receipt_item_id": 24212914,
+    "created_date": 1589295663000,
+    "main_receipt_id": 19680344,
+    "rate": 7.65,
+    "currency": "USD",
+    "expiry_date": 1604847662000,
+    "label_cached": 1589295666000
+  }, {
+    "label_id": 4,
+    "tracking": "9405500205309038753691",
+    "refundable_amount": 7.65,
+    "created": 1589295659638,
+    "carrier_id": "usps",
+    "service_name": "USPS - Priority Mail",
+    "status": "PURCHASED",
+    "package_name": "Small Flat Rate Box",
+    "product_names": ["Polo", "T-Shirt"],
+    "receipt_item_id": 24212914,
+    "created_date": 1589295663000,
+    "main_receipt_id": 19680344,
+    "rate": 7.65,
+    "currency": "USD",
+    "expiry_date": 1604847662000,
+    "label_cached": 1589295666000
+  }, {
+    "label_id": 5,
+    "tracking": "9405500205309038753691",
+    "refundable_amount": 7.65,
+    "created": 1589295659638,
+    "carrier_id": "usps",
+    "service_name": "USPS - Priority Mail",
+    "status": "PURCHASED",
+    "package_name": "Small Flat Rate Box",
+    "product_names": ["Polo", "T-Shirt"],
+    "receipt_item_id": 24212914,
+    "created_date": 1589295663000,
+    "main_receipt_id": 19680344,
+    "rate": 7.65,
+    "currency": "USD",
+    "expiry_date": 1604847662000,
+    "label_cached": 1589295666000
+  }],
+  "storeOptions": {
+    "currency_symbol": "$",
+    "dimension_unit": "in",
+    "weight_unit": "oz",
+    "origin_country": "US"
+  },
+  "canChangeCountries": true,
+  "success": true
+}

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -3,6 +3,8 @@ package org.wordpress.android.fluxc.annotations.endpoint;
 public class WCWPAPIEndpoint {
     private static final String WC_PREFIX_V3 = "wc/v3";
 
+    private static final String WC_PREFIX_V1 = "wc/v1";
+
     private static final String WC_PREFIX_V2 = "wc/v2";
 
     private static final String WC_PREFIX_V4 = "wc/v4";
@@ -33,6 +35,10 @@ public class WCWPAPIEndpoint {
 
     public String getPathV2() {
         return "/" + WC_PREFIX_V2 + mEndpoint;
+    }
+
+    public String getPathV1() {
+        return "/" + WC_PREFIX_V1 + mEndpoint;
     }
 
     public String getPathV4() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 104
+        return 105
     }
 
     override fun getDbName(): String {
@@ -1078,6 +1078,17 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 103 -> migrate(version) {
                     db.execSQL("ALTER TABLE CommentModel ADD URL TEXT")
+                }
+                104 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL(
+                            "CREATE TABLE WCShippingLabelModel (_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "LOCAL_SITE_ID INTEGER,LOCAL_ORDER_ID INTEGER,REMOTE_SHIPPING_LABEL_ID INTEGER," +
+                                    "CARRIER_ID TEXT NOT NULL,PRODUCT_NAMES TEXT NULL," +
+                                    "TRACKING_NUMBER TEXT NOT NULL,SERVICE_NAME TEXT NOT NULL,STATUS TEXT NOT NULL," +
+                                    "PACKAGE_NAME TEXT NOT NULL,RATE REAL NOT NULL,REFUNDABLE_AMOUNT REAL NOT NULL," +
+                                    "CURRENCY TEXT NOT NULL,PAPER_SIZE TEXT NOT NULL,FORM_DATA TEXT NOT NULL," +
+                                    "STORE_OPTIONS TEXT NOT NULL)"
+                    )
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1081,12 +1081,22 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 104 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL(
-                            "CREATE TABLE WCShippingLabelModel (_id INTEGER PRIMARY KEY AUTOINCREMENT," +
-                                    "LOCAL_SITE_ID INTEGER,LOCAL_ORDER_ID INTEGER,REMOTE_SHIPPING_LABEL_ID INTEGER," +
-                                    "CARRIER_ID TEXT NOT NULL,PRODUCT_NAMES TEXT NULL," +
-                                    "TRACKING_NUMBER TEXT NOT NULL,SERVICE_NAME TEXT NOT NULL,STATUS TEXT NOT NULL," +
-                                    "PACKAGE_NAME TEXT NOT NULL,RATE REAL NOT NULL,REFUNDABLE_AMOUNT REAL NOT NULL," +
-                                    "CURRENCY TEXT NOT NULL,PAPER_SIZE TEXT NOT NULL,FORM_DATA TEXT NOT NULL," +
+                            "CREATE TABLE WCShippingLabelModel (" +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "LOCAL_ORDER_ID INTEGER," +
+                                    "REMOTE_SHIPPING_LABEL_ID INTEGER," +
+                                    "CARRIER_ID TEXT NOT NULL," +
+                                    "PRODUCT_NAMES TEXT NULL," +
+                                    "TRACKING_NUMBER TEXT NOT NULL," +
+                                    "SERVICE_NAME TEXT NOT NULL," +
+                                    "STATUS TEXT NOT NULL," +
+                                    "PACKAGE_NAME TEXT NOT NULL," +
+                                    "RATE REAL NOT NULL," +
+                                    "REFUNDABLE_AMOUNT REAL NOT NULL," +
+                                    "CURRENCY TEXT NOT NULL," +
+                                    "PAPER_SIZE TEXT NOT NULL," +
+                                    "FORM_DATA TEXT NOT NULL," +
                                     "STORE_OPTIONS TEXT NOT NULL)"
                     )
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse.LabelItem
+import javax.inject.Inject
+
+class WCShippingLabelMapper
+@Inject constructor() {
+    fun map(response: ShippingLabelApiResponse, labelItem: LabelItem): WCShippingLabelModel {
+        return WCShippingLabelModel().apply {
+            remoteShippingLabelId = labelItem.labelId ?: 0L
+            trackingNumber = labelItem.trackingNumber ?: ""
+            carrierId = labelItem.carrierId ?: ""
+            serviceName = labelItem.serviceName ?: ""
+            status = labelItem.status ?: ""
+            packageName = labelItem.packageName ?: ""
+            rate = labelItem.rate?.toFloat() ?: 0F
+            refundableAmount = labelItem.refundableAmount?.toFloat() ?: 0F
+            currency = labelItem.currency ?: ""
+            productNames = labelItem.productNames.toString()
+
+            localOrderId = response.orderId ?: 0L
+            paperSize = response.paperSize ?: ""
+            storeOptions = response.storeOptions.toString()
+            formData = response.formData.toString()
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -1,28 +1,32 @@
 package org.wordpress.android.fluxc.model.shippinglabels
 
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse.LabelItem
 import javax.inject.Inject
 
 class WCShippingLabelMapper
 @Inject constructor() {
-    fun map(response: ShippingLabelApiResponse, labelItem: LabelItem): WCShippingLabelModel {
-        return WCShippingLabelModel().apply {
-            remoteShippingLabelId = labelItem.labelId ?: 0L
-            trackingNumber = labelItem.trackingNumber ?: ""
-            carrierId = labelItem.carrierId ?: ""
-            serviceName = labelItem.serviceName ?: ""
-            status = labelItem.status ?: ""
-            packageName = labelItem.packageName ?: ""
-            rate = labelItem.rate?.toFloat() ?: 0F
-            refundableAmount = labelItem.refundableAmount?.toFloat() ?: 0F
-            currency = labelItem.currency ?: ""
-            productNames = labelItem.productNames.toString()
+    fun map(response: ShippingLabelApiResponse, site: SiteModel): List<WCShippingLabelModel> {
+        return response.labelsData?.map { labelItem ->
+            WCShippingLabelModel().apply {
+                remoteShippingLabelId = labelItem.labelId ?: 0L
+                trackingNumber = labelItem.trackingNumber ?: ""
+                carrierId = labelItem.carrierId ?: ""
+                serviceName = labelItem.serviceName ?: ""
+                status = labelItem.status ?: ""
+                packageName = labelItem.packageName ?: ""
+                rate = labelItem.rate?.toFloat() ?: 0F
+                refundableAmount = labelItem.refundableAmount?.toFloat() ?: 0F
+                currency = labelItem.currency ?: ""
+                productNames = labelItem.productNames.toString()
 
-            localOrderId = response.orderId ?: 0L
-            paperSize = response.paperSize ?: ""
-            storeOptions = response.storeOptions.toString()
-            formData = response.formData.toString()
-        }
+                localOrderId = response.orderId ?: 0L
+                paperSize = response.paperSize ?: ""
+                storeOptions = response.storeOptions.toString()
+                formData = response.formData.toString()
+
+                localSiteId = site.id
+            }
+        } ?: emptyList()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -23,7 +23,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     @Column var refundableAmount = 0F
     @Column var currency = ""
     @Column var paperSize = ""
-    @Column var productNames = ""  // list of product names the shipping label was purchased for
+    @Column var productNames = "" // list of product names the shipping label was purchased for
 
     @Column var formData = "" // map containing package and product details related to that shipping label
     @Column var storeOptions = "" // map containing store settings such as currency and dimensions

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -23,7 +23,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     @Column var refundableAmount = 0F
     @Column var currency = ""
     @Column var paperSize = ""
-    @Column var productNames = ""
+    @Column var productNames = ""  // list of product names the shipping label was purchased for
 
     @Column var formData = "" // map containing package and product details related to that shipping label
     @Column var storeOptions = "" // map containing store settings such as currency and dimensions
@@ -48,21 +48,31 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
      */
     fun getOriginAddress() = getFormData()?.origin
 
+    /**
+     * Returns the product details for the order wrapped in a list of [ProductItem]
+     */
     fun getProductItems() = getFormData()?.selectedPackage?.defaultBox?.productItems ?: emptyList()
 
     /**
-     * Returns the shipping details wrapped in a [WCShippingLabelAddress].
+     * Returns the store details such as currency, country and dimensions wrapped in [StoreOptions]
      */
     fun getStoreOptions(): StoreOptions? {
         val responseType = object : TypeToken<StoreOptions>() {}.type
         return gson.fromJson(storeOptions, responseType) as? StoreOptions
     }
 
+    /**
+     * Returns default data related to the order such as the origin address,
+     * destination address and product items associated with the order.
+     */
     private fun getFormData(): FormData? {
         val responseType = object : TypeToken<FormData>() {}.type
         return gson.fromJson(formData, responseType) as? FormData
     }
 
+    /**
+     * Returns the list of products the shipping labels were purchased for
+     */
     fun getProductNames(): List<String> {
         val responseType = object : TypeToken<List<String>>() {}.type
         return gson.fromJson(productNames, responseType) as? List<String> ?: emptyList()
@@ -75,6 +85,12 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
         @SerializedName("origin_country") val originCountry: String? = null
     }
 
+    /**
+     * Model class corresponding to the [formData] map from the API response.
+     * The [formData] contains the [origin] and [destination] address and the
+     * product details associated with the order.
+     * (nested under [selectedPackage] -> [DefaultBox] -> List of [ProductItem]).
+     */
     class FormData {
         val origin: ShippingLabelAddress? = null
         val destination: ShippingLabelAddress? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -1,0 +1,114 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var localOrderId = 0L // The local db unique identifier for the parent order object
+    @Column var remoteShippingLabelId = 0L // The unique identifier for this note on the server
+    @Column var trackingNumber = ""
+    @Column var carrierId = ""
+    @Column var serviceName = ""
+    @Column var status = ""
+    @Column var packageName = ""
+    @Column var rate = 0F
+    @Column var refundableAmount = 0F
+    @Column var currency = ""
+    @Column var paperSize = ""
+    @Column var productNames = ""
+
+    @Column var formData = "" // map containing package and product details related to that shipping label
+    @Column var storeOptions = "" // map containing store settings such as currency and dimensions
+
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    companion object {
+        private val gson by lazy { Gson() }
+    }
+
+    /**
+     * Returns the destination details wrapped in a [ShippingLabelAddress].
+     */
+    fun getDestinationAddress() = getFormData()?.destination
+
+    /**
+     * Returns the shipping details wrapped in a [ShippingLabelAddress].
+     */
+    fun getOriginAddress() = getFormData()?.origin
+
+    fun getProductItems() = getFormData()?.selectedPackage?.defaultBox?.productItems ?: emptyList()
+
+    /**
+     * Returns the shipping details wrapped in a [WCShippingLabelAddress].
+     */
+    fun getStoreOptions(): StoreOptions? {
+        val responseType = object : TypeToken<StoreOptions>() {}.type
+        return gson.fromJson(storeOptions, responseType) as? StoreOptions
+    }
+
+    private fun getFormData(): FormData? {
+        val responseType = object : TypeToken<FormData>() {}.type
+        return gson.fromJson(formData, responseType) as? FormData
+    }
+
+    fun getProductNames(): List<String> {
+        val responseType = object : TypeToken<List<String>>() {}.type
+        return gson.fromJson(productNames, responseType) as? List<String> ?: emptyList()
+    }
+
+    class StoreOptions {
+        @SerializedName("currency_symbol") val currencySymbol: String? = null
+        @SerializedName("dimension_unit") val dimensionUnit: String? = null
+        @SerializedName("weight_unit") val weightUnit: String? = null
+        @SerializedName("origin_country") val originCountry: String? = null
+    }
+
+    class FormData {
+        val origin: ShippingLabelAddress? = null
+        val destination: ShippingLabelAddress? = null
+        @SerializedName("selected_packages") val selectedPackage: SelectedPackage? = null
+    }
+
+    class ShippingLabelAddress {
+        val company: String? = null
+        val name: String? = null
+        val phone: String? = null
+        val country: String? = null
+        val state: String? = null
+        val address: String? = null
+        val address2: String? = null
+        val city: String? = null
+        val postcode: String? = null
+    }
+
+    class SelectedPackage {
+        @SerializedName("default_box") val defaultBox: DefaultBox? = null
+    }
+
+    class DefaultBox {
+        @SerializedName("items") val productItems: List<ProductItem>? = null
+    }
+
+    class ProductItem {
+        val height: Int? = null
+        val length: Int? = null
+        val quantity: Int? = null
+        val width: Int? = null
+        val name: String? = null
+        val url: String? = null
+        val value: Int? = null
+        @SerializedName("product_id") val productId: Long? = null
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient
 import javax.inject.Named
 import javax.inject.Singleton
@@ -93,6 +94,17 @@ class ReleaseWCNetworkModule {
         token: AccessToken,
         userAgent: UserAgent
     ) = WCTaxRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideShippingLabelRestClient(
+        appContext: Context,
+        requestBuilder: JetpackTunnelGsonRequestBuilder,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = ShippingLabelRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
 
     @Singleton
     @Provides

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
+
+import com.google.gson.JsonElement
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+import java.math.BigDecimal
+
+class ShippingLabelApiResponse : Response {
+    val orderId: Long? = null
+    val paperSize: String? = null
+
+    val formData: JsonElement? = null
+    val storeOptions: JsonElement? = null
+    val labelsData: List<LabelItem>? = null
+
+    class LabelItem {
+        @SerializedName("label_id") val labelId: Long? = null
+        @SerializedName("tracking") val trackingNumber: String? = null
+        @SerializedName("carrier_id") val carrierId: String? = null
+        @SerializedName("service_name") val serviceName: String? = null
+        @SerializedName("package_name") val packageName: String? = null
+        @SerializedName("product_names") val productNames: List<String>? = emptyList()
+        @SerializedName("refundable_amount") val refundableAmount: BigDecimal? = null
+        val status: String? = null
+        val rate: BigDecimal? = null
+        val currency: String? = null
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Singleton
+
+@Singleton
+class ShippingLabelRestClient
+constructor(
+    dispatcher: Dispatcher,
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
+    appContext: Context?,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchShippingLabelsForOrder(
+        orderId: Long,
+        site: SiteModel
+    ): WooPayload<ShippingLabelApiResponse> {
+        val url = WOOCOMMERCE.connect.label.order(orderId).pathV1
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                emptyMap(),
+                ShippingLabelApiResponse::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.WCShippingLabelModelTable
+import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
+
+object WCShippingLabelSqlUtils {
+    fun getShippingClassesForOrder(
+        localSiteId: Int,
+        orderId: Long
+    ): List<WCShippingLabelModel> {
+        return WellSql.select(WCShippingLabelModel::class.java)
+                .where()
+                .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(WCShippingLabelModelTable.LOCAL_ORDER_ID, orderId)
+                .endWhere()
+                .asModel
+    }
+
+    fun insertOrUpdateShippingLabels(shippingLabels: List<WCShippingLabelModel>): Int {
+        var totalChanged = 0
+        shippingLabels.forEach { totalChanged += insertOrUpdateShippingLabel(it) }
+        return totalChanged
+    }
+
+    fun insertOrUpdateShippingLabel(shippingLabel: WCShippingLabelModel): Int {
+        val orderResult = WellSql.select(WCShippingLabelModel::class.java)
+                .where().beginGroup()
+                .equals(WCShippingLabelModelTable.ID, shippingLabel.id)
+                .or()
+                .beginGroup()
+                .equals(WCShippingLabelModelTable.REMOTE_SHIPPING_LABEL_ID, shippingLabel.remoteShippingLabelId)
+                .equals(WCShippingLabelModelTable.LOCAL_ORDER_ID, shippingLabel.localOrderId)
+                .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, shippingLabel.localSiteId)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel
+
+        return if (orderResult.isEmpty()) {
+            // Insert
+            WellSql.insert(shippingLabel).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            val oldId = orderResult[0].id
+            WellSql.update(WCShippingLabelModel::class.java).whereId(oldId)
+                    .put(shippingLabel, UpdateAllExceptId(WCShippingLabelModel::class.java)).execute()
+        }
+    }
+
+    fun deleteShippingLabelsForOrder(orderId: Long): Int =
+            WellSql.delete(WCShippingLabelModel::class.java)
+                    .where()
+                    .equals(WCShippingLabelModelTable.LOCAL_ORDER_ID, orderId)
+                    .endWhere().execute()
+
+    fun deleteShippingLabelsForSite(localSiteId: Int): Int {
+        return WellSql.delete(WCShippingLabelModel::class.java)
+                .where()
+                .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, localSiteId)
+                .or()
+                .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, 0) // Should never happen, but sanity cleanup
+                .endWhere().execute()
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -39,10 +39,8 @@ class WCShippingLabelStore @Inject constructor(
                 response.isError -> {
                     WooResult(response.error)
                 }
-                response.result?.labelsData != null -> {
-                    val shippingLabels = response.result.labelsData.map {
-                        mapper.map(response.result, it).apply { localSiteId = site.id }
-                    }
+                response.result != null -> {
+                    val shippingLabels = mapper.map(response.result, site)
 
                     // delete existing shipping labels for the order before adding incoming entries
                     WCShippingLabelSqlUtils.deleteShippingLabelsForOrder(orderId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelMapper
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
+import org.wordpress.android.fluxc.persistence.WCShippingLabelSqlUtils
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WCShippingLabelStore @Inject constructor(
+    private val restClient: ShippingLabelRestClient,
+    private val coroutineEngine: CoroutineEngine,
+    private val mapper: WCShippingLabelMapper
+) {
+    /**
+     * returns a list of shipping labels for an order from the database
+     */
+    fun getShippingLabelsForOrder(
+        site: SiteModel,
+        orderId: Long
+    ): List<WCShippingLabelModel> =
+            WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
+
+    suspend fun fetchShippingLabelsForOrder(
+        site: SiteModel,
+        orderId: Long
+    ): WooResult<List<WCShippingLabelModel>> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchShippingLabelsForOrder") {
+            val response = restClient.fetchShippingLabelsForOrder(orderId, site)
+            return@withDefaultContext when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+                response.result?.labelsData != null -> {
+                    val shippingLabels = response.result.labelsData.map {
+                        mapper.map(response.result, it).apply { localSiteId = site.id }
+                    }
+
+                    // delete existing shipping labels for the order before adding incoming entries
+                    WCShippingLabelSqlUtils.deleteShippingLabelsForOrder(orderId)
+                    WCShippingLabelSqlUtils.insertOrUpdateShippingLabels(shippingLabels)
+                    WooResult(shippingLabels)
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -28,3 +28,6 @@
 
 /taxes
 /taxes/classes/
+
+/connect/label/
+/connect/label/<order_id>/


### PR DESCRIPTION
Fixes #1556 by adding support to fetch shipping labels for an order. 

#### Changes
- Even though, shipping labels are part of the orders feature, the endpoints differ so I chose to create new classes/rest clients for the implementation. Also nice to use coroutines 😄
- Adds new endpoint `/wc/v1/connect/label/<orderId>`.  Since this is a new implementation, added all subsequent logic under the `shippinglabels` package.
- Added new `WCShippingLabelModel` model class and a migration script to create table.
- Added new classes, stores and mapper classes to fetch, store, update, delete shipping labels for a site.
- Added unit tests.
- Added a new page to the example app to fetch shipping labels for an order.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/81919508-922a6700-95f5-11ea-87ad-7e9b1e18ae5f.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/81919516-93f42a80-95f5-11ea-8d81-7c362f026af6.png"> 

#### Testing
- Since this PR adds a migration script, it would be nice to test updating the app.
- Run `WCShippingLabelStoreTest` and `WCShippingLabelSqlUtilsTest`.
- In the example app, click on `Woo` -> `Shipping Labels` -> `Select Site` -> `Fetch Shipping Labels`.
  - Enter an invalid order number and verify that an error message is displayed. 
  - Enter a valid order number without any shipping labels and verify that the list is empty, while the request is successful. 
  - Enter a valid order number with shipping labels and verify that the shipping labels are fetched successfully. 
   - Try deleting or refunding a shipping label for the order and verify it is updated in the app.
  - Try fetching shipping labels for multiple orders and verify the correct list is fetched and displayed.
