### PR TITLE
Encrypted Logs Integration Improvements

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/LogEncrypterTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/LogEncrypterTest.kt
@@ -1,0 +1,163 @@
+package org.wordpress.android.fluxc
+
+import android.util.Base64
+import android.util.Base64.DEFAULT
+import com.goterl.lazycode.lazysodium.interfaces.SecretStream
+import com.goterl.lazycode.lazysodium.utils.KeyPair
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedSecretStreamKey
+import org.wordpress.android.fluxc.model.encryptedlogging.EncryptionUtils
+import org.wordpress.android.fluxc.model.encryptedlogging.LogEncrypter
+import org.wordpress.android.fluxc.model.encryptedlogging.SecretStreamKey
+import java.util.UUID
+
+class LogEncrypterTest {
+    private lateinit var keypair: KeyPair
+    private val logDecrypter: LogDecrypter = LogDecrypter()
+
+    @Before
+    fun setup() {
+        keypair = EncryptionUtils.sodium.cryptoBoxKeypair()
+    }
+
+    @Test
+    @Throws
+    fun testThatEncryptedLogsMatchV1FileFormat() {
+        val testLogString = UUID.randomUUID().toString()
+        val encryptedLog = encryptContent(testLogString)
+
+        val json = JSONObject(encryptedLog)
+        assertEquals(
+                "`keyedWith` must ALWAYS be v1 in this version of the file format",
+                "v1",
+                json.getString("keyedWith")
+        )
+
+        assertNotNull(
+                "The UUID must be valid",
+                UUID.fromString(json.getString("uuid"))
+        )
+
+        assertEquals(
+                "The header must be 32 bytes long",
+                32,
+                json.getString("header").count()
+        )
+
+        assertEquals(
+                "The encrypted key should be 108 bytes long",
+                108,
+                json.getString("encryptedKey").count()
+        )
+
+        assertEquals(
+                "There should be one message and the closing tag",
+                2,
+                json.getJSONArray("messages").length()
+        )
+    }
+
+    @Test
+    fun testThatLogsCanBeDecrypted() {
+        val testLogString = UUID.randomUUID().toString()
+        assertEquals(testLogString, decryptContent(encryptContent(testLogString)))
+    }
+
+    @Test
+    fun testThatEmptyLogsCanBeEncrypted() {
+        val testLogString = ""
+        assertEquals(testLogString, decryptContent(encryptContent(testLogString)))
+    }
+
+    @Test
+    fun testThatExplicitUUIDsCanBeRetrievedFromEncryptedLogs() {
+        val testUuid = UUID.randomUUID().toString()
+
+        val (_, uuid) = logDecrypter.decrypt(encryptContent("", testUuid), keypair)
+        assertEquals(uuid, testUuid)
+    }
+
+    // Helpers
+
+    private fun encryptContent(content: String, uuid: String = UUID.randomUUID().toString()): String {
+        val file = createTempFile()
+        file.writeText(content)
+        return LogEncrypter(file, uuid, keypair.publicKey).encrypt()
+    }
+
+    private fun decryptContent(encryptedText: String): String {
+        return logDecrypter.decrypt(encryptedText, keypair).first
+    }
+}
+
+/**
+ * EncryptedStream represents the encrypted stream once the key has been decrypted. It exists to separate
+ * the key decryption from the stream decryption while decoding.
+ *
+ * @param key An unencrypted SecretStreamKey used to decrypt the remainder of the log.
+ * @param header A `ByteArray` representing the stream header – it's used to initialize the decryption stream.
+ * @param messages A `List<ByteArray>` of encrypted messages
+ */
+private class EncryptedStream(val key: SecretStreamKey, val header: ByteArray, val messages: List<ByteArray>)
+
+private const val JSON_KEYED_WITH_KEY = "keyedWith"
+private const val JSON_UUID_KEY = "uuid"
+private const val JSON_HEADER_KEY = "header"
+private const val JSON_ENCRYPTED_KEY_KEY = "encryptedKey"
+private const val JSON_MESSAGES_KEY = "messages"
+
+/**
+ * LogDecrypter allows decrypting encrypted content.
+ */
+private class LogDecrypter {
+    private val sodium = EncryptionUtils.sodium
+    private val state = SecretStream.State.ByReference()
+
+    private fun encryptedStream(encryptedText: String, keyPair: KeyPair): Pair<EncryptedStream, String> {
+        val json = JSONObject(encryptedText)
+
+        require(json.getString(JSON_KEYED_WITH_KEY) == "v1") {
+            "This class can only parse files keyedWith the v1 implementation"
+        }
+
+        val uuid = json.getString(JSON_UUID_KEY)
+        val header = json.getString(JSON_HEADER_KEY).base64Decode()
+        val encryptedKey = EncryptedSecretStreamKey(json.getString(JSON_ENCRYPTED_KEY_KEY).base64Decode())
+        val messagesJson = json.getJSONArray(JSON_MESSAGES_KEY)
+
+        val messages = (0 until messagesJson.length()).map { messagesJson.getString(it).base64Decode() }
+
+        val encryptedStream = EncryptedStream(encryptedKey.decrypt(keyPair), header, messages)
+        check(sodium.cryptoSecretStreamInitPull(state, encryptedStream.header, encryptedStream.key.bytes))
+        return Pair(encryptedStream, uuid)
+    }
+
+    /**
+     * Decrypts and returns the log file as a String.
+     *
+     * @param encryptedText The encrypted text to decrypt.
+     * @param keyPair The public and secret key pair associated with this file. Both are required to decrypt the file.
+     */
+    fun decrypt(encryptedText: String, keyPair: KeyPair): Pair<String, String> {
+        val (encryptedStream, uuid) = encryptedStream(encryptedText, keyPair)
+        val decryptedText = encryptedStream.messages.fold("") { accumulated: String, cipherBytes: ByteArray ->
+            String
+            val plainBytes = ByteArray(cipherBytes.size - SecretStream.ABYTES)
+
+            val tag = ByteArray(1) // Stores the extracted tag. This implementation doesn't do anything with it.
+            check(sodium.cryptoSecretStreamPull(state, plainBytes, tag, cipherBytes, cipherBytes.size.toLong()))
+
+            accumulated + String(plainBytes)
+        }
+        return Pair(decryptedText, uuid)
+    }
+}
+
+// On Android base64 has lots of options, so define an extension to make it easier to avoid decoding issues.
+private fun String.base64Decode(): ByteArray {
+    return Base64.decode(this, DEFAULT)
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
@@ -49,7 +49,11 @@ class ReleaseStack_EncryptedLogTest : ReleaseStack_Base() {
         val testIds = testIds()
         mCountDownLatch = CountDownLatch(testIds.size)
         testIds.forEach { uuid ->
-            val payload = UploadEncryptedLogPayload(uuid = uuid, file = createTempFile(suffix = uuid))
+            val payload = UploadEncryptedLogPayload(
+                    uuid = uuid,
+                    file = createTempFile(suffix = uuid),
+                    shouldStartUploadImmediately = true
+            )
             mDispatcher.dispatch(EncryptedLogActionBuilder.newUploadLogAction(payload))
         }
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -60,7 +64,11 @@ class ReleaseStack_EncryptedLogTest : ReleaseStack_Base() {
         nextEvent = ENCRYPTED_LOG_UPLOAD_FAILED_WITH_INVALID_UUID
 
         mCountDownLatch = CountDownLatch(1)
-        val payload = UploadEncryptedLogPayload(uuid = INVALID_UUID, file = createTempFile(suffix = INVALID_UUID))
+        val payload = UploadEncryptedLogPayload(
+                uuid = INVALID_UUID,
+                file = createTempFile(suffix = INVALID_UUID),
+                shouldStartUploadImmediately = true
+        )
         mDispatcher.dispatch(EncryptedLogActionBuilder.newUploadLogAction(payload))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.EncryptedLogStore.OnEncryptedLogUploade
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.InvalidRequest
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.TooManyRequests
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogPayload
+import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -51,7 +52,7 @@ class ReleaseStack_EncryptedLogTest : ReleaseStack_Base() {
         testIds.forEach { uuid ->
             val payload = UploadEncryptedLogPayload(
                     uuid = uuid,
-                    file = createTempFile(suffix = uuid),
+                    file = createTempFileWithContent(suffix = uuid, content = "Testing FluxC log upload for $uuid"),
                     shouldStartUploadImmediately = true
             )
             mDispatcher.dispatch(EncryptedLogActionBuilder.newUploadLogAction(payload))
@@ -97,5 +98,11 @@ class ReleaseStack_EncryptedLogTest : ReleaseStack_Base() {
 
     private fun testIds() = (1..NUMBER_OF_LOGS_TO_UPLOAD).map { i ->
         "$TEST_UUID_PREFIX$i"
+    }
+
+    private fun createTempFileWithContent(suffix: String, content: String): File {
+        val file = createTempFile(suffix = suffix)
+        file.writeText(content)
+        return file
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
+import org.wordpress.android.fluxc.store.EncryptedLoggingKey;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -39,5 +40,10 @@ public class AppConfigModule {
     @Provides
     public UserAgent provideUserAgent(Context appContext) {
         return new UserAgent(appContext, "fluxc-example-android");
+    }
+
+    @Provides
+    public EncryptedLoggingKey provideEncryptedLoggingKey() {
+        return new EncryptedLoggingKey(getStringBuildConfigValue("ENCRYPTED_LOGGING_PUBLIC_KEY"));
     }
 }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
     // Encrypted Logging
-    implementation "com.goterl.lazycode:lazysodium-android:4.1.0@aar"
+    api "com.goterl.lazycode:lazysodium-android:4.1.0@aar"
     implementation "net.java.dev.jna:jna:4.5.1@aar"
 }
 

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -105,7 +105,7 @@ dependencies {
 
     // Encrypted Logging
     api "com.goterl.lazycode:lazysodium-android:4.1.0@aar"
-    implementation "net.java.dev.jna:jna:4.5.1@aar"
+    api "net.java.dev.jna:jna:4.5.1@aar"
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/EncryptedLogAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/EncryptedLogAction.kt
@@ -8,5 +8,7 @@ import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogPay
 @ActionEnum
 enum class EncryptedLogAction : IAction {
     @Action(payloadType = UploadEncryptedLogPayload::class)
-    UPLOAD_LOG
+    UPLOAD_LOG,
+    @Action
+    RESET_UPLOAD_STATES
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
@@ -28,7 +28,6 @@ class EncryptedLogSqlUtils @Inject constructor() {
         return getEncryptedLogModel(uuid)?.let { EncryptedLog.fromEncryptedLogModel(it) }
     }
 
-    // TODO: Add unit tests
     fun getUploadingEncryptedLogs(): List<EncryptedLog> =
             getUploadingEncryptedLogsQuery().asModel.map { EncryptedLog.fromEncryptedLogModel(it) }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt
@@ -14,20 +14,25 @@ import javax.inject.Singleton
 @Singleton
 class EncryptedLogSqlUtils @Inject constructor() {
     fun insertOrUpdateEncryptedLog(encryptedLog: EncryptedLog) {
+        insertOrUpdateEncryptedLogs(listOf(encryptedLog))
+    }
+
+    fun insertOrUpdateEncryptedLogs(encryptedLogs: List<EncryptedLog>) {
+        val encryptedLogModels = encryptedLogs.map { EncryptedLogModel.fromEncryptedLog(it) }
         // Since we have a unique constraint for uuid with 'on conflict replace', if there is an existing log,
         // it'll be replaced with the new one. No need to check if the log already exists.
-        WellSql.insert(EncryptedLogModel.fromEncryptedLog(encryptedLog)).execute()
+        WellSql.insert(encryptedLogModels).execute()
     }
 
     fun getEncryptedLog(uuid: String): EncryptedLog? {
         return getEncryptedLogModel(uuid)?.let { EncryptedLog.fromEncryptedLogModel(it) }
     }
 
-    fun getNumberOfUploadingEncryptedLogs(): Long = WellSql.select(EncryptedLogModel::class.java)
-            .where()
-            .equals(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, UPLOADING.value)
-            .endWhere()
-            .count()
+    // TODO: Add unit tests
+    fun getUploadingEncryptedLogs(): List<EncryptedLog> =
+            getUploadingEncryptedLogsQuery().asModel.map { EncryptedLog.fromEncryptedLogModel(it) }
+
+    fun getNumberOfUploadingEncryptedLogs(): Long = getUploadingEncryptedLogsQuery().count()
 
     fun deleteEncryptedLogs(encryptedLogList: List<EncryptedLog>) {
         if (encryptedLogList.isEmpty()) {
@@ -63,5 +68,12 @@ class EncryptedLogSqlUtils @Inject constructor() {
                 .endWhere()
                 .asModel
                 .firstOrNull()
+    }
+
+    private fun getUploadingEncryptedLogsQuery(): SelectQuery<EncryptedLogModel> {
+        return WellSql.select(EncryptedLogModel::class.java)
+            .where()
+            .equals(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, UPLOADING.value)
+            .endWhere()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -6,6 +6,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.EncryptedLogAction
+import org.wordpress.android.fluxc.action.EncryptedLogAction.RESET_UPLOAD_STATES
 import org.wordpress.android.fluxc.action.EncryptedLogAction.UPLOAD_LOG
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLog
@@ -52,6 +53,11 @@ class EncryptedLogStore @Inject constructor(
                     queueLogForUpload(action.payload as UploadEncryptedLogPayload)
                 }
             }
+            RESET_UPLOAD_STATES -> {
+                coroutineEngine.launch(API, this, "EncryptedLogStore: On RESET_UPLOAD_STATES") {
+                    resetUploadStates()
+                }
+            }
         }
     }
 
@@ -78,6 +84,12 @@ class EncryptedLogStore @Inject constructor(
 
         if (payload.shouldStartUploadImmediately) {
             uploadNext()
+        }
+    }
+
+    private fun resetUploadStates() {
+        encryptedLogSqlUtils.getUploadingEncryptedLogs().map {
+            it.copy(uploadState = FAILED)
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -88,9 +88,9 @@ class EncryptedLogStore @Inject constructor(
     }
 
     private fun resetUploadStates() {
-        encryptedLogSqlUtils.getUploadingEncryptedLogs().map {
+        encryptedLogSqlUtils.insertOrUpdateEncryptedLogs(encryptedLogSqlUtils.getUploadingEncryptedLogs().map {
             it.copy(uploadState = FAILED)
-        }
+        })
     }
 
     private suspend fun uploadNextWithBackOffTiming() {


### PR DESCRIPTION
This is a collection of improvements to encrypted logging as a follow up to #1629. Here are the changes:

* Unit tests for `LogEncrypter`: This also includes the `LogDecrypter` which I opted to include as part of the unit tests. Until we decide to use the decryption directly, I think this is the best place to keep this code as it's only used for testing. All this code (including tests) is brought from WPAndroid thanks to @jkmassel's implementation and only modified to fit the new structure.
* `UploadEncryptedLogPayload.shouldStartUploadImmediately` which is used to decide whether we'll try to upload the logs immediately or not. This is set to `false` by default since we'll queue the logs during a crash and we are unlikely to have enough time to complete the upload.
* `RESET_UPLOAD_STATES` action which is used during application launch to set the state of all encrypted logs with `UPLOADING` state to `FAILED`. (there will be at most 1 in our current setting) I think this action is necessary because if the application is closed during the upload it can remain in the uploading state without any way to recover and will prevent any other log from being uploaded. During the initial implementation I assumed we'd hit the failure callback of the request in such a case, but during testing this didn't seem to be the case.
* Convert the dependencies from `implementation` to `api` which was necessary to integrate it to WPAndroid and add the unit tests. (as integration tests unfortunately) I think we may be able to get rid of this dependency if we don't have to expose the public key to the integration side, but at least for now it was a necessary step.

~With these changes, the only *known* issue left is the `Invalid Log File` error in the MC side after the logs are uploaded. I've spent a lot of time trying to figure out why we are hitting that error, but as far as I can tell we are properly encrypting the logs since we can also decrypt it without issues in the unit tests. I've also tried to upload a test json with this setup and I was able to view it in the MC side. The only problem I can think of on the client side is the `header` and `messages` fields in the json that we create, but I don't know a good way to test what might be wrong with them aside from the already passing unit tests.~

~@jkmassel Do you have any thoughts on this? Is it at all possible that there might be an issue on the server side? I assume not, since we were able to get everything working on the iOS side, but I am running out of ideas.~

_Edit: The issue ^ has been fixed._

_P.S: There are some things that are kind of in between two different structures they were written in. This is due to us starting the work on WPAndroid with a different approach and moving everything to FluxC. However, I don't think any of it is a major concern even if we were to leave them as is and once we get everything working, it should be a fairly easy step to polish everything up._