### PR TITLE
Product variation details fields

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -272,9 +272,9 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertEquals(WCProductAction.FETCHED_PRODUCT_VARIATIONS, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteProductVariationsPayload
         assertNull(payload.error)
-        assertEquals(payload.remoteProductId, remoteProductId)
-        assertEquals(payload.variations.size, 3)
-        assertEquals(payload.variations[0].image, "")
+        assertEquals(remoteProductId, payload.remoteProductId)
+        assertEquals(3, payload.variations.size)
+        assertEquals("null", payload.variations[0].image)
         assertNotNull(payload.variations[1].image)
 
         // save the variation to the db

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -271,8 +271,8 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertNull(payload.error)
         assertEquals(payload.remoteProductId, remoteProductId)
         assertEquals(payload.variations.size, 3)
-        assertEquals(payload.variations[0].imageUrl, "")
-        assertNotNull(payload.variations[1].imageUrl)
+        assertEquals(payload.variations[0].image, "")
+        assertNotNull(payload.variations[1].image)
 
         // save the variation to the db
         assertEquals(ProductSqlUtils.insertOrUpdateProductVariations(payload.variations), 3)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1080,12 +1080,37 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE CommentModel ADD URL TEXT")
                 }
                 104 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("DELETE FROM WCProductVariationModel")
-                    db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_FROM_GMT TEXT")
-                    db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_TO_GMT TEXT")
-                    db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_FROM TEXT")
-                    db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_TO TEXT")
-                    db.execSQL("ALTER TABLE WCProductVariationModel ADD IMAGE TEXT")
+                    db.execSQL("DROP TABLE IF EXISTS WCProductVariationModel")
+                    db.execSQL("CREATE TABLE WCProductVariationModel (" +
+                            "LOCAL_SITE_ID INTEGER," +
+                            "REMOTE_PRODUCT_ID INTEGER," +
+                            "REMOTE_VARIATION_ID INTEGER," +
+                            "DATE_CREATED TEXT NOT NULL," +
+                            "DATE_MODIFIED TEXT NOT NULL," +
+                            "DESCRIPTION TEXT NOT NULL," +
+                            "PERMALINK TEXT NOT NULL," +
+                            "SKU TEXT NOT NULL," +
+                            "STATUS TEXT NOT NULL," +
+                            "PRICE TEXT NOT NULL," +
+                            "REGULAR_PRICE TEXT NOT NULL," +
+                            "SALE_PRICE TEXT NOT NULL," +
+                            "DATE_ON_SALE_FROM TEXT NOT NULL," +
+                            "DATE_ON_SALE_TO TEXT NOT NULL," +
+                            "DATE_ON_SALE_FROM_GMT TEXT NOT NULL," +
+                            "DATE_ON_SALE_TO_GMT TEXT NOT NULL," +
+                            "ON_SALE INTEGER,PURCHASABLE INTEGER," +
+                            "VIRTUAL INTEGER,DOWNLOADABLE INTEGER," +
+                            "MANAGE_STOCK INTEGER," +
+                            "STOCK_QUANTITY INTEGER," +
+                            "STOCK_STATUS TEXT NOT NULL," +
+                            "IMAGE TEXT NOT NULL," +
+                            "WEIGHT TEXT NOT NULL," +
+                            "LENGTH TEXT NOT NULL," +
+                            "WIDTH TEXT NOT NULL," +
+                            "HEIGHT TEXT NOT NULL," +
+                            "MENU_ORDER INTEGER," +
+                            "ATTRIBUTES TEXT NOT NULL," +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT)")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1015,7 +1015,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     )
                 }
                 91 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCOrderModel ADD SHIPPING_LINES TEXT NULL")
+                    db.execSQL("ALTER TABLE WCOrderModel ADD SHIPPING_LINES TEXT")
                 }
                 92 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD DATE_ON_SALE_FROM TEXT")
@@ -1074,7 +1074,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE WCProductModel ADD MENU_ORDER INTEGER")
                 }
                 102 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCProductModel ADD BUTTON_TEXT STRING")
