### PR TITLE
Revert "Update Gradle version"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
     steps:
       - run:
           name: Setup gradle.properties
-          command: cp example/gradle.properties-example example/gradle.properties && cp gradle.properties-example gradle.properties
+          command: cp example/gradle.properties-example example/gradle.properties
   decrypt-file:
     parameters:
       input:
@@ -43,7 +43,7 @@ commands:
 
 jobs:
   Lint:
-    executor:
+    executor: 
       name: android/default
       api-version: "27"
     steps:
@@ -61,7 +61,7 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Unit Tests:
-    executor:
+    executor: 
       name: android/default
       api-version: "27"
     steps:
@@ -87,14 +87,13 @@ jobs:
         type: boolean
       device:
         type: string
-    executor:
+    executor: 
       name: android/default
       api-version: "27"
     steps:
       - checkout
       - android/restore-gradle-cache:
           cache-prefix: connected-tests
-      - copy-gradle-properties
       - decrypt-properties-files
       - run:
           name: Build
@@ -138,7 +137,7 @@ jobs:
                 success_message: '${SLACK_SUCCESS_MESSAGE}'
                 webhook: '${SLACK_STATUS_WEBHOOK}'
   WooCommerce API Tests:
-    executor:
+    executor: 
       name: android/default
       api-version: "27"
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.automattic.android:fetchstyle:1.1'
     }
 }

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,3 +1,0 @@
-org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
-android.useAndroidX=true
-android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 22 11:05:28 CEST 2020
+#Mon Sep 30 16:27:52 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-FluxC-Android#1610

Since we need a `gradle.properties` file to build now, Jitpack is unable to build the project. This PR reverts the change until we can figure out a good way to handle this.