### PR TITLE
Woo: Add all the missing variation properties

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 108
+        return 109
     }
 
     override fun getDbName(): String {
@@ -1140,8 +1140,55 @@ open class WellSqlConfig : DefaultWellConfig {
                             "DATE_ON_SALE_TO TEXT NOT NULL," +
                             "DATE_ON_SALE_FROM_GMT TEXT NOT NULL," +
                             "DATE_ON_SALE_TO_GMT TEXT NOT NULL," +
-                            "ON_SALE INTEGER,PURCHASABLE INTEGER," +
-                            "VIRTUAL INTEGER,DOWNLOADABLE INTEGER," +
+                            "ON_SALE INTEGER," +
+                            "PURCHASABLE INTEGER," +
+                            "VIRTUAL INTEGER," +
+                            "DOWNLOADABLE INTEGER," +
+                            "MANAGE_STOCK INTEGER," +
+                            "STOCK_QUANTITY INTEGER," +
+                            "STOCK_STATUS TEXT NOT NULL," +
+                            "IMAGE TEXT NOT NULL," +
+                            "WEIGHT TEXT NOT NULL," +
+                            "LENGTH TEXT NOT NULL," +
+                            "WIDTH TEXT NOT NULL," +
+                            "HEIGHT TEXT NOT NULL," +
+                            "MENU_ORDER INTEGER," +
+                            "ATTRIBUTES TEXT NOT NULL," +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT)")
+                }
+                108 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCProductVariationModel")
+                    db.execSQL("CREATE TABLE WCProductVariationModel (" +
+                            "LOCAL_SITE_ID INTEGER," +
+                            "REMOTE_PRODUCT_ID INTEGER," +
+                            "REMOTE_VARIATION_ID INTEGER," +
+                            "DATE_CREATED TEXT NOT NULL," +
+                            "DATE_MODIFIED TEXT NOT NULL," +
+                            "DESCRIPTION TEXT NOT NULL," +
+                            "PERMALINK TEXT NOT NULL," +
+                            "SKU TEXT NOT NULL," +
+                            "STATUS TEXT NOT NULL," +
+                            "PRICE TEXT NOT NULL," +
+                            "REGULAR_PRICE TEXT NOT NULL," +
+                            "SALE_PRICE TEXT NOT NULL," +
+                            "DATE_ON_SALE_FROM TEXT NOT NULL," +
+                            "DATE_ON_SALE_TO TEXT NOT NULL," +
+                            "DATE_ON_SALE_FROM_GMT TEXT NOT NULL," +
+                            "DATE_ON_SALE_TO_GMT TEXT NOT NULL," +
+                            "ON_SALE INTEGER," +
+                            "PURCHASABLE INTEGER," +
+                            "VIRTUAL INTEGER," +
+                            "DOWNLOADABLE INTEGER," +
+                            "TAX_STATUS TEXT NOT NULL," +
+                            "TAX_CLASS TEXT NOT NULL," +
+                            "DOWNLOAD_LIMIT INTEGER," +
+                            "DOWNLOAD_EXPIRY INTEGER," +
+                            "DOWNLOADS TEXT NOT NULL," +
+                            "BACKORDERS TEXT NOT NULL," +
+                            "BACKORDERS_ALLOWED INTEGER," +
+                            "BACKORDERED INTEGER," +
+                            "SHIPPING_CLASS TEXT NOT NULL," +
+                            "SHIPPING_CLASS_ID INTEGER," +
                             "MANAGE_STOCK INTEGER," +
                             "STOCK_QUANTITY INTEGER," +
                             "STOCK_STATUS TEXT NOT NULL," +

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -42,10 +42,25 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     @Column var dateOnSaleFromGmt = ""
     @Column var dateOnSaleToGmt = ""
 
+    @Column var taxStatus = "" // taxable, shipping, none
+    @Column var taxClass = ""
+
     @Column var onSale = false
     @Column var purchasable = false
     @Column var virtual = false
     @Column var downloadable = false
+
+    @Column var downloadLimit = 0
+    @Column var downloadExpiry = 0
+
+    @Column var downloads = "" // array of downloadable files
+    @Column var backorders = "" // no, notify, yes
+
+    @Column var backordersAllowed = false
+    @Column var backordered = false
+
+    @Column var shippingClass = ""
+    @Column var shippingClassId = 0
 
     @Column var manageStock = false
     @Column var stockQuantity = 0

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -963,6 +963,19 @@ class ProductRestClient(
             dateOnSaleFromGmt = response.date_on_sale_from_gmt ?: ""
             dateOnSaleToGmt = response.date_on_sale_to_gmt ?: ""
 
+            taxStatus = response.tax_status ?: ""
+            taxClass = response.tax_class ?: ""
+
+            backorders = response.backorders ?: ""
+            backordersAllowed = response.backorders_allowed
+            backordered = response.backordered
+
+            shippingClass = response.shipping_class ?: ""
+            shippingClassId = response.shipping_class_id
+
+            downloadLimit = response.download_limit
+            downloadExpiry = response.download_expiry
+
             virtual = response.virtual
             downloadable = response.downloadable
             purchasable = response.purchasable
@@ -975,6 +988,9 @@ class ProductRestClient(
 
             weight = response.weight ?: ""
             menuOrder = response.menu_order
+
+            attributes = response.attributes?.toString() ?: ""
+            downloads = response.downloads?.toString() ?: ""
 
             response.dimensions?.asJsonObject?.let { json ->
                 length = json.getString("length") ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -20,6 +20,9 @@ class ProductVariationApiResponse : Response {
     var date_on_sale_from_gmt: String? = null
     var date_on_sale_to_gmt: String? = null
 
+    var tax_status: String? = null
+    var tax_class: String? = null
+
     var date_created: String? = null
     var date_modified: String? = null
 
@@ -27,6 +30,16 @@ class ProductVariationApiResponse : Response {
     var purchasable = false
     var virtual = false
     var downloadable = false
+
+    var backorders: String? = null
+    var backorders_allowed = false
+    var backordered = false
+
+    var shipping_class: String? = null
+    var shipping_class_id = 0
+
+    var download_limit = 0
+    var download_expiry = 0
 
     var manage_stock = false
     var stock_quantity = 0
@@ -39,4 +52,5 @@ class ProductVariationApiResponse : Response {
 
     var dimensions: JsonElement? = null
     var attributes: JsonElement? = null
+    var downloads: JsonElement? = null
 }


### PR DESCRIPTION
This PR adds the missing variation properties that are being returned by the API but weren't being used, namely:

`tax status`
`tax class`
`download limit`
`download expiry`
`downloads`
`backorders`
`backordered`
`shipping class`
`shipping class id`