### PR TITLE
Issue/add app ver targets to whats new db

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1252,7 +1252,13 @@ open class WellSqlConfig : DefaultWellConfig {
                     )
                 }
                 112 -> migrate(version) {
-                    db.execSQL("ALTER TABLE WhatsNewAnnouncement ADD APP_VERSION_TARGETS TEXT")
+                    db.execSQL("DROP TABLE IF EXISTS WhatsNewAnnouncement")
+                    db.execSQL(
+                            "CREATE TABLE WhatsNewAnnouncement (_announcement_id INTEGER PRIMARY KEY," +
+                                    "APP_VERSION_NAME TEXT NOT NULL,MINIMUM_APP_VERSION TEXT NOT NULL," +
+                                    "MAXIMUM_APP_VERSION TEXT NOT NULL,APP_VERSION_TARGETS TEXT NOT NULL," +
+                                    "LOCALIZED INTEGER,RESPONSE_LOCALE TEXT NOT NULL,DETAILS_URL TEXT)"
+                    )
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 112
+        return 113
     }
 
     override fun getDbName(): String {
@@ -1250,6 +1250,9 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "UNIQUE (REMOTE_TAG_ID, LOCAL_SITE_ID) " +
                                     "ON CONFLICT REPLACE)"
                     )
+                }
+                112 -> migrate(version) {
+                    db.execSQL("ALTER TABLE WhatsNewAnnouncementModel ADD APP_VERSION_TARGETS TEXT NOT NULL")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1223,8 +1223,8 @@ open class WellSqlConfig : DefaultWellConfig {
                     )
                 }
                 110 -> migrate(version) {
-                    db.execSQL("DROP TABLE IF EXISTS WhatsNewAnnouncementModel")
-                    db.execSQL("DROP TABLE IF EXISTS WhatsNewAnnouncementFeatureModel")
+                    db.execSQL("DROP TABLE IF EXISTS WhatsNewAnnouncement")
+                    db.execSQL("DROP TABLE IF EXISTS WhatsNewAnnouncementFeature")
                     db.execSQL(
                             "CREATE TABLE WhatsNewAnnouncement (_announcement_id INTEGER PRIMARY KEY," +
                                     "APP_VERSION_NAME TEXT NOT NULL,MINIMUM_APP_VERSION TEXT NOT NULL," +
@@ -1252,7 +1252,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     )
                 }
                 112 -> migrate(version) {
-                    db.execSQL("ALTER TABLE WhatsNewAnnouncementModel ADD APP_VERSION_TARGETS TEXT NOT NULL")
+                    db.execSQL("ALTER TABLE WhatsNewAnnouncement ADD APP_VERSION_TARGETS TEXT NOT NULL")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1252,7 +1252,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     )
                 }
                 112 -> migrate(version) {
-                    db.execSQL("ALTER TABLE WhatsNewAnnouncement ADD APP_VERSION_TARGETS TEXT NOT NULL")
+                    db.execSQL("ALTER TABLE WhatsNewAnnouncement ADD APP_VERSION_TARGETS TEXT")
                 }
             }
         }


### PR DESCRIPTION
Added an `APP_VERSION_TARGETS` field to `WhatsNewAnnouncement` table and fixed table names for DB ver 110.

Can be tested with [this](https://github.com/wordpress-mobile/WordPress-Android/pull/12351) PR.