### PR TITLE
Woo/batch add tags

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload
@@ -769,6 +770,47 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
 
         assertEquals(WCProductAction.FETCHED_PRODUCT_TAGS, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteProductTagsPayload
+        assertNotNull(payload.error)
+    }
+
+    @Test
+    fun testAddProductTagsSuccess() {
+        val tagNames = listOf("batchAdd1", "batchAdd6")
+        interceptor.respondWith("wc-add-product-tags-response-success.json")
+        productRestClient.addProductTags(siteModel, tagNames)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCProductAction.ADDED_PRODUCT_TAGS, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteAddProductTagsResponsePayload
+        assertNull(payload.error)
+        assertEquals(2, payload.tags.size)
+        assertEquals(payload.tags[0].name, "")
+        assertEquals(payload.tags[1].name, "batchAdd6")
+
+        // save the tags to the db
+        payload.tags.map {
+            if (it.name.isNotEmpty()) {
+                assertEquals(1, ProductSqlUtils.insertOrUpdateProductTag(it))
+            }
+        }
+
+        val savedTags = ProductSqlUtils.getProductTagsByNames(siteModel.id, tagNames)
+        assertEquals(1, savedTags.size)
+        assertEquals("batchAdd6", savedTags[0].name)
+    }
+
+    @Test
+    fun testAddProductTagsError() {
+        interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
+        productRestClient.addProductTags(siteModel, listOf("test1", "test2"))
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCProductAction.ADDED_PRODUCT_TAGS, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteAddProductTagsResponsePayload
         assertNotNull(payload.error)
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
@@ -46,6 +47,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload
+import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
@@ -68,7 +70,8 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         UPDATED_PRODUCT_PASSWORD,
         FETCH_PRODUCT_CATEGORIES,
         ADDED_PRODUCT_CATEGORY,
-        FETCHED_PRODUCT_TAGS
+        FETCHED_PRODUCT_TAGS,
+        ADDED_PRODUCT_TAGS
     }
 
     @Inject internal lateinit var productStore: WCProductStore
@@ -550,6 +553,28 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         assertTrue(fetchedTags.isNotEmpty())
     }
 
+    @Throws(InterruptedException::class)
+    @Test
+    fun testAddProductTags() {
+        // Remove all product tags from the database
+        ProductSqlUtils.deleteProductTagsForSite(sSite)
+        assertEquals(0, ProductSqlUtils.getProductTagsForSite(sSite.id).size)
+
+        nextEvent = TestEvent.ADDED_PRODUCT_TAGS
+        mCountDownLatch = CountDownLatch(1)
+
+        val productTags = listOf("Test" + Date().time, "Test1" + Date().time)
+        mDispatcher.dispatch(WCProductActionBuilder.newAddProductTagsAction(
+                AddProductTagsPayload(sSite, productTags)
+        ))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        // Verify results
+        val fetchAllTags = productStore.getProductTagsByNames(sSite, productTags)
+        assertTrue(fetchAllTags.isNotEmpty())
+        assertTrue(fetchAllTags.size == 2)
+    }
+
     /**
      * Used by the update images test to fetch a single media model for this site
      */
@@ -729,6 +754,10 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         when (event.causeOfChange) {
             WCProductAction.FETCH_PRODUCT_TAGS -> {
                 assertEquals(TestEvent.FETCHED_PRODUCT_TAGS, nextEvent)
+                mCountDownLatch.countDown()
+            }
+            WCProductAction.ADDED_PRODUCT_TAGS -> {
+                assertEquals(TestEvent.ADDED_PRODUCT_TAGS, nextEvent)
                 mCountDownLatch.countDown()
             }
             else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)

