### PR TITLE
Woo/fetch product tags

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload
@@ -723,6 +724,52 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RemoteProductCategoriesPayload
         assertTrue(payload.isError)
         assertEquals(ProductErrorType.GENERIC_ERROR, payload.error.type)
+    }
+
+    @Test
+    fun testFetchProductTagsSuccess() {
+        interceptor.respondWith("wc-fetch-product-tags-response-success.json")
+        productRestClient.fetchProductTags(siteModel)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCProductAction.FETCHED_PRODUCT_TAGS, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteProductTagsPayload
+        assertNull(payload.error)
+        assertEquals(payload.tags.size, 3)
+        assertEquals(payload.tags[0].remoteTagId, 1)
+        assertEquals(payload.tags[0].name, "awoo")
+        assertEquals(payload.tags[0].slug, "awoo")
+        assertEquals(payload.tags[0].description, "")
+
+        // save the tags to the db
+        assertEquals(ProductSqlUtils.insertOrUpdateProductTags(payload.tags), 3)
+
+        // now delete all tags for this site and save again
+        ProductSqlUtils.deleteProductTagsForSite(siteModel)
+        assertEquals(ProductSqlUtils.insertOrUpdateProductTags(payload.tags), 3)
+
+        // now verify the db stored the tags correctly
+        val dbTags = ProductSqlUtils.getProductTagsForSite(siteModel.id)
+        assertEquals(dbTags.size, 3)
+        with(dbTags.first()) {
+            assertEquals(this.remoteTagId, 1)
+            assertEquals(this.localSiteId, siteModel.id)
+        }
+    }
+
+    @Test
+    fun testFetchProductTagsError() {
+        interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
+        productRestClient.fetchProductTags(siteModel)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCProductAction.FETCHED_PRODUCT_TAGS, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteProductTagsPayload
+        assertNotNull(payload.error)
     }
 
     @Suppress("unused")

--- a/example/src/androidTest/resources/wc-fetch-product-tags-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-tags-response-success.json
@@ -1,0 +1,45 @@
+{
+  "data": [{
+    "id": 1,
+    "name": "awoo",
+    "slug": "awoo",
+    "description": "",
+    "count": 0,
+    "_links": {
+      "self": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/tags\/155"
+      }],
+      "collection": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/tags"
+      }]
+    }
+  }, {
+    "id": 2,
+    "name": "saturn",
+    "slug": "saturn",
+    "description": "",
+    "count": 0,
+    "_links": {
+      "self": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/tags\/156"
+      }],
+      "collection": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/tags"
+      }]
+    }
+  }, {
+    "id": 3,
+    "name": "test",
+    "slug": "test",
+    "description": "",
+    "count": 0,
+    "_links": {
+      "self": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/tags\/154"
+      }],
+      "collection": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/tags"
+      }]
+    }
+  }]
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPa
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
@@ -47,6 +48,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductImagesChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClassesChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductSkuAvailabilityChanged
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductTagChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductsSearched
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
@@ -69,6 +71,7 @@ class WooProductsFragment : Fragment() {
 
     private var pendingFetchProductShippingClassListOffset: Int = 0
     private var pendingFetchProductCategoriesOffset: Int = 0
+    private var pendingFetchProductTagsOffset: Int = 0
 
     private var enteredCategoryName: String? = null
 
@@ -283,6 +286,22 @@ class WooProductsFragment : Fragment() {
             }
         }
 
+        fetch_product_tags.setOnClickListener {
+            selectedSite?.let { site ->
+                prependToLog("Submitting request to fetch product tags for site ${site.id}")
+                val payload = FetchProductTagsPayload(site)
+                dispatcher.dispatch(WCProductActionBuilder.newFetchProductTagsAction(payload))
+            }
+        }
+
+        load_more_product_tags.setOnClickListener {
+            selectedSite?.let { site ->
+                prependToLog("Submitting offset request to fetch product tags for site ${site.id}")
+                val payload = FetchProductTagsPayload(site, offset = pendingFetchProductTagsOffset)
+                dispatcher.dispatch(WCProductActionBuilder.newFetchProductTagsAction(payload))
+            }
+        }
+
         update_product_images.setOnClickListener {
             showSingleLineDialog(
                     activity,
@@ -483,6 +502,25 @@ class WooProductsFragment : Fragment() {
                     }
                 }
             }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductTagChanged(event: OnProductTagChanged) {
+        if (event.isError) {
+            prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
+            return
+        }
+
+        prependToLog("Fetched ${event.rowsAffected} product tags. More tags available ${event.canLoadMore}")
+        if (event.canLoadMore) {
+            pendingFetchProductTagsOffset += event.rowsAffected
+            load_more_product_tags.visibility = View.VISIBLE
+            load_more_product_tags.isEnabled = true
+        } else {
+            pendingFetchProductTagsOffset = 0
+            load_more_product_tags.isEnabled = false
         }
     }
 

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -159,6 +159,20 @@
             android:text="Update Product Images"/>
 
         <Button
