### PR TITLE
[Gutenberg] Adjust the fetching of custom colors

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.mocked
 
+import android.os.Bundle
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.junit.Assert
@@ -46,9 +47,17 @@ class MockedStack_EditorThemeStoreTest : MockedStack_Base() {
 
         // See onEditorThemeChanged for the latch's countdown to fire.
         Assert.assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        // Validate Callback
         assertNotEmpty(editorTheme)
+
+        // Validate Cache
         val cachedTheme = editorThemeStore.getEditorThemeForSite(site)
         assertNotEmpty(cachedTheme)
+
+        // Validate Bundle
+        val themeBundle = editorTheme!!.themeSupport.toBundle()
+        assertNotEmpty(themeBundle)
     }
 
     @Test
@@ -58,9 +67,17 @@ class MockedStack_EditorThemeStoreTest : MockedStack_Base() {
 
         // See onEditorThemeChanged for the latch's countdown to fire.
         Assert.assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        // Validate Callback
         assertEmpty(editorTheme)
+
+        // Validate Cache
         val cachedTheme = editorThemeStore.getEditorThemeForSite(site)
         assertEmpty(cachedTheme)
+
+        // Validate Bundle
+        val themeBundle = editorTheme!!.themeSupport.toBundle()
+        assertEmpty(themeBundle)
     }
 
     private fun assertNotEmpty(theme: EditorTheme?) {
@@ -69,8 +86,22 @@ class MockedStack_EditorThemeStoreTest : MockedStack_Base() {
     }
 
     private fun assertEmpty(theme: EditorTheme?) {
-        Assert.assertTrue(theme?.themeSupport?.colors.isNullOrEmpty())
-        Assert.assertTrue(theme?.themeSupport?.gradients.isNullOrEmpty())
+        Assert.assertTrue(theme?.themeSupport?.colors == null)
+        Assert.assertTrue(theme?.themeSupport?.gradients == null)
+    }
+
+    private fun assertEmpty(theme: Bundle) {
+        val colors = theme.getSerializable("colors")
+        val gradients = theme.getSerializable("gradients")
+        Assert.assertTrue(colors == null)
+        Assert.assertTrue(gradients == null)
+    }
+
+    private fun assertNotEmpty(theme: Bundle) {
+        val colors = theme.getSerializable("colors") as ArrayList<*>
+        val gradients = theme.getSerializable("gradients") as ArrayList<*>
+        Assert.assertFalse(colors.isNullOrEmpty())
+        Assert.assertFalse(gradients.isNullOrEmpty())
     }
 
     @Suppress("unused")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -92,15 +92,17 @@ class EditorThemeSqlUtils {
         override fun getId() = mId
 
         fun toEditorTheme(
-            storedColors: List<EditorThemeElementBuilder>,
-            storedGradients: List<EditorThemeElementBuilder>
+            storedColors: List<EditorThemeElementBuilder>?,
+            storedGradients: List<EditorThemeElementBuilder>?
         ): EditorTheme {
-            val colors = if (storedColors.count() > 0) storedColors.mapNotNull { it.toEditorThemeElement() } else null
-            val gradients: List<EditorThemeElement>?
-            if (storedColors.count() > 0) {
+            var colors: List<EditorThemeElement>? = null
+            if (storedColors != null && storedColors.count() > 0) {
+                colors = storedColors.mapNotNull { it.toEditorThemeElement() }
+            }
+
+            var gradients: List<EditorThemeElement>? = null
+            if (storedGradients != null && storedGradients.count() > 0) {
                 gradients = storedGradients.mapNotNull { it.toEditorThemeElement() }
-            } else {
-                        gradients = null
             }
 
             val editorThemeSupport = EditorThemeSupport(colors, gradients)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -92,11 +92,11 @@ class EditorThemeSqlUtils {
         override fun getId() = mId
 
         fun toEditorTheme(
-            storedColors: List<EditorThemeElementBuilder>?,
-            storedGradients: List<EditorThemeElementBuilder>?
+            storedColors: List<EditorThemeElementBuilder>,
+            storedGradients: List<EditorThemeElementBuilder>
         ): EditorTheme {
-            val colors = storedColors?.mapNotNull { it.toEditorThemeElement() }
-            val gradients = storedGradients?.mapNotNull { it.toEditorThemeElement() }
+            val colors = if (storedColors.count() > 0) storedColors.mapNotNull { it.toEditorThemeElement() } else null
+            val gradients = if (storedColors.count() > 0) storedGradients.mapNotNull { it.toEditorThemeElement() } else null
             val editorThemeSupport = EditorThemeSupport(colors, gradients)
 
             return EditorTheme(editorThemeSupport, stylesheet, version)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -96,7 +96,13 @@ class EditorThemeSqlUtils {
             storedGradients: List<EditorThemeElementBuilder>
         ): EditorTheme {
             val colors = if (storedColors.count() > 0) storedColors.mapNotNull { it.toEditorThemeElement() } else null
-            val gradients = if (storedColors.count() > 0) storedGradients.mapNotNull { it.toEditorThemeElement() } else null
+            val gradients: List<EditorThemeElement>?
+            if (storedColors.count() > 0) {
+                gradients = storedGradients.mapNotNull { it.toEditorThemeElement() }
+            } else {
+                        gradients = null
+            }
+
             val editorThemeSupport = EditorThemeSupport(colors, gradients)
 
             return EditorTheme(editorThemeSupport, stylesheet, version)


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2432
WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/12289

To Test:
1. Log in to the demo app for a self-hosted site
2. Set a theme with custom colors and/or gradients on your site
3. In the demo app select Fetch theme from first site
**Expect** to see a log of colors and/or gradients
4. Set a theme with out custom colors and/or gradients on your site
5. In the demo app select Fetch theme from first site
**Expect** to see a log of `[null]` for colors and gradients
