### PR TITLE
Single variation actions

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -101,7 +101,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         dateCreated = "2018-04-20T15:45:14Z"
         taxStatus = "taxable"
         stockStatus = "instock"
-        image = "{}"
+        image = ""
     }
 
     private val remoteProductReviewId = BuildConfig.TEST_WC_PRODUCT_REVIEW_ID.toLong()

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductTagsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
+import org.wordpress.android.fluxc.example.ui.products.WooUpdateVariationFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
 import org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
@@ -80,6 +81,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooUpdateProductFragmentInjector(): WooUpdateProductFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooUpdateVariationFragmentInjector(): WooUpdateVariationFragment
 
     @ContributesAndroidInjector
     abstract fun provideWooProductFiltersFragmentInjector(): WooProductFiltersFragment

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIO
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_REVIEW
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_VARIATION
 import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
@@ -43,6 +44,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload
+import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleVariationPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductCategoryChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductImagesChanged
@@ -50,6 +52,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClasses
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductSkuAvailabilityChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductTagChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductsSearched
+import org.wordpress.android.fluxc.store.WCProductStore.OnVariationChanged
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -64,9 +67,10 @@ class WooProductsFragment : Fragment() {
     private var selectedPos: Int = -1
     private var selectedSite: SiteModel? = null
     private var pendingFetchSingleProductRemoteId: Long? = null
+    private var pendingFetchSingleVariationRemoteId: Long? = null
     private var pendingFetchSingleProductShippingClassRemoteId: Long? = null
 
-    private var pendingFetchSingleProductVariationRemoteId: Long? = null
+    private var pendingFetchProductVariationsProductRemoteId: Long? = null
     private var pendingFetchSingleProductVariationOffset: Int = 0
 
     private var pendingFetchProductShippingClassListOffset: Int = 0
@@ -106,6 +110,31 @@ class WooProductsFragment : Fragment() {
                         val payload = FetchSingleProductPayload(site, id)
                         dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
                     } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
+                }
+            }
+        }
+
+        fetch_single_variation.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter the remoteProductId of variation to fetch:"
+                ) { productIdText ->
+                    pendingFetchSingleProductRemoteId = productIdText.text.toString().toLongOrNull()
+                    pendingFetchSingleProductRemoteId?.let { productId ->
+                        showSingleLineDialog(
+                                activity,
+                                "Enter the remoteVariationId of variation to fetch:"
+                        ) { variationIdText ->
+                            pendingFetchSingleVariationRemoteId = variationIdText.text.toString().toLongOrNull()
+                            pendingFetchSingleVariationRemoteId?.let { variationId ->
+                                prependToLog("Submitting request to fetch product by " +
+                                        "remoteProductId $pendingFetchSingleProductRemoteId, remoteVariationProductID $variationId")
+                                val payload = FetchSingleVariationPayload(site, productId, variationId)
+                                dispatcher.dispatch(WCProductActionBuilder.newFetchSingleVariationAction(payload))
+                            } ?: prependToLog("No valid remoteVariationId defined...doing nothing")
+                        }
+                    } ?: prependToLog("No valid remoteProductId defined...doing nothing")
                 }
             }
         }
