### PR TITLE
Woo/get product category by id

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -70,6 +70,8 @@ class WooProductsFragment : Fragment() {
     private var pendingFetchProductShippingClassListOffset: Int = 0
     private var pendingFetchProductCategoriesOffset: Int = 0
 
+    private var enteredCategoryName: String? = null
+
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
@@ -264,15 +266,19 @@ class WooProductsFragment : Fragment() {
             selectedSite?.let { site ->
                 showSingleLineDialog(
                         activity,
-                        "Enter a catrgory name:"
+                        "Enter a category name:"
                 ) { editText ->
-                    val categoryName = editText.text.toString()
-                    if (categoryName.isNotEmpty()) {
+                    enteredCategoryName = editText.text.toString()
+                    if (enteredCategoryName != null && enteredCategoryName?.isNotEmpty() == true) {
                         prependToLog("Submitting request to add product category")
-                        val wcProductCategoryModel = WCProductCategoryModel().apply { name = categoryName }
+                        val wcProductCategoryModel = WCProductCategoryModel().apply {
+                            name = enteredCategoryName!!
+                        }
                         val payload = AddProductCategoryPayload(site, wcProductCategoryModel)
                         dispatcher.dispatch(WCProductActionBuilder.newAddProductCategoryAction(payload))
-                    } else prependToLog("No category name entered...doing nothing")
+                    } else {
+                        prependToLog("No category name entered...doing nothing")
+                    }
                 }
             }
         }
@@ -435,7 +441,8 @@ class WooProductsFragment : Fragment() {
                     }
                 }
                 ADDED_PRODUCT_CATEGORY -> {
-                    prependToLog("${event.rowsAffected} product category added")
+                    val category = enteredCategoryName?.let { wcProductStore.getProductCategoryByName(site, it) }
+                    prependToLog("${event.rowsAffected} product category added with name: ${category?.name}")
                 } else -> { }
             }
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -441,7 +441,9 @@ class WooProductsFragment : Fragment() {
                     }
                 }
                 ADDED_PRODUCT_CATEGORY -> {
-                    val category = enteredCategoryName?.let { wcProductStore.getProductCategoryByName(site, it) }
+                    val category = enteredCategoryName?.let {
+                        wcProductStore.getProductCategoryByNameAndParentId(site, it)
+                    }
                     prependToLog("${event.rowsAffected} product category added with name: ${category?.name}")
                 } else -> { }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -477,15 +477,17 @@ object ProductSqlUtils {
                 .asModel.firstOrNull()
     }
 
-    fun getProductCategoryByName(
+    fun getProductCategoryByNameAndParentId(
         localSiteId: Int,
-        categoryName: String
+        categoryName: String,
+        parentId: Long
     ): WCProductCategoryModel? {
         return WellSql.select(WCProductCategoryModel::class.java)
                 .where()
                 .beginGroup()
                 .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, localSiteId)
                 .equals(WCProductCategoryModelTable.NAME, categoryName)
+                .equals(WCProductCategoryModelTable.PARENT, parentId)
                 .endGroup()
                 .endWhere()
                 .asModel.firstOrNull()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -477,6 +477,20 @@ object ProductSqlUtils {
                 .asModel.firstOrNull()
     }
 
+    fun getProductCategoryByName(
+        localSiteId: Int,
+        categoryName: String
+    ): WCProductCategoryModel? {
+        return WellSql.select(WCProductCategoryModel::class.java)
+                .where()
+                .beginGroup()
+                .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(WCProductCategoryModelTable.NAME, categoryName)
+                .endGroup()
+                .endWhere()
+                .asModel.firstOrNull()
+    }
+
     fun insertOrUpdateProductCategories(productCategories: List<WCProductCategoryModel>): Int {
         var rowsAffected = 0
         productCategories.forEach {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -526,8 +526,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getProductCategoryByRemoteId(site: SiteModel, remoteId: Long) =
             ProductSqlUtils.getProductCategoryByRemoteId(site.id, remoteId)
 
-    fun getProductCategoryByName(site: SiteModel, categoryName: String) =
-            ProductSqlUtils.getProductCategoryByName(site.id, categoryName)
+    fun getProductCategoryByNameAndParentId(
+        site: SiteModel,
+        categoryName: String,
+        parentId: Long = 0L
+    ) = ProductSqlUtils.getProductCategoryByNameAndParentId(site.id, categoryName, parentId)
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -523,6 +523,9 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getProductCategoriesForSite(site: SiteModel, sortType: ProductCategorySorting = DEFAULT_CATEGORY_SORTING) =
             ProductSqlUtils.getProductCategoriesForSite(site, sortType)
 
+    fun getProductCategoryByRemoteId(site: SiteModel, remoteId: Long) =
+            ProductSqlUtils.getProductCategoryByRemoteId(site.id, remoteId)
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? WCProductAction ?: return

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -526,6 +526,9 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getProductCategoryByRemoteId(site: SiteModel, remoteId: Long) =
             ProductSqlUtils.getProductCategoryByRemoteId(site.id, remoteId)
 
+    fun getProductCategoryByName(site: SiteModel, categoryName: String) =
+            ProductSqlUtils.getProductCategoryByName(site.id, categoryName)
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? WCProductAction ?: return

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -31,7 +31,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     companion object {
         const val NUM_REVIEWS_PER_FETCH = 25
         const val DEFAULT_PRODUCT_PAGE_SIZE = 25
-        const val DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE = 25
+        const val DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE = 100
         const val DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE = 25
         const val DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE = 25
         val DEFAULT_PRODUCT_SORTING = TITLE_ASC


### PR DESCRIPTION
Fixes #1598 by adding the following the minor changes:
- **change the default page size we use to fetch categories from 25 to 100**. This is because the API does not provide a way to order the categories that is needed by the mobile app i.e. there are instances when subcategories are returned in a different page of the request and it would not be a good user experience. The number 100 was chosen because it is the maximum number of categories we can fetch in a single request without throwing an error on the API side. Fixed in d6a6122
- **Add a method to `WCProductStore` to fetch a category by it's ID.** This is already available in `ProductSqlUtils` so we just need to add the method to `WCProductStore` so that it's available to the client side. Fixed in 9f95e44
- **Added method to `WCProductStore` to fetch a category by it's name**: Fixed in 1398b42 and added an example in 44c567b. To test, click on `Woo` -> `Products` -> `Add Product Category` and verify that the category name you entered is displayed in the logs once the add category API is successful.