### PR TITLE
Fix the failing API unit test

### DIFF
--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -86,7 +86,7 @@ public class APITesting_WCOrder {
             get().
         then().
             statusCode(200).
-            body("data", hasSize(7));
+            body("data", hasSize(8));
     }
 
     @Test


### PR DESCRIPTION
The response from the backend has changed, so the expected result had to be updated. 

By the way, I was looking at the WC REST API repo and I noticed that the affected endpoint will be removed in v4, so that's something to keep in mind when we point the tests to the new version.