### PR TITLE
Multiple pages call bug

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalChangesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreLocalChangesTest.kt
@@ -27,7 +27,8 @@ class PageStoreLocalChangesTest {
             postStore = mock(),
             dispatcher = mock(),
             coroutineEngine = initCoroutineEngine(),
-            postSqlUtils = postSqlUtils
+            postSqlUtils = postSqlUtils,
+            currentDateUtils = mock()
     )
 
     @Before

--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
@@ -123,6 +123,28 @@ class PageStoreTest {
     }
 
     @Test
+    fun requestPagesFetchesFromServerAndReturnsEventFromTwoRequests() = test {
+        val expected = OnPostChanged(CauseOfOnPostChanged.FetchPages, 5, false)
+        var firstEvent: OnPostChanged? = null
+        var secondEvent: OnPostChanged? = null
+        val firstJob = launch {
+            firstEvent = store.requestPagesFromServer(site)
+        }
+        val secondJob = launch {
+            secondEvent = store.requestPagesFromServer(site)
+        }
+        delay(10)
+        store.onPostChanged(expected)
+        delay(10)
+        firstJob.join()
+        secondJob.join()
+
+        assertThat(firstEvent).isEqualTo(expected)
+        assertThat(secondEvent).isEqualTo(expected)
+        verify(dispatcher).dispatch(any())
+    }
+
+    @Test
     fun requestPagesFetchesPaginatedFromServerAndReturnsSecondEvent() = test {
         val firstEvent = OnPostChanged(CauseOfOnPostChanged.FetchPages, 5, true)
         val lastEvent = OnPostChanged(CauseOfOnPostChanged.FetchPages, 5, false)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
@@ -12,4 +12,5 @@ sealed class CauseOfOnPostChanged {
     class RemovePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
     class UpdatePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
     class RemoteAutoSavePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
+    object HasCachedData : CauseOfOnPostChanged()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
@@ -12,5 +12,4 @@ sealed class CauseOfOnPostChanged {
     class RemovePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
     class UpdatePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
     class RemoteAutoSavePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
-    object HasCachedData : CauseOfOnPostChanged()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/CurrentDateUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/CurrentDateUtils.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.fluxc.network.utils
 
+import java.util.Calendar
 import java.util.Date
 import javax.inject.Inject
 
 class CurrentDateUtils
 @Inject constructor() {
     fun getCurrentDate() = Date()
+    fun getCurrentCalendar() = Calendar.getInstance()
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/11294

There were several issues that are fixed in this PR. The first one is that the pages call takes a long time because we're loading the pages by 20 items. This can take quite some time even with fast data. If you have a site with 100+ pages, it is possible to go to pages, go back and go to pages and see different data. This is because the call is still in progress and as the first step it clears the database. 

- You go to pages 
- 100 Pages are loaded from the DB and shown
- Fetch pages is triggered
- Fetch pages clears the DB and starts loading the pages by 20
- You go back to My Site
- You go to Pages
- The DB now contains a random number of sites between 0 and 100
- This is OK if there are < 100 pages because the screen gets updated when the pages are loaded
- With > 100 pages this looks strange because we have a different view for > 100 pages (flat view vs topological for < 100)

There are a few things in this PR that fix this issue. One is that if the client calls `fetch` now, we check whether there is an ongoing call and if there is one, we just wait for it to finish (by saving the continuation to a list). Once the call is finished, we finish all the continuations and clear the continuation list. 

The second thing I've added is a time stamp of the last fetch. Now we only fetch the new pages once an hour (if it's not pull to refresh call). This should make the experience smoother. 

This could be tested with the WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/12299

I'm only adding you @0nko because you worked on the original changes, feel free to not review this PR :-) 