### PR TITLE
Woo/fetch product categories

### DIFF
--- a/example/src/androidTest/resources/wc-fetch-all-product-categories-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-all-product-categories-response-success.json
@@ -1,0 +1,194 @@
+{
+  "data": [
+    {
+      "id": 15,
+      "name": "Albums",
+      "slug": "albums",
+      "parent": 11,
+      "description": "",
+      "display": "default",
+      "image": [],
+      "menu_order": 0,
+      "count": 4,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/15"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories"
+          }
+        ],
+        "up": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/11"
+          }
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "name": "Clothing",
+      "slug": "clothing",
+      "parent": 0,
+      "description": "",
+      "display": "default",
+      "image": {
+        "id": 730,
+        "date_created": "2017-03-23T00:01:07",
+        "date_created_gmt": "2017-03-23T03:01:07",
+        "date_modified": "2017-03-23T00:01:07",
+        "date_modified_gmt": "2017-03-23T03:01:07",
+        "src": "https://example.com/wp-content/uploads/2017/03/T_2_front.jpg",
+        "name": "",
+        "alt": ""
+      },
+      "menu_order": 0,
+      "count": 36,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example/wp-json/wc/v3/products/categories/9"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example/wp-json/wc/v3/products/categories"
+          }
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "name": "Hoodies",
+      "slug": "hoodies",
+      "parent": 9,
+      "description": "",
+      "display": "default",
+      "image": [],
+      "menu_order": 0,
+      "count": 6,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/10"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories"
+          }
+        ],
+        "up": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/9"
+          }
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "name": "Music",
+      "slug": "music",
+      "parent": 0,
+      "description": "",
+      "display": "default",
+      "image": [],
+      "menu_order": 0,
+      "count": 7,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/11"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories"
+          }
+        ]
+      }
+    },
+    {
+      "id": 12,
+      "name": "Posters",
+      "slug": "posters",
+      "parent": 0,
+      "description": "",
+      "display": "default",
+      "image": [],
+      "menu_order": 0,
+      "count": 5,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/12"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories"
+          }
+        ]
+      }
+    },
+    {
+      "id": 13,
+      "name": "Singles",
+      "slug": "singles",
+      "parent": 11,
+      "description": "",
+      "display": "default",
+      "image": [],
+      "menu_order": 0,
+      "count": 3,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/13"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories"
+          }
+        ],
+        "up": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/11"
+          }
+        ]
+      }
+    },
+    {
+      "id": 14,
+      "name": "T-shirts",
+      "slug": "t-shirts",
+      "parent": 9,
+      "description": "",
+      "display": "default",
+      "image": [],
+      "menu_order": 0,
+      "count": 6,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/14"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories"
+          }
+        ],
+        "up": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/9"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -131,6 +131,20 @@
             android:text="Load More Shipping classes" />
 
         <Button
+            android:id="@+id/fetch_product_categories"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Product Categories"/>
+
+        <Button
+            android:id="@+id/load_more_product_categories"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:text="Load More Product Categories" />
+
+        <Button
             android:id="@+id/update_product_images"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -556,6 +556,24 @@ class ProductSqlUtilsTest {
         assertEquals(0, savedCategories.size)
     }
 
