### PR TITLE
Correct version conflict from merge

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 109
+        return 110
     }
 
     override fun getDbName(): String {
@@ -1201,7 +1201,7 @@ open class WellSqlConfig : DefaultWellConfig {
                             "ATTRIBUTES TEXT NOT NULL," +
                             "_id INTEGER PRIMARY KEY AUTOINCREMENT)")
                 }
-                108 -> migrate(version) {
+                109 -> migrate(version) {
                     db.execSQL(
                             "CREATE TABLE EditorTheme(" +
                                     "_id INTEGER PRIMARY KEY AUTOINCREMENT," +


### PR DESCRIPTION
From the last merge, there was a conflict in the WellSqlConfig that had two version 108 migration steps. Correcting this error here. 

cc @khaykov 