### PR TITLE
Fix crash when response has no body

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
@@ -5,9 +5,9 @@ import com.android.volley.RequestQueue
 import com.google.gson.JsonElement
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.fail
 import junit.framework.AssertionFailedError
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
@@ -58,7 +58,7 @@ class ReactNativeWPAPIRestClientTest {
 
         val expected = mock<ReactNativeFetchResponse>()
         val expectedJson = mock<JsonElement>()
-        val successHandler = { data: JsonElement ->
+        val successHandler = { data: JsonElement? ->
             if (data != expectedJson) fail("expected data was not passed to successHandler")
             expected
         }
@@ -69,7 +69,7 @@ class ReactNativeWPAPIRestClientTest {
 
     @Test
     fun `fetch handles failure response`() = test {
-        val successHandler = { _: JsonElement ->
+        val successHandler = { _: JsonElement? ->
             throw AssertionFailedError("successHandler should not have been called")
         }
 
@@ -180,7 +180,7 @@ class ReactNativeWPAPIRestClientTest {
     }
 
     private suspend fun verifyRestApi(
-        successHandler: (JsonElement) -> ReactNativeFetchResponse,
+        successHandler: (JsonElement?) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
         expectedRestCallResponse: WPAPIResponse<JsonElement>,
         expected: ReactNativeFetchResponse

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIResponse.kt
@@ -3,6 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpapi
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 
 sealed class WPAPIResponse<T> {
-    data class Success<T>(val data: T) : WPAPIResponse<T>()
+    data class Success<T>(val data: T?) : WPAPIResponse<T>()
     data class Error<T>(val error: BaseNetworkError) : WPAPIResponse<T>()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -48,7 +48,7 @@ class ReactNativeWPAPIRestClient @VisibleForTesting constructor(
     suspend fun fetch(
         url: String,
         params: Map<String, String>,
-        successHandler: (data: JsonElement) -> ReactNativeFetchResponse,
+        successHandler: (data: JsonElement?) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
         nonce: String? = null,
         enableCaching: Boolean = true
@@ -84,7 +84,7 @@ class ReactNativeWPAPIRestClient @VisibleForTesting constructor(
         val response =
                 wpApiEncodedBodyRequestBuilder.syncPostRequest(this, wpLoginUrl, body = body)
         return when (response) {
-            is Success -> if (response.data.matches("[0-9a-zA-Z]{2,}".toRegex())) {
+            is Success -> if (response.data?.matches("[0-9a-zA-Z]{2,}".toRegex()) == true) {
                 Available(response.data)
             } else {
                 FailedRequest(currentTimeMillis())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -79,7 +79,7 @@ class EditorThemeStore
 
         when (response) {
             is Success -> {
-                val responseTheme = response.result.asJsonArray.first() ?: return
+                val responseTheme = response.result?.asJsonArray?.first() ?: return
                 val newTheme = Gson().fromJson(responseTheme, EditorTheme::class.java)
                 val existingTheme = editorThemeSqlUtils.getEditorThemeForSite(site)
                 if (newTheme != existingTheme) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -79,7 +79,7 @@ class EditorThemeStore
 
         when (response) {
             is Success -> {
-                val responseTheme = response.result?.asJsonArray?.first() ?: return
+                val responseTheme = response.result?.asJsonArray?.firstOrNull() ?: return
                 val newTheme = Gson().fromJson(responseTheme, EditorTheme::class.java)
                 val existingTheme = editorThemeSqlUtils.getEditorThemeForSite(site)
                 if (newTheme != existingTheme) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -211,6 +211,6 @@ class ReactNativeStore
 private fun Error.statusCode() = error.volleyError?.networkResponse?.statusCode
 
 sealed class ReactNativeFetchResponse {
-    class Success(val result: JsonElement) : ReactNativeFetchResponse()
+    class Success(val result: JsonElement?) : ReactNativeFetchResponse()
     class Error(val error: BaseNetworkError) : ReactNativeFetchResponse()
 }


### PR DESCRIPTION
Fixes #1578 

We're getting some crashes in production because the response's body field (`data`) is being parsed as `null` by GSON. Since that field was not nullable, the exception was thrown when it got passed to a method that expected a non-null argument. This fixes that by making the `data` field nullable.

#### (Lack of) WPAndroid Changes

I have created a related [WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/12219). Interestingly, there are no actual code changes required on the WPAndroid side when we bring in this FluxC change. That is because the only place the [now-nullable result field](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/e639702afec9796a3048bccc43fc96a1e586dd5a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt#L214) 

```
class Success(val result: JsonElement?) : ReactNativeFetchResponse()
```

is currently used in WPAndroid is when [it is converted to a `String` by calling `.toString()`](https://github.com/wordpress-mobile/WordPress-Android/blob/d91beb38e63825fe0e16d56576e227841eeb29af/WordPress/src/main/java/org/wordpress/android/ui/posts/reactnative/ReactNativeRequestHandler.kt#L54):

```
is Success -> onSuccess(response.result.toString())
``` 

Conveniently, I discovered that this works even if the `result` is `null`: calling `null.toString()` is valid Kotlin because [there is an `Any?.toString` extension method](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/to-string.html), so `null.toString()` returns "null", which is valid JSON that will be successfully parsed [when Gutenberg calls `JSON.parse` on the result of the `toString()` call](https://github.com/mchowning/gutenberg-mobile/blob/d5c1c95ab1c419c5edd764521be74bf1880e84b4/src/api-fetch-setup.js#L24):

```
const parseResponse = ( response ) => {
	if ( typeof response === 'string' ) {
		response = JSON.parse( response );
	}
	return response;
};
```

#### To Test

Insure that an empty response body (resulting in a `null` data field) does not cause a crash.