+    @Test
+    fun testDeleteProductCategoriesForSite() {
+        val categories = ProductTestUtils.getProductCategories(site.id)
+
+        var rowsAffected = ProductSqlUtils.insertOrUpdateProductCategories(categories)
+        assertEquals(categories.size, rowsAffected)
+
+        // Verify categories inserted
+        var savedCategories = ProductSqlUtils.getProductCategoriesForSite(site)
+        assertEquals(categories.size, savedCategories.size)
+
+        // Delete categories for site and verify
+        rowsAffected = ProductSqlUtils.deleteAllProductCategoriesForSite(site)
+        assertEquals(categories.size, rowsAffected)
+        savedCategories = ProductSqlUtils.getProductCategoriesForSite(site)
+        assertEquals(0, savedCategories.size)
+    }
+
     private fun getProductReviews(localSiteId: Int): List<WCProductReviewModel> {
         val reviewJson = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/product-reviews.json")
         return ProductTestUtils.getProductReviewsFromJsonString(reviewJson, localSiteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -2,10 +2,13 @@ package org.wordpress.android.fluxc.wc.product
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import org.wordpress.android.fluxc.UnitTestUtils
+import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductCategoryApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductReviewApiResponse
 
 object ProductTestUtils {
@@ -62,16 +65,31 @@ object ProductTestUtils {
         return converted.map {
             WCProductReviewModel().apply {
                 localSiteId = siteId
-                remoteProductReviewId = it.id ?: 0L
-                remoteProductId = it.product_id ?: 0L
+                remoteProductReviewId = it.id
+                remoteProductId = it.product_id
                 dateCreated = it.date_created_gmt?.let { "${it}Z" } ?: ""
                 status = it.status ?: ""
                 reviewerName = it.reviewer ?: ""
                 reviewerEmail = it.reviewer_email ?: ""
                 review = it.review ?: ""
-                rating = it.rating ?: 0
-                verified = it.verified ?: false
+                rating = it.rating
+                verified = it.verified
                 reviewerAvatarsJson = it.reviewer_avatar_urls.toString()
+            }
+        }
+    }
+
+    fun getProductCategories(siteId: Int): List<WCProductCategoryModel> {
+        val categoryJson = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/product-categories.json")
+        val responseType = object : TypeToken<List<ProductCategoryApiResponse>>() {}.type
+        val converted = Gson().fromJson(categoryJson, responseType) as? List<ProductCategoryApiResponse> ?: emptyList()
+        return converted.map {
+            WCProductCategoryModel().apply {
+                localSiteId = siteId
+                remoteCategoryId = it.id
+                name = it.name ?: ""
+                slug = it.slug ?: ""
+                parent = it.parent ?: 0L
             }
         }
     }

--- a/example/src/test/resources/wc/product-categories.json
+++ b/example/src/test/resources/wc/product-categories.json
@@ -1,0 +1,192 @@
+[
+  {
+    "id": 15,
+    "name": "Albums",
+    "slug": "albums",
+    "parent": 11,
+    "description": "",
+    "display": "default",
+    "image": [],
+    "menu_order": 0,
+    "count": 4,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/15"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories"
+        }
+      ],
+      "up": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/11"
+        }
+      ]
+    }
+  },
+  {
+    "id": 9,
+    "name": "Clothing",
+    "slug": "clothing",
+    "parent": 0,
+    "description": "",
+    "display": "default",
+    "image": {
+      "id": 730,
+      "date_created": "2017-03-23T00:01:07",
+      "date_created_gmt": "2017-03-23T03:01:07",
+      "date_modified": "2017-03-23T00:01:07",
+      "date_modified_gmt": "2017-03-23T03:01:07",
+      "src": "https://example.com/wp-content/uploads/2017/03/T_2_front.jpg",
+      "name": "",
+      "alt": ""
+    },
+    "menu_order": 0,
+    "count": 36,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example/wp-json/wc/v3/products/categories/9"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example/wp-json/wc/v3/products/categories"
+        }
+      ]
+    }
+  },
+  {
+    "id": 10,
+    "name": "Hoodies",
+    "slug": "hoodies",
+    "parent": 9,
+    "description": "",
+    "display": "default",
+    "image": [],
+    "menu_order": 0,
+    "count": 6,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/10"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories"
+        }
+      ],
+      "up": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/9"
+        }
+      ]
+    }
+  },
+  {
+    "id": 11,
+    "name": "Music",
+    "slug": "music",
+    "parent": 0,
+    "description": "",
+    "display": "default",
+    "image": [],
+    "menu_order": 0,
+    "count": 7,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/11"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories"
+        }
+      ]
+    }
+  },
+  {
+    "id": 12,
+    "name": "Posters",
+    "slug": "posters",
+    "parent": 0,
+    "description": "",
+    "display": "default",
+    "image": [],
+    "menu_order": 0,
+    "count": 5,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/12"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories"
+        }
+      ]
+    }
+  },
+  {
+    "id": 13,
+    "name": "Singles",
+    "slug": "singles",
+    "parent": 11,
+    "description": "",
+    "display": "default",
+    "image": [],
+    "menu_order": 0,
+    "count": 3,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/13"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories"
+        }
+      ],
+      "up": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/11"
+        }
+      ]
+    }
+  },
+  {
+    "id": 14,
+    "name": "T-shirts",
+    "slug": "t-shirts",
+    "parent": 9,
+    "description": "",
+    "display": "default",
+    "image": [],
+    "menu_order": 0,
+    "count": 6,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/14"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories"
+        }
+      ],
+      "up": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/categories/9"
+        }
+      ]
+    }
+  }
+]

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1107,7 +1107,7 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "LOCAL_SITE_ID INTEGER," +
                                     "REMOTE_CATEGORY_ID INTEGER," +
                                     "NAME TEXT NOT NULL," +