@@ -151,8 +180,8 @@ class WooProductsFragment : Fragment() {
                         activity,
                         "Enter the remoteProductId of product to fetch variations:"
                 ) { editText ->
-                    pendingFetchSingleProductVariationRemoteId = editText.text.toString().toLongOrNull()
-                    pendingFetchSingleProductVariationRemoteId?.let { id ->
+                    pendingFetchProductVariationsProductRemoteId = editText.text.toString().toLongOrNull()
+                    pendingFetchProductVariationsProductRemoteId?.let { id ->
                         prependToLog("Submitting request to fetch product variations by remoteProductID $id")
                         val payload = FetchProductVariationsPayload(site, id)
                         dispatcher.dispatch(WCProductActionBuilder.newFetchProductVariationsAction(payload))
@@ -163,7 +192,7 @@ class WooProductsFragment : Fragment() {
 
         load_more_product_variations.setOnClickListener {
             selectedSite?.let { site ->
-                pendingFetchSingleProductVariationRemoteId?.let { id ->
+                pendingFetchProductVariationsProductRemoteId?.let { id ->
                     prependToLog("Submitting offset request to fetch product variations by remoteProductID $id")
                     val payload = FetchProductVariationsPayload(
                             site, id, offset = pendingFetchSingleProductVariationOffset
@@ -400,6 +429,33 @@ class WooProductsFragment : Fragment() {
                 }
                 UPDATE_PRODUCT_REVIEW_STATUS -> {
                     prependToLog("${event.rowsAffected} product reviews updated")
+                }
+                else -> prependToLog("Product store was updated from a " + event.causeOfChange)
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onVariationChanged(event: OnVariationChanged) {
+        if (event.isError) {
+            prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
+            return
+        }
+
+        selectedSite?.let { site ->
+            when (event.causeOfChange) {
+                FETCH_SINGLE_VARIATION -> {
+                    pendingFetchSingleVariationRemoteId = null
+                    pendingFetchSingleProductRemoteId = null
+                    val variation = wcProductStore.getVariationByRemoteId(
+                            site,
+                            event.remoteProductId,
+                            event.remoteVariationId
+                    )
+                    variation?.let {
+                        prependToLog("Single variation fetched! ${it.remoteVariationId}")
+                    } ?: prependToLog("WARNING: Fetched product not found in the local database!")
                 }
                 else -> prependToLog("Product store was updated from a " + event.causeOfChange)
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -129,7 +129,8 @@ class WooProductsFragment : Fragment() {
                             pendingFetchSingleVariationRemoteId = variationIdText.text.toString().toLongOrNull()
                             pendingFetchSingleVariationRemoteId?.let { variationId ->
                                 prependToLog("Submitting request to fetch product by " +
-                                        "remoteProductId $pendingFetchSingleProductRemoteId, remoteVariationProductID $variationId")
+                                        "remoteProductId $pendingFetchSingleProductRemoteId, " +
+                                        "remoteVariationProductID $variationId")
                                 val payload = FetchSingleVariationPayload(site, productId, variationId)
                                 dispatcher.dispatch(WCProductActionBuilder.newFetchSingleVariationAction(payload))
                             } ?: prependToLog("No valid remoteVariationId defined...doing nothing")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -352,6 +352,10 @@ class WooProductsFragment : Fragment() {
         update_product.setOnClickListener {
             replaceFragment(WooUpdateProductFragment.newInstance(selectedPos))
         }
+
+        update_variation.setOnClickListener {
+            replaceFragment(WooUpdateVariationFragment.newInstance(selectedPos))
+        }
     }
 
     /**

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateVariationFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateVariationFragment.kt
@@ -1,0 +1,305 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.app.DatePickerDialog
+import android.app.DatePickerDialog.OnDateSetListener
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_update_variation.*
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.ARG_LIST_SELECTED_ITEM
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.LIST_SELECTOR_REQUEST_CODE
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductBackOrders
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductTaxStatus
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.OnVariationUpdated
+import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.DateUtils
+import org.wordpress.android.util.StringUtils
+import java.util.Calendar
+import javax.inject.Inject
+
+class WooUpdateVariationFragment : Fragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var wcProductStore: WCProductStore
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    private var selectedSitePosition: Int = -1
+    private var selectedRemoteProductId: Long? = null
+    private var selectedRemoteVariationId: Long? = null
+    private var selectedVariationModel: WCProductVariationModel? = null
+
+    companion object {
+        const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
+        const val ARG_SELECTED_PRODUCT_ID = "ARG_SELECTED_PRODUCT_ID"
+        const val ARG_SELECTED_VARIATION_ID = "ARG_SELECTED_VARIATION_ID"
+        const val LIST_RESULT_CODE_TAX_STATUS = 101
+        const val LIST_RESULT_CODE_STOCK_STATUS = 102
+        const val LIST_RESULT_CODE_BACK_ORDERS = 103
+
+        fun newInstance(selectedSitePosition: Int): WooUpdateVariationFragment {
+            val fragment = WooUpdateVariationFragment()
+            val args = Bundle()
+            args.putInt(ARG_SELECTED_SITE_POS, selectedSitePosition)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        arguments?.let {
+            selectedSitePosition = it.getInt(ARG_SELECTED_SITE_POS, 0)
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(layout.fragment_woo_update_variation, container, false)
+
+    override fun onStart() {
+        super.onStart()
+        dispatcher.register(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        dispatcher.unregister(this)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(ARG_SELECTED_SITE_POS, selectedSitePosition)
+        selectedRemoteProductId?.let { outState.putLong(ARG_SELECTED_PRODUCT_ID, it) }
+        selectedRemoteVariationId?.let { outState.putLong(ARG_SELECTED_VARIATION_ID, it) }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        product_enter_product_id.setOnClickListener {
+            showSingleLineDialog(activity, "Enter the remoteProductId of product to fetch:") { editText ->
+                selectedRemoteProductId = editText.text.toString().toLongOrNull()
+                selectedRemoteProductId?.let { productId ->
+                    showSingleLineDialog(activity, "Enter the remoteVariation of variation to fetch:") { editText ->
+                        selectedRemoteVariationId = editText.text.toString().toLongOrNull()
+                        selectedRemoteVariationId?.let { variationId ->
+                            updateSelectedProductId(productId, variationId)
+                        } ?: prependToLog("No valid remoteVariation defined...doing nothing")
+                    }
+                } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+            }
+        }
+
+        product_description.onTextChanged { selectedVariationModel?.description = it }
+        product_sku.onTextChanged { selectedVariationModel?.sku = it }
+        product_regular_price.onTextChanged { selectedVariationModel?.regularPrice = it }
+        product_sale_price.onTextChanged { selectedVariationModel?.salePrice = it }
+        product_width.onTextChanged { selectedVariationModel?.width = it }
+        product_height.onTextChanged { selectedVariationModel?.height = it }
+        product_length.onTextChanged { selectedVariationModel?.length = it }
+        product_weight.onTextChanged { selectedVariationModel?.weight = it }
+        product_stock_quantity.onTextChanged {
+            if (it.isNotEmpty()) { selectedVariationModel?.stockQuantity = it.toInt() }
+        }
+
+        product_manage_stock.setOnCheckedChangeListener { _, isChecked ->
+            selectedVariationModel?.manageStock = isChecked
+            for (i in 0 until manageStockContainer.childCount) {
+                val child = manageStockContainer.getChildAt(i)
+                if (child is Button || child is FloatingLabelEditText) {
+                    child.isEnabled = isChecked
+                }
+            }
+        }
+
+        variation_visibility.setOnCheckedChangeListener { _, isChecked ->
+            selectedVariationModel?.status = if (isChecked) "publish" else "private"
+        }
+
+        product_tax_status.setOnClickListener {
+            showListSelectorDialog(
+                    CoreProductTaxStatus.values().map { it.value }.toList(),
+                    LIST_RESULT_CODE_TAX_STATUS, selectedVariationModel?.taxStatus
+            )
+        }
+
+        product_stock_status.setOnClickListener {
+            showListSelectorDialog(
+                    CoreProductStockStatus.values().map { it.value }.toList(),
+                    LIST_RESULT_CODE_STOCK_STATUS, selectedVariationModel?.stockStatus
+            )
+        }
+
+        product_back_orders.setOnClickListener {
+            showListSelectorDialog(
+                    CoreProductBackOrders.values().map { it.value }.toList(),
+                    LIST_RESULT_CODE_BACK_ORDERS, selectedVariationModel?.backorders
+            )
+        }
+
+        product_from_date.setOnClickListener {
+            showDatePickerDialog(product_from_date.text.toString(), OnDateSetListener { _, year, month, dayOfMonth ->
+                product_from_date.text = DateUtils.getFormattedDateString(year, month, dayOfMonth)
+                selectedVariationModel?.dateOnSaleFromGmt = product_from_date.text.toString()
+            })
+        }
+
+        product_to_date.setOnClickListener {
+            showDatePickerDialog(product_to_date.text.toString(), OnDateSetListener { _, year, month, dayOfMonth ->
+                product_to_date.text = DateUtils.getFormattedDateString(year, month, dayOfMonth)
+                selectedVariationModel?.dateOnSaleToGmt = product_to_date.text.toString()
+            })
+        }
+
+        product_update.setOnClickListener {
+            getWCSite()?.let { site ->
+                if (selectedVariationModel?.remoteProductId != null &&
+                        selectedVariationModel?.remoteVariationId != null) {
+                    val payload = UpdateVariationPayload(site, selectedVariationModel!!)
+                    dispatcher.dispatch(WCProductActionBuilder.newUpdateVariationAction(payload))
+                } else {
+                    prependToLog("No valid remoteProductId or remoteVariationId defined...doing nothing")
+                }
+            } ?: prependToLog("No site found...doing nothing")
+        }
+
+        product_menu_order.onTextChanged { selectedVariationModel?.menuOrder = StringUtils.stringToInt(it) }
+
+        savedInstanceState?.let { bundle ->
+            selectedRemoteProductId = bundle.getLong(ARG_SELECTED_PRODUCT_ID)
+            selectedRemoteVariationId = bundle.getLong(ARG_SELECTED_VARIATION_ID)
+            selectedSitePosition = bundle.getInt(ARG_SELECTED_SITE_POS)
+        }
+
+        if (selectedRemoteProductId != null && selectedRemoteVariationId != null) {
+            updateSelectedProductId(selectedRemoteProductId!!, selectedRemoteVariationId!!)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == LIST_SELECTOR_REQUEST_CODE) {
+            val selectedItem = data?.getStringExtra(ARG_LIST_SELECTED_ITEM)
+            when (resultCode) {
+                LIST_RESULT_CODE_TAX_STATUS -> {
+                    selectedItem?.let {
+                        product_tax_status.text = it
+                        selectedVariationModel?.taxStatus = it
+                    }
+                }
+                LIST_RESULT_CODE_STOCK_STATUS -> {
+                    selectedItem?.let {
+                        product_stock_status.text = it
+                        selectedVariationModel?.stockStatus = it
+                    }
+                }
+                LIST_RESULT_CODE_BACK_ORDERS -> {
+                    selectedItem?.let {
+                        product_back_orders.text = it
+                        selectedVariationModel?.backorders = it
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateSelectedProductId(remoteProductId: Long, remoteVariationId: Long) {
+        getWCSite()?.let { siteModel ->
+            enableProductDependentButtons()
+            product_entered_product_id.text = "P: $remoteProductId, V: $remoteVariationId"
+
+            selectedVariationModel = wcProductStore.getVariationByRemoteId(
+                    siteModel,
+                    remoteProductId,
+                    remoteVariationId
+            )?.also {
+                product_description.setText(it.description)
+                product_sku.setText(it.sku)
+                product_regular_price.setText(it.regularPrice)
+                product_sale_price.setText(it.salePrice)
+                product_width.setText(it.width)
+                product_height.setText(it.height)
+                product_length.setText(it.length)
+                product_weight.setText(it.weight)
+                product_tax_status.text = it.taxStatus
+                product_from_date.text = it.dateOnSaleFromGmt.split('T')[0]
+                product_to_date.text = it.dateOnSaleToGmt.split('T')[0]
+                product_manage_stock.isChecked = it.manageStock
+                product_stock_status.text = it.stockStatus
+                product_back_orders.text = it.backorders
+                product_stock_quantity.setText(it.stockQuantity.toString())
+                product_stock_quantity.isEnabled = product_manage_stock.isChecked
+                product_menu_order.setText(it.menuOrder.toString())
+                variation_visibility.isChecked = it.status == "publish"
+            } ?: WCProductVariationModel().apply {
+                this.remoteProductId = remoteProductId
+                this.remoteVariationId = remoteVariationId
+                prependToLog("Variation not found in the DB. Did you fetch the variations?")
+            }
+        } ?: prependToLog("No valid site found...doing nothing")
+    }
+
+    private fun showListSelectorDialog(listItems: List<String>, resultCode: Int, selectedItem: String?) {
+        fragmentManager?.let { fm ->
+            val dialog = ListSelectorDialog.newInstance(
+                    this, listItems, resultCode, selectedItem
+            )
+            dialog.show(fm, "ListSelectorDialog")
+        }
+    }
+
+    private fun showDatePickerDialog(dateString: String?, listener: OnDateSetListener) {
+        val date = if (dateString.isNullOrEmpty()) {
+            DateUtils.getCurrentDateString()
+        } else dateString
+        val calendar = DateUtils.getCalendarInstance(date)
+        DatePickerDialog(requireActivity(), listener, calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH), calendar.get(Calendar.DATE))
+                .show()
+    }
+
+    private fun getWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(selectedSitePosition)
+
+    private fun enableProductDependentButtons() {
+        for (i in 0 until productContainer.childCount) {
+            val child = productContainer.getChildAt(i)
+            if (child is Button || child is EditText) {
+                child.isEnabled = true
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductUpdated(event: OnVariationUpdated) {
+        if (event.isError) {
+            prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
+            return
+        }
+        prependToLog("Variation updated ${event.rowsAffected}")
+    }
+}

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -185,5 +185,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Update Product"/>
+
+        <Button
+            android:id="@+id/update_variation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update Variation"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -82,6 +82,13 @@
             android:text="Fetch Product Variations"/>
 
         <Button
+            android:id="@+id/fetch_single_variation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Single Variation"/>
+
+        <Button
             android:id="@+id/load_more_product_variations"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/main/res/layout/fragment_woo_update_variation.xml
+++ b/example/src/main/res/layout/fragment_woo_update_variation.xml
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="12dp"
+    tools:context="org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment"
+    tools:ignore="HardcodedText">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Perform actions on a selected product Id:"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/product_enter_product_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Enter Product and Variation Id"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+    <TextView
+        android:id="@+id/product_entered_product_id"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="12dp"
+        android:gravity="center"
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+        android:textColor="@android:color/holo_blue_bright"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/product_enter_product_id"
+        tools:text="P: 79, V: 97" />
+
+    <ImageButton
+        android:id="@+id/product_update"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:clickable="false"
+        android:focusable="false"
+        android:src="@drawable/ic_check"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView"
+        android:contentDescription="TODO" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/productContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/product_entered_product_id"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="textMultiLine"
+            android:lines="2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:textHint="Product description" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_sku"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_description"
+            app:textHint="Product SKU" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_regular_price"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="10dp"
+            android:layout_marginRight="10dp"
+            android:enabled="false"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toStartOf="@+id/product_sale_price"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_sku"
+            app:textHint="Regular price" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_sale_price"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_regular_price"
+            app:layout_constraintTop_toBottomOf="@+id/product_sku"
+            app:textHint="Sale price" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_width"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="10dp"
+            android:layout_marginRight="10dp"
+            android:enabled="false"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toStartOf="@+id/product_height"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_regular_price"
+            app:textHint="Product Width" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_height"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_width"
+            app:layout_constraintTop_toBottomOf="@+id/product_regular_price"
+            app:textHint="Product Height" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_length"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="10dp"
+            android:layout_marginRight="10dp"
+            android:enabled="false"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toStartOf="@+id/product_weight"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_width"
+            app:textHint="Product Width" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_weight"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:inputType="numberDecimal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_length"
+            app:layout_constraintTop_toBottomOf="@+id/product_width"
+            app:textHint="Product Height" />
+
+        <Switch
+            android:id="@+id/variation_visibility"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Is enabled"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_weight" />
+
+        <Button
+            android:id="@+id/product_tax_status"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Tax Status"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/variation_visibility" />
+
+        <TextView
+            android:id="@+id/product_schedule_sale"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="Schedule Sale"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_tax_status" />
+
+        <Button
+            android:id="@+id/product_from_date"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Start Date"
+            android:hint="Start Date"
+            app:layout_constraintEnd_toStartOf="@+id/product_to_date"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_schedule_sale" />
+
+        <Button
+            android:id="@+id/product_to_date"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="End Date"
+            android:hint="End Date"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/product_from_date"
+            app:layout_constraintTop_toBottomOf="@+id/product_schedule_sale" />
+
+        <Button
+            android:id="@+id/product_stock_status"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Stock Status"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_from_date" />
+
+        <Switch
+            android:id="@+id/product_manage_stock"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Manage Stock"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_stock_status" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/manageStockContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_manage_stock">
+
+            <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+                android:id="@+id/product_stock_quantity"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:inputType="number"
+                app:layout_constraintEnd_toStartOf="@+id/product_back_orders"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:textHint="Stock quantity" />
+
+            <Button
+                android:id="@+id/product_back_orders"
+                style="?android:attr/spinnerStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:enabled="false"
+                android:text="Allow Back Orders"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toEndOf="@+id/product_stock_quantity"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/product_menu_order"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="number"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/manageStockContainer"
+            app:textHint="Menu order" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductTagModel
+import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductCategoryApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductReviewApiResponse
@@ -29,6 +30,20 @@ object ProductTestUtils {
             this.name = name
             this.virtual = virtual
             this.stockStatus = stockStatus
+            this.status = status
+        }
+    }
+
+    fun generateSampleVariation(
+        remoteId: Long,
+        variationId: Long,
+        siteId: Int = 6,
+        status: String = "publish"
+    ): WCProductVariationModel {
+        return WCProductVariationModel().apply {
+            remoteProductId = remoteId
+            remoteVariationId = variationId
+            localSiteId = siteId
             this.status = status
         }
     }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsP
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload;
@@ -38,6 +39,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload;
 
 @ActionEnum
 public enum WCProductAction implements IAction {
@@ -66,6 +68,8 @@ public enum WCProductAction implements IAction {
     UPDATE_PRODUCT_IMAGES,
     @Action(payloadType = UpdateProductPayload.class)
     UPDATE_PRODUCT,
+    @Action(payloadType = UpdateVariationPayload.class)
+    UPDATE_VARIATION,
     @Action(payloadType = FetchProductSkuAvailabilityPayload.class)
     FETCH_PRODUCT_SKU_AVAILABILITY,
     @Action(payloadType = FetchProductPasswordPayload.class)
@@ -105,6 +109,8 @@ public enum WCProductAction implements IAction {
     UPDATED_PRODUCT_IMAGES,
     @Action(payloadType = RemoteUpdateProductPayload.class)
     UPDATED_PRODUCT,
+    @Action(payloadType = RemoteUpdateVariationPayload.class)
+    UPDATED_VARIATION,
     @Action(payloadType = RemoteProductSkuAvailabilityPayload.class)
     FETCHED_PRODUCT_SKU_AVAILABILITY,
     @Action(payloadType = RemoteProductPasswordPayload.class)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleVariationPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
@@ -31,6 +32,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayl
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload;
@@ -42,6 +44,8 @@ public enum WCProductAction implements IAction {
     // Remote actions
     @Action(payloadType = FetchSingleProductPayload.class)
     FETCH_SINGLE_PRODUCT,
+    @Action(payloadType = FetchSingleVariationPayload.class)
+    FETCH_SINGLE_VARIATION,
     @Action(payloadType = FetchProductsPayload.class)
     FETCH_PRODUCTS,
     @Action(payloadType = SearchProductsPayload.class)
@@ -79,6 +83,8 @@ public enum WCProductAction implements IAction {
     // Remote responses
     @Action(payloadType = RemoteProductPayload.class)
     FETCHED_SINGLE_PRODUCT,
+    @Action(payloadType = RemoteVariationPayload.class)
+    FETCHED_SINGLE_VARIATION,
     @Action(payloadType = RemoteProductListPayload.class)
     FETCHED_PRODUCTS,
     @Action(payloadType = RemoteSearchProductsPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
 import android.content.Context
+import android.util.Log
 import com.android.volley.RequestQueue
 import com.google.gson.JsonArray
 import com.google.gson.reflect.TypeToken
@@ -1064,7 +1065,7 @@ class ProductRestClient(
             body["shipping_class"] = updatedVariationModel.shippingClass
         }
         if (storedVariationModel.image != updatedVariationModel.image) {
-            body["image"] = updatedVariationModel.image
+//            body["image"] = "null"
         }
         if (storedVariationModel.menuOrder != updatedVariationModel.menuOrder) {
             body["menu_order"] = updatedVariationModel.menuOrder

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
 import android.content.Context
-import android.util.Log
 import com.android.volley.RequestQueue
 import com.google.gson.JsonArray
 import com.google.gson.reflect.TypeToken

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1064,8 +1064,9 @@ class ProductRestClient(
         if (storedVariationModel.shippingClass != updatedVariationModel.shippingClass) {
             body["shipping_class"] = updatedVariationModel.shippingClass
         }
-        if (storedVariationModel.image != updatedVariationModel.image) {
-//            body["image"] = "null"
+        // TODO: Once removal is supported, we can remove the extra isNotBlank() condition
+        if (storedVariationModel.image != updatedVariationModel.image && updatedVariationModel.image.isNotBlank()) {
+            body["image"] = updatedVariationModel.image
         }
         if (storedVariationModel.menuOrder != updatedVariationModel.menuOrder) {
             body["menu_order"] = updatedVariationModel.menuOrder

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -60,6 +60,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayl
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload
 import java.util.HashMap
 import javax.inject.Singleton
 
@@ -535,6 +536,48 @@ class ProductRestClient(
     }
 
     /**
+     * Makes a PUT request to `/wp-json/wc/v3/products/remoteProductId` to update a product
+     *
+     * Dispatches a WCProductAction.UPDATED_PRODUCT action with the result
+     *
+     * @param [site] The site to fetch product reviews for
+     * @param [storedWCProductModel] the stored model to compare with the [updatedProductModel]
+     * @param [updatedProductModel] the product model that contains the update
+     */
+    fun updateVariation(
+        site: SiteModel,
+        storedWCProductVariationModel: WCProductVariationModel?,
+        updatedProductVariationModel: WCProductVariationModel
+    ) {
+        val remoteProductId = updatedProductVariationModel.remoteProductId
+        val remoteVariationId = updatedProductVariationModel.remoteVariationId
+        val url = WOOCOMMERCE.products.id(remoteProductId).variations.variation(remoteVariationId).pathV3
+        val responseType = object : TypeToken<ProductApiResponse>() {}.type
+        val body = variantModelToProductJsonBody(storedWCProductVariationModel, updatedProductVariationModel)
+
+        val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, body, responseType,
+                { response: ProductApiResponse? ->
+                    response?.let {
+                        val newModel = productResponseToProductModel(it).apply {
+                            localSiteId = site.id
+                        }
+                        val payload = RemoteUpdateProductPayload(site, newModel)
+                        dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductAction(payload))
+                    }
+                },
+                WPComErrorListener { networkError ->
+                    val productError = networkErrorToProductError(networkError)
+                    val payload = RemoteUpdateProductPayload(
+                            productError,
+                            site,
+                            WCProductModel().apply { this.remoteProductId = remoteProductId }
+                    )
+                    dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductAction(payload))
+                })
+        add(request)
+    }
+
+    /**
      * Makes a PUT request to `/wp-json/wc/v3/products/[remoteProductId]` to replace a product's images
      * with the passed media list
      *
@@ -929,6 +972,96 @@ class ProductRestClient(
                     it.add(tag.toJson())
                 }
             }
+        }
+        return body
+    }
+
+    /**
+     * Build json body of product items to be updated to the backend.
+     *
+     * This method checks if there is a cached version of the product stored locally.
+     * If not, it generates a new product model for the same product ID, with default fields
+     * and verifies that the [updatedVariationModel] has fields that are different from the default
+     * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any changes
+     */
+    private fun variantModelToProductJsonBody(
+        variationModel: WCProductVariationModel?,
+        updatedVariationModel: WCProductVariationModel
+    ): HashMap<String, Any> {
+        val body = HashMap<String, Any>()
+
+        val storedVariationModel = variationModel ?: WCProductVariationModel().apply {
+            remoteProductId = updatedVariationModel.remoteProductId
+            remoteVariationId = updatedVariationModel.remoteVariationId
+        }
+        if (storedVariationModel.description != updatedVariationModel.description) {
+            body["description"] = updatedVariationModel.description
+        }
+        if (storedVariationModel.sku != updatedVariationModel.sku) {
+            body["sku"] = updatedVariationModel.sku
+        }
+        if (storedVariationModel.status != updatedVariationModel.status) {
+            body["status"] = updatedVariationModel.status
+        }
+        if (storedVariationModel.manageStock != updatedVariationModel.manageStock) {
+            body["manage_stock"] = updatedVariationModel.manageStock
+        }
+
+        // only allowed to change the following params if manageStock is enabled
+        if (updatedVariationModel.manageStock) {
+            if (storedVariationModel.stockQuantity != updatedVariationModel.stockQuantity) {
+                body["stock_quantity"] = updatedVariationModel.stockQuantity
+            }
+            if (storedVariationModel.backorders != updatedVariationModel.backorders) {
+                body["backorders"] = updatedVariationModel.backorders
+            }
+        }
+        if (storedVariationModel.stockStatus != updatedVariationModel.stockStatus) {
+            body["stock_status"] = updatedVariationModel.stockStatus
+        }
+        if (storedVariationModel.regularPrice != updatedVariationModel.regularPrice) {
+            body["regular_price"] = updatedVariationModel.regularPrice
+        }
+        if (storedVariationModel.salePrice != updatedVariationModel.salePrice) {
+            body["sale_price"] = updatedVariationModel.salePrice
+        }
+        if (storedVariationModel.dateOnSaleFromGmt != updatedVariationModel.dateOnSaleFromGmt) {
+            body["date_on_sale_from_gmt"] = updatedVariationModel.dateOnSaleFromGmt
+        }
+        if (storedVariationModel.dateOnSaleToGmt != updatedVariationModel.dateOnSaleToGmt) {
+            body["date_on_sale_to_gmt"] = updatedVariationModel.dateOnSaleToGmt
+        }
+        if (storedVariationModel.taxStatus != updatedVariationModel.taxStatus) {
+            body["tax_status"] = updatedVariationModel.taxStatus
+        }
+        if (storedVariationModel.taxClass != updatedVariationModel.taxClass) {
+            body["tax_class"] = updatedVariationModel.taxClass
+        }
+        if (storedVariationModel.weight != updatedVariationModel.weight) {
+            body["weight"] = updatedVariationModel.weight
+        }
+
+        val dimensionsBody = mutableMapOf<String, String>()
+        if (storedVariationModel.height != updatedVariationModel.height) {
+            dimensionsBody["height"] = updatedVariationModel.height
+        }
+        if (storedVariationModel.width != updatedVariationModel.width) {
+            dimensionsBody["width"] = updatedVariationModel.width
+        }
+        if (storedVariationModel.length != updatedVariationModel.length) {
+            dimensionsBody["length"] = updatedVariationModel.length
+        }
+        if (dimensionsBody.isNotEmpty()) {
+            body["dimensions"] = dimensionsBody
+        }
+        if (storedVariationModel.shippingClass != updatedVariationModel.shippingClass) {
+            body["shipping_class"] = updatedVariationModel.shippingClass
+        }
+        if (storedVariationModel.image != updatedVariationModel.image) {
+            body["image"] = updatedVariationModel.image
+        }
+        if (storedVariationModel.menuOrder != updatedVariationModel.menuOrder) {
+            body["menu_order"] = updatedVariationModel.menuOrder
         }
         return body
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -73,6 +73,20 @@ object ProductSqlUtils {
                 .asModel.firstOrNull()
     }
 
+    fun getVariationByRemoteId(
+        site: SiteModel,
+        remoteProductId: Long,
+        remoteVariationId: Long
+    ): WCProductVariationModel? {
+        return WellSql.select(WCProductVariationModel::class.java)
+                .where().beginGroup()
+                .equals(WCProductVariationModelTable.REMOTE_PRODUCT_ID, remoteProductId)
+                .equals(WCProductVariationModelTable.REMOTE_VARIATION_ID, remoteVariationId)
+                .equals(WCProductVariationModelTable.LOCAL_SITE_ID, site.id)
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+    }
+
     fun getProductsByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): List<WCProductModel> {
         return WellSql.select(WCProductModel::class.java)
                 .where().beginGroup()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -533,6 +533,16 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
             ProductSqlUtils.getProductByRemoteId(site, remoteProductId)
 
     /**
+     * returns the corresponding variation from the database as a [WCProductVariationModel].
+     */
+    fun getVariationByRemoteId(
+        site: SiteModel,
+        remoteProductId: Long,
+        remoteVariationId: Long
+    ): WCProductVariationModel? =
+            ProductSqlUtils.getVariationByRemoteId(site, remoteProductId, remoteVariationId)
+
+    /**
      * returns true if the corresponding product exists in the database
      */
     fun geProductExistsByRemoteId(site: SiteModel, remoteProductId: Long) =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -829,24 +829,24 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
     }
 
     private fun handleFetchSingleVariationCompleted(payload: RemoteVariationPayload) {
-        val onProductChanged: OnVariationChanged
+        val onVariationChanged: OnVariationChanged
 
         if (payload.isError) {
-            onProductChanged = OnVariationChanged(0).also {
+            onVariationChanged = OnVariationChanged(0).also {
                 it.error = payload.error
                 it.remoteProductId = payload.variation.remoteProductId
                 it.remoteVariationId = payload.variation.remoteVariationId
             }
         } else {
             val rowsAffected = ProductSqlUtils.insertOrUpdateProductVariation(payload.variation)
-            onProductChanged = OnVariationChanged(rowsAffected).also {
+            onVariationChanged = OnVariationChanged(rowsAffected).also {
                 it.remoteProductId = payload.variation.remoteProductId
                 it.remoteVariationId = payload.variation.remoteVariationId
             }
         }
 
-        onProductChanged.causeOfChange = WCProductAction.FETCH_SINGLE_VARIATION
-        emitChange(onProductChanged)
+        onVariationChanged.causeOfChange = WCProductAction.FETCH_SINGLE_VARIATION
+        emitChange(onVariationChanged)
     }
 
     private fun handleFetchProductSkuAvailabilityCompleted(payload: RemoteProductSkuAvailabilityPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -449,8 +449,8 @@ class WCProductStore @Inject constructor(dispatcher: Dispatcher, private val wcP
 
     class OnVariationChanged(
         var rowsAffected: Int,
-        var remoteProductId: Long = 0L, // only set for fetching a single product
-        var remoteVariationId: Long = 0L, // only set for fetching a single product
+        var remoteProductId: Long = 0L, // only set for fetching a single variation
+        var remoteVariationId: Long = 0L, // only set for fetching a single variation
         var canLoadMore: Boolean = false
     ) : OnChanged<ProductError>() {
         var causeOfChange: WCProductAction? = null

--- a/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
+++ b/plugins/woocommerce/src/main/tools/wc-wp-api-endpoints.txt
@@ -7,6 +7,7 @@
 
 /products/<id>/
 /products/<id>/variations/
+/products/<id>/variations/<variation_id>
 /products/
 /products/shipping_classes
 /products/shipping_classes/<id>/


### PR DESCRIPTION
This PR adds client implementation for fetching and updating a single product variation.

**To test:**
1. Run `ReleaseStack_WCProductTest` tests
2. Run `WCProductStoreTest` tests
3. Go to Woo -> Products -> Select site -> Fetch Single Variation & Update Variation