### PR TITLE
Issue/1557 refund shipping labels

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -78,6 +78,36 @@ class WooShippingLabelFragment : Fragment() {
                 }
             }
         }
+
+        refund_shipping_label.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(activity, "Enter the order ID:") { orderEditText ->
+                    val orderId = orderEditText.text.toString().toLong()
+                    showSingleLineDialog(activity, "Enter the remote shipping Label Id:") { remoteIdEditText ->
+                        val remoteId = remoteIdEditText.text.toString().toLong()
+                        prependToLog("Submitting request to refund shipping label for order $orderId with id $remoteId")
+
+                        coroutineScope.launch {
+                            try {
+                                val response = withContext(Dispatchers.Default) {
+                                    wcShippingLabelStore.refundShippingLabelForOrder(site, orderId, remoteId)
+                                }
+                                response.error?.let {
+                                    prependToLog("${it.type}: ${it.message}")
+                                }
+                                response.model?.let {
+                                    prependToLog(
+                                            "Refund for $orderId with shipping label $remoteId is ${response.model}"
+                                    )
+                                }
+                            } catch (e: Exception) {
+                                prependToLog("Error: ${e.message}")
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -82,8 +82,18 @@ class WooShippingLabelFragment : Fragment() {
         refund_shipping_label.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the order ID:") { orderEditText ->
+                    if (orderEditText.text.isEmpty()) {
+                        prependToLog("OrderId is null so doing nothing")
+                        return@showSingleLineDialog
+                    }
+
                     val orderId = orderEditText.text.toString().toLong()
                     showSingleLineDialog(activity, "Enter the remote shipping Label Id:") { remoteIdEditText ->
+                        if (remoteIdEditText.text.isEmpty()) {
+                            prependToLog("Remote Id is null so doing nothing")
+                            return@showSingleLineDialog
+                        }
+
                         val remoteId = remoteIdEditText.text.toString().toLong()
                         prependToLog("Submitting request to refund shipping label for order $orderId with id $remoteId")
 

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -45,5 +45,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Fetch Shipping Labels"/>
+
+        <Button
+            android:id="@+id/refund_shipping_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Refund Shipping Label"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
@@ -56,10 +56,12 @@ class WCShippingLabelSqlUtilsTest {
         assertEquals(savedShippingLabels[0].localOrderId, shippingLabel.localOrderId)
         assertEquals(savedShippingLabels[0].remoteShippingLabelId, shippingLabel.remoteShippingLabelId)
         assertEquals(savedShippingLabels[0].serviceName, shippingLabel.serviceName)
+        assertNotNull(savedShippingLabels[0].refund)
 
         // Test updating the same shipping label
         shippingLabel.apply {
             serviceName = "Test service name"
+            refund = ""
         }
         rowsAffected = WCShippingLabelSqlUtils.insertOrUpdateShippingLabel(shippingLabel)
         assertEquals(1, rowsAffected)
@@ -69,6 +71,7 @@ class WCShippingLabelSqlUtilsTest {
         assertEquals(savedShippingLabels[0].localOrderId, shippingLabel.localOrderId)
         assertEquals(savedShippingLabels[0].remoteShippingLabelId, shippingLabel.remoteShippingLabelId)
         assertEquals(savedShippingLabels[0].serviceName, shippingLabel.serviceName)
+        assertEquals(savedShippingLabels[0].refund, shippingLabel.refund)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -18,7 +18,8 @@ object WCShippingLabelTestUtils {
         rate: Float = 7.65F,
         refundableAmount: Float = 7.65F,
         currency: String = "USD",
-        paperSize: String = "label"
+        paperSize: String = "label",
+        refund: String? = null
     ): WCShippingLabelModel {
         return WCShippingLabelModel().apply {
             localSiteId = siteId
@@ -32,6 +33,7 @@ object WCShippingLabelTestUtils {
             this.refundableAmount = refundableAmount
             this.currency = currency
             this.paperSize = paperSize
+            refund?.let { this.refund = it }
         }
     }
 
@@ -41,7 +43,12 @@ object WCShippingLabelTestUtils {
         remoteShippingLabelId: Long = 0
     ): List<WCShippingLabelModel> {
         with(ArrayList<WCShippingLabelModel>()) {
-            add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 1))
+            add(generateSampleShippingLabel(
+                    siteId = siteId,
+                    orderId = orderId,
+                    remoteId = remoteShippingLabelId + 1,
+                    refund = "{\"status\": \"pending\",\"request_date\": 1604847663000}"
+            ))
             add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 2))
             add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 3))
             add(generateSampleShippingLabel(siteId = siteId, orderId = orderId, remoteId = remoteShippingLabelId + 4))

--- a/example/src/test/resources/wc/shipping-labels.json
+++ b/example/src/test/resources/wc/shipping-labels.json
@@ -89,7 +89,11 @@
     "rate": 7.65,
     "currency": "USD",
     "expiry_date": 1604847662000,
-    "label_cached": 1589295666000
+    "label_cached": 1589295666000,
+    "refund":{
+      "status": "pending",
+      "request_date": 1604847663000
+    }
   }, {
     "label_id": 2,
     "tracking": "9405500205309038753691",

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1097,7 +1097,8 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "CURRENCY TEXT NOT NULL," +
                                     "PAPER_SIZE TEXT NOT NULL," +
                                     "FORM_DATA TEXT NOT NULL," +
-                                    "STORE_OPTIONS TEXT NOT NULL)"
+                                    "STORE_OPTIONS TEXT NOT NULL," +
+                                    "REFUND TEXT NULL)"
                     )
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -19,12 +19,12 @@ class WCShippingLabelMapper
                 refundableAmount = labelItem.refundableAmount?.toFloat() ?: 0F
                 currency = labelItem.currency ?: ""
                 productNames = labelItem.productNames.toString()
+                refund = labelItem.refund.toString()
 
                 localOrderId = response.orderId ?: 0L
                 paperSize = response.paperSize ?: ""
                 storeOptions = response.storeOptions.toString()
                 formData = response.formData.toString()
-                refund = response.refund.toString()
 
                 localSiteId = site.id
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -24,6 +24,7 @@ class WCShippingLabelMapper
                 paperSize = response.paperSize ?: ""
                 storeOptions = response.storeOptions.toString()
                 formData = response.formData.toString()
+                refund = response.refund.toString()
 
                 localSiteId = site.id
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -28,6 +28,8 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     @Column var formData = "" // map containing package and product details related to that shipping label
     @Column var storeOptions = "" // map containing store settings such as currency and dimensions
 
+    @Column var refund = "" // map containing refund information for a shipping label
+
     override fun getId() = id
 
     override fun setId(id: Int) {
@@ -78,6 +80,15 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
         return gson.fromJson(productNames, responseType) as? List<String> ?: emptyList()
     }
 
+    /**
+     * Returns data related to the refund of a shipping label.
+     * Will only be available in the API if a refund has been initiated
+     */
+    fun getRefund(): WCShippingLabelRefundModel? {
+        val responseType = object : TypeToken<WCShippingLabelRefundModel>() {}.type
+        return gson.fromJson(refund, responseType) as? WCShippingLabelRefundModel
+    }
+
     class StoreOptions {
         @SerializedName("currency_symbol") val currencySymbol: String? = null
         @SerializedName("dimension_unit") val dimensionUnit: String? = null
@@ -126,5 +137,10 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
         val url: String? = null
         val value: Int? = null
         @SerializedName("product_id") val productId: Long? = null
+    }
+
+    class WCShippingLabelRefundModel {
+        val status: String? = null
+        @SerializedName("request_date") val requestDate: Long? = null
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
@@ -12,6 +12,7 @@ class ShippingLabelApiResponse : Response {
     val formData: JsonElement? = null
     val storeOptions: JsonElement? = null
     val labelsData: List<LabelItem>? = null
+    val refund: JsonElement? = null
 
     class LabelItem {
         @SerializedName("label_id") val labelId: Long? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
@@ -12,7 +12,8 @@ class ShippingLabelApiResponse : Response {
     val formData: JsonElement? = null
     val storeOptions: JsonElement? = null
     val labelsData: List<LabelItem>? = null
-    val refund: JsonElement? = null
+
+    val success: Boolean? = null
 
     class LabelItem {
         @SerializedName("label_id") val labelId: Long? = null
@@ -25,5 +26,6 @@ class ShippingLabelApiResponse : Response {
         val status: String? = null
         val rate: BigDecimal? = null
         val currency: String? = null
+        val refund: JsonElement? = null
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -47,4 +47,28 @@ constructor(
             }
         }
     }
+
+    suspend fun refundShippingLabelForOrder(
+        site: SiteModel,
+        orderId: Long,
+        remoteShippingLabelId: Long
+    ): WooPayload<ShippingLabelApiResponse> {
+        val url = WOOCOMMERCE.connect.label.order(orderId).shippingLabelId(remoteShippingLabelId).refund.pathV1
+
+        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
+                this,
+                site,
+                url,
+                emptyMap(),
+                ShippingLabelApiResponse::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -51,4 +51,23 @@ class WCShippingLabelStore @Inject constructor(
             }
         }
     }
+
+    suspend fun refundShippingLabelForOrder(
+        site: SiteModel,
+        orderId: Long,
+        remoteShippingLabelId: Long
+    ): WooResult<Boolean> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "refundShippingLabelForOrder") {
+            val response = restClient.refundShippingLabelForOrder(site, orderId, remoteShippingLabelId)
+            return@withDefaultContext when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+                response.result != null -> {
+                    WooResult(response.result.success)
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
 }

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -29,6 +29,6 @@
 /taxes
 /taxes/classes/
 
-/connect/label/
 /connect/label/<order_id>/
-/connect/label/<order_id>/<label_id>/refund
+/connect/label/<order_id>/<shippingLabelId>/
+/connect/label/<order_id>/<shippingLabelId>/refund

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -31,3 +31,4 @@
 
 /connect/label/
 /connect/label/<order_id>/
+/connect/label/<order_id>/<label_id>/refund


### PR DESCRIPTION
Fixes #1557. After #1556, this PR adds support to refund a shipping label.

**Note that this PR is targeted against a feature branch since I will be working on adding more columns to the migration script for the `WCShippingLabelModel` and it didn't make sense to keep adding new scripts for the same table, when the feature hasn't been live yet.**

### Changes
- Adds new endpoint `/wc/v1/connect/label/<orderId>/<label_id>/refund`.
- Added new model `WCShippingLabelRefundModel` to `WCShippingLabelModel` model class and updated the migration script from #1556 to include `refund` column.
- Added new method to `WCShippingLabelStore` and `ShippingLabelRestClient` to refund shipping label for an order.
- Added unit tests.
- Added a new button to the example app to test refunding a shipping label.

### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/82300375-6253d880-99d4-11ea-8853-8da0d70bed47.gif" width="300"/>

### Note
Since this feature is not live yet, I decided to add a new column to the existing migration script. This might cause the app to crash if you have installed a version of FluxC that includes the `WCShippingLabelModel` table. So please uninstall the previous version of the app before installing this version.

### Testing
- Run `WCShippingLabelStoreTest` and `WCShippingLabelSqlUtilsTest`. 
- In the example app, click on `Woo` -> `Shipping Labels` -> `Select Site` -> `Refund Shipping Label`.
  - Enter a valid order number with shipping label already purchased.
  - Enter the label id of the shipping label purchased.
  - Verify that the refund is successful.
  - Now click on `Fetch Shipping Labels`.
  - Use Stethos to verify that the `WCShippingLabelModel` consists of a `refund` column that is not empty.  