-                                    "SLUG TEXT," +
+                                    "SLUG TEXT NOT NULL," +
                                     "PARENT INTEGER," +
                                     "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
                                     "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 105
+        return 106
     }
 
     override fun getDbName(): String {
@@ -1099,6 +1099,20 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "FORM_DATA TEXT NOT NULL," +
                                     "STORE_OPTIONS TEXT NOT NULL," +
                                     "REFUND TEXT NULL)"
+                    )
+                }
+                105 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL(
+                            "CREATE TABLE WCProductCategoryModel (" +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "REMOTE_CATEGORY_ID INTEGER," +
+                                    "NAME TEXT NOT NULL," +
+                                    "SLUG TEXT," +
+                                    "PARENT INTEGER," +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
+                                    "UNIQUE (REMOTE_CATEGORY_ID, LOCAL_SITE_ID) " +
+                                    "ON CONFLICT REPLACE)"
                     )
                 }
             }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload;
@@ -13,6 +14,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload;
@@ -62,6 +64,8 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_PASSWORD,
     @Action(payloadType = UpdateProductPasswordPayload.class)
     UPDATE_PRODUCT_PASSWORD,
+    @Action(payloadType = FetchProductCategoriesPayload.class)
+    FETCH_PRODUCT_CATEGORIES,
 
 
     // Remote responses
