### PR TITLE
[Feature] Add Search Filter for XML RPC Requests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestXMLRPC.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestXMLRPC.kt
@@ -27,10 +27,13 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.DEFAULT_POST_STATUS_LIST
 import javax.inject.Inject
 
+private const val TEST_POST_LIST_SEARCH_QUERY = "a"
+
 internal class XmlRpcPostListTestCase(
     val statusList: List<PostStatus> = DEFAULT_POST_STATUS_LIST,
     val order: ListOrder = ListOrder.DESC,
     val orderBy: PostListOrderBy = PostListOrderBy.DATE,
+    val searchQuery: String? = null,
     val testMode: ListStoreConnectedTestMode = SinglePage(false)
 )
 
@@ -59,7 +62,8 @@ internal class ReleaseStack_PostListTestXMLRPC(
                 XmlRpcPostListTestCase(statusList = listOf(SCHEDULED)),
                 XmlRpcPostListTestCase(statusList = listOf(TRASHED)),
                 XmlRpcPostListTestCase(order = ListOrder.ASC, testMode = MultiplePages),
-                XmlRpcPostListTestCase(orderBy = PostListOrderBy.ID, testMode = MultiplePages)
+                XmlRpcPostListTestCase(orderBy = PostListOrderBy.ID, testMode = MultiplePages),
+                XmlRpcPostListTestCase(searchQuery = TEST_POST_LIST_SEARCH_QUERY)
         )
     }
 
@@ -83,6 +87,7 @@ internal class ReleaseStack_PostListTestXMLRPC(
                 statusList = testCase.statusList,
                 order = testCase.order,
                 orderBy = testCase.orderBy,
+                searchQuery = testCase.searchQuery,
                 config = TEST_LIST_CONFIG
         )
         return listStoreConnectedTestHelper.getList(descriptor, TestPostListDataSource(mDispatcher))

--- a/example/src/test/java/org/wordpress/android/fluxc/list/post/PostListDescriptorTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/post/PostListDescriptorTest.kt
@@ -179,6 +179,20 @@ internal class PostListDescriptorTest(
                             shouldHaveSameTypeIdentifier = true,
                             shouldHaveSameUniqueIdentifier = false
                     ),
