### PR TITLE
Fixed json exception when parsing product names in shipping labels

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
@@ -96,6 +96,7 @@ class WCShippingLabelSqlUtilsTest {
         // Get shipping label list for site and order and verify
         val savedShippingLabelListExists = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
         assertEquals(shippingLabels.size, savedShippingLabelListExists.size)
+        assertEquals(shippingLabels[0].getProductNames(), savedShippingLabelListExists[0].getProductNames())
 
         // Get shipping label list for a site that does not exist
         val nonExistingSite = SiteModel().apply { id = 400 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -20,7 +20,8 @@ object WCShippingLabelTestUtils {
         refundableAmount: Float = 7.65F,
         currency: String = "USD",
         paperSize: String = "label",
-        refund: String? = null
+        refund: String? = null,
+        productNames: String = "[Woo T-shirt, Herman Chair]"
     ): WCShippingLabelModel {
         return WCShippingLabelModel().apply {
             localSiteId = siteId
@@ -34,6 +35,7 @@ object WCShippingLabelTestUtils {
             this.refundableAmount = refundableAmount
             this.currency = currency
             this.paperSize = paperSize
+            this.productNames = productNames
             refund?.let { this.refund = it }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -74,10 +74,16 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
 
     /**
      * Returns the list of products the shipping labels were purchased for
+     *
+     * For instance: "[Belt, Cap, Herman Miller Chair Embody]" would be split into a list
+     * ["Belt", "Cap", "Herman Miller Chair Embody"]
      */
     fun getProductNames(): List<String> {
-        val responseType = object : TypeToken<List<String>>() {}.type
-        return gson.fromJson(productNames, responseType) as? List<String> ?: emptyList()
+        return productNames
+                .trim() // remove extra spaces between commas
+                .removePrefix("[") // remove the String prefix
+                .removeSuffix("]") // remove the String suffix
+                .split(",") // split the string into list using comma spearators
     }
 
     /**


### PR DESCRIPTION
Closes #1608. This tiny PR modifies the way we parse the product names of a shipping label. The API response is returned as `[Belt, Long Sleeve Tee]`. This throws an exception when trying to parse using `Gson`. This PR fixes this logic and adds a test case to ensure that the parsing the product names of a shipping labels works as expected.

### To test
- Run `WCShippingLabelSqlUtilsTest`