### PR TITLE
Woo/add product categories

### DIFF
--- a/example/src/androidTest/resources/wc-add-product-category-response-success.json
+++ b/example/src/androidTest/resources/wc-add-product-category-response-success.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "id": 105,
+    "name": "test12",
+    "slug": "test12",
+    "parent": 0,
+    "description": "",
+    "display": "default",
+    "image": null,
+    "menu_order": 0,
+    "count": 0,
+    "_links": {
+      "self": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/categories\/105"
+      }],
+      "collection": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/categories"
+      }]
+    }
+  }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -12,6 +12,7 @@ import kotlinx.android.synthetic.main.fragment_woo_products.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_CATEGORY
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_CATEGORIES
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_REVIEWS
@@ -27,9 +28,11 @@ import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload
@@ -257,6 +260,23 @@ class WooProductsFragment : Fragment() {
             }
         }
 
+        add_product_category.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter a catrgory name:"
+                ) { editText ->
+                    val categoryName = editText.text.toString()
+                    if (categoryName.isNotEmpty()) {
+                        prependToLog("Submitting request to add product category")
+                        val wcProductCategoryModel = WCProductCategoryModel().apply { name = categoryName }
+                        val payload = AddProductCategoryPayload(site, wcProductCategoryModel)
+                        dispatcher.dispatch(WCProductActionBuilder.newAddProductCategoryAction(payload))
+                    } else prependToLog("No category name entered...doing nothing")
+                }
+            }
+        }
+
         update_product_images.setOnClickListener {
             showSingleLineDialog(
                     activity,
@@ -414,6 +434,9 @@ class WooProductsFragment : Fragment() {
                         load_more_product_categories.isEnabled = false
                     }
                 }
+                ADDED_PRODUCT_CATEGORY -> {
+                    prependToLog("${event.rowsAffected} product category added")
+                } else -> { }
             }
         }
     }

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -145,6 +145,13 @@
             android:text="Load More Product Categories" />
 
         <Button
+            android:id="@+id/add_product_category"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Add Product Category" />
+
+        <Button
             android:id="@+id/update_product_images"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
@@ -14,6 +15,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload;
@@ -66,6 +68,8 @@ public enum WCProductAction implements IAction {
     UPDATE_PRODUCT_PASSWORD,
     @Action(payloadType = FetchProductCategoriesPayload.class)
     FETCH_PRODUCT_CATEGORIES,
+    @Action(payloadType = AddProductCategoryPayload.class)
+    ADD_PRODUCT_CATEGORY,
 
 
     // Remote responses
@@ -98,5 +102,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteUpdatedProductPasswordPayload.class)
     UPDATED_PRODUCT_PASSWORD,
     @Action(payloadType = RemoteProductCategoriesPayload.class)
-    FETCHED_PRODUCT_CATEGORIES
+    FETCHED_PRODUCT_CATEGORIES,
+    @Action(payloadType = RemoteAddProductCategoryResponsePayload.class)
+    ADDED_PRODUCT_CATEGORY
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1018,6 +1018,7 @@ class ProductRestClient(
             "woocommerce_rest_review_invalid_id" -> ProductErrorType.INVALID_REVIEW_ID
             "woocommerce_product_invalid_image_id" -> ProductErrorType.INVALID_IMAGE_ID
             "product_invalid_sku" -> ProductErrorType.DUPLICATE_SKU
+            "term_exists" -> ProductErrorType.DUPLICATE_CATEGORY_NAME
             else -> ProductErrorType.fromString(wpComError.apiError)
         }
         return ProductError(productErrorType, wpComError.message)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload
@@ -547,6 +548,43 @@ class ProductRestClient(
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductCategoriesAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
+    /**
+     * Posts a new Add Category record to the API for a category.
+     *
+     * Makes a POST call `/wc/v3/products/categories/id` to save a Category record via the Jetpack tunnel.
+     * Returns a [WCProductCategoryModel] on successful response.
+     *
+     * Dispatches [WCProductAction.ADDED_PRODUCT_CATEGORY] action with the results.
+     */
+    fun addProductCategory(
+        site: SiteModel,
+        category: WCProductCategoryModel
+    ) {
+        val url = WOOCOMMERCE.products.categories.id(category.remoteCategoryId).pathV3
+
+        val responseType = object : TypeToken<ProductCategoryApiResponse>() {}.type
+        val params = mutableMapOf(
+                "name" to category.name,
+                "parent" to category.parent.toString()
+        )
+        val request = JetpackTunnelGsonRequest.buildPostRequest(url, site.siteId, params, responseType,
+                { response: ProductCategoryApiResponse? ->
+                    val categoryResponse = response?.let {
+                        productCategoryResponseToProductCategoryModel(it).apply {
+                            localSiteId = site.id
+                        }
+                    }
+                    val payload = RemoteAddProductCategoryResponsePayload(site, categoryResponse)
+                    dispatcher.dispatch(WCProductActionBuilder.newAddedProductCategoryAction(payload))
+                },
+                WPComErrorListener { networkError ->
+                    val productCategorySaveError = networkErrorToProductError(networkError)
+                    val payload = RemoteAddProductCategoryResponsePayload(productCategorySaveError, site, category)
+                    dispatcher.dispatch(WCProductActionBuilder.newAddedProductCategoryAction(payload))
+                })
         add(request)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1018,7 +1018,7 @@ class ProductRestClient(
             "woocommerce_rest_review_invalid_id" -> ProductErrorType.INVALID_REVIEW_ID
             "woocommerce_product_invalid_image_id" -> ProductErrorType.INVALID_IMAGE_ID
             "product_invalid_sku" -> ProductErrorType.DUPLICATE_SKU
-            "term_exists" -> ProductErrorType.DUPLICATE_CATEGORY_NAME
+            "term_exists" -> ProductErrorType.TERM_EXISTS
             else -> ProductErrorType.fromString(wpComError.apiError)
         }
         return ProductError(productErrorType, wpComError.message)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -563,7 +563,7 @@ class ProductRestClient(
         site: SiteModel,
         category: WCProductCategoryModel
     ) {
-        val url = WOOCOMMERCE.products.categories.id(category.remoteCategoryId).pathV3
+        val url = WOOCOMMERCE.products.categories.pathV3
 
         val responseType = object : TypeToken<ProductCategoryApiResponse>() {}.type
         val params = mutableMapOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -149,6 +149,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         INVALID_REVIEW_ID,
         INVALID_IMAGE_ID,
         DUPLICATE_SKU,
+        DUPLICATE_CATEGORY_NAME,
         GENERIC_ERROR;
 
         companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -149,7 +149,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         INVALID_REVIEW_ID,
         INVALID_IMAGE_ID,
         DUPLICATE_SKU,
-        DUPLICATE_CATEGORY_NAME,
+        TERM_EXISTS, // indicates duplicate term name. Currently only used when adding product categories
         GENERIC_ERROR;
 
         companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -139,6 +139,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var productCategorySorting: ProductCategorySorting = DEFAULT_CATEGORY_SORTING
     ) : Payload<BaseNetworkError>()
 
+    class AddProductCategoryPayload(
+        val site: SiteModel,
+        val category: WCProductCategoryModel
+    ) : Payload<BaseNetworkError>()
+
     enum class ProductErrorType {
         INVALID_PARAM,
         INVALID_REVIEW_ID,
@@ -359,6 +364,17 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         ) : this(site) {
             this.error = error
         }
+    }
+
+    class RemoteAddProductCategoryResponsePayload(
+        val site: SiteModel,
+        val category: WCProductCategoryModel?
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel,
+            category: WCProductCategoryModel?
+        ) : this(site, category) { this.error = error }
     }
 
     // OnChanged events


### PR DESCRIPTION
Fixes #1589 by adding support to add a new category.

#### Changes
- Added new action and action classes to `WCProductStore` and `ProductRestClient` to add a new product category for a site.
- Added unit tests.
- Added a new button to the example app to add a new product category.

#### Notes
- ~**This PR is in draft till this [Shipping Labels PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1585) and this [Step 1 PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1590) and this [Step 2 PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1591) can be reviewed and merged.**~

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/82638113-c7513d80-9c23-11ea-9975-1ca525fce8e7.gif" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/82638117-c91b0100-9c23-11ea-892a-8039d1918b7a.gif" width="300" />

#### To Test
- Run `MockedStack_WCProductsTest` and `ReleaseStack_WCProductTest`.
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Add Product Category`.
- Enter a unique category name and verify that the category is added successfully to the test site.
- Now click on `Add Product Category` again and enter the same category name from the previous step. Notice that a error message is displayed: `DUPLICATE_CATEGORY_NAME`. This is because the API throws an error when we try to update the same category name for the same `parentId`. 

