### PR TITLE
Woo/update product tags

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment
+import org.wordpress.android.fluxc.example.ui.products.WooProductTagsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
@@ -85,6 +86,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooProductCategoriesFragmentInjector(): WooProductCategoriesFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooProductTagsFragmentInjector(): WooProductTagsFragment
 
     @ContributesAndroidInjector
     abstract fun provideWooOrdersFragmentInjector(): WooOrdersFragment

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductTagsAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductTagsAdapter.kt
@@ -1,0 +1,98 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.product_category_list_item.view.*
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.ui.products.WooProductTagsAdapter.ProductTagViewHolder
+import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment.ProductTag
+
+class WooProductTagsAdapter(
+    private val context: Context,
+    private val clickListener: OnProductTagClickListener
+) : RecyclerView.Adapter<ProductTagViewHolder>() {
+    private val productTagList = ArrayList<ProductTagViewHolderModel>()
+
+    interface OnProductTagClickListener {
+        fun onProductTagClick(productTagViewHolderModel: ProductTagViewHolderModel)
+    }
+
+    data class ProductTagViewHolderModel(val tag: ProductTag, var isSelected: Boolean = false)
+
+    override fun getItemCount() = productTagList.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductTagViewHolder {
+        return ProductTagViewHolder(
+                LayoutInflater.from(context)
+                        .inflate(R.layout.product_category_list_item, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: ProductTagViewHolder, position: Int) {
+        val productTag = productTagList[position]
+
+        holder.txtTagName.text = productTag.tag.name
+        holder.checkBox.isChecked = productTag.isSelected
+
+        holder.checkBox.setOnClickListener {
+            handleTagClick(holder, productTag)
+        }
+
+        holder.itemView.setOnClickListener {
+            holder.checkBox.isChecked = !holder.checkBox.isChecked
+            handleTagClick(holder, productTag)
+        }
+    }
+
+    private fun handleTagClick(
+        holder: ProductTagViewHolder,
+        productTag: ProductTagViewHolderModel
+    ) {
+        productTag.isSelected = holder.checkBox.isChecked
+        clickListener.onProductTagClick(productTag)
+    }
+
+    fun setProductTags(productsTags: List<ProductTagViewHolderModel>) {
+        if (productTagList.isEmpty()) {
+            productTagList.addAll(productsTags)
+            notifyDataSetChanged()
+        } else {
+            val diffResult = DiffUtil.calculateDiff(ProductItemDiffUtil(productTagList, productsTags))
+            productTagList.clear()
+            productTagList.addAll(productsTags)
+            diffResult.dispatchUpdatesTo(this)
+        }
+    }
+
+    class ProductTagViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val txtTagName: TextView = view.categoryName
+        val checkBox: CheckBox = view.categorySelected
+    }
+
+    private class ProductItemDiffUtil(
+        val items: List<ProductTagViewHolderModel>,
+        val result: List<ProductTagViewHolderModel>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+                items[oldItemPosition].tag.name == result[newItemPosition].tag.name
+
+        override fun getOldListSize(): Int = items.size
+
+        override fun getNewListSize(): Int = result.size
+
+        fun isSameTag(left: ProductTag, right: ProductTag): Boolean {
+            return left.name == right.name
+        }
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = items[oldItemPosition]
+            val newItem = result[newItemPosition]
+            return isSameTag(oldItem.tag, newItem.tag)
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductTagsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductTagsFragment.kt
@@ -1,0 +1,106 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_product_categories.*
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.ui.products.WooProductTagsAdapter.OnProductTagClickListener
+import org.wordpress.android.fluxc.example.ui.products.WooProductTagsAdapter.ProductTagViewHolderModel
+import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment.ProductTag
+
+class WooProductTagsFragment : Fragment(), OnProductTagClickListener {
+    private var resultCode: Int = -1
+    private var productTags: List<ProductTag>? = null
+    private var selectedProductTags: MutableList<ProductTag>? = null
+
+    private lateinit var productTagsAdapter: WooProductTagsAdapter
+
+    companion object {
+        const val PRODUCT_TAGS_REQUEST_CODE = 3000
+        const val ARG_RESULT_CODE = "ARG_RESULT_CODE"
+        const val ARG_PRODUCT_TAGS = "ARG_PRODUCT_TAGS"
+        const val ARG_SELECTED_PRODUCT_TAGS = "ARG_SELECTED_PRODUCT_TAGS"
+
+        fun newInstance(
+            fragment: Fragment,
+            resultCode: Int,
+            productTags: List<ProductTag>,
+            selectedProductTags: MutableList<ProductTag>?
+        ) = WooProductTagsFragment().apply {
+            this.setTargetFragment(fragment, PRODUCT_TAGS_REQUEST_CODE)
+            this.resultCode = resultCode
+            this.productTags = productTags
+            this.selectedProductTags = selectedProductTags
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(layout.fragment_woo_product_categories, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        savedInstanceState?.let {
+            resultCode = it.getInt(ARG_RESULT_CODE)
+            productTags = it.getParcelableArrayList(ARG_PRODUCT_TAGS)
+            selectedProductTags = it.getParcelableArrayList(ARG_SELECTED_PRODUCT_TAGS)
+        }
+
+        productTagsAdapter = WooProductTagsAdapter(requireContext(), this)
+        with(category_list) {
+            layoutManager = LinearLayoutManager(activity)
+            adapter = productTagsAdapter
+        }
+
+        val allTags = productTags?.map { productTag ->
+            ProductTagViewHolderModel(
+                    tag = productTag,
+                    isSelected = selectedProductTags?.any { it.name == productTag.name } ?: false
+            )
+        } ?: emptyList()
+
+        productTagsAdapter.setProductTags(allTags.toList())
+
+        btn_done.setOnClickListener {
+            val intent = activity?.intent
+            intent?.putParcelableArrayListExtra(
+                    ARG_SELECTED_PRODUCT_TAGS, selectedProductTags as? ArrayList
+            )
+            targetFragment?.onActivityResult(PRODUCT_TAGS_REQUEST_CODE, resultCode, intent)
+            fragmentManager?.popBackStack()
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(ARG_RESULT_CODE, resultCode)
+        productTags?.let {
+            outState.putParcelableArrayList(ARG_PRODUCT_TAGS, it as? ArrayList)
+        }
+        selectedProductTags?.let {
+            outState.putParcelableArrayList(ARG_SELECTED_PRODUCT_TAGS, it as? ArrayList)
+        }
+    }
+
+    override fun onProductTagClick(productTagViewHolderModel: ProductTagViewHolderModel) {
+        val found = selectedProductTags?.find {
+            it.name == productTagViewHolderModel.tag.name
+        }
+        if (!productTagViewHolderModel.isSelected && found != null) {
+            selectedProductTags?.remove(found)
+        } else if (productTagViewHolderModel.isSelected && found == null) {
+            selectedProductTags?.add(productTagViewHolderModel.tag)
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -59,11 +59,13 @@ class WooUpdateProductFragment : Fragment() {
     private var selectedProductModel: WCProductModel? = null
     private var password: String? = null
     private var selectedCategories: List<ProductCategory>? = null
+    private var selectedTags: MutableList<ProductTag>? = null
 
     companion object {
         const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
         const val ARG_SELECTED_PRODUCT_ID = "ARG_SELECTED_PRODUCT_ID"
         const val ARG_SELECTED_CATEGORIES = "ARG_SELECTED_CATEGORIES"
+        const val ARG_SELECTED_TAGS = "ARG_SELECTED_TAGS"
         const val LIST_RESULT_CODE_TAX_STATUS = 101
         const val LIST_RESULT_CODE_STOCK_STATUS = 102
         const val LIST_RESULT_CODE_BACK_ORDERS = 103
@@ -111,6 +113,7 @@ class WooUpdateProductFragment : Fragment() {
         outState.putInt(ARG_SELECTED_SITE_POS, selectedSitePosition)
         selectedRemoteProductId?.let { outState.putLong(ARG_SELECTED_PRODUCT_ID, it) }
         selectedCategories?.let { outState.putParcelableArrayList(ARG_SELECTED_CATEGORIES, it as? ArrayList) }
+        selectedTags?.let { outState.putParcelableArrayList(ARG_SELECTED_TAGS, it as? ArrayList) }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -265,6 +268,7 @@ class WooUpdateProductFragment : Fragment() {
             selectedRemoteProductId = bundle.getLong(ARG_SELECTED_PRODUCT_ID)
             selectedSitePosition = bundle.getInt(ARG_SELECTED_SITE_POS)
             selectedCategories = bundle.getParcelableArrayList(ARG_SELECTED_CATEGORIES)
+            selectedTags = bundle.getParcelableArrayList(ARG_SELECTED_TAGS)
             selectedRemoteProductId?.let { updateSelectedProductId(it) }
         }
     }
@@ -353,6 +357,9 @@ class WooUpdateProductFragment : Fragment() {
                         selectedCategories?.joinToString(", ") { it.name }
                                 ?: it.getCommaSeparatedCategoryNames()
                 )
+                product_tags.setText(
+                        selectedTags?.joinToString(", ") { it.name } ?: it.getCommaSeparatedTagNames()
+                )
             } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
     }
@@ -429,6 +436,13 @@ class WooUpdateProductFragment : Fragment() {
             return ProductTriplet(this.id, this.name, this.slug)
         }
     }
+
+    @Parcelize
+    data class ProductTag(
+        val id: Long? = 0L,
+        val name: String,
+        val slug: String
+    ) : Parcelable
 
     private fun ProductTriplet.toProductCategory(): ProductCategory {
         return ProductCategory(this.id, this.name, this.slug)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -28,6 +28,8 @@ import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.ARG_L
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.LIST_SELECTOR_REQUEST_CODE
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment.Companion.ARG_SELECTED_PRODUCT_CATEGORIES
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment.Companion.PRODUCT_CATEGORIES_REQUEST_CODE
+import org.wordpress.android.fluxc.example.ui.products.WooProductTagsFragment.Companion.ARG_SELECTED_PRODUCT_TAGS
+import org.wordpress.android.fluxc.example.ui.products.WooProductTagsFragment.Companion.PRODUCT_TAGS_REQUEST_CODE
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.WCProductModel
@@ -59,7 +61,7 @@ class WooUpdateProductFragment : Fragment() {
     private var selectedProductModel: WCProductModel? = null
     private var password: String? = null
     private var selectedCategories: List<ProductCategory>? = null
-    private var selectedTags: MutableList<ProductTag>? = null
+    private var selectedTags: List<ProductTag>? = null
 
     companion object {
         const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
@@ -72,6 +74,7 @@ class WooUpdateProductFragment : Fragment() {
         const val LIST_RESULT_CODE_VISIBILITY = 104
         const val LIST_RESULT_CODE_STATUS = 105
         const val LIST_RESULT_CODE_CATEGORIES = 106
+        const val LIST_RESULT_CODE_TAGS = 107
 
         fun newInstance(selectedSitePosition: Int): WooUpdateProductFragment {
             val fragment = WooUpdateProductFragment()
@@ -198,6 +201,9 @@ class WooUpdateProductFragment : Fragment() {
                     selectedCategories?.let { selectedProductModel?.categories =
                             it.map { it.toProductTriplet().toJson() }.toString() }
 
+                    selectedTags?.let { selectedProductModel?.tags =
+                            it.map { it.toProductTriplet().toJson() }.toString() }
+
                     val payload = UpdateProductPayload(site, selectedProductModel!!)
                     dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
                     val updatedPassword = product_password.getText()
@@ -246,6 +252,23 @@ class WooUpdateProductFragment : Fragment() {
             }
         }
 
+        select_product_tags.setOnClickListener {
+            getWCSite()?.let {
+                val tags = wcProductStore.getTagsForSite(it)
+                        .map { ProductTag(it.remoteTagId, it.name, it.slug) }
+
+                val selectedProductTags = selectedTags ?: selectedProductModel?.getTags()
+                        ?.map { it.toProductTag() }
+
+                replaceFragment(WooProductTagsFragment.newInstance(
+                        fragment = this,
+                        productTags = tags,
+                        resultCode = LIST_RESULT_CODE_TAGS,
+                        selectedProductTags = selectedProductTags?.toMutableList()
+                ))
+            }
+        }
+
         product_is_featured.setOnCheckedChangeListener { _, isChecked ->
             selectedProductModel?.featured = isChecked
         }
@@ -269,8 +292,8 @@ class WooUpdateProductFragment : Fragment() {
             selectedSitePosition = bundle.getInt(ARG_SELECTED_SITE_POS)
             selectedCategories = bundle.getParcelableArrayList(ARG_SELECTED_CATEGORIES)
             selectedTags = bundle.getParcelableArrayList(ARG_SELECTED_TAGS)
-            selectedRemoteProductId?.let { updateSelectedProductId(it) }
         }
+        selectedRemoteProductId?.let { updateSelectedProductId(it) }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -311,6 +334,8 @@ class WooUpdateProductFragment : Fragment() {
             }
         } else if (requestCode == PRODUCT_CATEGORIES_REQUEST_CODE) {
             this.selectedCategories = data?.getParcelableArrayListExtra(ARG_SELECTED_PRODUCT_CATEGORIES)
+        } else if (requestCode == PRODUCT_TAGS_REQUEST_CODE) {
+            this.selectedTags = data?.getParcelableArrayListExtra(ARG_SELECTED_PRODUCT_TAGS)
         }
     }
 
@@ -358,7 +383,8 @@ class WooUpdateProductFragment : Fragment() {
                                 ?: it.getCommaSeparatedCategoryNames()
                 )
                 product_tags.setText(
-                        selectedTags?.joinToString(", ") { it.name } ?: it.getCommaSeparatedTagNames()
+                        selectedTags?.joinToString(", ") { it.name }
+                                ?: it.getCommaSeparatedTagNames()
                 )
             } ?: WCProductModel().apply { this.remoteProductId = remoteProductId }
         } ?: prependToLog("No valid site found...doing nothing")
@@ -439,12 +465,20 @@ class WooUpdateProductFragment : Fragment() {
 
     @Parcelize
     data class ProductTag(
-        val id: Long? = 0L,
+        val id: Long,
         val name: String,
         val slug: String
-    ) : Parcelable
+    ) : Parcelable {
+        fun toProductTriplet(): ProductTriplet {
+            return ProductTriplet(this.id, this.name, this.slug)
+        }
+    }
 
     private fun ProductTriplet.toProductCategory(): ProductCategory {
         return ProductCategory(this.id, this.name, this.slug)
+    }
+
+    private fun ProductTriplet.toProductTag(): ProductTag {
+        return ProductTag(this.id, this.name, this.slug)
     }
 }

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -142,6 +142,20 @@
             app:layout_constraintStart_toEndOf="@+id/product_categories"
             app:layout_constraintTop_toBottomOf="@+id/product_short_desc" />
 
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_tags"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="text"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_categories"
+            app:textHint="Product Tags" />
+
         <Button
             android:id="@+id/product_catalog_visibility"
             style="?android:attr/spinnerStyle"
@@ -153,7 +167,7 @@
             app:layout_constraintEnd_toStartOf="@+id/product_status"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_categories" />
+            app:layout_constraintTop_toBottomOf="@+id/product_tags" />
 
         <Button
             android:id="@+id/product_status"
@@ -166,7 +180,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toEndOf="@+id/product_catalog_visibility"
-            app:layout_constraintTop_toBottomOf="@+id/product_categories" />
+            app:layout_constraintTop_toBottomOf="@+id/product_tags" />
 
         <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_regular_price"

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -147,14 +147,26 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:inputType="text"
             android:focusable="false"
             android:focusableInTouchMode="false"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:inputType="text"
+            app:layout_constraintEnd_toStartOf="@+id/select_product_tags"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_categories"
             app:textHint="Product Tags" />
+
+        <Button
+            android:id="@+id/select_product_tags"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Select Tags"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_tags"
+            app:layout_constraintTop_toBottomOf="@+id/product_categories" />
 
         <Button
             android:id="@+id/product_catalog_visibility"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -316,4 +316,22 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         }
         return true
     }
+
+    /**
+     * Compares this product's tags with the passed product's tags, returns true only if both
+     * lists contain the same tags in the same order
+     */
+    fun hasSameTags(updatedProduct: WCProductModel): Boolean {
+        val updatedTags = updatedProduct.getTags()
+        val storedTags = getTags()
+        if (storedTags.size != updatedTags.size) {
+            return false
+        }
+        for (i in storedTags.indices) {
+            if (storedTags[i].id != updatedTags[i].id) {
+                return false
+            }
+        }
+        return true
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -883,6 +883,14 @@ class ProductRestClient(
                 }
             }
         }
+        if (!storedWCProductModel.hasSameTags(updatedProductModel)) {
+            val updatedTags = updatedProductModel.getTags()
+            body["tags"] = JsonArray().also {
+                for (tag in updatedTags) {
+                    it.add(tag.toJson())
+                }
+            }
+        }
         return body
     }
 


### PR DESCRIPTION
Fixes #1612 by adding logic to update tags for a product.

#### Changes
Adds a new option in the `WooUpdateProductFragment` to view tags of a product and to select multiple tags and update the product.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/85567146-3fa98500-b64e-11ea-9286-e21b4d593abd.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/85567139-3ddfc180-b64e-11ea-9c88-f7a18a9d2902.png" width="300"/>

#### To test
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Fetch product tags`.
- Click the back button and click on `Update product`.
- Enter a valid product Id and notice that the product tags are displayed.
- Click on `Select Tags`. (This will fetch the tags stored locally in the app and will be empty if there are no tags stored locally).
- Select multiple tags and click on the `Done` button. 
- Click on the `Tick` icon and notice that the tags are updated successfully.