@@ -93,4 +97,6 @@ public enum WCProductAction implements IAction {
     FETCHED_PRODUCT_PASSWORD,
     @Action(payloadType = RemoteUpdatedProductPasswordPayload.class)
     UPDATED_PRODUCT_PASSWORD,
+    @Action(payloadType = RemoteProductCategoriesPayload.class)
+    FETCHED_PRODUCT_CATEGORIES
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductCategoryModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductCategoryModel.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+data class WCProductCategoryModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var remoteCategoryId = 0L // The unique identifier for this category on the server
+    @Column var name = ""
+    @Column var slug = ""
+    @Column var parent = 0L
+
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductCategoryModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductCategoryModel.kt
@@ -3,10 +3,15 @@ package org.wordpress.android.fluxc.model
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+@RawConstraints(
+        "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+        "UNIQUE (REMOTE_CATEGORY_ID, LOCAL_SITE_ID) ON CONFLICT REPLACE"
+)
 data class WCProductCategoryModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var localSiteId = 0
     @Column var remoteCategoryId = 0L // The unique identifier for this category on the server

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductCategoryApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductCategoryApiResponse.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import org.wordpress.android.fluxc.network.Response
+
+@Suppress("PropertyName")
+class ProductCategoryApiResponse : Response {
+    val id: Long = 0L
+    var localSiteId = 0
+    var name: String? = null
+    var slug: String? = null
+    var parent: Long? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
@@ -26,11 +27,15 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
 import org.wordpress.android.fluxc.network.utils.getString
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
+import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_PAGE_SIZE
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload
+import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting
+import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting.NAME_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductError
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
@@ -39,6 +44,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload
@@ -490,6 +496,61 @@ class ProductRestClient(
     }
 
     /**
+     * Makes a GET call to `/wc/v3/products/categories` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
+     * retrieving a list of product categories for a given WooCommerce [SiteModel].
+     *
+     * The number of categories to fetch is defined in [WCProductStore.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE], and retrieving older
+     * categories is done by passing an [offset].
+     *
+     * Dispatches a [WCProductAction.FETCHED_PRODUCT_CATEGORIES]
+     *
+     * @param [site] The site to fetch product categories for
+     * @param [offset] The offset to use for the fetch
+     * @param [productCategorySorting] Optional. The sorting type of the categories
+     */
+    fun fetchProductCategories(
+        site: SiteModel,
+        pageSize: Int = DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE,
+        offset: Int = 0,
+        productCategorySorting: ProductCategorySorting? = DEFAULT_CATEGORY_SORTING
+    ) {
+        val sortOrder = when (productCategorySorting) {
+            NAME_DESC -> "desc"
+            else -> "asc"
+        }
+
+        val url = WOOCOMMERCE.products.categories.pathV3
+        val responseType = object : TypeToken<List<ProductCategoryApiResponse>>() {}.type
+        val params = mutableMapOf(
+                "per_page" to pageSize.toString(),
+                "offset" to offset.toString(),
+                "order" to sortOrder,
+                "orderby" to "name"
+        )
+        val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
+                { response: List<ProductCategoryApiResponse>? ->
+                    response?.let {
+                        val categories = it.map { category ->
+                            productCategoryResponseToProductCategoryModel(category).apply { localSiteId = site.id }
+                        }
+                        val canLoadMore = categories.size == pageSize
+                        val loadedMore = offset > 0
+                        val payload = RemoteProductCategoriesPayload(
+                                site, categories, offset, loadedMore, canLoadMore
+                        )
+                        dispatcher.dispatch(WCProductActionBuilder.newFetchedProductCategoriesAction(payload))
+                    }
+                },
+                WPComErrorListener { networkError ->
+                    val productCategoryError = networkErrorToProductError(networkError)
+                    val payload = RemoteProductCategoriesPayload(productCategoryError, site)
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchedProductCategoriesAction(payload))
+                },
+                { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
+    /**
      * Makes a GET call to `/wc/v3/products/reviews` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * retrieving a list of product reviews for a given WooCommerce [SiteModel].
      *
@@ -891,6 +952,17 @@ class ProductRestClient(
             rating = response.rating
             verified = response.verified
             reviewerAvatarsJson = response.reviewer_avatar_urls?.toString() ?: ""
+        }
+    }
+
+    private fun productCategoryResponseToProductCategoryModel(
+        response: ProductCategoryApiResponse
+    ): WCProductCategoryModel {
+        return WCProductCategoryModel().apply {
+            remoteCategoryId = response.id
+            name = response.name ?: ""
+            slug = response.slug ?: ""
+            parent = response.parent ?: 0L
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.persistence
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import com.wellsql.generated.WCProductCategoryModelTable
 import com.wellsql.generated.WCProductModelTable
 import com.wellsql.generated.WCProductReviewModelTable
 import com.wellsql.generated.WCProductShippingClassModelTable
@@ -9,12 +10,17 @@ import com.wellsql.generated.WCProductVariationModelTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_SORTING
+import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting
+import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting.NAME_ASC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting.NAME_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
@@ -420,4 +426,97 @@ object ProductSqlUtils {
                     .put(shippingClass, UpdateAllExceptId(WCProductShippingClassModel::class.java)).execute()
         }
     }
+
+    private fun sortCategoriesByName(
+        categories: List<WCProductCategoryModel>,
+        descending: Boolean
+    ): List<WCProductCategoryModel> {
+        return if (descending) {
+            categories.sortedByDescending { it.name.toLowerCase(Locale.getDefault()) }
+        } else {
+            categories.sortedBy { it.name.toLowerCase(Locale.getDefault()) }
+        }
+    }
+
+    fun getProductCategoriesForSite(
+        site: SiteModel,
+        sortType: ProductCategorySorting = DEFAULT_CATEGORY_SORTING
+    ): List<WCProductCategoryModel> {
+        val sortOrder = when (sortType) {
+            NAME_ASC -> SelectQuery.ORDER_ASCENDING
+            NAME_DESC -> SelectQuery.ORDER_DESCENDING
+        }
+        val sortField = when (sortType) {
+            NAME_ASC, NAME_DESC -> WCProductCategoryModelTable.NAME
+        }
+        val categories = WellSql.select(WCProductCategoryModel::class.java)
+                .where()
+                .equals(WCProductModelTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .orderBy(sortField, sortOrder)
+                .asModel
+
+        return if (sortType == NAME_ASC || sortType == NAME_DESC) {
+            sortCategoriesByName(categories, descending = sortType == NAME_DESC)
+        } else {
+            categories
+        }
+    }
+
+    fun getProductCategoryByRemoteId(
+        localSiteId: Int,
+        categoryId: Long
+    ): WCProductCategoryModel? {
+        return WellSql.select(WCProductCategoryModel::class.java)
+                .where()
+                .beginGroup()
+                .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(WCProductCategoryModelTable.REMOTE_CATEGORY_ID, categoryId)
+                .endGroup()
+                .endWhere()
+                .asModel.firstOrNull()
+    }
+
+    fun insertOrUpdateProductCategories(productCategories: List<WCProductCategoryModel>): Int {
+        var rowsAffected = 0
+        productCategories.forEach {
+            rowsAffected += insertOrUpdateProductCategory(it)
+        }
+        return rowsAffected
+    }
+
+    fun insertOrUpdateProductCategory(productCategory: WCProductCategoryModel): Int {
+        val result = WellSql.select(WCProductCategoryModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductCategoryModelTable.ID, productCategory.id)
+                .or()
+                .beginGroup()
+                .equals(WCProductCategoryModelTable.REMOTE_CATEGORY_ID, productCategory.remoteCategoryId)
+                .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, productCategory.localSiteId)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+
+        return if (result == null) {
+            // Insert
+            WellSql.insert(productCategory).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            val oldId = result.id
+            WellSql.update(WCProductCategoryModel::class.java).whereId(oldId)
+                    .put(productCategory, UpdateAllExceptId(WCProductCategoryModel::class.java)).execute()
+        }
+    }
+
+    fun deleteAllProductCategoriesForSite(site: SiteModel): Int {
+        return WellSql.delete(WCProductCategoryModel::class.java)
+                .where()
+                .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, site.id)
+                .or()
+                .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, 0)  // Should never happen, but sanity cleanup
+                .endWhere().execute()
+    }
+
+    fun deleteAllProductCategories() = WellSql.delete(WCProductCategoryModel::class.java).execute()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -514,7 +514,7 @@ object ProductSqlUtils {
                 .where()
                 .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, site.id)
                 .or()
-                .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, 0)  // Should never happen, but sanity cleanup
+                .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, 0) // Should never happen, but sanity cleanup
                 .endWhere().execute()
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
@@ -30,6 +31,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     companion object {
         const val NUM_REVIEWS_PER_FETCH = 25
         const val DEFAULT_PRODUCT_PAGE_SIZE = 25
+        const val DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE = 25
         const val DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE = 25
         const val DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE = 25
         val DEFAULT_PRODUCT_SORTING = TITLE_ASC
@@ -128,6 +130,13 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class UpdateProductPayload(
         var site: SiteModel,
         val product: WCProductModel
+    ) : Payload<BaseNetworkError>()
+
+    class FetchProductCategoriesPayload(
+        var site: SiteModel,
+        var pageSize: Int = DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE,
+        var offset: Int = 1,
+        var productCategorySorting: ProductCategorySorting = DEFAULT_CATEGORY_SORTING
     ) : Payload<BaseNetworkError>()
 
     enum class ProductErrorType {
@@ -337,6 +346,20 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         constructor(error: ProductError, site: SiteModel) : this(site) { this.error = error }
     }
 
+    class RemoteProductCategoriesPayload(
+        val site: SiteModel,
+        val categories: List<WCProductCategoryModel> = emptyList(),
+        var loadedMore: Boolean = false,
+        var canLoadMore: Boolean = false
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel
+        ) : this(site) {
+            this.error = error
+        }
+    }
+
     // OnChanged events
     class OnProductChanged(
         var rowsAffected: Int,
@@ -390,6 +413,13 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class OnProductUpdated(
         var rowsAffected: Int,
         var remoteProductId: Long
+    ) : OnChanged<ProductError>() {
+        var causeOfChange: WCProductAction? = null
+    }
+
+    class OnProductCategoryChanged(
+        var rowsAffected: Int,
+        var canLoadMore: Boolean = false
     ) : OnChanged<ProductError>() {
         var causeOfChange: WCProductAction? = null
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
+import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting.NAME_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.util.AppLog
@@ -32,6 +33,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         const val DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE = 25
         const val DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE = 25
         val DEFAULT_PRODUCT_SORTING = TITLE_ASC
+        val DEFAULT_CATEGORY_SORTING = NAME_ASC
     }
 
     /**
@@ -39,7 +41,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
      */
     enum class ProductFilterOption {
         STOCK_STATUS, STATUS, TYPE;
-        override fun toString() = name.toLowerCase()
+        override fun toString() = name.toLowerCase(Locale.US)
     }
 
     class FetchProductSkuAvailabilityPayload(
@@ -148,6 +150,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         TITLE_DESC,
         DATE_ASC,
         DATE_DESC
+    }
+
+    enum class ProductCategorySorting {
+        NAME_ASC,
+        NAME_DESC
     }
 
     class RemoteProductSkuAvailabilityPayload(

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -14,6 +14,9 @@
 /products/reviews/
 /products/reviews/<id>/
 
+/products/categories/
+/products/categories/<id>/
+
 /reports/orders/totals/
 /reports/revenue/stats/
 


### PR DESCRIPTION
Fixes #1587 by adding support to fetch product categories for a given site.

#### Changes
- Adds a new endpoint `wc/v3/products/categories/` to fetch product categories for a site.
- Added new `WCProductCategoryModel` model class and a migration script to create table. 
- Added new action and action classes to `WCProductStore` and `ProductRestClient` to fetch product categories for a site.
- Added unit tests.
- Added a new button to the example app to fetch product categories.

#### Notes
- ~**This PR is in draft till this [Shipping Labels PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1585) can be reviewed and merged.**~
- This work has largely pulled changes from this [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1569) but rather than submitting it as a single PR, I chose to split the PR into smaller chunks and clean up the examples and unit tests in order for better review.
- The option to update a product category and add a product category will be implemented in subsequent PRs.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/82629753-42a7f480-9c0e-11ea-9256-206d78ed48f4.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82629637-f8bf0e80-9c0d-11ea-9168-9db188b979e5.gif" width="300"/>

#### To test
- Since this PR adds a migration script, it would be nice to test updating the app.
- Run `MockedStack_WCProductsTest` and `ReleaseStack_WCProductTest` and `ProductSqlUtilsTest`.
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Fetch product categories`.
  - Verify that the categories are fetched correctly.
  - Click on `Lore more categories` and verify that the categories are fetched correctly.
  - If there is no more categories data found in the API response, the `Load more categories` button should NOT be displayed.