### PR TITLE
Woo/add product tags

### DIFF
--- a/example/src/androidTest/resources/wc-add-product-tag-response-success.json
+++ b/example/src/androidTest/resources/wc-add-product-tag-response-success.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "id": 1,
+    "name": "test12",
+    "slug": "test12",
+    "description": "",
+    "count": 0,
+    "_links": {
+      "self": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/tags\/155"
+      }],
+      "collection": [{
+        "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wc\/v3\/products\/tags"
+      }]
+    }
+  }
+}

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -173,6 +173,13 @@
             android:text="Load More Product Tags" />
 
         <Button
+            android:id="@+id/add_product_tag"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Add Product Tag" />
+
+        <Button
             android:id="@+id/update_product"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
@@ -17,6 +18,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayloa
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload;
@@ -74,6 +76,8 @@ public enum WCProductAction implements IAction {
     ADD_PRODUCT_CATEGORY,
     @Action(payloadType = FetchProductTagsPayload.class)
     FETCH_PRODUCT_TAGS,
+    @Action(payloadType = AddProductTagPayload.class)
+    ADD_PRODUCT_TAG,
 
 
     // Remote responses
@@ -110,5 +114,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteAddProductCategoryResponsePayload.class)
     ADDED_PRODUCT_CATEGORY,
     @Action(payloadType = RemoteProductTagsPayload.class)
-    FETCHED_PRODUCT_TAGS
+    FETCHED_PRODUCT_TAGS,
+    @Action(payloadType = RemoteAddProductTagResponsePayload.class)
+    ADDED_PRODUCT_TAG,
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -152,6 +152,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var offset: Int = 0
     ) : Payload<BaseNetworkError>()
 
+    class AddProductTagPayload(
+        val site: SiteModel,
+        val tag: WCProductTagModel
+    ) : Payload<BaseNetworkError>()
+
     enum class ProductErrorType {
         INVALID_PARAM,
         INVALID_REVIEW_ID,
@@ -399,6 +404,17 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         ) : this(site) {
             this.error = error
         }
+    }
+
+    class RemoteAddProductTagResponsePayload(
+        val site: SiteModel,
+        val tag: WCProductTagModel?
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel,
+            tag: WCProductTagModel?
+        ) : this(site, tag) { this.error = error }
     }
 
     // OnChanged events


### PR DESCRIPTION
Fixes #1613 by adding support to add a new tag.

#### Changes
- Added new action and action classes to `WCProductStore` and `ProductRestClient` to add a new product tag for a site.
- Added unit tests.
- Added a new button to the example app to add a new product tag.

#### Notes
~- **This PR is in draft till this [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1617) can be reviewed and merged.**~

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/85689869-a41d2080-b6f0-11ea-966c-e5ed7c0cb29b.png" width="300" />

#### To Test
- Run `MockedStack_WCProductsTest` and `ReleaseStack_WCProductTest`.
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Add Product Tag`.
- Enter a unique tag name and verify that the tag is added successfully to the test site.
- Now click on `Add Product Tag` again and enter the same tag name from the previous step. Notice that an error message is displayed: `TERM_EXISTS`. This is because the API throws an error when we try to update the same tag name.