+                    PostListDescriptorTestCase(
+                            typeIdentifierReason = "Different search query should have same type identifiers",
+                            uniqueIdentifierReason = "Different search query should have different unique identifiers",
+                            descriptor1 = PostListDescriptorForXmlRpcSite(
+                                    mockSite,
+                                    searchQuery = LIST_DESCRIPTOR_TEST_QUERY_1
+                            ),
+                            descriptor2 = PostListDescriptorForXmlRpcSite(
+                                    mockSite,
+                                    searchQuery = LIST_DESCRIPTOR_TEST_QUERY_2
+                            ),
+                            shouldHaveSameTypeIdentifier = true,
+                            shouldHaveSameUniqueIdentifier = false
+                    ),
                     // Different list config
                     PostListDescriptorTestCase(
                             typeIdentifierReason = "Different list configs should have same type identifiers",

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -67,7 +67,7 @@ sealed class PostListDescriptor(
     class PostListDescriptorForRestSite(
         site: SiteModel,
         statusList: List<PostStatus> = DEFAULT_POST_STATUS_LIST,
-        val author: AuthorFilter = AuthorFilter.Everyone,
+        val author: AuthorFilter = Everyone,
         order: ListOrder = DESC,
         orderBy: PostListOrderBy = DATE,
         val searchQuery: String? = null,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -41,9 +41,7 @@ sealed class PostListDescriptor(
         }
     }
 
-    override val typeIdentifier: ListDescriptorTypeIdentifier by lazy {
-        calculateTypeIdentifier(site.id)
-    }
+    override val typeIdentifier: ListDescriptorTypeIdentifier by lazy { calculateTypeIdentifier(site.id) }
 
     override fun hashCode(): Int {
         return uniqueIdentifier.value

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -46,7 +46,8 @@ sealed class PostListDescriptor(
                                 "-${site.id}" +
                                 "-st$statusStr" +
                                 "-o${order.value}" +
-                                "-ob${orderBy.value}").hashCode()
+                                "-ob${orderBy.value}" +
+                                "-sq$searchQuery").hashCode()
                 )
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -88,6 +88,7 @@ sealed class PostListDescriptor(
         statusList: List<PostStatus> = DEFAULT_POST_STATUS_LIST,
         order: ListOrder = DESC,
         orderBy: PostListOrderBy = DATE,
+        val searchQuery: String? = null,
         config: ListConfig = ListConfig.default
     ) : PostListDescriptor(site, statusList, order, orderBy, config)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -29,13 +29,24 @@ sealed class PostListDescriptor(
                 }
 
                 ListDescriptorUniqueIdentifier(
-                        ("rest-site-post-list-${site.id}-st$statusStr-a$authorFilter-o${order.value}" +
-                                "-ob${orderBy.value}-sq$searchQuery").hashCode()
+                        ("rest-site" +
+                                "-post-list" +
+                                "-${site.id}" +
+                                "-st$statusStr" +
+                                "-a$authorFilter" +
+                                "-o${order.value}" +
+                                "-ob${orderBy.value}" +
+                                "-sq$searchQuery").hashCode()
                 )
             }
             is PostListDescriptorForXmlRpcSite -> {
                 ListDescriptorUniqueIdentifier(
-                        "xml-rpc-site-post-list-${site.id}-st$statusStr-o${order.value}-ob${orderBy.value}".hashCode()
+                        ("xml-rpc-site" +
+                                "-post-list" +
+                                "-${site.id}" +
+                                "-st$statusStr" +
+                                "-o${order.value}" +
+                                "-ob${orderBy.value}").hashCode()
                 )
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PostListDescriptor.kt
@@ -42,7 +42,7 @@ sealed class PostListDescriptor(
     }
 
     override val typeIdentifier: ListDescriptorTypeIdentifier by lazy {
-        PostListDescriptor.calculateTypeIdentifier(site.id)
+        calculateTypeIdentifier(site.id)
     }
 
     override fun hashCode(): Int {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -143,18 +143,11 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         SiteModel site = listDescriptor.getSite();
         List<String> fields = Arrays.asList("post_id", "post_modified_gmt", "post_status");
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
-        List<Object> params = createFetchPostListParameters(
-                site.getSelfHostedSiteId(),
-                site.getUsername(),
-                site.getPassword(),
-                false,
-                offset,
-                pageSize,
-                listDescriptor.getStatusList(),
-                fields,
-                listDescriptor.getOrderBy().getValue(),
-                listDescriptor.getOrder().getValue(),
-                listDescriptor.getSearchQuery());
+        List<Object> params =
+                createFetchPostListParameters(site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(), false,
+                        offset, pageSize, listDescriptor.getStatusList(), fields,
+                        listDescriptor.getOrderBy().getValue(), listDescriptor.getOrder().getValue(),
+                        listDescriptor.getSearchQuery());
         final boolean loadedMore = offset > 0;
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POSTS, params,
@@ -187,18 +180,9 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchPosts(final SiteModel site, final boolean getPages, List<PostStatus> statusList,
                            final int offset) {
-        List<Object> params = createFetchPostListParameters(
-                site.getSelfHostedSiteId(),
-                site.getUsername(),
-                site.getPassword(),
-                getPages,
-                offset,
-                PostStore.NUM_POSTS_PER_FETCH,
-                statusList,
-                null,
-                null,
-                null,
-                null);
+        List<Object> params =
+                createFetchPostListParameters(site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(),
+                        getPages, offset, PostStore.NUM_POSTS_PER_FETCH, statusList, null, null, null, null);
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POSTS, params,
                 new Listener<Object[]>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -153,7 +153,8 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                 listDescriptor.getStatusList(),
                 fields,
                 listDescriptor.getOrderBy().getValue(),
-                listDescriptor.getOrder().getValue());
+                listDescriptor.getOrder().getValue(),
+                listDescriptor.getSearchQuery());
         final boolean loadedMore = offset > 0;
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POSTS, params,
@@ -194,6 +195,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                 offset,
                 PostStore.NUM_POSTS_PER_FETCH,
                 statusList,
+                null,
                 null,
                 null,
                 null);
@@ -609,7 +611,8 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             @Nullable final List<PostStatus> statusList,
             @Nullable final List<String> fields,
             @Nullable final String orderBy,
-            @Nullable final String order) {
+            @Nullable final String order,
+            @Nullable final String searchQuery) {
         Map<String, Object> contentStruct = new HashMap<>();
         contentStruct.put("number", number);
         contentStruct.put("offset", offset);
@@ -621,6 +624,9 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         }
         if (statusList != null && statusList.size() > 0) {
             contentStruct.put("post_status", PostStatus.postStatusListToString(statusList));
+        }
+        if (!TextUtils.isEmpty(searchQuery)) {
+            contentStruct.put("s", searchQuery);
         }
 
         if (getPages) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -197,12 +197,10 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
                         FetchPostsResponsePayload payload = new FetchPostsResponsePayload(posts, site, getPages,
                                 offset > 0, canLoadMore);
 
