### PR TITLE
issue/wellsql_1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ subprojects {
 
 ext {
     daggerVersion = '2.22.1'
-    wellSqlVersion = '1.5.0'
+    wellSqlVersion = '1.6.0'
     supportLibraryVersion = '27.1.1'
     arch_paging_version = '1.0.1'
     arch_lifecycle_version = '1.1.1'

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -8,6 +8,7 @@ import androidx.annotation.StringDef
 import com.yarolegovich.wellsql.DefaultWellConfig
 import com.yarolegovich.wellsql.WellSql
 import com.yarolegovich.wellsql.WellTableManager
+import org.wordpress.android.fluxc.BuildConfig
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import kotlin.annotation.AnnotationRetention.SOURCE
@@ -1093,6 +1094,14 @@ open class WellSqlConfig : DefaultWellConfig {
             db.execSQL("PRAGMA foreign_keys=ON")
         }
     }
+
+    /**
+     * For debug builds we want a cursor window size of 5MB so we can test for any problems caused by
+     * a larger size. Once we're confident this works we'll return 5MB in release builds to hopefully
+     * reduce the number of SQLiteBlobTooBigExceptions. Note that this is only called on API 28 and
+     * above since earlier versions don't allow adjusting the cursor window size.
+     */
+    override fun getCursorWindowSize() = if (BuildConfig.DEBUG) (1024L * 1024L * 5L) else 0L
 
     /**
      * Drop and create all tables


### PR DESCRIPTION
Updates to WellSql 1.6.0, which has [this change](https://github.com/wordpress-mobile/wellsql/pull/18) that enables enlarging the cursor window size, which hopefully will cut back on `SQLiteBlobTooBigExceptions`.

Once this is merged, we'll need to update both WCAndroid and WPAndroid to this hash and then implement `WellSqlConfig.getCursorWindowSize()` in both apps.