+                    db.execSQL("ALTER TABLE WCProductModel ADD BUTTON_TEXT TEXT")
                 }
                 103 -> migrate(version) {
                     db.execSQL("ALTER TABLE CommentModel ADD URL TEXT")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1080,10 +1080,12 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE CommentModel ADD URL TEXT")
                 }
                 104 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DELETE FROM WCProductVariationModel")
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_FROM_GMT TEXT")
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_TO_GMT TEXT")
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_FROM TEXT")
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_TO TEXT")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD IMAGE TEXT")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,7 +27,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 104
+        return 105
     }
 
     override fun getDbName(): String {
@@ -1078,6 +1078,12 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 103 -> migrate(version) {
                     db.execSQL("ALTER TABLE CommentModel ADD URL TEXT")
+                }
+                104 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_FROM_GMT TEXT")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_TO_GMT TEXT")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_FROM TEXT")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD DATE_ON_SALE_TO TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -127,7 +127,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         val imageList = ArrayList<WCProductImageModel>()
         if (!images.isEmpty()) {
             try {
-                Gson().fromJson<JsonElement>(images, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+                Gson().fromJson(images, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
                     with(jsonElement.asJsonObject) {
                         WCProductImageModel(this.getLong("id")).also {
                             it.name = this.getString("name") ?: ""
@@ -149,7 +149,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      */
     fun getFirstImageUrl(): String? {
         try {
-            Gson().fromJson<JsonElement>(images, JsonElement::class.java).asJsonArray.firstOrNull { jsonElement ->
+            Gson().fromJson(images, JsonElement::class.java).asJsonArray.firstOrNull { jsonElement ->
                 return (jsonElement.asJsonObject).getString("src")
             }
         } catch (e: JsonParseException) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -125,7 +125,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      */
     fun getImages(): ArrayList<WCProductImageModel> {
         val imageList = ArrayList<WCProductImageModel>()
-        if (!images.isEmpty()) {
+        if (images.isNotEmpty()) {
             try {
                 Gson().fromJson(images, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
                     with(jsonElement.asJsonObject) {
@@ -138,6 +138,9 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
                     }
                 }
             } catch (e: JsonParseException) {
+                AppLog.e(T.API, e)
+            }
+            catch (e: IllegalStateException) {
                 AppLog.e(T.API, e)
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -148,8 +148,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
                 }
             } catch (e: JsonParseException) {
                 AppLog.e(T.API, e)
-            }
-            catch (e: IllegalStateException) {
+            } catch (e: IllegalStateException) {
                 AppLog.e(T.API, e)
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -30,6 +30,11 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     @Column var regularPrice = ""
     @Column var salePrice = ""
 
+    @Column var dateOnSaleFrom = ""
+    @Column var dateOnSaleTo = ""
+    @Column var dateOnSaleFromGmt = ""
+    @Column var dateOnSaleToGmt = ""
+
     @Column var onSale = false
     @Column var purchasable = false
     @Column var virtual = false

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -91,8 +91,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
             } catch (e: JsonParseException) {
                 AppLog.e(T.API, e)
                 return null
-            }
-            catch (e: IllegalStateException) {
+            } catch (e: IllegalStateException) {
                 AppLog.e(T.API, e)
                 return null
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.network.utils.getString
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import java.lang.IllegalStateException
 
 /**
  * Product variations - see http://woocommerce.github.io/woocommerce-rest-api-docs/#product-variations
@@ -88,6 +89,10 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
                     }
                 }
             } catch (e: JsonParseException) {
+                AppLog.e(T.API, e)
+                return null
+            }
+            catch (e: IllegalStateException) {
                 AppLog.e(T.API, e)
                 return null
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -852,6 +852,11 @@ class ProductRestClient(
             salePrice = response.sale_price ?: ""
             onSale = response.on_sale
 
+            dateOnSaleFrom = response.date_on_sale_from ?: ""
+            dateOnSaleTo = response.date_on_sale_to ?: ""
+            dateOnSaleFromGmt = response.date_on_sale_from_gmt ?: ""
+            dateOnSaleToGmt = response.date_on_sale_to_gmt ?: ""
+
             virtual = response.virtual
             downloadable = response.downloadable
             purchasable = response.purchasable

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -876,11 +876,7 @@ class ProductRestClient(
                 height = json.getString("height") ?: ""
             }
 
-            response.image?.let {
-                (it as? JsonObject)?.let { json ->
-                    imageUrl = json.getString("src") ?: ""
-                } ?: ""
-            }
+            image = response.image?.toString() ?: ""
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 import android.content.Context
 import com.android.volley.RequestQueue
 import com.google.gson.JsonArray
-import com.google.gson.JsonObject
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -15,6 +15,11 @@ class ProductVariationApiResponse : Response {
     var regular_price: String? = null
     var sale_price: String? = null
 
+    var date_on_sale_from: String? = null
+    var date_on_sale_to: String? = null
+    var date_on_sale_from_gmt: String? = null
+    var date_on_sale_to_gmt: String? = null
+
     var date_created: String? = null
     var date_modified: String? = null
 


### PR DESCRIPTION
This PR adds new DB columns and API fields required to support the new Product variation details screen in Woo. These include: sale dates and image object (instead of just the URL).

Testing the migration and smoke-testing the example app should do it.