### PR TITLE
Log progress of fetchVisits call to investigate stale data issue

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import java.util.Date
 import kotlin.test.assertEquals
@@ -44,6 +45,7 @@ class VisitsAndViewsStoreTest {
     @Mock lateinit var statsUtils: StatsUtils
     @Mock lateinit var currentTimeProvider: CurrentTimeProvider
     @Mock lateinit var mapper: TimeStatsMapper
+    @Mock lateinit var appLogWrapper: AppLogWrapper
     private lateinit var store: VisitsAndViewsStore
     @Before
     fun setUp() {
@@ -53,7 +55,8 @@ class VisitsAndViewsStoreTest {
                 mapper,
                 statsUtils,
                 currentTimeProvider,
-                initCoroutineEngine()
+                initCoroutineEngine(),
+                appLogWrapper
         )
         val currentDate = Date(0)
         whenever(currentTimeProvider.currentDate).thenReturn(currentDate)


### PR DESCRIPTION
To investigate https://github.com/wordpress-mobile/WordPress-Android/issues/11412

This PR adds tracking of the fetchVisits method. Visits and Views store retrieves the data for the first Overview block. This block is crucial for the load of the other blocks (because it allows the user to select a period to load the data). This logging is added because some users experience stale data in the Stats granular tabs (days/weeks/months/years). I don't think there is any issue in the app. This logging should show us whether there is an issue with the responses we're receiving from the backend. 

This PR can be tested with a WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/12176