--- a/example/src/androidTest/resources/wc-add-product-tags-response-success.json
+++ b/example/src/androidTest/resources/wc-add-product-tags-response-success.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "create": [
+      {
+        "id": 0,
+        "error": {
+          "code": "term_exists",
+          "message": "A term with the name provided already exists in this taxonomy.",
+          "data": {
+            "status": 400,
+            "resource_id": 197
+          }
+        }
+      },
+      {
+        "id": 202,
+        "name": "batchAdd6",
+        "slug": "batchadd6",
+        "description": "",
+        "count": 0,
+        "_links": {
+          "self": [
+            {
+              "href": "https://awootestshop.mystagingwebsite.com/wp-json/wc/v3/products/tags/202"
+            }
+          ],
+          "collection": [
+            {
+              "href": "https://awootestshop.mystagingwebsite.com/wp-json/wc/v3/products/tags"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -13,9 +13,11 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_CATEGORY
+import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_TAGS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_CATEGORIES
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_REVIEWS
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_TAGS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIONS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_REVIEW
@@ -33,6 +35,7 @@ import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload
@@ -74,6 +77,7 @@ class WooProductsFragment : Fragment() {
     private var pendingFetchProductTagsOffset: Int = 0
 
     private var enteredCategoryName: String? = null
+    private val enteredTagNames: MutableList<String> = mutableListOf()
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -302,6 +306,32 @@ class WooProductsFragment : Fragment() {
             }
         }
 
+        add_product_tags.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter tag name:"
+                ) { editTextTagName1 ->
+                    showSingleLineDialog(
+                            activity,
+                            "Enter another tag name:"
+                    ) { editTextTagName2 ->
+                        val tagName1 = editTextTagName1.text.toString()
+                        val tagName2 = editTextTagName2.text.toString()
+                        if (tagName1.isNotEmpty() && tagName2.isNotEmpty()) {
+                            enteredTagNames.add(tagName1)
+                            enteredTagNames.add(tagName2)
+                            prependToLog("Submitting request to add product tags for site ${site.id}")
+                            val payload = AddProductTagsPayload(site, enteredTagNames)
+                            dispatcher.dispatch(WCProductActionBuilder.newAddProductTagsAction(payload))
+                        } else {
+                            prependToLog("Tag name is empty. Doing nothing..")
+                        }
+                    }
+                }
+            }
+        }
+
         update_product_images.setOnClickListener {
             showSingleLineDialog(
                     activity,
@@ -513,14 +543,30 @@ class WooProductsFragment : Fragment() {
             return
         }
 
-        prependToLog("Fetched ${event.rowsAffected} product tags. More tags available ${event.canLoadMore}")
-        if (event.canLoadMore) {
-            pendingFetchProductTagsOffset += event.rowsAffected
-            load_more_product_tags.visibility = View.VISIBLE
-            load_more_product_tags.isEnabled = true
-        } else {
-            pendingFetchProductTagsOffset = 0
-            load_more_product_tags.isEnabled = false
+        selectedSite?.let { site ->
+            when (event.causeOfChange) {
+                FETCH_PRODUCT_TAGS -> {
+                    prependToLog("Fetched ${event.rowsAffected} product tags. More tags available ${event.canLoadMore}")
+                    if (event.canLoadMore) {
+                        pendingFetchProductTagsOffset += event.rowsAffected
+                        load_more_product_tags.visibility = View.VISIBLE
+                        load_more_product_tags.isEnabled = true
+                    } else {
+                        pendingFetchProductTagsOffset = 0
+                        load_more_product_tags.isEnabled = false
+                    }
+                }
+
+                ADDED_PRODUCT_TAGS -> {
+                    val tags = wcProductStore.getProductTagsByNames(site, enteredTagNames)
+                    val tagNames = tags.map { it.name }.joinToString(",")
+                    prependToLog("${event.rowsAffected} product tags added for $tagNames")
+                    if (enteredTagNames.size > event.rowsAffected) {
+                        prependToLog("Error occurred when trying to add some product tags")
+                    }
+                }
+                else -> { }
+            }
         }
     }
 

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -173,6 +173,13 @@
             android:text="Load More Product Tags" />
 
         <Button
+            android:id="@+id/add_product_tags"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Add Product Tags" />
+
+        <Button
             android:id="@+id/update_product"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -646,7 +646,7 @@ class ProductSqlUtilsTest {
         assertEquals(tagList.size, rowsAffected)
 
         // Get tag by name and verify
-        val savedTagExists = ProductSqlUtils.getProductTagsByName(site.id, tagList[0].name)
+        val savedTagExists = ProductSqlUtils.getProductTagByName(site.id, tagList[0].name)
         assertEquals(tagList[0].name, savedTagExists?.name)
         assertEquals(tagList[0].remoteTagId, savedTagExists?.remoteTagId)
         assertEquals(tagList[0].slug, savedTagExists?.slug)
@@ -654,7 +654,7 @@ class ProductSqlUtilsTest {
 
         // Get tag for a name that does not exist
         val nonExistingTagName = "test"
-        val savedTag = ProductSqlUtils.getProductTagsByName(site.id, nonExistingTagName)
+        val savedTag = ProductSqlUtils.getProductTagByName(site.id, nonExistingTagName)
         assertNull(savedTag)
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -637,6 +637,57 @@ class ProductSqlUtilsTest {
     }
 
     @Test
+    fun testGetProductTagByName() {
+        val tagList = ProductTestUtils.generateProductTags(site.id)
+        assertTrue(tagList.isNotEmpty())
+
+        // Insert product tag list
+        val rowsAffected = ProductSqlUtils.insertOrUpdateProductTags(tagList)
+        assertEquals(tagList.size, rowsAffected)
+
+        // Get tag by name and verify
+        val savedTagExists = ProductSqlUtils.getProductTagsByName(site.id, tagList[0].name)
+        assertEquals(tagList[0].name, savedTagExists?.name)
+        assertEquals(tagList[0].remoteTagId, savedTagExists?.remoteTagId)
+        assertEquals(tagList[0].slug, savedTagExists?.slug)
+        assertEquals(tagList[0].description, savedTagExists?.description)
+
+        // Get tag for a name that does not exist
+        val nonExistingTagName = "test"
+        val savedTag = ProductSqlUtils.getProductTagsByName(site.id, nonExistingTagName)
+        assertNull(savedTag)
+    }
+
+    @Test
+    fun testGetProductTagsByNames() {
+        val tagList = ProductTestUtils.generateProductTags(site.id)
+        assertTrue(tagList.isNotEmpty())
+
+        // Insert product tag list
+        val rowsAffected = ProductSqlUtils.insertOrUpdateProductTags(tagList)
+        assertEquals(tagList.size, rowsAffected)
+
+        // Get tags by list of name and verify
+        val tagNames = tagList.map { it.name }.toList()
+        val savedTagListExists = ProductSqlUtils.getProductTagsByNames(site.id, tagNames)
+        assertEquals(tagList.size, savedTagListExists.size)
+        assertEquals(tagList[0].name, savedTagListExists[0].name)
+        assertEquals(tagList[1].name, savedTagListExists[1].name)
+        assertEquals(tagList[2].name, savedTagListExists[2].name)
+
+        // Get tags for a name that does not exist
+        val monExistingTagList = ProductSqlUtils.getProductTagsByNames(
+                site.id, listOf("test", "test1", "test2")
+        )
+        assertEquals(0, monExistingTagList.size)
+
+        val savedTagList = ProductSqlUtils.getProductTagsByNames(
+                site.id, listOf(tagNames[0], tagNames[1], "test")
+        )
+        assertEquals(2, savedTagList.size)
+    }
+
+    @Test
     fun testDeleteProductTagsForSite() {
         val tags = ProductTestUtils.generateProductTags(site.id)
 

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
@@ -17,6 +18,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayloa
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload;
@@ -74,6 +76,8 @@ public enum WCProductAction implements IAction {
     ADD_PRODUCT_CATEGORY,
     @Action(payloadType = FetchProductTagsPayload.class)
     FETCH_PRODUCT_TAGS,
+    @Action(payloadType = AddProductTagsPayload.class)
+    ADD_PRODUCT_TAGS,
 
 
     // Remote responses
@@ -110,5 +114,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteAddProductCategoryResponsePayload.class)
     ADDED_PRODUCT_CATEGORY,
     @Action(payloadType = RemoteProductTagsPayload.class)
-    FETCHED_PRODUCT_TAGS
+    FETCHED_PRODUCT_TAGS,
+    @Action(payloadType = RemoteAddProductTagsResponsePayload.class)
+    ADDED_PRODUCT_TAGS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/BatchAddProductTagApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/BatchAddProductTagApiResponse.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+
+class BatchAddProductTagApiResponse : Response {
+    @SerializedName("create")
+    val addedTags: List<ProductTagApiResponse>? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload
@@ -187,6 +188,42 @@ class ProductRestClient(
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductTagsAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) })
+        add(request)
+    }
+
+    /**
+     * Makes a POST request to `POST /wp-json/wc/v3/products/tags/batch` to add
+     * product tags for a site
+     *
+     * Dispatches a WCProductAction.ADDED_PRODUCT_TAGS action with the result
+     *
+     * @param [site] The site to fetch product shipping class list for
+     * @param [tags] The list of tag names that needed to be added to the site
+     */
+    fun addProductTags(
+        site: SiteModel,
+        tags: List<String>
+    ) {
+        val url = WOOCOMMERCE.products.tags.batch.pathV3
+        val responseType = object : TypeToken<BatchAddProductTagApiResponse>() {}.type
+        val params = mutableMapOf(
+                "create" to tags.map { mapOf("name" to it) }
+        )
+
+        val request = JetpackTunnelGsonRequest.buildPostRequest(url, site.siteId, params, responseType,
+                { response: BatchAddProductTagApiResponse? ->
+                    val addedTags = response?.addedTags?.map {
+                        productTagApiResponseToProductTagModel(it, site)
+                    }.orEmpty()
+
+                    val payload = RemoteAddProductTagsResponsePayload(site, addedTags)
+                    dispatcher.dispatch(WCProductActionBuilder.newAddedProductTagsAction(payload))
+                },
+                WPComErrorListener { networkError ->
+                    val productError = networkErrorToProductError(networkError)
+                    val payload = RemoteAddProductTagsResponsePayload(productError, site)
+                    dispatcher.dispatch(WCProductActionBuilder.newAddedProductTagsAction(payload))
+                })
         add(request)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductTagApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductTagApiResponse.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
+import com.google.gson.JsonElement
 import org.wordpress.android.fluxc.network.Response
 
 @Suppress("PropertyName")
@@ -9,6 +10,8 @@ class ProductTagApiResponse : Response {
     var name: String? = null
     var slug: String? = null
     var description: String? = null
+
+    val error: JsonElement? = null
 
     var count = 0
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -548,6 +548,30 @@ object ProductSqlUtils {
                 .asModel
     }
 
+    fun getProductTagsByNames(
+        localSiteId: Int,
+        tags: List<String>
+    ): List<WCProductTagModel> {
+        return WellSql.select(WCProductTagModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductTagModelTable.LOCAL_SITE_ID, localSiteId)
+                .isIn(WCProductModelTable.NAME, tags)
+                .endGroup().endWhere()
+                .asModel
+    }
+
+    fun getProductTagsByName(
+        localSiteId: Int,
+        tagName: String
+    ): WCProductTagModel? {
+        return WellSql.select(WCProductTagModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductTagModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(WCProductTagModelTable.NAME, tagName)
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+    }
+
     fun getProductTagByRemoteId(
         remoteTagId: Long,
         localSiteId: Int

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -560,7 +560,7 @@ object ProductSqlUtils {
                 .asModel
     }
 
-    fun getProductTagsByName(
+    fun getProductTagByName(
         localSiteId: Int,
         tagName: String
     ): WCProductTagModel? {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -152,6 +152,11 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         var offset: Int = 0
     ) : Payload<BaseNetworkError>()
 
+    class AddProductTagsPayload(
+        val site: SiteModel,
+        val tags: List<String>
+    ) : Payload<BaseNetworkError>()
+
     enum class ProductErrorType {
         INVALID_PARAM,
         INVALID_REVIEW_ID,
@@ -399,6 +404,19 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         ) : this(site) {
             this.error = error
         }
+    }
+
+    class RemoteAddProductTagsResponsePayload(
+        val site: SiteModel,
+        val tags: List<String>,
+        val addedTags: List<WCProductTagModel> = emptyList()
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel,
+            tags: List<String>,
+            addedTags: List<WCProductTagModel> = emptyList()
+        ) : this(site, tags, addedTags) { this.error = error }
     }
 
     // OnChanged events

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -562,7 +562,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getProductTagsByNames(site: SiteModel, tagNames: List<String>) =
             ProductSqlUtils.getProductTagsByNames(site.id, tagNames)
 
-    fun getProductTagsByName(site: SiteModel, tagName: String) =
+    fun getProductTagByName(site: SiteModel, tagName: String) =
             ProductSqlUtils.getProductTagByName(site.id, tagName)
 
     fun getProductReviewByRemoteId(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -35,7 +35,7 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
         const val DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE = 100
         const val DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE = 25
         const val DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE = 25
-        const val DEFAULT_PRODUCT_TAGS_PAGE_SIZE = 25
+        const val DEFAULT_PRODUCT_TAGS_PAGE_SIZE = 100
         val DEFAULT_PRODUCT_SORTING = TITLE_ASC
         val DEFAULT_CATEGORY_SORTING = NAME_ASC
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -559,6 +559,12 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     fun getTagsForSite(site: SiteModel): List<WCProductTagModel> =
             ProductSqlUtils.getProductTagsForSite(site.id)
 
+    fun getProductTagsByNames(site: SiteModel, tagNames: List<String>) =
+            ProductSqlUtils.getProductTagsByNames(site.id, tagNames)
+
+    fun getProductTagsByName(site: SiteModel, tagName: String) =
+            ProductSqlUtils.getProductTagByName(site.id, tagName)
+
     fun getProductReviewByRemoteId(
         localSiteId: Int,
         remoteReviewId: Long

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -19,6 +19,7 @@
 
 /products/tags/
 /products/tags/<id>/
+/products/tags/batch/
 
 /reports/orders/totals/
 /reports/revenue/stats/


### PR DESCRIPTION
Fixes #1613 by adding support to batch add tags. 

#### Changes
- Added new action and action classes to `WCProductStore` and `ProductRestClient` to add a new product tags for a site.
- Added unit tests.
- Added a new button to the example app to add new product tags.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/87902661-de6fa880-ca77-11ea-8f53-be7efafe9256.png" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/87902663-e0d20280-ca77-11ea-9098-03317701ee4a.png" width="300" />


#### To Test
- Run `MockedStack_WCProductsTest` and `ReleaseStack_WCProductTest`.
- In the example app, click on `Woo` -> `Products` - > `Select Site` - > `Add Product Tags`.
- Enter two unique tag names and verify that the tags are added successfully to the test site.
- Now click on `Add Product Tag` again and enter the same tag names from the previous step. Notice that an error message is displayed for both tags. This is because the API throws an error when we try to update the same tag name.