### PR TITLE
Update gradle to 4.0 again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
     steps:
       - run:
           name: Setup gradle.properties
-          command: cp example/gradle.properties-example example/gradle.properties
+          command: cp example/gradle.properties-example example/gradle.properties && cp gradle.properties-example gradle.properties
   decrypt-file:
     parameters:
       input:
@@ -43,7 +43,7 @@ commands:
 
 jobs:
   Lint:
-    executor: 
+    executor:
       name: android/default
       api-version: "27"
     steps:
@@ -61,7 +61,7 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Unit Tests:
-    executor: 
+    executor:
       name: android/default
       api-version: "27"
     steps:
@@ -87,13 +87,14 @@ jobs:
         type: boolean
       device:
         type: string
-    executor: 
+    executor:
       name: android/default
       api-version: "27"
     steps:
       - checkout
       - android/restore-gradle-cache:
           cache-prefix: connected-tests
+      - copy-gradle-properties
       - decrypt-properties-files
       - run:
           name: Build
@@ -137,7 +138,7 @@ jobs:
                 success_message: '${SLACK_SUCCESS_MESSAGE}'
                 webhook: '${SLACK_STATUS_WEBHOOK}'
   WooCommerce API Tests:
-    executor: 
+    executor:
       name: android/default
       api-version: "27"
     steps:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ file and create the gradle.properties file. The easiest way is to copy
 our example:
 
     $ echo "sdk.dir=YOUR_SDK_DIR" > local.properties
+    $ cp gradle.properties-example gradle.properties
     $ ./gradlew fluxc:build
 
 ## Building and running tests and the example app

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.automattic.android:fetchstyle:1.1'
     }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -14,7 +14,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.example"

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import android.net.Uri
 import com.android.volley.NetworkResponse
 import com.android.volley.VolleyError
 import com.nhaarman.mockitokotlin2.any
@@ -14,6 +15,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.reactnative.Nonce
 import org.wordpress.android.fluxc.network.rest.wpapi.reactnative.ReactNativeWPAPIRestClient
@@ -421,6 +423,28 @@ class ReactNativeStoreWPAPITest {
         assertEquals("begin/end", ReactNativeStore.slashJoin("begin/", "end"))
         assertEquals("begin/end", ReactNativeStore.slashJoin("begin", "/end"))
         assertEquals("begin/end", ReactNativeStore.slashJoin("begin/", "/end"))
+    }
+
+    @Test
+    fun `handles failure to parse path`() = test {
+        val mockUri = mock<Uri>()
+        assertNull(mockUri.path, "path must be null to represent failure to parse the path in this test")
+        val uriParser = { _: String -> mockUri }
+
+        store = ReactNativeStore(
+                mock(),
+                wpApiRestClient,
+                discoveryWPAPIRestClient,
+                initCoroutineEngine(),
+                mutableMapOf(),
+                { currentTime },
+                sitePersistenceMock,
+                uriParser
+        )
+
+        val response = store.executeRequest(mock(), "")
+        val errorType = (response as? Error)?.error?.type
+        assertEquals(UNKNOWN, errorType)
     }
 
     private suspend fun ReactNativeWPAPIRestClient.fetch(url: String, nonce: String? = null) =

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -21,14 +21,13 @@ repositories {
 android {
     useLibrary 'org.apache.http.legacy'
 
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
 
     defaultConfig {
         versionCode 4
         versionName "0.1"
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
     buildTypes {
         release {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -279,7 +279,9 @@ constructor(
     }
 
     private fun unregisterDevice() {
-        val deviceId = preferences.getString(WPCOM_PUSH_DEVICE_SERVER_ID, "")
+        val deviceId = requireNotNull(preferences.getString(WPCOM_PUSH_DEVICE_SERVER_ID, ""), {
+            "Because we are giving it a default value, preferences.getString shouldn't return null"
+        })
         notificationRestClient.unregisterDeviceForPushNotifications(deviceId)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -174,9 +174,9 @@ class ReactNativeStore
     private fun parsePathAndParams(pathWithParams: String): Pair<String, Map<String, String>> {
         val uri = Uri.parse(pathWithParams)
         val paramMap = uri.queryParameterNames.map { name ->
-            name to uri.getQueryParameter(name)
+            name to requireNotNull(uri.getQueryParameter(name))
         }.toMap()
-        return Pair(uri.path, paramMap)
+        return Pair(requireNotNull(uri.path), paramMap)
     }
 
     private fun persistSiteSafely(site: SiteModel) {

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 30 16:27:52 EDT 2019
+#Mon Jun 22 11:05:28 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -16,13 +16,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.instaflux"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,2 @@
 before_install:
-- yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
-- yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;28.0.3"
+  - cp gradle.properties-example gradle.properties

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -18,14 +18,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
 
     defaultConfig {
         versionCode 1
         versionName "0.1"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 29
     }
     buildTypes {
         release {


### PR DESCRIPTION
This is the second attempt at upgrading Gradle to 4.0. It starts with the reverting the revert which will re-add the changes from #1610 and builds on top of it to fix the issue with Jitpack. There are a few things to note:

1. The issue with Jitpack was the missing `useAndroidX` flag which as far as I can tell, we can only set through `gradle.properties` which we normally `.gitignore`. Technically, there is no reason we can't just add a root `gradle.properties` file in the repo. I actually tried this and verified that everything would work as expected, but my worry is that since we add secrets to `gradle.properties`, someday a developer might accidentally add it to the one that's not ignored and push to remote. I think it's best to just eliminate this possibility. Instead, we use the `jitpack.yml` file to copy the example file just like we do for CircleCI.
2. The previous contents of `jitpack.yml` are no longer necessary because the original bug referred in #1095 has been fixed.
3. e1773d9d27b798b96a15c5a57d54b2c6d1eef2c1 fixes the following warnings:
```
WARNING: The specified Android SDK Build Tools version (28.0.3) is ignored, as it is below the minimum supported version (29.0.2) for Android Gradle Plugin 4.0.0.
Android SDK Build Tools 29.0.2 will be used.

To suppress this warning, remove "buildToolsVersion '28.0.3'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
```
4. ecf76ff6381c04499302b65455cd23ea0543fa99 fixes some nullability issues that showed up due to the build tools update. I'll ping specific people to verify my changes since I don't have any context for them.
5. I am not thrilled to have a very low memory value in the `gradle.properties-example` file. This is necessary for CircleCI, but shouldn't be set to this low for our local machines. (or Jitpack if it's taking this value into account) However, I don't want to muddy this PR and fixing that is unfortunately not a priority right now.
