### PR TITLE
Issue/1558 print shipping label

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -19,6 +19,20 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <!--
+            Provider for exposing file URIs on Android 7+
+            (required for storing temp pdf file in Woo)
+        -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -71,6 +71,11 @@ class WooShippingLabelFragment : Fragment() {
         fetch_shipping_labels.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the order ID:") { orderEditText ->
+                    if (orderEditText.text.isEmpty()) {
+                        prependToLog("OrderId is null so doing nothing")
+                        return@showSingleLineDialog
+                    }
+
                     val orderId = orderEditText.text.toString().toLong()
                     prependToLog("Submitting request to fetch shipping labels for order $orderId")
                     coroutineScope.launch {
@@ -82,7 +87,8 @@ class WooShippingLabelFragment : Fragment() {
                                 prependToLog("${it.type}: ${it.message}")
                             }
                             response.model?.let {
-                                prependToLog("Order $orderId has ${it.size} shipping labels")
+                                val labelIds = it.map { it.remoteShippingLabelId }.joinToString(",")
+                                prependToLog("Order $orderId has ${it.size} shipping labels with ids $labelIds")
                             }
                         } catch (e: Exception) {
                             prependToLog("Error: ${e.message}")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -135,31 +135,34 @@ class WooShippingLabelFragment : Fragment() {
         print_shipping_label.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the remote shipping Label Id:") { remoteIdEditText ->
-                    if (remoteIdEditText.text.toString().isNotEmpty()) {
-                        val remoteId = remoteIdEditText.text.toString().toLong()
-                        prependToLog("Submitting request to print shipping label for id $remoteId")
+                    if (remoteIdEditText.text.isEmpty()) {
+                        prependToLog("Remote Id is null so doing nothing")
+                        return@showSingleLineDialog
+                    }
 
-                        coroutineScope.launch {
-                            try {
-                                val response = withContext(Dispatchers.Default) {
-                                    // the paper size can be label, legal, letter
-                                    // For the example app, the default is set as label
-                                    wcShippingLabelStore.printShippingLabel(site, "label", remoteId)
-                                }
-                                response.error?.let {
-                                    prependToLog("${it.type}: ${it.message}")
-                                }
-                                response.model?.let { base64Content ->
-                                    // Since this function is used only by Woo testers and the Woo app
-                                    // only supports API > 21, it's fine to add a check here to support devices
-                                    // above API 19
-                                    if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-                                        writePDFToFile(base64Content)?.let { openWebView(it) }
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                prependToLog("Error: ${e.message}")
+                    val remoteId = remoteIdEditText.text.toString().toLong()
+                    prependToLog("Submitting request to print shipping label for id $remoteId")
+
+                    coroutineScope.launch {
+                        try {
+                            val response = withContext(Dispatchers.Default) {
+                                // the paper size can be label, legal, letter
+                                // For the example app, the default is set as label
+                                wcShippingLabelStore.printShippingLabel(site, "label", remoteId)
                             }
+                            response.error?.let {
+                                prependToLog("${it.type}: ${it.message}")
+                            }
+                            response.model?.let { base64Content ->
+                                // Since this function is used only by Woo testers and the Woo app
+                                // only supports API > 21, it's fine to add a check here to support devices
+                                // above API 19
+                                if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
+                                    writePDFToFile(base64Content)?.let { openWebView(it) }
+                                }
+                            }
+                        } catch (e: Exception) {
+                            prependToLog("Error: ${e.message}")
                         }
                     }
                 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -1,11 +1,18 @@
 package org.wordpress.android.fluxc.example.ui.shippinglabels
 
 import android.content.Context
+import android.content.Intent
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
+import android.os.Environment
+import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import androidx.annotation.RequiresApi
+import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_shippinglabels.*
@@ -21,6 +28,12 @@ import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 class WooShippingLabelFragment : Fragment() {
@@ -108,6 +121,40 @@ class WooShippingLabelFragment : Fragment() {
                 }
             }
         }
+
+        print_shipping_label.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(activity, "Enter the remote shipping Label Id:") { remoteIdEditText ->
+                    if (remoteIdEditText.text.toString().isNotEmpty()) {
+                        val remoteId = remoteIdEditText.text.toString().toLong()
+                        prependToLog("Submitting request to print shipping label for id $remoteId")
+
+                        coroutineScope.launch {
+                            try {
+                                val response = withContext(Dispatchers.Default) {
+                                    // the paper size can be label, legal, letter
+                                    // For the example app, the default is set as label
+                                    wcShippingLabelStore.printShippingLabel(site, "label", remoteId)
+                                }
+                                response.error?.let {
+                                    prependToLog("${it.type}: ${it.message}")
+                                }
+                                response.model?.let { base64Content ->
+                                    // Since this function is used only by Woo testers and the Woo app
+                                    // only supports API > 21, it's fine to add a check here to support devices
+                                    // above API 19
+                                    if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
+                                        writePDFToFile(base64Content)?.let { openWebView(it) }
+                                    }
+                                }
+                            } catch (e: Exception) {
+                                prependToLog("Error: ${e.message}")
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
@@ -124,5 +171,63 @@ class WooShippingLabelFragment : Fragment() {
                 child.isEnabled = enabled
             }
         }
+    }
+
+    /**
+     * Creates a temporary file for storing captured photos
+     */
+    @RequiresApi(VERSION_CODES.KITKAT)
+    private fun createTempPdfFile(context: Context): File? {
+        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        val storageDir = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)
+        return try {
+            File.createTempFile(
+                    "PDF_${timeStamp}_",
+                    ".pdf",
+                    storageDir
+            )
+        } catch (ex: IOException) {
+            ex.printStackTrace()
+            prependToLog("Error when creating temp file: ${ex.message}")
+            null
+        }
+    }
+
+    /**
+     * Since this function is used only by Woo testers and the Woo app
+     * only supports API > 21, it's fine to leave this method to support only
+     * API 19 and above.
+     */
+    @RequiresApi(VERSION_CODES.KITKAT)
+    private fun writePDFToFile(base64Content: String): File? {
+        return try {
+            createTempPdfFile(requireContext())?.let { file ->
+                val out = FileOutputStream(file)
+                val pdfAsBytes = Base64.decode(base64Content, 0)
+                out.write(pdfAsBytes)
+                out.flush()
+                out.close()
+                file
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            prependToLog("Error when writing pdf to file: ${e.message}")
+            null
+        }
+    }
+
+    private fun openWebView(file: File) {
+        val authority = requireContext().applicationContext.packageName + ".provider"
+        val fileUri = FileProvider.getUriForFile(
+                requireContext(),
+                authority,
+                file
+        )
+
+        val sendIntent = Intent(Intent.ACTION_VIEW)
+        sendIntent.setDataAndType(fileUri, "application/pdf")
+        sendIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        sendIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        startActivity(sendIntent)
     }
 }

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -52,5 +52,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Refund Shipping Label"/>
+
+        <Button
+            android:id="@+id/print_shipping_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Print Shipping Label"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/xml/provider_paths.xml
+++ b/example/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path
+        name="external_files"
+        path="."/>
+</paths>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -5,6 +5,7 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.PrintShippingLabelApiResponse
 
 object WCShippingLabelTestUtils {
     private fun generateSampleShippingLabel(
@@ -61,5 +62,11 @@ object WCShippingLabelTestUtils {
         val json = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/shipping-labels.json")
         val responseType = object : TypeToken<ShippingLabelApiResponse>() {}.type
         return Gson().fromJson(json, responseType) as? ShippingLabelApiResponse
+    }
+
+    fun generateSamplePrintShippingLabelApiResponse(): PrintShippingLabelApiResponse? {
+        val json = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/print-shipping-labels.json")
+        val responseType = object : TypeToken<PrintShippingLabelApiResponse>() {}.type
+        return Gson().fromJson(json, responseType) as? PrintShippingLabelApiResponse
     }
 }

--- a/example/src/test/resources/wc/print-shipping-labels.json
+++ b/example/src/test/resources/wc/print-shipping-labels.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "mimeType": "application\/pdf",
+    "b64Content": "12345=",
+    "success": true
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -71,4 +71,40 @@ constructor(
             }
         }
     }
+
+    suspend fun printShippingLabel(
+        site: SiteModel,
+        paperSize: String,
+        remoteShippingLabelId: Long
+    ): WooPayload<PrintShippingLabelApiResponse> {
+        val url = WOOCOMMERCE.connect.label.print.pathV1
+        val params = mapOf(
+                "paper_size" to paperSize,
+                "label_id_csv" to remoteShippingLabelId.toString(),
+                "caption_csv" to "",
+                "json" to "true"
+        )
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                params,
+                PrintShippingLabelApiResponse::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
+    data class PrintShippingLabelApiResponse(
+        val mimeType: String,
+        val b64Content: String,
+        val success: Boolean
+    )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -70,4 +70,23 @@ class WCShippingLabelStore @Inject constructor(
             }
         }
     }
+
+    suspend fun printShippingLabel(
+        site: SiteModel,
+        paperSize: String,
+        remoteShippingLabelId: Long
+    ): WooResult<String> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "printShippingLabel") {
+            val response = restClient.printShippingLabel(site, paperSize, remoteShippingLabelId)
+            return@withDefaultContext when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+                response.result?.success == true -> {
+                    WooResult(response.result.b64Content)
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
 }

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -29,6 +29,7 @@
 /taxes
 /taxes/classes/
 
+/connect/label/print
 /connect/label/<order_id>/
 /connect/label/<order_id>/<shippingLabelId>/
 /connect/label/<order_id>/<shippingLabelId>/refund


### PR DESCRIPTION
Fixes #1558 by adding endpoint to preview a shipping label PDF.

~**Note that this PR is in draft till this [refund PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1582) can be merged.**~

#### Changes
- Adds new endpoint `/wc/v1/connect/label/print`.
- Added new data model `PrintShippingLabelModel` to parse the preview endpoint api response.
- Added new methods to `WCShippingLabelStore` and `ShippingLabelRestClient` to preview a shipping label.
- Added unit tests.
- Added new button in example app to test previewing a shipping label. The API response returns a `b64Content` string. This is stored in a temp pdf file in the device and opened as a preview in the example app.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/82407201-33963a80-9a86-11ea-8739-8d355ee1af93.gif" width="300" />

#### To test
- Run `WCShippingLabelSqlUtilsTest`.
- In the example app, click on `Woo` -> `Shipping Labels` -> `Select Site` -> `Print Shipping Label`.
  - Enter the label id of the shipping label purchased.
  - Verify that the request is successful. Notice that you are redirected to the preview pdf of the shipping label.