+            android:id="@+id/fetch_product_tags"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Product Tags"/>
+
+        <Button
+            android:id="@+id/load_more_product_tags"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:text="Load More Product Tags" />
+
+        <Button
             android:id="@+id/update_product"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
+import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductCategoryApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductReviewApiResponse
@@ -92,5 +93,37 @@ object ProductTestUtils {
                 parent = it.parent ?: 0L
             }
         }
+    }
+
+    fun generateSampleProductTag(
+        remoteId: Long = 1L,
+        name: String = "",
+        slug: String = "",
+        description: String = "",
+        count: Int = 3,
+        siteId: Int = 6
+    ): WCProductTagModel {
+        return WCProductTagModel().apply {
+            remoteTagId = remoteId
+            localSiteId = siteId
+            this.name = name
+            this.slug = slug
+            this.description = description
+            this.count = count
+        }
+    }
+
+    fun generateProductTags(siteId: Int = 6): List<WCProductTagModel> {
+        val tagList = mutableListOf<WCProductTagModel>()
+        for (i in 0 until 5) {
+            tagList.add(generateSampleProductTag(
+                    i.toLong(),
+                    siteId = siteId,
+                    name = "$i",
+                    slug = "$i",
+                    description = "$i"
+            ))
+        }
+        return tagList
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 111
+        return 112
     }
 
     override fun getDbName(): String {
@@ -1234,6 +1234,21 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL(
                             "CREATE TABLE WhatsNewAnnouncementFeature (_id INTEGER PRIMARY KEY AUTOINCREMENT," +
                                     "ANNOUNCEMENT_ID INTEGER,TITLE TEXT,SUBTITLE TEXT,ICON_URL TEXT,ICON_BASE64 TEXT)"
+                    )
+                }
+                111 -> migrate(version) {
+                    db.execSQL(
+                            "CREATE TABLE WCProductTagModel (" +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "REMOTE_TAG_ID INTEGER," +
+                                    "NAME TEXT NOT NULL," +
+                                    "SLUG TEXT NOT NULL," +
+                                    "DESCRIPTION TEXT," +
+                                    "COUNT INTEGER," +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
+                                    "UNIQUE (REMOTE_TAG_ID, LOCAL_SITE_ID) " +
+                                    "ON CONFLICT REPLACE)"
                     )
                 }
             }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
@@ -24,6 +25,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
@@ -70,6 +72,8 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_CATEGORIES,
     @Action(payloadType = AddProductCategoryPayload.class)
     ADD_PRODUCT_CATEGORY,
+    @Action(payloadType = FetchProductTagsPayload.class)
+    FETCH_PRODUCT_TAGS,
 
 
     // Remote responses
@@ -104,5 +108,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteProductCategoriesPayload.class)
     FETCHED_PRODUCT_CATEGORIES,
     @Action(payloadType = RemoteAddProductCategoryResponsePayload.class)
