### PR TITLE
Woo/shipping labels fetch label by remoteShippingId

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.persistence.WCShippingLabelSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Config(manifest = Config.NONE)
@@ -108,6 +109,31 @@ class WCShippingLabelSqlUtilsTest {
         val nonExistentOrderShippingLabelList =
                 WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, nonExistingOrderId)
         assertEquals(0, nonExistentOrderShippingLabelList.size)
+    }
+
+    @Test
+    fun testGetShippingLabelsById() {
+        val shippingLabelId = 1L
+        val shippingLabels = WCShippingLabelTestUtils.generateShippingLabelList(
+                site.id, orderId, shippingLabelId
+        )
+        assertTrue(shippingLabels.isNotEmpty())
+
+        // Insert shipping label list
+        val rowsAffected = WCShippingLabelSqlUtils.insertOrUpdateShippingLabels(shippingLabels)
+        assertEquals(shippingLabels.size, rowsAffected)
+
+        // Get shipping label list by id and verify
+        val savedShippingLabelExists = WCShippingLabelSqlUtils.getShippingLabelById(
+                site.id, orderId, shippingLabelId + 1
+        )
+        assertEquals(shippingLabels[0].localOrderId, savedShippingLabelExists?.localOrderId)
+        assertEquals(shippingLabels[0].remoteShippingLabelId, savedShippingLabelExists?.remoteShippingLabelId)
+        assertEquals(shippingLabels[0].localSiteId, savedShippingLabelExists?.localSiteId)
+
+        // Get shipping label for am id that does not exist
+        val savedShippingLabel = WCShippingLabelSqlUtils.getShippingLabelById(site.id, orderId, 100)
+        assertNull(savedShippingLabel)
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 113
+        return 114
     }
 
     override fun getDbName(): String {
@@ -1259,6 +1259,9 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "MAXIMUM_APP_VERSION TEXT NOT NULL,APP_VERSION_TARGETS TEXT NOT NULL," +
                                     "LOCALIZED INTEGER,RESPONSE_LOCALE TEXT NOT NULL,DETAILS_URL TEXT)"
                     )
+                }
+                113 -> migrate(version) {
+                    db.execSQL("ALTER TABLE WCShippingLabelModel ADD DATE_CREATED TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -20,6 +20,7 @@ class WCShippingLabelMapper
                 currency = labelItem.currency ?: ""
                 productNames = labelItem.productNames.toString()
                 refund = labelItem.refund.toString()
+                dateCreated = labelItem.dateCreated?.toString() ?: ""
 
                 localOrderId = response.orderId ?: 0L
                 paperSize = response.paperSize ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -16,6 +16,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     @Column var remoteShippingLabelId = 0L // The unique identifier for this note on the server
     @Column var trackingNumber = ""
     @Column var carrierId = ""
+    @Column var dateCreated = ""
     @Column var serviceName = ""
     @Column var status = ""
     @Column var packageName = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
@@ -20,6 +20,7 @@ class ShippingLabelApiResponse : Response {
         @SerializedName("tracking") val trackingNumber: String? = null
         @SerializedName("carrier_id") val carrierId: String? = null
         @SerializedName("service_name") val serviceName: String? = null
+        @SerializedName("created_date") val dateCreated: Long? = null
         @SerializedName("package_name") val packageName: String? = null
         @SerializedName("product_names") val productNames: List<String>? = emptyList()
         @SerializedName("refundable_amount") val refundableAmount: BigDecimal? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
@@ -17,6 +17,20 @@ object WCShippingLabelSqlUtils {
                 .asModel
     }
 
+    fun getShippingLabelById(
+        localSiteId: Int,
+        orderId: Long,
+        remoteShippingLabelId: Long
+    ): WCShippingLabelModel? {
+        return WellSql.select(WCShippingLabelModel::class.java)
+                .where()
+                .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(WCShippingLabelModelTable.LOCAL_ORDER_ID, orderId)
+                .equals(WCShippingLabelModelTable.REMOTE_SHIPPING_LABEL_ID, remoteShippingLabelId)
+                .endWhere()
+                .asModel.firstOrNull()
+    }
+
     fun insertOrUpdateShippingLabels(shippingLabels: List<WCShippingLabelModel>): Int {
         var totalChanged = 0
         shippingLabels.forEach { totalChanged += insertOrUpdateShippingLabel(it) }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -29,6 +29,13 @@ class WCShippingLabelStore @Inject constructor(
     ): List<WCShippingLabelModel> =
             WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
 
+    fun getShippingLabelById(
+        site: SiteModel,
+        orderId: Long,
+        remoteShippingLabelId: Long
+    ): WCShippingLabelModel? =
+            WCShippingLabelSqlUtils.getShippingLabelById(site.id, orderId, remoteShippingLabelId)
+
     suspend fun fetchShippingLabelsForOrder(
         site: SiteModel,
         orderId: Long


### PR DESCRIPTION
This tiny PR:
- fixes #1637 by adding logic to fetch a shipping label by the shipping label id.
- adds a new column to `WCShippingLabelModel` to include the purchase date of a shipping label. (Missed that during the first round of PRs 🤦‍♀️) 

#### To test
- Run `WCShippingLabelSqlUtilsTest`.
- Since a new column is being added to the migration script, it would be great if we could test updating the app.