### PR TITLE
Modified the width/length/height of the shipping label product item to BigDecimal

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -8,6 +8,7 @@ import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import java.math.BigDecimal
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
@@ -135,13 +136,13 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     }
 
     class ProductItem {
-        val height: Int? = null
-        val length: Int? = null
+        val height: BigDecimal? = null
+        val length: BigDecimal? = null
         val quantity: Int? = null
-        val width: Int? = null
+        val width: BigDecimal? = null
         val name: String? = null
         val url: String? = null
-        val value: Int? = null
+        val value: BigDecimal? = null
         @SerializedName("product_id") val productId: Long? = null
     }
 


### PR DESCRIPTION
Fixes woocommerce/woocommerce-android#2559. This PR modifies the product item fields in `ShippingLabel` from `Int` to `BigDecimal` to fix the below crash:

```
2020-07-16 18:16:56.837 9904-9904/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.woocommerce.android.dev, PID: 9904
    com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: Expected an int but was 6.5 at line 1 column 228 path $.selected_packages.default_box.items[0].width
        at com.google.gson.internal.bind.TypeAdapters$7.read(TypeAdapters.java:228)
        at com.google.gson.internal.bind.TypeAdapters$7.read(TypeAdapters.java:218)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222)
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41)
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:82)
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222)
        at com.google.gson.Gson.fromJson(Gson.java:927)
        at com.google.gson.Gson.fromJson(Gson.java:892)
        at com.google.gson.Gson.fromJson(Gson.java:841)
        at org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.getFormData(WCShippingLabelModel.kt:72)
        at org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.getOriginAddress(WCShippingLabelModel.kt:51)
        at com.woocommerce.android.model.ShippingLabelKt.toAppModel(ShippingLabel.kt:109)
        at com.woocommerce.android.ui.orders.OrderDetailRepository$fetchOrderDetailInfo$2.invokeSuspend(OrderDetailRepository.kt:103)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
        at android.os.Handler.handleCallback(Handler.java:873)
``` 