### PR TITLE
Woo/update product categories

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -81,6 +81,10 @@ android.buildTypes.all { buildType ->
     }
 }
 
+androidExtensions {
+    experimental = true
+}
+
 dependencies {
     implementation project(':fluxc')
     implementation project(':plugins:woocommerce')

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
+import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
@@ -80,6 +81,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooProductFiltersFragmentInjector(): WooProductFiltersFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooProductCategoriesFragmentInjector(): WooProductCategoriesFragment
 
     @ContributesAndroidInjector
     abstract fun provideWooOrdersFragmentInjector(): WooOrdersFragment

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesAdapter.kt
@@ -59,7 +59,6 @@ class WooProductCategoriesAdapter(
 
     fun setProductCategories(productsCategories: List<ProductCategoryViewHolderModel>) {
         if (productCategoryList.isEmpty()) {
-            productCategoryList.clear()
             productCategoryList.addAll(productsCategories)
             notifyDataSetChanged()
         } else {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesAdapter.kt
@@ -1,0 +1,99 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.product_category_list_item.view.*
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesAdapter.ProductCategoryViewHolder
+import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment.ProductCategory
+
+class WooProductCategoriesAdapter(
+    private val context: Context,
+    private val clickListener: OnProductCategoryClickListener
+) : RecyclerView.Adapter<ProductCategoryViewHolder>() {
+    private val productCategoryList = ArrayList<ProductCategoryViewHolderModel>()
+
+    interface OnProductCategoryClickListener {
+        fun onProductCategoryClick(productCategoryViewHolderModel: ProductCategoryViewHolderModel)
+    }
+
+    data class ProductCategoryViewHolderModel(val category: ProductCategory, var isSelected: Boolean = false)
+
+    override fun getItemCount() = productCategoryList.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductCategoryViewHolder {
+        return ProductCategoryViewHolder(
+                LayoutInflater.from(context)
+                        .inflate(R.layout.product_category_list_item, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: ProductCategoryViewHolder, position: Int) {
+        val productCategory = productCategoryList[position]
+
+        holder.txtCategoryName.text = productCategory.category.name
+        holder.checkBox.isChecked = productCategory.isSelected
+
+        holder.checkBox.setOnClickListener {
+            handleCategoryClick(holder, productCategory)
+        }
+
+        holder.itemView.setOnClickListener {
+            holder.checkBox.isChecked = !holder.checkBox.isChecked
+            handleCategoryClick(holder, productCategory)
+        }
+    }
+
+    private fun handleCategoryClick(
+        holder: ProductCategoryViewHolder,
+        productCategory: ProductCategoryViewHolderModel
+    ) {
+        productCategory.isSelected = holder.checkBox.isChecked
+        clickListener.onProductCategoryClick(productCategory)
+    }
+
+    fun setProductCategories(productsCategories: List<ProductCategoryViewHolderModel>) {
+        if (productCategoryList.isEmpty()) {
+            productCategoryList.clear()
+            productCategoryList.addAll(productsCategories)
+            notifyDataSetChanged()
+        } else {
+            val diffResult = DiffUtil.calculateDiff(ProductItemDiffUtil(productCategoryList, productsCategories))
+            productCategoryList.clear()
+            productCategoryList.addAll(productsCategories)
+            diffResult.dispatchUpdatesTo(this)
+        }
+    }
+
+    class ProductCategoryViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val txtCategoryName: TextView = view.categoryName
+        val checkBox: CheckBox = view.categorySelected
+    }
+
+    private class ProductItemDiffUtil(
+        val items: List<ProductCategoryViewHolderModel>,
+        val result: List<ProductCategoryViewHolderModel>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+                items[oldItemPosition].category.name == result[newItemPosition].category.name
+
+        override fun getOldListSize(): Int = items.size
+
+        override fun getNewListSize(): Int = result.size
+
+        fun isSameCategory(left: ProductCategory, right: ProductCategory): Boolean {
+            return left.name == right.name
+        }
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = items[oldItemPosition]
+            val newItem = result[newItemPosition]
+            return isSameCategory(oldItem.category, newItem.category)
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesFragment.kt
@@ -1,0 +1,106 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_product_categories.*
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesAdapter.OnProductCategoryClickListener
+import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesAdapter.ProductCategoryViewHolderModel
+import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment.ProductCategory
+
+class WooProductCategoriesFragment : Fragment(), OnProductCategoryClickListener {
+    private var resultCode: Int = -1
+    private var productCategories: List<ProductCategory>? = null
+    private var selectedProductCategories: MutableList<ProductCategory>? = null
+
+    private lateinit var productCategoriesAdapter: WooProductCategoriesAdapter
+
+    companion object {
+        const val PRODUCT_CATEGORIES_REQUEST_CODE = 2000
+        const val ARG_RESULT_CODE = "ARG_RESULT_CODE"
+        const val ARG_PRODUCT_CATEGORIES = "ARG_PRODUCT_CATEGORIES"
+        const val ARG_SELECTED_PRODUCT_CATEGORIES = "ARG_SELECTED_PRODUCT_CATEGORIES"
+
+        fun newInstance(
+            fragment: Fragment,
+            resultCode: Int,
+            productCategories: List<ProductCategory>,
+            selectedProductCategories: MutableList<ProductCategory>?
+        ) = WooProductCategoriesFragment().apply {
+            this.setTargetFragment(fragment, PRODUCT_CATEGORIES_REQUEST_CODE)
+            this.resultCode = resultCode
+            this.productCategories = productCategories
+            this.selectedProductCategories = selectedProductCategories
+        }
+    }
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(layout.fragment_woo_product_categories, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        savedInstanceState?.let {
+            resultCode = it.getInt(ARG_RESULT_CODE)
+            productCategories = it.getParcelableArrayList(ARG_PRODUCT_CATEGORIES)
+            selectedProductCategories = it.getParcelableArrayList(ARG_SELECTED_PRODUCT_CATEGORIES)
+        }
+
+        productCategoriesAdapter = WooProductCategoriesAdapter(requireContext(), this)
+        with(category_list) {
+            layoutManager = LinearLayoutManager(activity)
+            adapter = productCategoriesAdapter
+        }
+
+        val allCategories = productCategories?.map { productCategory ->
+            ProductCategoryViewHolderModel(
+                    category = productCategory,
+                    isSelected = selectedProductCategories?.any { it.name == productCategory.name } ?: false
+            )
+        } ?: emptyList()
+
+        productCategoriesAdapter.setProductCategories(allCategories.toList())
+
+        btn_done.setOnClickListener {
+            val intent = activity?.intent
+            intent?.putParcelableArrayListExtra(
+                    ARG_SELECTED_PRODUCT_CATEGORIES, selectedProductCategories as? ArrayList
+            )
+            targetFragment?.onActivityResult(PRODUCT_CATEGORIES_REQUEST_CODE, resultCode, intent)
+            fragmentManager?.popBackStack()
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(ARG_RESULT_CODE, resultCode)
+        productCategories?.let {
+            outState.putParcelableArrayList(ARG_PRODUCT_CATEGORIES, it as? ArrayList)
+        }
+        selectedProductCategories?.let {
+            outState.putParcelableArrayList(ARG_SELECTED_PRODUCT_CATEGORIES, it as? ArrayList)
+        }
+    }
+
+    override fun onProductCategoryClick(productCategoryViewHolderModel: ProductCategoryViewHolderModel) {
+        val found = selectedProductCategories?.find {
+            it.name == productCategoryViewHolderModel.category.name
+        }
+        if (!productCategoryViewHolderModel.isSelected && found != null) {
+            selectedProductCategories?.remove(found)
+        } else if (productCategoryViewHolderModel.isSelected && found == null) {
+            selectedProductCategories?.add(productCategoryViewHolderModel.category)
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -5,6 +5,7 @@ import android.app.DatePickerDialog.OnDateSetListener
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +13,7 @@ import android.widget.Button
 import android.widget.EditText
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.parcel.Parcelize
 import kotlinx.android.synthetic.main.fragment_woo_update_product.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -19,13 +21,17 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.ARG_LIST_SELECTED_ITEM
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.LIST_SELECTOR_REQUEST_CODE
+import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment.Companion.ARG_SELECTED_PRODUCT_CATEGORIES
+import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment.Companion.PRODUCT_CATEGORIES_REQUEST_CODE
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductModel.ProductTriplet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductBackOrders
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
@@ -52,15 +58,18 @@ class WooUpdateProductFragment : Fragment() {
     private var selectedRemoteProductId: Long? = null
     private var selectedProductModel: WCProductModel? = null
     private var password: String? = null
+    private var selectedCategories: List<ProductCategory>? = null
 
     companion object {
         const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
         const val ARG_SELECTED_PRODUCT_ID = "ARG_SELECTED_PRODUCT_ID"
+        const val ARG_SELECTED_CATEGORIES = "ARG_SELECTED_CATEGORIES"
         const val LIST_RESULT_CODE_TAX_STATUS = 101
         const val LIST_RESULT_CODE_STOCK_STATUS = 102
         const val LIST_RESULT_CODE_BACK_ORDERS = 103
         const val LIST_RESULT_CODE_VISIBILITY = 104
         const val LIST_RESULT_CODE_STATUS = 105
+        const val LIST_RESULT_CODE_CATEGORIES = 106
 
         fun newInstance(selectedSitePosition: Int): WooUpdateProductFragment {
             val fragment = WooUpdateProductFragment()
@@ -101,6 +110,7 @@ class WooUpdateProductFragment : Fragment() {
         super.onSaveInstanceState(outState)
         outState.putInt(ARG_SELECTED_SITE_POS, selectedSitePosition)
         selectedRemoteProductId?.let { outState.putLong(ARG_SELECTED_PRODUCT_ID, it) }
+        selectedCategories?.let { outState.putParcelableArrayList(ARG_SELECTED_CATEGORIES, it as? ArrayList) }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -181,6 +191,10 @@ class WooUpdateProductFragment : Fragment() {
         product_update.setOnClickListener {
             getWCSite()?.let { site ->
                 if (selectedProductModel?.remoteProductId != null) {
+                    // update categories only if new categories has been selected
+                    selectedCategories?.let { selectedProductModel?.categories =
+                            it.map { it.toProductTriplet().toJson() }.toString() }
+
                     val payload = UpdateProductPayload(site, selectedProductModel!!)
                     dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
                     val updatedPassword = product_password.getText()
@@ -213,7 +227,20 @@ class WooUpdateProductFragment : Fragment() {
         }
 
         select_product_categories.setOnClickListener {
-            // TODO: display list of categories
+            getWCSite()?.let {
+                val categories = wcProductStore.getProductCategoriesForSite(it)
+                        .map { ProductCategory(it.remoteCategoryId, it.name, it.slug) }
+
+                val selectedProductCategories = selectedCategories ?: selectedProductModel?.getCategories()
+                        ?.map { it.toProductCategory() }
+
+                replaceFragment(WooProductCategoriesFragment.newInstance(
+                        fragment = this,
+                        productCategories = categories,
+                        resultCode = LIST_RESULT_CODE_CATEGORIES,
+                        selectedProductCategories = selectedProductCategories?.toMutableList()
+                ))
+            }
         }
 
         product_is_featured.setOnCheckedChangeListener { _, isChecked ->
@@ -237,8 +264,9 @@ class WooUpdateProductFragment : Fragment() {
         savedInstanceState?.let { bundle ->
             selectedRemoteProductId = bundle.getLong(ARG_SELECTED_PRODUCT_ID)
             selectedSitePosition = bundle.getInt(ARG_SELECTED_SITE_POS)
-            selectedRemoteProductId?.let { updateSelectedProductId(it) }
+            selectedCategories = bundle.getParcelableArrayList(ARG_SELECTED_CATEGORIES)
         }
+        selectedRemoteProductId?.let { updateSelectedProductId(it) }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -277,6 +305,8 @@ class WooUpdateProductFragment : Fragment() {
                     }
                 }
             }
+        } else if (requestCode == PRODUCT_CATEGORIES_REQUEST_CODE) {
+            this.selectedCategories = data?.getParcelableArrayListExtra(ARG_SELECTED_PRODUCT_CATEGORIES)
         }
     }
 
@@ -318,8 +348,11 @@ class WooUpdateProductFragment : Fragment() {
                 product_purchase_note.setText(it.purchaseNote)
                 product_menu_order.setText(it.menuOrder.toString())
                 product_external_url.setText(it.externalUrl)
-                product_categories.setText(it.getCommaSeparatedCategoryNames())
                 product_button_text.setText(it.buttonText)
+                product_categories.setText(
+                        selectedCategories?.joinToString(", ") { it.name }
+                                ?: it.getCommaSeparatedCategoryNames()
+                )
             } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
     }
@@ -367,18 +400,37 @@ class WooUpdateProductFragment : Fragment() {
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onProductPasswordChanged(event: OnProductPasswordChanged) {
-        if (event.isError) {
-            event.error?.let {
-                prependToLog("onProductPasswordChanged has unexpected error: ${it.type}, ${it.message}")
+        when {
+            event.isError -> {
+                event.error?.let {
+                    prependToLog("onProductPasswordChanged has unexpected error: ${it.type}, ${it.message}")
+                }
             }
-        } else if (event.causeOfChange == WCProductAction.FETCH_PRODUCT_PASSWORD) {
-            prependToLog("Password fetched: ${event.password}")
-            product_password.setText(event.password ?: "")
-            password = event.password
-        } else if (event.causeOfChange == WCProductAction.UPDATE_PRODUCT_PASSWORD) {
-            prependToLog("Password updated: ${event.password}")
-            product_password.setText(event.password ?: "")
-            password = event.password
+            event.causeOfChange == WCProductAction.FETCH_PRODUCT_PASSWORD -> {
+                prependToLog("Password fetched: ${event.password}")
+                product_password.setText(event.password ?: "")
+                password = event.password
+            }
+            event.causeOfChange == WCProductAction.UPDATE_PRODUCT_PASSWORD -> {
+                prependToLog("Password updated: ${event.password}")
+                product_password.setText(event.password ?: "")
+                password = event.password
+            }
         }
+    }
+
+    @Parcelize
+    data class ProductCategory(
+        val id: Long,
+        val name: String,
+        val slug: String
+    ) : Parcelable {
+        fun toProductTriplet(): ProductTriplet {
+            return ProductTriplet(this.id, this.name, this.slug)
+        }
+    }
+
+    private fun ProductTriplet.toProductCategory(): ProductCategory {
+        return ProductCategory(this.id, this.name, this.slug)
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -265,8 +265,8 @@ class WooUpdateProductFragment : Fragment() {
             selectedRemoteProductId = bundle.getLong(ARG_SELECTED_PRODUCT_ID)
             selectedSitePosition = bundle.getInt(ARG_SELECTED_SITE_POS)
             selectedCategories = bundle.getParcelableArrayList(ARG_SELECTED_CATEGORIES)
+            selectedRemoteProductId?.let { updateSelectedProductId(it) }
         }
-        selectedRemoteProductId?.let { updateSelectedProductId(it) }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -212,6 +212,10 @@ class WooUpdateProductFragment : Fragment() {
             )
         }
 
+        select_product_categories.setOnClickListener {
+            // TODO: display list of categories
+        }
+
         product_is_featured.setOnCheckedChangeListener { _, isChecked ->
             selectedProductModel?.featured = isChecked
         }
@@ -314,6 +318,7 @@ class WooUpdateProductFragment : Fragment() {
                 product_purchase_note.setText(it.purchaseNote)
                 product_menu_order.setText(it.menuOrder.toString())
                 product_external_url.setText(it.externalUrl)
+                product_categories.setText(it.getCommaSeparatedCategoryNames())
                 product_button_text.setText(it.buttonText)
             } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")

--- a/example/src/main/res/layout/fragment_woo_product_categories.xml
+++ b/example/src/main/res/layout/fragment_woo_product_categories.xml
@@ -1,0 +1,29 @@
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/category_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:itemCount="10"
+        tools:listitem="@layout/product_category_list_item"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/btn_done"/>
+
+    <Button
+        android:id="@+id/btn_done"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="Done"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:ignore="HardcodedText" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -116,6 +116,32 @@
             app:layout_constraintTop_toBottomOf="@+id/product_slug"
             app:textHint="Short description" />
 
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_categories"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="text"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            app:layout_constraintEnd_toStartOf="@+id/select_product_categories"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_short_desc"
+            app:textHint="Product Categories" />
+
+        <Button
+            android:id="@+id/select_product_categories"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Select Categories"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_categories"
+            app:layout_constraintTop_toBottomOf="@+id/product_short_desc" />
+
         <Button
             android:id="@+id/product_catalog_visibility"
             style="?android:attr/spinnerStyle"
@@ -127,7 +153,7 @@
             app:layout_constraintEnd_toStartOf="@+id/product_status"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_short_desc" />
+            app:layout_constraintTop_toBottomOf="@+id/product_categories" />
 
         <Button
             android:id="@+id/product_status"
@@ -140,7 +166,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toEndOf="@+id/product_catalog_visibility"
-            app:layout_constraintTop_toBottomOf="@+id/product_short_desc" />
+            app:layout_constraintTop_toBottomOf="@+id/product_categories" />
 
         <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_regular_price"

--- a/example/src/main/res/layout/product_category_list_item.xml
+++ b/example/src/main/res/layout/product_category_list_item.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/categoryItemLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/categoryName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        style="@style/TextAppearance.AppCompat.Medium"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/categorySelected"
+        tools:text="Category" />
+
+    <CheckBox
+        android:id="@+id/categorySelected"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toEndOf="@id/categoryName"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/categoryName"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -793,6 +793,14 @@ class ProductRestClient(
         if (storedWCProductModel.menuOrder != updatedProductModel.menuOrder) {
             body["menu_order"] = updatedProductModel.menuOrder
         }
+        if (!storedWCProductModel.hasSameCategories(updatedProductModel)) {
+            val updatedCategories = updatedProductModel.getCategories()
+            body["categories"] = JsonArray().also {
+                for (category in updatedCategories) {
+                    it.add(category.toJson())
+                }
+            }
+        }
         return body
     }
 


### PR DESCRIPTION
Fixes #1588 by adding logic to update categories of a product.

#### Changes
Adds a new option in the `WooUpdateProductFragment` to view categories of a product and to select multiple categories and update the product.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/82631704-c3b5ba80-9c13-11ea-85c3-61cbbc973e23.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82631706-c57f7e00-9c13-11ea-8943-e90e64b9bbe8.png" width="300"/>

#### Notes
- ~**This PR is in draft till this [Shipping Labels PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1585) and this [Step 1 PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1590) can be reviewed and merged.**~
- The option to add a product category will be implemented in a subsequent PR.

#### To test
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Fetch product categories`.
- Click the back button and click on `Update product`.
- Enter a valid product Id and notice that the product categories are displayed.
- Click on `Select Categories`. (This will fetch the categories stored locally in the app and will be empty if there are no categories stored locally).
- Select multiple categories and click on the `Done` button. 
- Click on the `Tick` icon and notice that the categories are updated successfully. 
