### PR TITLE
Catch assertion error in Visits and Views store

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -41,7 +41,12 @@ class VisitsAndViewsStore
                 SiteUtils.getNormalizedTimezone(site.timezone)
         )
         logProgress(granularity, "Site timezone: ${site.timezone}")
-        logProgress(granularity, "Current date: ${currentTimeProvider.currentDate}")
+        try {
+            logProgress(granularity, "Current date: ${currentTimeProvider.currentDate}")
+        } catch (e: AssertionError) {
+            // Workaround for a bug in Android that can cause crashes on Android 8.0 and 8.1
+            logProgress(granularity, "Cannot print current date because of AssertionError: $e")
+        }
         logProgress(granularity, "Fetching for date with applied timezone: $dateWithTimeZone")
         if (!forced && sqlUtils.hasFreshRequest(site, granularity, dateWithTimeZone, limitMode.limit)) {
             logProgress(granularity, "Loading cached data")


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1627

Related WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/12430

There is a crash in Android 8.1 that happens on some devices when you're trying to call `Date.toString()`. This PR implements a workaround to catch it (https://stackoverflow.com/questions/51453091/android-facebook-sdk-internal-utility-java-lang-assertionerror/52035884#52035884)