-    ADDED_PRODUCT_CATEGORY
+    ADDED_PRODUCT_CATEGORY,
+    @Action(payloadType = RemoteProductTagsPayload.class)
+    FETCHED_PRODUCT_TAGS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductTagModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductTagModel.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+@RawConstraints(
+        "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+        "UNIQUE (REMOTE_TAG_ID, LOCAL_SITE_ID) ON CONFLICT REPLACE"
+)
+class WCProductTagModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var remoteTagId = 0L // The unique identifier for this tag on the server
+    @Column var name = ""
+    @Column var slug = ""
+    @Column var description = ""
+    @Column var count = 0
+
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -163,7 +163,7 @@ class ProductRestClient(
         pageSize: Int = DEFAULT_PRODUCT_TAGS_PAGE_SIZE,
         offset: Int = 0
     ) {
-        val url = WOOCOMMERCE.products.shipping_classes.pathV3
+        val url = WOOCOMMERCE.products.tags.pathV3
         val responseType = object : TypeToken<List<ProductTagApiResponse>>() {}.type
         val params = mutableMapOf(
                 "per_page" to pageSize.toString(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductTagApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductTagApiResponse.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import org.wordpress.android.fluxc.network.Response
+
+@Suppress("PropertyName")
+class ProductTagApiResponse : Response {
+    var id: Long = 0L
+
+    var name: String? = null
+    var slug: String? = null
+    var description: String? = null
+
+    var count = 0
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -6,6 +6,7 @@ import com.wellsql.generated.WCProductCategoryModelTable
 import com.wellsql.generated.WCProductModelTable
 import com.wellsql.generated.WCProductReviewModelTable
 import com.wellsql.generated.WCProductShippingClassModelTable
+import com.wellsql.generated.WCProductTagModelTable
 import com.wellsql.generated.WCProductVariationModelTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
@@ -15,6 +16,7 @@ import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
+import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_SORTING
@@ -535,4 +537,67 @@ object ProductSqlUtils {
     }
 
     fun deleteAllProductCategories() = WellSql.delete(WCProductCategoryModel::class.java).execute()
+
+    fun getProductTagsForSite(
+        localSiteId: Int
+    ): List<WCProductTagModel> {
+        return WellSql.select(WCProductTagModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductTagModelTable.LOCAL_SITE_ID, localSiteId)
+                .endGroup().endWhere()
+                .asModel
+    }
+
+    fun getProductTagByRemoteId(
+        remoteTagId: Long,
+        localSiteId: Int
+    ): WCProductTagModel? {
+        return WellSql.select(WCProductTagModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductTagModelTable.REMOTE_TAG_ID, remoteTagId)
+                .equals(WCProductTagModelTable.LOCAL_SITE_ID, localSiteId)
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+    }
+
+    fun deleteProductTagsForSite(site: SiteModel): Int {
+        return WellSql.delete(WCProductTagModel::class.java)
+                .where()
+                .equals(WCProductTagModelTable.LOCAL_SITE_ID, site.id)
+                .or()
+                .equals(WCProductTagModelTable.LOCAL_SITE_ID, 0) // Should never happen, but sanity cleanup
+                .endWhere().execute()
+    }
+
+    fun insertOrUpdateProductTags(tags: List<WCProductTagModel>): Int {
+        var rowsAffected = 0
+        tags.forEach {
+            rowsAffected += insertOrUpdateProductTag(it)
+        }
+        return rowsAffected
+    }
+
+    fun insertOrUpdateProductTag(tag: WCProductTagModel): Int {
+        val result = WellSql.select(WCProductTagModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductTagModelTable.ID, tag.id)
+                .or()
+                .beginGroup()
+                .equals(WCProductTagModelTable.LOCAL_SITE_ID, tag.localSiteId)
+                .equals(WCProductTagModelTable.REMOTE_TAG_ID, tag.remoteTagId)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+
+        return if (result == null) {
+            // Insert
+            WellSql.insert(tag).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            val oldId = result.id
+            WellSql.update(WCProductTagModel::class.java).whereId(oldId)
+                    .put(tag, UpdateAllExceptId(WCProductTagModel::class.java)).execute()
+        }
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
+import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
@@ -34,6 +35,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         const val DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE = 100
         const val DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE = 25
         const val DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE = 25
+        const val DEFAULT_PRODUCT_TAGS_PAGE_SIZE = 25
         val DEFAULT_PRODUCT_SORTING = TITLE_ASC
         val DEFAULT_CATEGORY_SORTING = NAME_ASC
     }
@@ -142,6 +144,12 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     class AddProductCategoryPayload(
         val site: SiteModel,
         val category: WCProductCategoryModel
+    ) : Payload<BaseNetworkError>()
+
+    class FetchProductTagsPayload(
+        var site: SiteModel,
+        var pageSize: Int = DEFAULT_PRODUCT_TAGS_PAGE_SIZE,
+        var offset: Int = 0
     ) : Payload<BaseNetworkError>()
 
     enum class ProductErrorType {
@@ -376,6 +384,21 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             site: SiteModel,
             category: WCProductCategoryModel?
         ) : this(site, category) { this.error = error }
+    }
+
+    class RemoteProductTagsPayload(
+        val site: SiteModel,
+        val tags: List<WCProductTagModel> = emptyList(),
+        var offset: Int = 0,
+        var loadedMore: Boolean = false,
+        var canLoadMore: Boolean = false
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel
+        ) : this(site) {
+            this.error = error
+        }
     }
 
     // OnChanged events

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -17,6 +17,9 @@
 /products/categories/
 /products/categories/<id>/
 
+/products/tags/
+/products/tags/<id>/
+
 /reports/orders/totals/
 /reports/revenue/stats/
 


### PR DESCRIPTION
Fixes #1611 by adding support to fetch product tags for a given site.

#### Changes
- Adds a new endpoint `wc/v3/products/tags/` to fetch product tags for a site.
- Added new `WCProductTagModel` model class and a migration script to create table.
- Added new action and action classes to `WCProductStore` and `ProductRestClient` to fetch product tags for a site.
- Added unit tests.
- Added a new button to the example app to fetch product tags.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/85400733-85931a00-b576-11ea-8ae2-76c2ec72dc63.png" width="300"/>

#### To test
- Since this PR adds a migration script, it would be nice to test updating the app.
- Run `MockedStack_WCProductsTest`, `ReleaseStack_WCProductTest` and `ProductSqlUtilsTest`.
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Fetch product tags`.
  - Verify that the categories are fetched correctly.
  - Click on `Load more Tags` and verify that the tags are fetched correctly.
  - If there is no more categories data found in the API response, the `Load more tags` button should NOT be displayed.