### PR TITLE
Revert "Fix the failing API unit test"

### DIFF
--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -86,7 +86,7 @@ public class APITesting_WCOrder {
             get().
         then().
             statusCode(200).
-            body("data", hasSize(8));
+            body("data", hasSize(7));
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 3f6f5cb86ed74c825e2c41caa6146484fbd3dd31, which will fix the failing API Test.

@bsessions85 Do you know why the response keeps changing? Is this site (woomobileapitesting.mystagingwebsite.com) being used for anything else besides API unit tests?

