### PR TITLE
Uncomment Payload configuration from some Account tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ workflows:
       - Firebase Test:
           name: Mocked Connected Tests
           results-history-name: CircleCI FluxC Mocked Tests
-          package: org.wordpress.android.fluxc.release
+          package: org.wordpress.android.fluxc.mocked
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           timeout: 10m
           num-flaky-test-attempts: 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ workflows:
       - Firebase Test:
           name: Mocked Connected Tests
           results-history-name: CircleCI FluxC Mocked Tests
-          package: org.wordpress.android.fluxc.mocked
+          package: org.wordpress.android.fluxc.release
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           timeout: 10m
           num-flaky-test-attempts: 0

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -418,8 +418,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     public void testFetchAuthOptionsForPasswordlessUser() throws InterruptedException {
         mNextEvent = TestEvents.FETCH_AUTH_OPTIONS_PASSWORDLESS_USER;
         mCountDownLatch = new CountDownLatch(1);
-//        FetchAuthOptionsPayload payload = new FetchAuthOptionsPayload(BuildConfig.TEST_WPCOM_EMAIL_PASSWORDLESS);
-//        mDispatcher.dispatch(AccountActionBuilder.newFetchAuthOptionsAction(payload));
+        FetchAuthOptionsPayload payload = new FetchAuthOptionsPayload(BuildConfig.TEST_WPCOM_EMAIL_PASSWORDLESS);
+        mDispatcher.dispatch(AccountActionBuilder.newFetchAuthOptionsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -427,8 +427,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
     public void testFetchAuthOptionsForUserWithUnverifiedEmail() throws InterruptedException {
         mNextEvent = TestEvents.FETCH_AUTH_OPTIONS_UNVERIFIED_EMAIL;
         mCountDownLatch = new CountDownLatch(1);
-//        FetchAuthOptionsPayload payload = new FetchAuthOptionsPayload(BuildConfig.TEST_WPCOM_EMAIL_UNVERIFIED);
-//        mDispatcher.dispatch(AccountActionBuilder.newFetchAuthOptionsAction(payload));
+        FetchAuthOptionsPayload payload = new FetchAuthOptionsPayload(BuildConfig.TEST_WPCOM_EMAIL_UNVERIFIED);
+        mDispatcher.dispatch(AccountActionBuilder.newFetchAuthOptionsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
@@ -624,6 +624,7 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
             authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         }
     }
+
     private void authenticate(String username, String password) throws InterruptedException {
         AuthenticatePayload payload = new AuthenticatePayload(username, password);
         mCountDownLatch = new CountDownLatch(1);


### PR DESCRIPTION
Summary
------------
This PR fixes the tests errors reported [right here](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-FluxC-Android/2426/workflows/6de0f7e7-060d-45dc-bb6d-e5580dc0e966/jobs/6940).

Changelog
------------
| Description | Commit |
| ------------- | ------------- |
| Uncomment the Payload configuration for `testFetchAuthOptionsForPasswordlessUser` and `testFetchAuthOptionsForUserWithUnverifiedEmail` tests | ca0024e243fdb162d13506a9ad81b595c13edb08 |