### PR TITLE
Encrypted logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
     }
 
     task checkstyle(type: Checkstyle) {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,7 +18,7 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.example"
-        minSdkVersion 15
+        minSdkVersion 16
         // Keep the targetSdkVersion 22 so we don't need to grant runtime permissions to the tests and the example app
         // An alternative would be granting the permissions via adb before running the test, like here:
         // https://afterecho.uk/blog/granting-marshmallow-permissions-for-testing-flavoured-builds.html

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -68,4 +68,5 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_PostSchedulingTestJetpack test);
     void inject(ReleaseStack_ReactNativeWPAPIRequestTest test);
     void inject(ReleaseStack_ReactNativeWPComRequestTest test);
+    void inject(ReleaseStack_EncryptedLogTest test);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 private const val TEST_UUID = "TEST-UUID"
 
-class ReleaseStack_EncryptedLogTest: ReleaseStack_Base() {
+class ReleaseStack_EncryptedLogTest : ReleaseStack_Base() {
     @Inject lateinit var encryptedLogStore: EncryptedLogStore
     @Inject lateinit var encryptedLogSqlUtils: EncryptedLogSqlUtils
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.fluxc.release
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.Is.`is`
+import org.hamcrest.core.IsNull.nullValue
+import org.junit.Test
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.UPLOADING
+import org.wordpress.android.fluxc.persistence.EncryptedLogSqlUtils
+import org.wordpress.android.fluxc.store.EncryptedLogStore
+import javax.inject.Inject
+
+private const val TEST_UUID = "TEST-UUID"
+
+class ReleaseStack_EncryptedLogTest: ReleaseStack_Base() {
+    @Inject lateinit var encryptedLogStore: EncryptedLogStore
+    @Inject lateinit var encryptedLogSqlUtils: EncryptedLogSqlUtils
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mReleaseStackAppComponent.inject(this)
+    }
+
+    @Test
+    fun testQueueForUpload() {
+        runBlocking {
+            encryptedLogStore.queueLogForUpload(TEST_UUID, createTempFile(suffix = TEST_UUID))
+            assertThat(encryptedLogSqlUtils.getEncryptedLog(TEST_UUID)?.uploadState, `is`(UPLOADING))
+
+            delay(5000)
+            assertThat(encryptedLogSqlUtils.getEncryptedLog(TEST_UUID), nullValue())
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
@@ -86,7 +86,7 @@ class EncryptedLogSqlUtilsTest {
         dateCreated: Date = Date(),
         uuid: String = TEST_UUID,
         filePath: String = TEST_FILE_PATH,
-        uploadState: EncryptedLogUploadState = EncryptedLogUploadState.DEFAULT
+        uploadState: EncryptedLogUploadState = EncryptedLogUploadState.CREATED
     ) = EncryptedLog(
             // Bypass the annoying milliseconds comparison issue
             dateCreated = Date.from(dateCreated.toInstant().truncatedTo(ChronoUnit.SECONDS)),

--- a/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
@@ -1,0 +1,97 @@
+package org.wordpress.android.fluxc.encryptedlog
+
+import com.yarolegovich.wellsql.WellSql
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.EncryptedLog
+import org.wordpress.android.fluxc.model.EncryptedLogModel
+import org.wordpress.android.fluxc.model.EncryptedLogUploadState
+import org.wordpress.android.fluxc.persistence.EncryptedLogSqlUtils
+import java.io.File
+import java.time.temporal.ChronoUnit
+import java.util.Date
+
+private const val TEST_UUID = "TEST_UUID"
+private const val TEST_FILE_PATH = "TEST_FILE_PATH"
+
+@RunWith(RobolectricTestRunner::class)
+class EncryptedLogSqlUtilsTest {
+    private lateinit var sqlUtils: EncryptedLogSqlUtils
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(appContext, EncryptedLogModel::class.java)
+        WellSql.init(config)
+        config.reset()
+
+        sqlUtils = EncryptedLogSqlUtils()
+    }
+
+    @Test
+    fun testInsertEncryptedLog() {
+        // Assert that there are no encrypted logs with the test uuid
+        assertThat(getTestEncryptedLogFromDB()).isNull()
+
+        // Insert an encrypted log with uuid
+        val logToBeInserted = createTestEncryptedLog()
+        sqlUtils.insertOrUpdateEncryptedLog(logToBeInserted)
+
+        // Assert that the encrypted log from the DB is the same as the one we inserted
+        val log = getTestEncryptedLogFromDB()
+        assertThat(log).isEqualToComparingFieldByField(logToBeInserted)
+    }
+
+    @Test
+    fun testUpdateEncryptedLog() {
+        // Insert an initial encrypted log
+        val initialLog = createTestEncryptedLog()
+        sqlUtils.insertOrUpdateEncryptedLog(initialLog)
+        assertThat(getTestEncryptedLogFromDB()).isEqualToComparingFieldByField(initialLog)
+
+        // Create a copy of the encrypted log by changing its upload state (which will be the common usage)
+        val newUploadState = EncryptedLogUploadState.NEEDS_UPLOAD
+        val updatedLog = initialLog.copy(uploadState = newUploadState)
+        sqlUtils.insertOrUpdateEncryptedLog(updatedLog)
+
+        // Assert that the encrypted log in the DB is the one with the correct upload state
+        val updatedLogFromDB = getTestEncryptedLogFromDB()
+        assertThat(requireNotNull(updatedLogFromDB?.uploadState)).isEqualTo(newUploadState)
+        // This verifies the expected state as well but separating the initial assertion is valuable to show intent
+        assertThat(updatedLogFromDB).isEqualToComparingFieldByField(updatedLog)
+    }
+
+    @Test
+    fun testDeleteEncryptedLog() {
+        // Insert an initial encrypted log
+        val initialLog = createTestEncryptedLog()
+        sqlUtils.insertOrUpdateEncryptedLog(initialLog)
+        assertThat(getTestEncryptedLogFromDB()).isEqualToComparingFieldByField(initialLog)
+
+        // Delete the encrypted log
+        sqlUtils.deleteEncryptedLog(TEST_UUID)
+
+        // Assert that the encrypted log no longer exists
+        assertThat(getTestEncryptedLogFromDB()).isNull()
+    }
+
+    private fun getTestEncryptedLogFromDB() = sqlUtils.getEncryptedLog(TEST_UUID)
+
+    private fun createTestEncryptedLog(
+        dateCreated: Date = Date(),
+        uuid: String = TEST_UUID,
+        filePath: String = TEST_FILE_PATH,
+        uploadState: EncryptedLogUploadState = EncryptedLogUploadState.DEFAULT
+    ) = EncryptedLog(
+            // Bypass the annoying milliseconds comparison issue
+            dateCreated = Date.from(dateCreated.toInstant().truncatedTo(ChronoUnit.SECONDS)),
+            uuid = uuid,
+            file = File(filePath),
+            uploadState = uploadState
+    )
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
@@ -8,12 +8,12 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
-import org.wordpress.android.fluxc.model.EncryptedLog
-import org.wordpress.android.fluxc.model.EncryptedLogModel
-import org.wordpress.android.fluxc.model.EncryptedLogUploadState
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLog
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogModel
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState
 import org.wordpress.android.fluxc.persistence.EncryptedLogSqlUtils
 import java.io.File
-import java.time.temporal.ChronoUnit
+import java.time.temporal.ChronoUnit.SECONDS
 import java.util.Date
 
 private const val TEST_UUID = "TEST_UUID"
@@ -89,7 +89,7 @@ class EncryptedLogSqlUtilsTest {
         uploadState: EncryptedLogUploadState = EncryptedLogUploadState.CREATED
     ) = EncryptedLog(
             // Bypass the annoying milliseconds comparison issue
-            dateCreated = Date.from(dateCreated.toInstant().truncatedTo(ChronoUnit.SECONDS)),
+            dateCreated = Date.from(dateCreated.toInstant().truncatedTo(SECONDS)),
             uuid = uuid,
             file = File(filePath),
             uploadState = uploadState

--- a/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
@@ -143,9 +143,9 @@ class EncryptedLogSqlUtilsTest {
         dateCreated: Date = Date(),
         uploadState: EncryptedLogUploadState = QUEUED
     ) = EncryptedLog(
-            // Bypass the annoying milliseconds comparison issue
             uuid = uuid,
             file = File(filePath),
+            // Bypass the annoying milliseconds comparison issue
             dateCreated = Date.from(dateCreated.toInstant().truncatedTo(SECONDS)),
             uploadState = uploadState
     )

--- a/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt
@@ -11,10 +11,14 @@ import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLog
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogModel
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.QUEUED
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.UPLOADING
 import org.wordpress.android.fluxc.persistence.EncryptedLogSqlUtils
 import java.io.File
 import java.time.temporal.ChronoUnit.SECONDS
 import java.util.Date
+import java.util.UUID
+import kotlin.random.Random
 
 private const val TEST_UUID = "TEST_UUID"
 private const val TEST_FILE_PATH = "TEST_FILE_PATH"
@@ -34,7 +38,7 @@ class EncryptedLogSqlUtilsTest {
     }
 
     @Test
-    fun testInsertEncryptedLog() {
+    fun `test insert encrypted log`() {
         // Assert that there are no encrypted logs with the test uuid
         assertThat(getTestEncryptedLogFromDB()).isNull()
 
@@ -48,14 +52,14 @@ class EncryptedLogSqlUtilsTest {
     }
 
     @Test
-    fun testUpdateEncryptedLog() {
+    fun `test update encrypted log`() {
         // Insert an initial encrypted log
         val initialLog = createTestEncryptedLog()
         sqlUtils.insertOrUpdateEncryptedLog(initialLog)
         assertThat(getTestEncryptedLogFromDB()).isEqualToComparingFieldByField(initialLog)
 
         // Create a copy of the encrypted log by changing its upload state (which will be the common usage)
-        val newUploadState = EncryptedLogUploadState.NEEDS_UPLOAD
+        val newUploadState = EncryptedLogUploadState.UPLOADING
         val updatedLog = initialLog.copy(uploadState = newUploadState)
         sqlUtils.insertOrUpdateEncryptedLog(updatedLog)
 
@@ -67,31 +71,51 @@ class EncryptedLogSqlUtilsTest {
     }
 
     @Test
-    fun testDeleteEncryptedLog() {
+    fun `test delete encrypted log`() {
         // Insert an initial encrypted log
         val initialLog = createTestEncryptedLog()
         sqlUtils.insertOrUpdateEncryptedLog(initialLog)
         assertThat(getTestEncryptedLogFromDB()).isEqualToComparingFieldByField(initialLog)
 
         // Delete the encrypted log
-        sqlUtils.deleteEncryptedLog(TEST_UUID)
+        sqlUtils.deleteEncryptedLogs(listOf(initialLog))
 
         // Assert that the encrypted log no longer exists
         assertThat(getTestEncryptedLogFromDB()).isNull()
     }
 
+    @Test
+    fun `test uploading encrypted logs count for empty DB`() {
+        assertThat(sqlUtils.getNumberOfUploadingEncryptedLogs()).isEqualTo(0)
+    }
+
+    @Test
+    fun `test uploading encrypted logs for random number`() {
+        Random.nextInt(100).let { numberOfLogs ->
+            repeat(numberOfLogs) {
+                sqlUtils.insertOrUpdateEncryptedLog(
+                        createTestEncryptedLog(
+                                uuid = UUID.randomUUID().toString(),
+                                uploadState = UPLOADING
+                        )
+                )
+            }
+            assertThat(sqlUtils.getNumberOfUploadingEncryptedLogs()).isEqualTo(numberOfLogs.toLong())
+        }
+    }
+
     private fun getTestEncryptedLogFromDB() = sqlUtils.getEncryptedLog(TEST_UUID)
 
     private fun createTestEncryptedLog(
-        dateCreated: Date = Date(),
         uuid: String = TEST_UUID,
         filePath: String = TEST_FILE_PATH,
-        uploadState: EncryptedLogUploadState = EncryptedLogUploadState.CREATED
+        dateCreated: Date = Date(),
+        uploadState: EncryptedLogUploadState = QUEUED
     ) = EncryptedLog(
             // Bypass the annoying milliseconds comparison issue
-            dateCreated = Date.from(dateCreated.toInstant().truncatedTo(SECONDS)),
             uuid = uuid,
             file = File(filePath),
+            dateCreated = Date.from(dateCreated.toInstant().truncatedTo(SECONDS)),
             uploadState = uploadState
     )
 }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -27,7 +27,7 @@ android {
     defaultConfig {
         versionCode 4
         versionName "0.1"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 28
     }
     buildTypes {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -103,6 +103,10 @@ dependencies {
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
+
+    // Encrypted Logging
+    implementation "com.goterl.lazycode:lazysodium-android:4.1.0@aar"
+    implementation "net.java.dev.jna:jna:4.5.1@aar"
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/EncryptedLogAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/EncryptedLogAction.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.action
+
+import org.wordpress.android.fluxc.annotations.Action
+import org.wordpress.android.fluxc.annotations.ActionEnum
+import org.wordpress.android.fluxc.annotations.action.IAction
+import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogPayload
+
+@ActionEnum
+enum class EncryptedLogAction : IAction {
+    @Action(payloadType = UploadEncryptedLogPayload::class)
+    UPLOAD_LOG
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.fluxc.model
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.util.DateTimeUtils
+import java.io.File
+import java.util.Date
+
+/**
+ * [EncryptedLog] and [EncryptedLogModel] are tied to each other, any change in one should be reflected in the other.
+ * Within the app, [EncryptedLog] should be used, for DB interactions [EncryptedLogModel] should be used.
+ */
+data class EncryptedLog(
+    val dateCreated: Date,
+    val uuid: String,
+    val file: File,
+    val uploadState: EncryptedLogUploadState
+) {
+    companion object {
+        fun fromEncryptedLogModel(encryptedLogModel: EncryptedLogModel) = EncryptedLog(
+                dateCreated = DateTimeUtils.dateUTCFromIso8601(encryptedLogModel.dateCreated),
+                // Crash if values are missing which shouldn't happen if there are no logic errors
+                uuid = encryptedLogModel.uuid!!,
+                file = File(encryptedLogModel.filePath),
+                uploadState = encryptedLogModel.uploadState
+        )
+    }
+}
+
+@Table
+@RawConstraints(
+        "UNIQUE(UUID) ON CONFLICT REPLACE"
+)
+class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    @Column var uuid: String? = null
+    @Column var filePath: String? = null
+    @Column var uploadStateDbValue: Int = EncryptedLogUploadState.DEFAULT.value
+
+    override fun getId(): Int = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    val uploadState: EncryptedLogUploadState
+        get() =
+            requireNotNull(
+                    EncryptedLogUploadState.values()
+                            .firstOrNull { it.value == uploadStateDbValue }) {
+                "The stateDbValue of the EncryptedLogUploadState didn't match any of the `EncryptedLogUploadState`s. " +
+                        "This likely happened because the EncryptedLogUploadState values " +
+                        "were altered without a DB migration."
+            }
+
+    companion object {
+        fun fromEncryptedLog(encryptedLog: EncryptedLog) = EncryptedLogModel().also {
+            it.dateCreated = DateTimeUtils.iso8601UTCFromDate(encryptedLog.dateCreated)
+            it.uuid = encryptedLog.uuid
+            it.filePath = encryptedLog.file.path
+            it.uploadStateDbValue = encryptedLog.uploadState.value
+        }
+    }
+}
+
+enum class EncryptedLogUploadState(val value: Int) {
+    DEFAULT(0),
+    NEEDS_UPLOAD(1),
+    UPLOAD_FAILED(2)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
@@ -36,7 +36,7 @@ class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @Column var uuid: String? = null
     @Column var filePath: String? = null
-    @Column var uploadStateDbValue: Int = EncryptedLogUploadState.DEFAULT.value
+    @Column var uploadStateDbValue: Int = EncryptedLogUploadState.CREATED.value
 
     override fun getId(): Int = id
 
@@ -65,7 +65,7 @@ class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
 }
 
 enum class EncryptedLogUploadState(val value: Int) {
-    DEFAULT(0),
+    CREATED(0),
     NEEDS_UPLOAD(1),
     UPLOAD_FAILED(2)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
@@ -31,9 +31,7 @@ data class EncryptedLog(
 }
 
 @Table
-@RawConstraints(
-        "UNIQUE(UUID) ON CONFLICT REPLACE"
-)
+@RawConstraints("UNIQUE(UUID) ON CONFLICT REPLACE")
 class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @Column var uuid: String? = null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
@@ -70,5 +70,6 @@ class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
 
 enum class EncryptedLogUploadState(val value: Int) {
     QUEUED(1),
-    FAILED(2)
+    UPLOADING(2),
+    FAILED(3)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EncryptedLog.kt
@@ -17,7 +17,7 @@ data class EncryptedLog(
     val uuid: String,
     val file: File,
     val dateCreated: Date = Date(),
-    val uploadState: EncryptedLogUploadState = EncryptedLogUploadState.CREATED,
+    val uploadState: EncryptedLogUploadState = EncryptedLogUploadState.QUEUED,
     val failedCount: Int = 0
 ) {
     companion object {
@@ -38,7 +38,7 @@ class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var uuid: String? = null
     @Column var filePath: String? = null
     @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
-    @Column var uploadStateDbValue: Int = EncryptedLogUploadState.CREATED.value
+    @Column var uploadStateDbValue: Int = EncryptedLogUploadState.QUEUED.value
     @Column var failedCount: Int = 0
 
     override fun getId(): Int = id
@@ -69,7 +69,6 @@ class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
 }
 
 enum class EncryptedLogUploadState(val value: Int) {
-    CREATED(0),
-    NEEDS_UPLOAD(1),
-    UPLOAD_FAILED(2)
+    QUEUED(1),
+    FAILED(2)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedLog.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedLog.kt
@@ -1,10 +1,11 @@
-package org.wordpress.android.fluxc.model
+package org.wordpress.android.fluxc.model.encryptedlogging
 
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.QUEUED
 import org.wordpress.android.util.DateTimeUtils
 import java.io.File
 import java.util.Date
@@ -17,18 +18,19 @@ data class EncryptedLog(
     val uuid: String,
     val file: File,
     val dateCreated: Date = Date(),
-    val uploadState: EncryptedLogUploadState = EncryptedLogUploadState.QUEUED,
+    val uploadState: EncryptedLogUploadState = QUEUED,
     val failedCount: Int = 0
 ) {
     companion object {
-        fun fromEncryptedLogModel(encryptedLogModel: EncryptedLogModel) = EncryptedLog(
-                dateCreated = DateTimeUtils.dateUTCFromIso8601(encryptedLogModel.dateCreated),
-                // Crash if values are missing which shouldn't happen if there are no logic errors
-                uuid = encryptedLogModel.uuid!!,
-                file = File(encryptedLogModel.filePath),
-                uploadState = encryptedLogModel.uploadState,
-                failedCount = encryptedLogModel.failedCount
-        )
+        fun fromEncryptedLogModel(encryptedLogModel: EncryptedLogModel) =
+                EncryptedLog(
+                        dateCreated = DateTimeUtils.dateUTCFromIso8601(encryptedLogModel.dateCreated),
+                        // Crash if values are missing which shouldn't happen if there are no logic errors
+                        uuid = encryptedLogModel.uuid!!,
+                        file = File(encryptedLogModel.filePath),
+                        uploadState = encryptedLogModel.uploadState,
+                        failedCount = encryptedLogModel.failedCount
+                )
     }
 }
 
@@ -38,7 +40,7 @@ class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var uuid: String? = null
     @Column var filePath: String? = null
     @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
-    @Column var uploadStateDbValue: Int = EncryptedLogUploadState.QUEUED.value
+    @Column var uploadStateDbValue: Int = QUEUED.value
     @Column var failedCount: Int = 0
 
     override fun getId(): Int = id
@@ -58,7 +60,8 @@ class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
             }
 
     companion object {
-        fun fromEncryptedLog(encryptedLog: EncryptedLog) = EncryptedLogModel().also {
+        fun fromEncryptedLog(encryptedLog: EncryptedLog) = EncryptedLogModel()
+                .also {
             it.uuid = encryptedLog.uuid
             it.filePath = encryptedLog.file.path
             it.dateCreated = DateTimeUtils.iso8601UTCFromDate(encryptedLog.dateCreated)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.fluxc.model.encryptedlogging
+
+
+import com.goterl.lazycode.lazysodium.interfaces.Box
+import com.goterl.lazycode.lazysodium.interfaces.SecretStream
+import com.goterl.lazycode.lazysodium.utils.KeyPair
+
+/**
+ * A class representing an Encrypted Secret Stream Key.
+ *
+ * It can be decrypted to provide an SecretStreamKey, which is used to
+ * decrypted the messages within an Encrypted Log File
+ *
+ * @see SecretStreamKey
+ */
+class EncryptedSecretStreamKey(val bytes: ByteArray) {
+    companion object {
+        /**
+         * The expected size (in bytes) of an Encrypted Secret Stream Key.
+         */
+        const val size: Int = SecretStream.KEYBYTES + Box.SEALBYTES
+    }
+
+    init {
+        require(bytes.size == size) {
+            "An Encrypted Secret Stream Key must be exactly $size bytes"
+        }
+    }
+
+    /**
+     * Decrypt the key using the assocaited KeyPair (the `publicKey` originally used to encrypt it, and its
+     * corresponding `secretKey`).
+     */
+    fun decrypt(keyPair: KeyPair): SecretStreamKey {
+        val sodium = EncryptionUtils.sodium
+
+        val publicKeyBytes = keyPair.publicKey.asBytes
+        val secretKeyBytes = keyPair.secretKey.asBytes
+
+        require(Box.Checker.checkPublicKey(publicKeyBytes.size)) {
+            "The public key size is incorrect (should be ${Box.PUBLICKEYBYTES} bytes)"
+        }
+
+        require(Box.Checker.checkSecretKey(secretKeyBytes.size)) {
+            "The secret key size is incorrect (should be ${Box.SECRETKEYBYTES} bytes)"
+        }
+
+        val decryptedBytes = ByteArray(SecretStream.KEYBYTES) // Stores the decrypted bytes
+        check(sodium.cryptoBoxSealOpen(decryptedBytes, bytes, bytes.size.toLong(), publicKeyBytes, secretKeyBytes)) {
+            "The message key couldn't be decrypted – it's likely the wrong key pair is being used for decryption"
+        }
+
+        return SecretStreamKey(decryptedBytes)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
-
 import com.goterl.lazycode.lazysodium.interfaces.Box
 import com.goterl.lazycode.lazysodium.interfaces.SecretStream
 import com.goterl.lazycode.lazysodium.utils.KeyPair

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptionUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptionUtils.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.fluxc.model.encryptedlogging
+
+import com.goterl.lazycode.lazysodium.LazySodiumAndroid
+import com.goterl.lazycode.lazysodium.SodiumAndroid
+
+/**
+ * Convenience helpers for Encrypted Logging
+ */
+class EncryptionUtils {
+    companion object {
+        /**
+         * Use a single shared instance of the Sodium library.
+         *
+         * The initialization is inexpensive, but verbose, so this is just syntactic sugar.
+         */
+        val sodium = LazySodiumAndroid(SodiumAndroid())
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
@@ -23,7 +23,7 @@ class LogEncrypter(private val sourceFile: File, private val uuid: String, priva
         }
     }
 
-    fun read(): String = buildString {
+    fun encrypt(): String = buildString {
         append(buildHeader())
         sourceFile.readLines().forEach { line ->
             append(buildMessage(line))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
@@ -1,0 +1,112 @@
+package org.wordpress.android.fluxc.model.encryptedlogging
+
+import android.util.Base64
+import com.goterl.lazycode.lazysodium.interfaces.SecretStream
+import java.io.File
+import com.goterl.lazycode.lazysodium.utils.Key
+
+/**
+ * [LogEncrypter] encrypts the logs for the given source file.
+ **
+ * @param sourceFile A file object representing the log file source..
+ * @param uuid Uuid for the encrypted log
+ * @param publicKey The public key used to encrypt the log.
+ *
+ */
+class LogEncrypter(private val sourceFile: File, private val uuid: String, private val publicKey: Key) {
+    private val sodium = EncryptionUtils.sodium
+    private val state = SecretStream.State.ByReference()
+
+    init {
+        check(sourceFile.exists()) {
+            "If the source log file doesn't exist we should never make it to this class"
+        }
+    }
+
+    fun read(): String {
+        buildString {
+            append(buildHeader())
+            sourceFile.readLines().forEach { line ->
+                append(buildMessage(line))
+            }
+            append(buildFooter())
+        }
+        val stringBuilder = StringBuilder()
+        stringBuilder.append(buildHeader())
+    }
+
+    /**
+     * Encrypt and write the provided string to the encrypted log file.
+     * @param string: The string to be written to the file.
+     */
+    private fun buildMessage(string: String): String {
+        val encryptedString = encryptMessage(string, SecretStream.TAG_MESSAGE)
+        return "\t\t\"$encryptedString\",\n"
+    }
+
+    /**
+     * An internal convenience function to extract the header building process.
+     */
+    private fun buildHeader(): String {
+        val header = ByteArray(SecretStream.HEADERBYTES)
+        val key = SecretStreamKey.generate().let {
+            check(sodium.cryptoSecretStreamInitPush(state, header, it.bytes))
+            it.encrypt(publicKey)
+        }
+
+        require(SecretStream.Checker.headerCheck(header.size)) {
+            "The secret stream header must be the correct length"
+        }
+
+        val encodedEncryptedKey = base64Encode(key.bytes)
+        check(encodedEncryptedKey.length == 108) {
+            "The encoded, encrypted key must always be 108 bytes long"
+        }
+
+        val encodedHeader = base64Encode(header)
+        check(encodedHeader.length == 32) {
+            "The encoded header must always be 32 bytes long"
+        }
+
+        return buildString {
+            append("{")
+            append("\t\"keyedWith\": \"v1\",\n")
+            append("\t\"encryptedKey\": \"$encodedEncryptedKey\",\n")
+            append("\t\"header\": \"$encodedHeader\",\n")
+            append("\t\"uuid\": \"$uuid\",\n")
+            append("\t\"messages\": [\n")
+        }
+    }
+
+    /**
+     * Add the closing file tag
+     */
+    private fun buildFooter(): String {
+        val encryptedClosingTag = encryptMessage("", SecretStream.TAG_FINAL)
+        return buildString {
+            append("\t\t\"$encryptedClosingTag\"\n")
+            append("\t]\n")
+            append("}")
+        }
+    }
+
+    /**
+     * An internal convenience function to push more data into the sodium secret stream.
+     */
+    private fun encryptMessage(string: String, tag: Byte): String {
+        val plainBytes = string.toByteArray()
+
+        val encryptedBytes = ByteArray(SecretStream.ABYTES + plainBytes.size) // Stores the encrypted bytes
+        check(sodium.cryptoSecretStreamPush(this.state, encryptedBytes, plainBytes, plainBytes.size.toLong(), tag)) {
+            "Unable to encrypt message: $string"
+        }
+
+        return base64Encode(encryptedBytes)
+    }
+}
+
+// On Android base64 has lots of options, so define a helper to make it easier to
+// avoid encoding issues.
+private fun base64Encode(byteArray: ByteArray): String {
+    return Base64.encodeToString(byteArray, Base64.NO_WRAP)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
@@ -23,16 +23,12 @@ class LogEncrypter(private val sourceFile: File, private val uuid: String, priva
         }
     }
 
-    fun read(): String {
-        buildString {
-            append(buildHeader())
-            sourceFile.readLines().forEach { line ->
-                append(buildMessage(line))
-            }
-            append(buildFooter())
+    fun read(): String = buildString {
+        append(buildHeader())
+        sourceFile.readLines().forEach { line ->
+            append(buildMessage(line))
         }
-        val stringBuilder = StringBuilder()
-        stringBuilder.append(buildHeader())
+        append(buildFooter())
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/SecretStreamKey.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/SecretStreamKey.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.model.encryptedlogging
+
+import com.goterl.lazycode.lazysodium.interfaces.Box
+import com.goterl.lazycode.lazysodium.interfaces.SecretStream
+import com.goterl.lazycode.lazysodium.utils.Key
+
+/**
+ * A class representing an unencrypted Secret Stream Key.
+ *
+ * It can be encrypted to provide an EncryptedSecretStreamKey, which is used to secure
+ * an Encrypted Log file.
+ *
+ * @see EncryptedSecretStreamKey
+ */
+class SecretStreamKey(val bytes: ByteArray) {
+    companion object {
+        /**
+         * Generate a new (and securely random) secret stream key
+         */
+        fun generate(): SecretStreamKey {
+            return SecretStreamKey(EncryptionUtils.sodium.cryptoSecretStreamKeygen().asBytes)
+        }
+    }
+
+    init {
+        require(bytes.size == SecretStream.KEYBYTES) {
+            "A Secret Stream Key must be exactly ${SecretStream.KEYBYTES} bytes"
+        }
+    }
+
+    val size: Long = bytes.size.toLong()
+
+    fun encrypt(publicKey: Key): EncryptedSecretStreamKey {
+        val sodium = EncryptionUtils.sodium
+
+        require(Box.Checker.checkPublicKey(publicKey.asBytes.size)) {
+            "The public key must be the right length"
+        }
+
+        val encryptedBytes = ByteArray(EncryptedSecretStreamKey.size) // Stores the encrypted bytes
+        check(sodium.cryptoBoxSeal(encryptedBytes, bytes, size, publicKey.asBytes)) {
+            "Encrypting the message key must not fail"
+        }
+
+        return EncryptedSecretStreamKey(encryptedBytes)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.EncryptedLogRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient;
@@ -438,6 +439,13 @@ public class ReleaseNetworkModule {
                                                          WPComGsonRequestBuilder wpComGsonRequestBuilder) {
         return new TransactionsRestClient(dispatcher, wpComGsonRequestBuilder, appContext, requestQueue, token,
                 userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public EncryptedLogRestClient provideEncryptedLogRestClient(@Named("regular") RequestQueue requestQueue,
+                                                                AppSecrets appSecrets) {
+        return new EncryptedLogRestClient(requestQueue, appSecrets);
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.fluxc.network
+
+import com.android.volley.NetworkResponse
+import com.android.volley.ParseError
+import com.android.volley.Request
+import com.android.volley.Response
+import com.android.volley.Response.ErrorListener
+import com.android.volley.VolleyError
+import com.android.volley.toolbox.HttpHeaderParser
+import org.json.JSONObject
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import java.io.File
+
+private const val AUTHORIZATION_HEADER = "Authorization"
+private const val CONTENT_TYPE_HEADER = "Content-Type"
+private const val CONTENT_TYPE_JSON = "application/json"
+private const val UUID_HEADER = "log-uuid"
+
+class EncryptedLogUploadRequest(
+    private val logUuid: String,
+    private val logFile: File,
+    private val clientSecret: String,
+    private val successListener: Response.Listener<NetworkResponse>,
+    errorListener: ErrorListener
+) : Request<NetworkResponse>(Method.POST, WPCOMREST.encrypted_logging.urlV1_1, errorListener) {
+    override fun getHeaders(): Map<String, String> {
+        return mapOf(
+                CONTENT_TYPE_HEADER to CONTENT_TYPE_JSON,
+                AUTHORIZATION_HEADER to clientSecret,
+                UUID_HEADER to logUuid
+        )
+    }
+
+    override fun getBody(): ByteArray {
+        // TODO: Max file size is 10MB - maybe we should just handle that in the error callback?
+        return logFile.readBytes()
+    }
+
+    override fun parseNetworkResponse(response: NetworkResponse?): Response<NetworkResponse> {
+        return try {
+            Response.success(response, HttpHeaderParser.parseCacheHeaders(response))
+        } catch (e: Exception) {
+            try {
+                val json = JSONObject(response.toString())
+                val errorMessage = json.getString("message")
+                Response.error(VolleyError(errorMessage))
+            } catch (jsonParsingError: Throwable) {
+                Response.error(ParseError(jsonParsingError))
+            }
+        }
+    }
+
+    override fun deliverResponse(response: NetworkResponse) {
+        successListener.onResponse(response)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt
@@ -9,7 +9,6 @@ import com.android.volley.VolleyError
 import com.android.volley.toolbox.HttpHeaderParser
 import org.json.JSONObject
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
-import java.io.File
 
 private const val AUTHORIZATION_HEADER = "Authorization"
 private const val CONTENT_TYPE_HEADER = "Content-Type"
@@ -18,7 +17,7 @@ private const val UUID_HEADER = "log-uuid"
 
 class EncryptedLogUploadRequest(
     private val logUuid: String,
-    private val logFile: File,
+    private val contents: String,
     private val clientSecret: String,
     private val successListener: Response.Listener<NetworkResponse>,
     errorListener: ErrorListener
@@ -33,7 +32,7 @@ class EncryptedLogUploadRequest(
 
     override fun getBody(): ByteArray {
         // TODO: Max file size is 10MB - maybe we should just handle that in the error callback?
-        return logFile.readBytes()
+        return contents.toByteArray()
     }
 
     override fun parseNetworkResponse(response: NetworkResponse?): Response<NetworkResponse> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.fluxc.network.EncryptedLogUploadRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
 import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.LogUploadResult.LogUploadFailed
 import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.LogUploadResult.LogUploaded
-import java.io.File
 import javax.inject.Singleton
 import kotlin.coroutines.resume
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
@@ -4,6 +4,7 @@ import com.android.volley.RequestQueue
 import com.android.volley.Response
 import com.android.volley.VolleyError
 import kotlinx.coroutines.suspendCancellableCoroutine
+import org.json.JSONObject
 import org.wordpress.android.fluxc.network.EncryptedLogUploadRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
 import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.UploadEncryptedLogResult.LogUploadFailed
@@ -11,6 +12,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.UploadEncrypt
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError
 import javax.inject.Singleton
 import kotlin.coroutines.resume
+
+private const val INVALID_REQUEST = "invalid-request"
+private const val TOO_MANY_REQUESTS = "too_many_requests"
 
 @Singleton
 class EncryptedLogRestClient
@@ -30,9 +34,18 @@ constructor(
         }
     }
 
+    // {"error":"too_many_requests","message":"You're sending too many messages. Please slow down."}
     // {"error":"invalid-request","message":"Invalid UUID: uuids must only contain letters, numbers, dashes, and curly brackets"}
     private fun mapError(error: VolleyError): UploadEncryptedLogError {
-        val errorMessageFromData = String(error.networkResponse.data)
+        val json = JSONObject(String(error.networkResponse.data))
+        val errorMessage = json.getString("message")
+        json.getString("error")?.let { errorType ->
+            if (errorType == INVALID_REQUEST) {
+                return UploadEncryptedLogError.InvalidRequest(errorMessage)
+            } else if (errorType == TOO_MANY_REQUESTS) {
+                return UploadEncryptedLogError.TooManyRequests(errorMessage)
+            }
+        }
         return UploadEncryptedLogError.Unknown
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
@@ -17,8 +17,8 @@ constructor(
     private val requestQueue: RequestQueue,
     private val appSecrets: AppSecrets
 ) {
-    suspend fun uploadLog(logUuid: String, logFile: File) = suspendCancellableCoroutine<LogUploadResult> { cont ->
-        val request = EncryptedLogUploadRequest(logUuid, logFile, appSecrets.appSecret, Response.Listener {
+    suspend fun uploadLog(logUuid: String, contents: String) = suspendCancellableCoroutine<LogUploadResult> { cont ->
+        val request = EncryptedLogUploadRequest(logUuid, contents, appSecrets.appSecret, Response.Listener {
             // TODO: add callbacks
             cont.resume(LogUploaded)
         }, Response.ErrorListener {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog
+
+import com.android.volley.RequestQueue
+import com.android.volley.Response
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.wordpress.android.fluxc.network.EncryptedLogUploadRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
+import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.LogUploadResult.LogUploadFailed
+import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.LogUploadResult.LogUploaded
+import java.io.File
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+@Singleton
+class EncryptedLogRestClient
+constructor(
+    private val requestQueue: RequestQueue,
+    private val appSecrets: AppSecrets
+) {
+    suspend fun uploadLog(logUuid: String, logFile: File) = suspendCancellableCoroutine<LogUploadResult> { cont ->
+        val request = EncryptedLogUploadRequest(logUuid, logFile, appSecrets.appSecret, Response.Listener {
+            // TODO: add callbacks
+            cont.resume(LogUploaded)
+        }, Response.ErrorListener {
+            cont.resume(LogUploadFailed)
+        })
+        cont.invokeOnCancellation { request.cancel() }
+        requestQueue.add(request)
+    }
+}
+
+sealed class LogUploadResult {
+    object LogUploaded : LogUploadResult()
+    object LogUploadFailed : LogUploadResult()
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
@@ -37,16 +37,20 @@ constructor(
     // {"error":"too_many_requests","message":"You're sending too many messages. Please slow down."}
     // {"error":"invalid-request","message":"Invalid UUID: uuids must only contain letters, numbers, dashes, and curly brackets"}
     private fun mapError(error: VolleyError): UploadEncryptedLogError {
-        val json = JSONObject(String(error.networkResponse.data))
-        val errorMessage = json.getString("message")
-        json.getString("error")?.let { errorType ->
-            if (errorType == INVALID_REQUEST) {
-                return UploadEncryptedLogError.InvalidRequest(errorMessage)
-            } else if (errorType == TOO_MANY_REQUESTS) {
-                return UploadEncryptedLogError.TooManyRequests(errorMessage)
+        error.networkResponse?.let { networkResponse ->
+            val statusCode = networkResponse.statusCode
+            val json = JSONObject(String(networkResponse.data))
+            val errorMessage = json.getString("message")
+            json.getString("error")?.let { errorType ->
+                if (errorType == INVALID_REQUEST) {
+                    return UploadEncryptedLogError.InvalidRequest(statusCode, errorMessage)
+                } else if (errorType == TOO_MANY_REQUESTS) {
+                    return UploadEncryptedLogError.TooManyRequests(statusCode, errorMessage)
+                }
             }
+            return UploadEncryptedLogError.Unknown(statusCode, errorMessage)
         }
-        return UploadEncryptedLogError.Unknown
+        return UploadEncryptedLogError.Unknown()
     }
 }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog
 
 import com.android.volley.RequestQueue
 import com.android.volley.Response
+import com.android.volley.VolleyError
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.fluxc.network.EncryptedLogUploadRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
@@ -18,17 +19,27 @@ constructor(
 ) {
     suspend fun uploadLog(logUuid: String, contents: String) = suspendCancellableCoroutine<LogUploadResult> { cont ->
         val request = EncryptedLogUploadRequest(logUuid, contents, appSecrets.appSecret, Response.Listener {
-            // TODO: add callbacks
             cont.resume(LogUploaded)
-        }, Response.ErrorListener {
-            cont.resume(LogUploadFailed)
+        }, Response.ErrorListener { error ->
+            cont.resume(LogUploadFailed(mapError(error)))
         })
         cont.invokeOnCancellation { request.cancel() }
         requestQueue.add(request)
+    }
+
+    // {"error":"invalid-request","message":"Invalid UUID: uuids must only contain letters, numbers, dashes, and curly brackets"}
+    private fun mapError(error: VolleyError): LogUploadErrorType {
+        val errorMessageFromData = String(error.networkResponse.data)
+        return LogUploadErrorType.Unknown
     }
 }
 
 sealed class LogUploadResult {
     object LogUploaded : LogUploadResult()
-    object LogUploadFailed : LogUploadResult()
+    class LogUploadFailed(val error: LogUploadErrorType) : LogUploadResult()
+}
+
+sealed class LogUploadErrorType {
+    object Unknown: LogUploadErrorType()
+    class InvalidUuid(val message: String): LogUploadErrorType()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
@@ -36,10 +36,10 @@ constructor(
 
 sealed class LogUploadResult {
     object LogUploaded : LogUploadResult()
-    class LogUploadFailed(val error: LogUploadErrorType) : LogUploadResult()
+    class LogUploadFailed(val errorType: LogUploadErrorType) : LogUploadResult()
 }
 
 sealed class LogUploadErrorType {
-    object Unknown: LogUploadErrorType()
-    class InvalidUuid(val message: String): LogUploadErrorType()
+    object Unknown : LogUploadErrorType()
+    class InvalidUuid(val message: String) : LogUploadErrorType()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
@@ -3,12 +3,11 @@ package org.wordpress.android.fluxc.persistence
 import com.wellsql.generated.EncryptedLogModelTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
-import org.wordpress.android.fluxc.model.EncryptedLog
-import org.wordpress.android.fluxc.model.EncryptedLogModel
-import org.wordpress.android.fluxc.model.EncryptedLogUploadState
-import org.wordpress.android.fluxc.model.EncryptedLogUploadState.FAILED
-import org.wordpress.android.fluxc.model.EncryptedLogUploadState.QUEUED
-import org.wordpress.android.fluxc.model.EncryptedLogUploadState.UPLOADING
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLog
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogModel
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.FAILED
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.QUEUED
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.UPLOADING
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
@@ -1,0 +1,38 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.EncryptedLogModelTable
+import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.EncryptedLog
+import org.wordpress.android.fluxc.model.EncryptedLogModel
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EncryptedLogSqlUtils @Inject constructor() {
+    fun insertOrUpdateEncryptedLog(encryptedLog: EncryptedLog) {
+        // Since we have a unique constraint for uuid with 'on conflict replace', if there is an existing log,
+        // it'll be replaced with the new one. No need to check if the log already exists.
+        WellSql.insert(EncryptedLogModel.fromEncryptedLog(encryptedLog)).execute()
+    }
+
+    fun getEncryptedLog(uuid: String): EncryptedLog? {
+        return getEncryptedLogModel(uuid)?.let { EncryptedLog.fromEncryptedLogModel(it) }
+    }
+
+    fun deleteEncryptedLog(uuid: String) {
+        WellSql.delete(EncryptedLogModel::class.java)
+                .where()
+                .equals(EncryptedLogModelTable.UUID, uuid)
+                .endWhere()
+                .execute()
+    }
+
+    private fun getEncryptedLogModel(uuid: String): EncryptedLogModel? {
+        return WellSql.select(EncryptedLogModel::class.java)
+                .where()
+                .equals(EncryptedLogModelTable.UUID, uuid)
+                .endWhere()
+                .asModel
+                .firstOrNull()
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.fluxc.persistence
 
 import com.wellsql.generated.EncryptedLogModelTable
+import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.EncryptedLog
 import org.wordpress.android.fluxc.model.EncryptedLogModel
+import org.wordpress.android.fluxc.model.EncryptedLogUploadState
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -26,6 +28,18 @@ class EncryptedLogSqlUtils @Inject constructor() {
                 .endWhere()
                 .execute()
     }
+
+    // TODO: Add a unit test for this
+    fun getEncryptedLogsForUploadState(uploadState: EncryptedLogUploadState): List<EncryptedLog> =
+            WellSql.select(EncryptedLogModel::class.java)
+                    .where()
+                    .equals(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, uploadState.value)
+                    .endWhere()
+                    .orderBy(EncryptedLogModelTable.DATE_CREATED, SelectQuery.ORDER_ASCENDING)
+                    .asModel
+                    .map {
+                        EncryptedLog.fromEncryptedLogModel(it)
+                    }
 
     private fun getEncryptedLogModel(uuid: String): EncryptedLogModel? {
         return WellSql.select(EncryptedLogModel::class.java)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.EncryptedLogModel
 import org.wordpress.android.fluxc.model.EncryptedLogUploadState
 import org.wordpress.android.fluxc.model.EncryptedLogUploadState.FAILED
 import org.wordpress.android.fluxc.model.EncryptedLogUploadState.QUEUED
+import org.wordpress.android.fluxc.model.EncryptedLogUploadState.UPLOADING
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,6 +23,12 @@ class EncryptedLogSqlUtils @Inject constructor() {
     fun getEncryptedLog(uuid: String): EncryptedLog? {
         return getEncryptedLogModel(uuid)?.let { EncryptedLog.fromEncryptedLogModel(it) }
     }
+
+    fun getNumberOfEncryptedLogsUploading(): Long = WellSql.select(EncryptedLogModel::class.java)
+            .where()
+            .equals(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, UPLOADING)
+            .endWhere()
+            .count()
 
     // TODO: Update the tests for this
     fun deleteEncryptedLogs(encryptedLogList: List<EncryptedLog>) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
@@ -23,20 +23,19 @@ class EncryptedLogSqlUtils @Inject constructor() {
         return getEncryptedLogModel(uuid)?.let { EncryptedLog.fromEncryptedLogModel(it) }
     }
 
-    fun getNumberOfEncryptedLogsUploading(): Long = WellSql.select(EncryptedLogModel::class.java)
+    fun getNumberOfUploadingEncryptedLogs(): Long = WellSql.select(EncryptedLogModel::class.java)
             .where()
-            .equals(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, UPLOADING)
+            .equals(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, UPLOADING.value)
             .endWhere()
             .count()
 
-    // TODO: Update the tests for this
     fun deleteEncryptedLogs(encryptedLogList: List<EncryptedLog>) {
         if (encryptedLogList.isEmpty()) {
             return
         }
         WellSql.delete(EncryptedLogModel::class.java)
                 .where()
-                .equals(EncryptedLogModelTable.UUID, encryptedLogList.map { it.uuid })
+                .isIn(EncryptedLogModelTable.UUID, encryptedLogList.map { it.uuid })
                 .endWhere()
                 .execute()
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
@@ -40,7 +40,6 @@ class EncryptedLogSqlUtils @Inject constructor() {
                 .execute()
     }
 
-    // TODO: Add a unit test for this
     fun getEncryptedLogsForUpload(): List<EncryptedLog> {
         val uploadStates = listOf(QUEUED, FAILED).map { it.value }
         return WellSql.select(EncryptedLogModel::class.java)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 112
+        return 113
     }
 
     override fun getDbName(): String {
@@ -1250,6 +1250,11 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "UNIQUE (REMOTE_TAG_ID, LOCAL_SITE_ID) " +
                                     "ON CONFLICT REPLACE)"
                     )
+                }
+                112 -> migrate(version) {
+                    db.execSQL("CREATE TABLE EncryptedLogModel (UUID TEXT,FILE_PATH TEXT,DATE_CREATED TEXT," +
+                            "UPLOAD_STATE_DB_VALUE INTEGER,FAILED_COUNT INTEGER," +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT,UNIQUE(UUID) ON CONFLICT REPLACE)")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -52,7 +52,7 @@ class EncryptedLogStore @Inject constructor(
     }
 
     private suspend fun uploadNext() {
-        if (encryptedLogSqlUtils.getNumberOfEncryptedLogsUploading() > 0) {
+        if (encryptedLogSqlUtils.getNumberOfUploadingEncryptedLogs() > 0) {
             // We are already uploading another log file
             return
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.model.EncryptedLog
+import org.wordpress.android.fluxc.model.EncryptedLogUploadState
+import org.wordpress.android.fluxc.model.EncryptedLogUploadState.NEEDS_UPLOAD
+import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.EncryptedLogRestClient
+import org.wordpress.android.fluxc.persistence.EncryptedLogSqlUtils
+import java.io.File
+import java.util.Date
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EncryptedLogStore @Inject constructor(
+    private val encryptedLogRestClient: EncryptedLogRestClient,
+    private val encryptedLogSqlUtils: EncryptedLogSqlUtils
+) {
+    /**
+     * Document the logic for when uploads will happen:
+     *
+     * Uploads should be checked:
+     * 1. After [queueLogForUpload]
+     * 2. After [handleSuccessfulUpload]
+     * 3. Sometimes after [handleFailedUpload]
+     * 4. At application start
+     * 5. After a timer - maybe due to [handleFailedUpload]
+     */
+    fun newLogFile(): EncryptedLog {
+        val encryptedLog = EncryptedLog(
+                dateCreated = Date(),
+                uuid = UUID.randomUUID().toString(),
+                file = File(""), // TODO: Give proper path
+                uploadState = EncryptedLogUploadState.CREATED
+        )
+        encryptedLogSqlUtils.insertOrUpdateEncryptedLog(encryptedLog)
+        return encryptedLog
+    }
+
+    private suspend fun queueLogForUpload(uuid: String) {
+        // TODO: Delete the file if we can't find a record in the DB
+        encryptedLogSqlUtils.getEncryptedLog(uuid)?.copy(uploadState = NEEDS_UPLOAD)?.let { encryptedLog ->
+            encryptedLogSqlUtils.insertOrUpdateEncryptedLog(encryptedLog)
+            uploadNext()
+        }
+    }
+
+    private suspend fun uploadNext(): EncryptedLog {
+        // TODO: Don't upload if we are already uploading something
+        val list = encryptedLogSqlUtils.getEncryptedLogsForUploadState(uploadState = NEEDS_UPLOAD)
+        list.forEach { encryptedLog ->
+            encryptedLogRestClient.uploadLog(encryptedLog.uuid, encryptedLog.file)
+        }
+    }
+
+    private suspend fun handleSuccessfulUpload(encryptedLog: EncryptedLog) {
+        deleteFile(encryptedLog.file)
+        encryptedLogSqlUtils.deleteEncryptedLog(encryptedLog.uuid)
+        uploadNext()
+    }
+
+    private suspend fun handleFailedUpload(encryptedLog: EncryptedLog) {
+        // TODO: increase failed count
+        // TODO: Delete the file and db record if the failed count is more than the limit
+        // TODO: Add a backoff timer and consider skipping the upload for the specific log for a bit
+        // TODO: Handle known server errors (might change above todos ^)
+        uploadNext()
+    }
+
+    private suspend fun deleteFile(file: File) {
+        // TODO
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -63,7 +63,7 @@ class EncryptedLogStore @Inject constructor(
      * 4. At application start
      * 5. After a timer - maybe due to [handleFailedUpload]
      */
-    suspend fun queueLogForUpload(payload: UploadEncryptedLogPayload) {
+    private suspend fun queueLogForUpload(payload: UploadEncryptedLogPayload) {
         // If the log file doesn't exist, there is nothing we can do
         if (!payload.file.exists()) {
             return

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -155,7 +155,6 @@ class EncryptedLogStore @Inject constructor(
     }
 
     private fun deleteEncryptedLog(encryptedLog: EncryptedLog) {
-        // TODO: Do we want to delete the unencrypted log file?
         encryptedLogSqlUtils.deleteEncryptedLogs(listOf(encryptedLog))
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -24,7 +24,8 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val MAX_FAIL_COUNT = 3
+// TODO: Increase the retry count
+private const val MAX_FAIL_COUNT = 1
 
 // TODO: Add EncryptedLogModel DB migration
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -1,15 +1,25 @@
 package org.wordpress.android.fluxc.store
 
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.action.EncryptedLogAction
+import org.wordpress.android.fluxc.action.EncryptedLogAction.UPLOAD_LOG
+import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLog
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.FAILED
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLogUploadState.UPLOADING
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptionUtils
 import org.wordpress.android.fluxc.model.encryptedlogging.LogEncrypter
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.EncryptedLogRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.LogUploadErrorType
-import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.LogUploadResult.LogUploadFailed
-import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.LogUploadResult.LogUploaded
+import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.UploadEncryptedLogResult.LogUploadFailed
+import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.UploadEncryptedLogResult.LogUploaded
 import org.wordpress.android.fluxc.persistence.EncryptedLogSqlUtils
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.API
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,9 +31,27 @@ private const val MAX_FAIL_COUNT = 3
 @Singleton
 class EncryptedLogStore @Inject constructor(
     private val encryptedLogRestClient: EncryptedLogRestClient,
-    private val encryptedLogSqlUtils: EncryptedLogSqlUtils
-) {
+    private val encryptedLogSqlUtils: EncryptedLogSqlUtils,
+    private val coroutineEngine: CoroutineEngine,
+    dispatcher: Dispatcher
+) : Store(dispatcher) {
     private val keyPair = EncryptionUtils.sodium.cryptoBoxKeypair()
+
+    override fun onRegister() {
+        AppLog.d(API, this.javaClass.name + ": onRegister")
+    }
+
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? EncryptedLogAction ?: return
+        when (actionType) {
+            UPLOAD_LOG -> {
+                coroutineEngine.launch(API, this, "EncryptedLogStore: On UPLOAD_LOG") {
+                    queueLogForUpload(action.payload as UploadEncryptedLogPayload)
+                }
+            }
+        }
+    }
 
     /**
      * Document the logic for when uploads will happen:
@@ -35,15 +63,14 @@ class EncryptedLogStore @Inject constructor(
      * 4. At application start
      * 5. After a timer - maybe due to [handleFailedUpload]
      */
-    // TODO: Remove `suspend` and move the logic to bg thread and return asap
-    suspend fun queueLogForUpload(uuid: String, file: File) {
+    suspend fun queueLogForUpload(payload: UploadEncryptedLogPayload) {
         // If the log file doesn't exist, there is nothing we can do
-        if (!file.exists()) {
+        if (!payload.file.exists()) {
             return
         }
         val encryptedLog = EncryptedLog(
-                uuid = uuid,
-                file = file
+                uuid = payload.uuid,
+                file = payload.file
         )
         encryptedLogSqlUtils.insertOrUpdateEncryptedLog(encryptedLog)
         uploadNext()
@@ -81,16 +108,17 @@ class EncryptedLogStore @Inject constructor(
         ).encrypt()
         when (val result = encryptedLogRestClient.uploadLog(encryptedLog.uuid, contents)) {
             is LogUploaded -> handleSuccessfulUpload(encryptedLog)
-            is LogUploadFailed -> handleFailedUpload(encryptedLog, result.errorType)
+            is LogUploadFailed -> handleFailedUpload(encryptedLog, result.error)
         }
     }
 
     private suspend fun handleSuccessfulUpload(encryptedLog: EncryptedLog) {
         deleteEncryptedLog(encryptedLog)
+        emitChange(OnEncryptedLogUploaded(uuid = encryptedLog.uuid, file = encryptedLog.file))
         uploadNext()
     }
 
-    private suspend fun handleFailedUpload(encryptedLog: EncryptedLog, errorType: LogUploadErrorType) {
+    private suspend fun handleFailedUpload(encryptedLog: EncryptedLog, error: UploadEncryptedLogError) {
         // TODO: Handle known server errors. If the upload failed for a temporary reason, don't increase failed count
         // TODO: and just queue it again with a back off timer
         val updatedEncryptedLog = encryptedLog.copy(
@@ -100,6 +128,9 @@ class EncryptedLogStore @Inject constructor(
         if (updatedEncryptedLog.failedCount >= MAX_FAIL_COUNT) {
             // If a log failed to upload too many times, assume we can't upload it
             deleteEncryptedLog(updatedEncryptedLog)
+
+            // Since we have a retry mechanism we should only notify that we failed to upload when we give up
+            emitChange(OnEncryptedLogUploaded(uuid = encryptedLog.uuid, file = encryptedLog.file, error = error))
         } else {
             encryptedLogSqlUtils.insertOrUpdateEncryptedLog(updatedEncryptedLog)
         }
@@ -109,5 +140,25 @@ class EncryptedLogStore @Inject constructor(
     private fun deleteEncryptedLog(encryptedLog: EncryptedLog) {
         // TODO: Do we want to delete the unencrypted log file?
         encryptedLogSqlUtils.deleteEncryptedLogs(listOf(encryptedLog))
+    }
+
+    class UploadEncryptedLogPayload(
+        val uuid: String,
+        val file: File
+    ) : Payload<BaseNetworkError>()
+
+    class OnEncryptedLogUploaded(
+        val uuid: String,
+        val file: File,
+        error: UploadEncryptedLogError? = null
+    ) : Store.OnChanged<UploadEncryptedLogError>() {
+        init {
+            this.error = error
+        }
+    }
+
+    sealed class UploadEncryptedLogError : OnChangedError {
+        object Unknown : UploadEncryptedLogError()
+        class InvalidUuid(val message: String) : UploadEncryptedLogError()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -158,8 +158,9 @@ class EncryptedLogStore @Inject constructor(
         }
     }
 
-    sealed class UploadEncryptedLogError : OnChangedError {
+    sealed class UploadEncryptedLogError(val message: String? = null) : OnChangedError {
         object Unknown : UploadEncryptedLogError()
-        class InvalidUuid(val message: String) : UploadEncryptedLogError()
+        class InvalidRequest(message: String?) : UploadEncryptedLogError(message)
+        class TooManyRequests(message: String?) : UploadEncryptedLogError(message)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -1,20 +1,17 @@
 package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.EncryptedLog
-import org.wordpress.android.fluxc.model.EncryptedLogUploadState
-import org.wordpress.android.fluxc.model.EncryptedLogUploadState.NEEDS_UPLOAD
-import org.wordpress.android.fluxc.model.EncryptedLogUploadState.UPLOAD_FAILED
+import org.wordpress.android.fluxc.model.EncryptedLogUploadState.FAILED
+import org.wordpress.android.fluxc.model.EncryptedLogUploadState.QUEUED
 import org.wordpress.android.fluxc.network.rest.wpcom.encryptedlog.EncryptedLogRestClient
 import org.wordpress.android.fluxc.persistence.EncryptedLogSqlUtils
 import java.io.File
-import java.util.Date
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val MAX_FAIL_COUNT = 3
 
-//TODO: Add EncryptedLogModel DB migration
+// TODO: Add EncryptedLogModel DB migration
 
 @Singleton
 class EncryptedLogStore @Inject constructor(
@@ -31,21 +28,14 @@ class EncryptedLogStore @Inject constructor(
      * 4. At application start
      * 5. After a timer - maybe due to [handleFailedUpload]
      */
-    fun newLogFile(): EncryptedLog {
-        val encryptedLog = EncryptedLog(
-                uuid = UUID.randomUUID().toString(),
-                file = File("") // TODO: Give proper path
-        )
-        encryptedLogSqlUtils.insertOrUpdateEncryptedLog(encryptedLog)
-        return encryptedLog
-    }
-
-    private suspend fun queueLogForUpload(uuid: String) {
-        // TODO: Delete the file if we can't find a record in the DB
-        encryptedLogSqlUtils.getEncryptedLog(uuid)?.copy(uploadState = NEEDS_UPLOAD)?.let { encryptedLog ->
-            encryptedLogSqlUtils.insertOrUpdateEncryptedLog(encryptedLog)
-            uploadNext()
+    private suspend fun queueLogForUpload(uuid: String, file: File) {
+        // If the log file doesn't exist, there is nothing we can do
+        if (!file.exists()) {
+            return
         }
+        val encryptedLog = EncryptedLog(uuid = uuid, file = file)
+        encryptedLogSqlUtils.insertOrUpdateEncryptedLog(encryptedLog)
+        uploadNext()
     }
 
     private suspend fun uploadNextWithBackOffTiming() {
@@ -55,10 +45,18 @@ class EncryptedLogStore @Inject constructor(
 
     private suspend fun uploadNext() {
         // TODO: Don't upload if we are already uploading something
-        val list = encryptedLogSqlUtils.getEncryptedLogsForUploadState(uploadState = NEEDS_UPLOAD)
-        list.forEach { encryptedLog ->
-            encryptedLogRestClient.uploadLog(encryptedLog.uuid, encryptedLog.file)
+        val (logsToUpload, logsToDelete) = encryptedLogSqlUtils.getEncryptedLogsForUpload()
+                .partition { it.file.exists() }
+        // Delete any queued encrypted log records if the log file no longer exists
+        encryptedLogSqlUtils.deleteEncryptedLogs(logsToDelete)
+        // We want to upload a single file at a time
+        logsToUpload.firstOrNull()?.let {
+            uploadEncryptedLog(it)
         }
+    }
+
+    private suspend fun uploadEncryptedLog(encryptedLog: EncryptedLog) {
+        encryptedLogRestClient.uploadLog(encryptedLog.uuid, encryptedLog.file)
     }
 
     private suspend fun handleSuccessfulUpload(encryptedLog: EncryptedLog) {
@@ -71,7 +69,7 @@ class EncryptedLogStore @Inject constructor(
         // TODO: and just queue it again with a back off timer
         val updatedEncryptedLog = encryptedLog.copy(
                 failedCount = encryptedLog.failedCount + 1,
-                uploadState = UPLOAD_FAILED
+                uploadState = FAILED
         )
         if (updatedEncryptedLog.failedCount >= MAX_FAIL_COUNT) {
             // If a log failed to upload too many times, assume we can't upload it

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -29,8 +29,6 @@ import javax.inject.Singleton
 
 private const val MAX_RETRY_COUNT = 3
 
-// TODO: Add EncryptedLogModel DB migration
-
 @Singleton
 class EncryptedLogStore @Inject constructor(
     private val encryptedLogRestClient: EncryptedLogRestClient,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -33,7 +33,7 @@ class EncryptedLogStore @Inject constructor(
      * 5. After a timer - maybe due to [handleFailedUpload]
      */
     // TODO: Remove `suspend` and move the logic to bg thread and return asap
-    private suspend fun queueLogForUpload(uuid: String, file: File) {
+    suspend fun queueLogForUpload(uuid: String, file: File) {
         // If the log file doesn't exist, there is nothing we can do
         if (!file.exists()) {
             return
@@ -75,7 +75,7 @@ class EncryptedLogStore @Inject constructor(
                 sourceFile = encryptedLog.file,
                 uuid = encryptedLog.uuid,
                 publicKey = keyPair.publicKey
-        ).read()
+        ).encrypt()
         encryptedLogRestClient.uploadLog(encryptedLog.uuid, contents)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import kotlinx.coroutines.delay
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -78,7 +79,8 @@ class EncryptedLogStore @Inject constructor(
     }
 
     private suspend fun uploadNextWithBackOffTiming() {
-        // TODO: Add a backoff timer
+        // TODO: Add a proper back off timing logic
+        delay(10000)
         uploadNext()
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/VerticalStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/VerticalStore.kt
@@ -33,7 +33,7 @@ class VerticalStore @Inject constructor(
     }
 
     override fun onRegister() {
-        AppLog.d(AppLog.T.API, ListStore::class.java.simpleName + " onRegister")
+        AppLog.d(AppLog.T.API, VerticalStore::class.java.simpleName + " onRegister")
     }
 
     private suspend fun fetchSegments(): OnSegmentsFetched {

--- a/fluxc/src/main/tools/wp-com-endpoints.txt
+++ b/fluxc/src/main/tools/wp-com-endpoints.txt
@@ -136,3 +136,5 @@
 /activity-log/$site/rewind/to/$rewind_ID#String
 
 /jetpack-install/$site#String
+
+/encrypted-logging

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         versionCode 1
         versionName "0.1"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 26
     }
     buildTypes {


### PR DESCRIPTION
This PR introduces encrypted logging support. It closely follows the FluxC conventions, but there are some minor differences due to this being a separate functionality from WordPress or Woo.

The intention for this design is for the client to ask FluxC to upload a given `File` and forget about it. There is some internal queuing logic which utilizes the DB for state keeping. The encryption logic has been brought in from the WPAndroid, thanks to @jkmassel's implementation and only minor modifications have been made to make it fit the FluxC ecosystem.

The best way to test and review this PR might be to run the connected tests in `ReleaseStack_EncryptedLogTest` and follow the logic with breakpoints. One gotcha to keep in mind is the `too_many_requests` error which I was hitting fairly quickly. The current tests are designed to ignore this error since there is nothing we can do about them on our end. We were either going to ignore them or not have these tests at all, since we wouldn't want to deal with randomly failing tests if we couldn't fix them. We may add some tests where we mock the network layer later on, but that'd provide very low value right now.

I left some todos in the code for future improvements and targeted a feature branch for this PR to give us a chance to work on them. The only thing that I couldn't figure out yet is bringing in [EncryptionUtilsTest](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.kt) from WPAndroid. I've spent way too much time on this and would love to get some help on the build issues it's causing. @jkmassel Do you think they are high value tests or should we just not add them if we can't get them to work quickly?

@jkmassel I assume you'll be the main reviewer for this PR. Please let me know if you want to go over these changes together.

@loremattei You may want to read this description and take a quick look at the few todos I left in the code to get a sense of where we are and whether any of it is something we should prioritize.