### PR TITLE
Fix wpcom endpoint url

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -183,6 +183,7 @@ class ReactNativeStore
                 val url = path?.let {
                     val newPath = it
                             .replace("wp/v2".toRegex(), "wp/v2/sites/$wpComSiteId")
+                            .replace("wpcom/v2/", "wpcom/v2/sites/$wpComSiteId/")
                     slashJoin(WPCOM_ENDPOINT, newPath)
                 }
                 Pair(url, params)


### PR DESCRIPTION
### Description
Change enables us to reach endpoint "/wpcom/v2/gutenberg/available-extensions" which is used in WPAndroid for checking which jetpack blocks are enabled for a given site. 

### Related PR's
WPAndroid PR:
Gutenberg-Mobile PR: 