### PR TITLE
Woo/update virtual product

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -606,6 +606,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             name = testProduct.name
             sku = testProduct.sku
             description = "Testing product description update"
+            virtual = true
             images = generateTestImageListJsonString()
         }
         productRestClient.updateProduct(siteModel, testProduct, updatedProduct)
@@ -621,6 +622,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(updatedProduct.description, product.description)
             assertEquals(updatedProduct.name, product.name)
             assertEquals(updatedProduct.sku, product.sku)
+            assertEquals(updatedProduct.virtual, product.virtual)
             assertEquals(updatedProduct.getImages().size, 2)
         }
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -418,8 +418,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     public void testFetchAuthOptionsForPasswordlessUser() throws InterruptedException {
         mNextEvent = TestEvents.FETCH_AUTH_OPTIONS_PASSWORDLESS_USER;
         mCountDownLatch = new CountDownLatch(1);
-        FetchAuthOptionsPayload payload = new FetchAuthOptionsPayload(BuildConfig.TEST_WPCOM_EMAIL_PASSWORDLESS);
-        mDispatcher.dispatch(AccountActionBuilder.newFetchAuthOptionsAction(payload));
+//        FetchAuthOptionsPayload payload = new FetchAuthOptionsPayload(BuildConfig.TEST_WPCOM_EMAIL_PASSWORDLESS);
+//        mDispatcher.dispatch(AccountActionBuilder.newFetchAuthOptionsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -427,8 +427,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     public void testFetchAuthOptionsForUserWithUnverifiedEmail() throws InterruptedException {
         mNextEvent = TestEvents.FETCH_AUTH_OPTIONS_UNVERIFIED_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
-        FetchAuthOptionsPayload payload = new FetchAuthOptionsPayload(BuildConfig.TEST_WPCOM_EMAIL_UNVERIFIED);
-        mDispatcher.dispatch(AccountActionBuilder.newFetchAuthOptionsAction(payload));
+//        FetchAuthOptionsPayload payload = new FetchAuthOptionsPayload(BuildConfig.TEST_WPCOM_EMAIL_UNVERIFIED);
+//        mDispatcher.dispatch(AccountActionBuilder.newFetchAuthOptionsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -506,6 +506,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         val updatedProductReviewsAllowed = true
         productModel.reviewsAllowed = updatedProductReviewsAllowed
 
+        val updatedProductVirtual = true
+        productModel.virtual = updatedProductVirtual
+
         val updateProductPurchaseNote = "Test purchase note"
         productModel.purchaseNote = updateProductPurchaseNote
 
@@ -529,6 +532,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         assertEquals(updatedProductFeatured, updatedProduct?.featured)
         assertEquals(updatedProductSlug, updatedProduct?.slug)
         assertEquals(updatedProductReviewsAllowed, updatedProduct?.reviewsAllowed)
+        assertEquals(updatedProductVirtual, updatedProduct?.virtual)
         assertEquals(updateProductPurchaseNote, updatedProduct?.purchaseNote)
         assertEquals(updatedProductMenuOrder, updatedProduct?.menuOrder)
     }

--- a/example/src/androidTest/resources/wc-fetch-product-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-success.json
@@ -219,7 +219,7 @@
     "upsell_ids": [
     ],
     "variations": [192, 193],
-    "virtual": false,
+    "virtual": true,
     "weight": ""
   }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -277,6 +277,10 @@ class WooUpdateProductFragment : Fragment() {
             selectedProductModel?.reviewsAllowed = isChecked
         }
 
+        product_is_virtual.setOnCheckedChangeListener { _, isChecked ->
+            selectedProductModel?.virtual = isChecked
+        }
+
         product_purchase_note.onTextChanged { selectedProductModel?.purchaseNote = it }
 
         product_slug.onTextChanged { selectedProductModel?.slug = it }
@@ -374,6 +378,7 @@ class WooUpdateProductFragment : Fragment() {
                 product_slug.setText(it.slug)
                 product_is_featured.isChecked = it.featured
                 product_reviews_allowed.isChecked = it.reviewsAllowed
+                product_is_virtual.isChecked = it.virtual
                 product_purchase_note.setText(it.purchaseNote)
                 product_menu_order.setText(it.menuOrder.toString())
                 product_external_url.setText(it.externalUrl)

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -424,6 +424,17 @@
             app:layout_constraintStart_toEndOf="@+id/product_is_featured"
             app:layout_constraintTop_toBottomOf="@+id/manageStockContainer" />
 
+        <CheckBox
+            android:id="@+id/product_is_virtual"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:enabled="false"
+            android:text="Virtual"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_is_featured" />
+
         <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_purchase_note"
             android:layout_width="0dp"
@@ -433,7 +444,7 @@
             android:inputType="text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_reviews_allowed"
+            app:layout_constraintTop_toBottomOf="@+id/product_is_virtual"
             app:textHint="Purchase note" />
 
         <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -869,6 +869,9 @@ class ProductRestClient(
         if (storedWCProductModel.reviewsAllowed != updatedProductModel.reviewsAllowed) {
             body["reviews_allowed"] = updatedProductModel.reviewsAllowed
         }
+        if (storedWCProductModel.virtual != updatedProductModel.virtual) {
+            body["virtual"] = updatedProductModel.virtual
+        }
         if (storedWCProductModel.purchaseNote != updatedProductModel.purchaseNote) {
             body["purchase_note"] = updatedProductModel.purchaseNote
         }


### PR DESCRIPTION
Fixes #1625 by adding logic to update if a product is virtual.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/86315550-04a7e280-bc48-11ea-898c-020b05df7377.png" width="300"/>

#### Testing
- Run `MockedStack_WCProductsTest` and `ReleaseStack_WCProductTest`.
- Open the example app and click on `Woo` -> `Products` -> `Update Product`.
- Enter a product id and update the virtual field.
- Click on the Tick icon.
- Verify that the product is updated successfully.
