### PR TITLE
Create Leaderboards endpoint requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ workflows:
       - Firebase Test:
           name: Mocked Connected Tests
           results-history-name: CircleCI FluxC Mocked Tests
-          package: org.wordpress.android.fluxc.mocked
+          package: org.wordpress.android.fluxc.release
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           timeout: 10m
           num-flaky-test-attempts: 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ workflows:
       - Firebase Test:
           name: Mocked Connected Tests
           results-history-name: CircleCI FluxC Mocked Tests
-          package: org.wordpress.android.fluxc.release
+          package: org.wordpress.android.fluxc.mocked
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           timeout: 10m
           num-flaky-test-attempts: 0

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.example.UploadsFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
+import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment
@@ -104,6 +105,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooShippingLabelFragmentInjector(): WooShippingLabelFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooLeaderboardsFragmentInjector(): WooLeaderboardsFragment
 
     @ContributesAndroidInjector
     abstract fun provideSiteSelectorDialogInjector(): SiteSelectorDialog

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
+import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
@@ -118,6 +119,12 @@ class WooCommerceFragment : Fragment() {
         shipping_labels.setOnClickListener {
             getFirstWCSite()?.let {
                 replaceFragment(WooShippingLabelFragment())
+            } ?: showNoWCSitesToast()
+        }
+
+        leaderboards.setOnClickListener {
+            getFirstWCSite()?.let {
+                replaceFragment(WooLeaderboardsFragment())
             } ?: showNoWCSitesToast()
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.example.ui.leaderboards
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WCLeaderboardsStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class WooLeaderboardsFragment : Fragment(), StoreSelectorDialog.Listener {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+    @Inject internal lateinit var wcLeaderboardsStore: WCLeaderboardsStore
+
+    private var selectedPos: Int = -1
+    private var selectedSite: SiteModel? = null
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_woo_leaderboards, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        leaderboards_select_site.setOnClickListener(::onLeaderboardsSelectSiteButtonClicked)
+    }
+
+    private fun onLeaderboardsSelectSiteButtonClicked(view: View) {
+        fragmentManager?.let { fm ->
+            val dialog = StoreSelectorDialog.newInstance(this, selectedPos)
+            dialog.show(fm, "StoreSelectorDialog")
+        }
+    }
+
+    override fun onSiteSelected(site: SiteModel, pos: Int) {
+        selectedSite = site
+        selectedPos = pos
+        buttonContainer.toggleSiteDependentButtons()
+        leaderboards_selected_site.text = site.name ?: site.displayName
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_products.*
@@ -26,6 +25,7 @@ import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
@@ -91,7 +91,7 @@ class WooProductsFragment : Fragment() {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
-                    toggleSiteDependentButtons(true)
+                    buttonContainer.toggleSiteDependentButtons(true)
                     stats_select_site.text = site.name ?: site.displayName
                 }
             })
@@ -528,15 +528,6 @@ class WooProductsFragment : Fragment() {
         fragmentManager?.let { fm ->
             val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
             dialog.show(fm, "StoreSelectorDialog")
-        }
-    }
-
-    private fun toggleSiteDependentButtons(enabled: Boolean) {
-        for (i in 0 until buttonContainer.childCount) {
-            val child = buttonContainer.getChildAt(i)
-            if (child is Button) {
-                child.isEnabled = enabled
-            }
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -10,7 +10,6 @@ import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
@@ -25,6 +24,7 @@ import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -62,7 +62,7 @@ class WooShippingLabelFragment : Fragment() {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
-                    toggleSiteDependentButtons(true)
+                    buttonContainer.toggleSiteDependentButtons(true)
                     shipping_labels_selected_site.text = site.name ?: site.displayName
                 }
             })
@@ -184,15 +184,6 @@ class WooShippingLabelFragment : Fragment() {
         fragmentManager?.let { fm ->
             val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
             dialog.show(fm, "StoreSelectorDialog")
-        }
-    }
-
-    private fun toggleSiteDependentButtons(enabled: Boolean) {
-        for (i in 0 until buttonContainer.childCount) {
-            val child = buttonContainer.getChildAt(i)
-            if (child is Button) {
-                child.isEnabled = enabled
-            }
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_revenue_stats.*
@@ -16,6 +15,7 @@ import org.wordpress.android.fluxc.action.WCStatsAction
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCStatsStore
@@ -52,7 +52,7 @@ class WooRevenueStatsFragment : Fragment() {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
-                    toggleSiteDependentButtons(true)
+                    buttonContainer.toggleSiteDependentButtons(true)
                     stats_select_site.text = site.name ?: site.displayName
                 }
             })
@@ -232,15 +232,6 @@ class WooRevenueStatsFragment : Fragment() {
         fragmentManager?.let { fm ->
             val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
             dialog.show(fm, "StoreSelectorDialog")
-        }
-    }
-
-    private fun toggleSiteDependentButtons(enabled: Boolean) {
-        for (i in 0 until buttonContainer.childCount) {
-            val child = buttonContainer.getChildAt(i)
-            if (child is Button) {
-                child.isEnabled = enabled
-            }
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_taxes.*
@@ -18,6 +17,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCTaxStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -47,7 +47,7 @@ class WooTaxFragment : Fragment() {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
-                    toggleSiteDependentButtons(true)
+                    buttonContainer.toggleSiteDependentButtons(true)
                     taxes_selected_site.text = site.name ?: site.displayName
                 }
             })
@@ -81,15 +81,6 @@ class WooTaxFragment : Fragment() {
         fragmentManager?.let { fm ->
             val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
             dialog.show(fm, "StoreSelectorDialog")
-        }
-    }
-
-    private fun toggleSiteDependentButtons(enabled: Boolean) {
-        for (i in 0 until buttonContainer.childCount) {
-            val child = buttonContainer.getChildAt(i)
-            if (child is Button) {
-                child.isEnabled = enabled
-            }
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/ViewGroupExt.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/ViewGroupExt.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.fluxc.example.utils
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+
+fun ViewGroup.toggleSiteDependentButtons(enabled: Boolean = true) =
+        childViewsAsSequence()
+                .filter { it is Button }
+                .forEach { it.isEnabled = enabled }
+
+fun ViewGroup.childViewsAsSequence(): Sequence<View> =
+        mutableListOf<View>().apply {
+            (0 until childCount).forEach { add(getChildAt(it)) }
+        }.asSequence()

--- a/example/src/main/res/layout/fragment_woo_leaderboards.xml
+++ b/example/src/main/res/layout/fragment_woo_leaderboards.xml
@@ -1,0 +1,49 @@
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:text="Perform actions on a selected site:"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/leaderboards_select_site"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Select Site"/>
+
+            <TextView
+                android:id="@+id/leaderboards_selected_site"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingLeft="10dp"
+                android:paddingStart="10dp"
+                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+                android:textColor="@android:color/holo_blue_bright"/>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/fetch_leaderboards"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Leaderboards"/>
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woo_leaderboards.xml
+++ b/example/src/main/res/layout/fragment_woo_leaderboards.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment">
+    tools:context="org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment">
 
     <LinearLayout
         android:id="@+id/buttonContainer"

--- a/example/src/main/res/layout/fragment_woo_leaderboards.xml
+++ b/example/src/main/res/layout/fragment_woo_leaderboards.xml
@@ -45,5 +45,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Fetch Leaderboards"/>
+
+        <Button
+            android:id="@+id/fetch_product_leaderboards"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Product Leaderboards"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -87,5 +87,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Shipping Labels"/>
+
+                <Button
+                    android:id="@+id/leaderboards"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Leadearboards"/>
         </LinearLayout>
 </ScrollView>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
@@ -105,6 +106,17 @@ class ReleaseWCNetworkModule {
         token: AccessToken,
         userAgent: UserAgent
     ) = ShippingLabelRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideLeaderboardsRestClient(
+        appContext: Context,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        accessToken: AccessToken,
+        userAgent: UserAgent,
+        requestBuilder: JetpackTunnelGsonRequestBuilder
+    ) = LeaderboardsRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent, requestBuilder)
 
     @Singleton
     @Provides

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsApiResponse.kt
@@ -1,14 +1,37 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards
 
 import org.wordpress.android.fluxc.network.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.CATEGORIES
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.COUPONS
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.CUSTOMERS
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.PRODUCTS
 
 class LeaderboardsApiResponse : Response {
+    private val rows: Array<Array<LeaderboardItem>>? = null
     val id: String? = null
     val label: String? = null
-    val rows: Array<Array<LeaderboardItem>>? = null
+    val type: Type?
+        get() = when (id) {
+            "customers" -> CUSTOMERS
+            "coupons" -> COUPONS
+            "categories" -> CATEGORIES
+            "products" -> PRODUCTS
+            else -> null
+        }
+    val items
+        get() = rows
+                ?.firstOrNull()
+                ?.toList()
 
     class LeaderboardItem {
         val display: String? = null
         val value: String? = null
+    }
+
+    enum class Type {
+        CUSTOMERS,
+        COUPONS,
+        CATEGORIES,
+        PRODUCTS
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsApiResponse.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards
+
+import org.wordpress.android.fluxc.network.Response
+
+class LeaderboardsApiResponse : Response {
+    val id: String? = null
+    val label: String? = null
+    val rows: Array<Array<LeaderboardItem>>? = null
+
+    class LeaderboardItem {
+        val display: String? = null
+        val value: String? = null
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsRestClient.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Singleton
+
+@Singleton
+class LeaderboardsRestClient
+constructor(
+    appContext: Context?,
+    dispatcher: Dispatcher,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchLeaderboards(
+        site: SiteModel
+    ) = WOOCOMMERCE.leaderboards.pathV4Analytics
+            .requestTo(site)
+            .handleResult()
+
+    private suspend fun String.requestTo(
+        site: SiteModel
+    ) = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+            this@LeaderboardsRestClient,
+            site,
+            this,
+            emptyMap(),
+            Array<LeaderboardsApiResponse>::class.java
+    )
+
+    private fun <T> JetpackResponse<T>.handleResult() =
+            when (this) {
+                is JetpackSuccess -> {
+                    WooPayload(data)
+                }
+                is JetpackError -> {
+                    WooPayload(error.toWooError())
+                }
+            }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.PRODUCTS
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsRestClient
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
@@ -29,4 +30,13 @@ class WCLeaderboardsStore @Inject constructor(
                     }
                 }
             }
+
+    suspend fun fetchProductLeaderboards(
+        site: SiteModel
+    ): WooResult<LeaderboardsApiResponse> =
+            fetchAllLeaderboards(site)
+                    .model
+                    ?.firstOrNull { it.type == PRODUCTS }
+                    ?.run { WooResult(this) }
+                    ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -19,13 +19,14 @@ class WCLeaderboardsStore @Inject constructor(
 ) {
     suspend fun fetchAllLeaderboards(
         site: SiteModel
-    ): WooResult<List<LeaderboardsApiResponse>> = coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchLeaderboards") {
-        with(restClient.fetchLeaderboards(site)) {
-            return@withDefaultContext when {
-                isError -> WooResult(error)
-                result != null -> WooResult(result.toList())
-                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+    ): WooResult<List<LeaderboardsApiResponse>> =
+            coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchLeaderboards") {
+                with(restClient.fetchLeaderboards(site)) {
+                    return@withDefaultContext when {
+                        isError -> WooResult(error)
+                        result != null -> WooResult(result.toList())
+                        else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+                    }
+                }
             }
-        }
-    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsRestClient
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WCLeaderboardsStore @Inject constructor(
+    private val restClient: LeaderboardsRestClient,
+    private val coroutineEngine: CoroutineEngine
+) {
+    suspend fun fetchAllLeaderboards(
+        site: SiteModel
+    ): WooResult<List<LeaderboardsApiResponse>> = coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchLeaderboards") {
+        with(restClient.fetchLeaderboards(site)) {
+            return@withDefaultContext when {
+                isError -> WooResult(error)
+                result != null -> WooResult(result.toList())
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -39,3 +39,5 @@
 /connect/label/<order_id>/
 /connect/label/<order_id>/<shippingLabelId>/
 /connect/label/<order_id>/<shippingLabelId>/refund
+
+/leaderboards


### PR DESCRIPTION
Summary
==========
Partially deliver implementation for the issue https://github.com/woocommerce/woocommerce-android/issues/2537, there will be further upcoming PRs to integrate with `feature/support_v4_top_performers`. this PR adds support to request Leaderboards data from the site using the v4-analytics API to fetch the top products (a.k.a Top Performers) using the following endpoint: `wc-analytics/leaderboards` and partially parses it. Also adds to the example app the capability to test and log the Leaderboards output from a given site.

*Tests covering some classes are missing because of some flakiness issue that I'll be handling on upcoming PRs*

Changelog
==========
| Description | Commit |
| ------------- | ------------- |
| Creates the `LeaderboardsRestClient`, `LeaderboardsApiResponse` and `WCLeaderboardsStore` basic structure in order to trigger requests to the `wc-analytics/leaderboards` endpoint | 821206f1fe55aa020258190b82137c0e6bfe333e |
| Creates basic view flow for Leaderboards testing within the example app, creating the `WooLeaderboardsFragment` and making it selectable through the app UI |  19f56da8a7857d43b5afbc505090051266c7ce26 |
| Small refactoring to take advantage of some ViewGroupExt created on the previous commit | 405b681f0bfe0697762891adec710dfd2ea81493 |
| Improve `WCLeaderboardsStore` and `LeaderboardsApiResponse` in order to be able to identify and extract the Leaderboards list by type | da2f2893ac2ab2ec9de58c3848df163aaadb8b30 |
| Improve the `WooLeaderboardsFragment` so it can properly call the `WCLeaderboardsStore` and log it into the view | 2bf8d759784d760a0eb23a9524d9f1133b002441 |

Screenshots & How to Test
==========
| Select the Leaderboards option inside the Woo section | Select one site from the list | Click on either fetch buttons to see the V4 top Performers data from your site
| ------------- | ------------- | ------------- |
| ![Screenshot_1595311683](https://user-images.githubusercontent.com/5920403/88019440-30f4a780-cb00-11ea-986c-2dcadf12a1d4.png) | ![Screenshot_1595311689](https://user-images.githubusercontent.com/5920403/88019608-8af56d00-cb00-11ea-9a76-457afca4cc84.png) | ![Screenshot_1595311694](https://user-images.githubusercontent.com/5920403/88019456-3a7e0f80-cb00-11ea-9085-eb1f02296e94.png) |