-                        if (posts != null) {
-                            mDispatcher.dispatch(PostActionBuilder.newFetchedPostsAction(payload));
-                        } else {
+                        if (posts == null) {
                             payload.error = new PostError(PostErrorType.INVALID_RESPONSE);
-                            mDispatcher.dispatch(PostActionBuilder.newFetchedPostsAction(payload));
                         }
+                        mDispatcher.dispatch(PostActionBuilder.newFetchedPostsAction(payload));
                     }
                 },
                 new BaseErrorListener() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -69,7 +69,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
     }
 
     public void fetchPost(final PostModel post, final SiteModel site, final PostAction origin) {
-        List<Object> params = createfetchPostParams(post, site);
+        List<Object> params = createFetchPostParams(post, site);
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POST, params,
                 new Listener<Object>() {
@@ -107,7 +107,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchPostStatus(final PostModel post, final SiteModel site) {
         final String postStatusField = "post_status";
-        List<Object> params = createfetchPostParams(post, site);
+        List<Object> params = createFetchPostParams(post, site);
         // If we only request the status, we get an empty response
         params.add(Arrays.asList("post_id", postStatusField));
 
@@ -625,7 +625,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         return params;
     }
 
-    private List<Object> createfetchPostParams(final PostModel post, final SiteModel site) {
+    private List<Object> createFetchPostParams(final PostModel post, final SiteModel site) {
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -143,10 +143,17 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         SiteModel site = listDescriptor.getSite();
         List<String> fields = Arrays.asList("post_id", "post_modified_gmt", "post_status");
         final int pageSize = listDescriptor.getConfig().getNetworkPageSize();
-        List<Object> params =
-                createFetchPostListParameters(site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(), false,
-                        offset, pageSize, listDescriptor.getStatusList(), fields,
-                        listDescriptor.getOrderBy().getValue(), listDescriptor.getOrder().getValue());
+        List<Object> params = createFetchPostListParameters(
+                site.getSelfHostedSiteId(),
+                site.getUsername(),
+                site.getPassword(),
+                false,
+                offset,
+                pageSize,
+                listDescriptor.getStatusList(),
+                fields,
+                listDescriptor.getOrderBy().getValue(),
+                listDescriptor.getOrder().getValue());
         final boolean loadedMore = offset > 0;
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POSTS, params,
@@ -179,9 +186,17 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
     public void fetchPosts(final SiteModel site, final boolean getPages, List<PostStatus> statusList,
                            final int offset) {
-        List<Object> params =
-                createFetchPostListParameters(site.getSelfHostedSiteId(), site.getUsername(), site.getPassword(),
-                        getPages, offset, PostStore.NUM_POSTS_PER_FETCH, statusList, null, null, null);
+        List<Object> params = createFetchPostListParameters(
+                site.getSelfHostedSiteId(),
+                site.getUsername(),
+                site.getPassword(),
+                getPages,
+                offset,
+                PostStore.NUM_POSTS_PER_FETCH,
+                statusList,
+                null,
+                null,
+                null);
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_POSTS, params,
                 new Listener<Object[]>() {


### PR DESCRIPTION
Feature requirement for [WordPress-Android - #12058](https://github.com/wordpress-mobile/WordPress-Android/issues/12058)

Description
-----
This PR is the first step towards solving the aforementioned [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android) issue. Briefly, it enables `search` for XML RPC requests, just like it is already enabled for Rest.

As such, when this PR gets merged with `develop` it will unlock the second step, which is to make search on blog posts available for self-hosted sites.

Test
-----
1. Build the FluxC `example` app
1. Sing in and fetch your self-hosted site (click on the `SIGN IN AND FETCH SITES` button)
1. Navigate to the post screen (click on the `POST` button)
1. Try fetching the available posts from your self-hosted site (click on the `FETCH POST FROM FIRST SITE` button)
1. Observer the output, example: `Fetched 20 posts from: Traditional Wolf`
1. Find the `PostXMLPRCClient.java` class and add a breakpoint at line 628 (see `if (!TextUtils.isEmpty(searchQuery)) { ... }`)
1. Attach a debugger and try fetching the available posts from the self-hosted site again
1. When the debugger blocks, find the `searchQuery` variable. It should be `null`. Replace it with a search term of your own, like `"tags"`. Click enter to replace `null` and resume the debugger.
1. Observer the new output, example: `Fetched 3 posts from: Traditional Wolf`
1. The above means that while without a search query the list of posts returned was 20, when that search query got updated to `tags` (normally done through the UI), then the resulting list of posts is different. In my case, because my self-hosted site has 3 posts matching the `tags` search query it returned those (that is, instead of the default 20 post, which is the page size).

PR Structure
-----
- Multiple commits are included in this PR, both 'feature' and 'refactor' commits,
- Each commit tackles a specific problem, be it formatting the code, adding `search` capabilities, etc,
- Each commit has a `title`, an empty line and a optional `description` afterwards. The line length of a commit message does not exceed the 72 characters limit.
- Test where included, both unit and connected tests. Where possible a TDD approach was followed,
- Both, `checkstyle` and `ktlint` were triggered before pushing the branch. `checkstyle` had already 43 warnings (it is probably out of scope for this PR to fix those). However, for those files that were touched, some warnings was fixed.