### PR TITLE
Bugfix: Expected BEGIN_OBJECT but was BEGIN_ARRAY at path $[0]

### DIFF
--- a/example/src/androidTest/resources/editor-theme-invalid-response.json
+++ b/example/src/androidTest/resources/editor-theme-invalid-response.json
@@ -1,0 +1,73 @@
+[
+  {
+    "theme_supports": {
+      "align-wide": false,
+      "automatic-feed-links": true,
+      "custom-header": {
+        "default-image": "",
+        "random-default": false,
+        "width": 1030,
+        "height": 680,
+        "flex-height": true,
+        "flex-width": false,
+        "default-text-color": "606666",
+        "header-text": true,
+        "uploads": true,
+        "video": false
+      },
+      "custom-background": {
+        "default-image": "",
+        "default-preset": "default",
+        "default-position-x": "left",
+        "default-position-y": "top",
+        "default-size": "auto",
+        "default-repeat": "repeat",
+        "default-attachment": "scroll",
+        "default-color": "f5f7f7"
+      },
+      "custom-logo": false,
+      "customize-selective-refresh-widgets": false,
+      "dark-editor-style": false,
+      "disable-custom-colors": false,
+      "disable-custom-font-sizes": false,
+      "disable-custom-gradients": false,
+      "editor-color-palette": [[]],
+      "editor-font-sizes": false,
+      "editor-gradient-presets": [[]],
+      "editor-styles": false,
+      "html5": [
+        "search-form",
+        "comment-form",
+        "comment-list",
+        "gallery",
+        "caption"
+      ],
+      "post-thumbnails": true,
+      "responsive-embeds": false,
+      "title-tag": true,
+      "wp-block-styles": false,
+      "formats": [
+        "standard",
+        "aside",
+        "image",
+        "video",
+        "quote",
+        "link",
+        "gallery",
+        "audio",
+        "chat",
+        "status"
+      ]
+    },
+    "author": "<a href=\"https://wordpress.org/\">the WordPress team</a>",
+    "author_name": "the WordPress team",
+    "author_uri": "https://wordpress.org/",
+    "description": "Our default theme for 2020 is designed to take full advantage of the flexibility of the block editor. Organizations and businesses have the ability to create dynamic landing pages with endless layouts using the group and column blocks. The centered content column and fine-tuned typography also makes it perfect for traditional blogs. Complete editor styles give you a good idea of what your content will look like, even before you publish. You can give your site a personal touch by changing the background colors and the accent color in the Customizer. The colors of all elements on your site are automatically calculated based on the colors you pick, ensuring a high, accessible color contrast for your visitors.",
+    "name": "Twenty Twenty",
+    "stylesheet": "pub/twentytwenty",
+    "template": "pub/twentytwenty",
+    "theme_uri": null,
+    "version": "1.3-wpcom",
+    "screenshot": "https://s2.wp.com/wp-content/themes/pub/twentytwenty/screenshot.png"
+  }
+]

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -11,7 +11,6 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.persistence.EditorThemeElementType
 import org.wordpress.android.fluxc.persistence.EditorThemeSqlUtils.EditorThemeBuilder
 import org.wordpress.android.fluxc.persistence.EditorThemeSqlUtils.EditorThemeElementBuilder
-import java.lang.IllegalStateException
 import java.lang.reflect.Type
 
 const val MAP_KEY_ELEMENT_DISPLAY_NAME: String = "name"
@@ -109,7 +108,7 @@ class EditorThemeElementListSerializer : JsonDeserializer<List<EditorThemeElemen
             var result: List<EditorThemeElement>?
             try {
                 result = context.deserialize(json, editorThemeElementListType)
-            } catch(e: JsonSyntaxException) {
+            } catch (e: JsonSyntaxException) {
                 result = null
             }
             return result

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -4,12 +4,14 @@ import android.os.Bundle
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
+import com.google.gson.JsonSyntaxException
 import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.persistence.EditorThemeElementType
 import org.wordpress.android.fluxc.persistence.EditorThemeSqlUtils.EditorThemeBuilder
 import org.wordpress.android.fluxc.persistence.EditorThemeSqlUtils.EditorThemeElementBuilder
+import java.lang.IllegalStateException
 import java.lang.reflect.Type
 
 const val MAP_KEY_ELEMENT_DISPLAY_NAME: String = "name"
@@ -104,7 +106,13 @@ class EditorThemeElementListSerializer : JsonDeserializer<List<EditorThemeElemen
     ): List<EditorThemeElement>? {
         if (context != null && json != null && json.isJsonArray()) {
             val editorThemeElementListType = object : TypeToken<List<EditorThemeElement>>() { }.getType()
-            return context.deserialize(json, editorThemeElementListType)
+            var result: List<EditorThemeElement>?
+            try {
+                result = context.deserialize(json, editorThemeElementListType)
+            } catch(e: JsonSyntaxException) {
+                result = null
+            }
+            return result
         } else {
             return null
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -79,7 +79,18 @@ class EditorThemeStore
 
         when (response) {
             is Success -> {
-                val responseTheme = response.result?.asJsonArray?.firstOrNull() ?: return
+                val noThemeError = OnEditorThemeChanged(EditorThemeError("Response does not contain a theme"), action)
+                if (response.result == null || !response.result.isJsonArray) {
+                    emitChange(noThemeError)
+                    return
+                }
+
+                val responseTheme = response.result.asJsonArray.firstOrNull()
+                if (responseTheme == null) {
+                    emitChange(noThemeError)
+                    return
+                }
+
                 val newTheme = Gson().fromJson(responseTheme, EditorTheme::class.java)
                 val existingTheme = editorThemeSqlUtils.getEditorThemeForSite(site)
                 if (newTheme != existingTheme) {


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1644
**Related PR:** https://github.com/wordpress-mobile/WordPress-Android/pull/12557

### To Test:
1.) Install a theme with an invalid configuration such as:

```
add_theme_support( 'editor-gradient-presets', array(array()));
```

or 

```
add_theme_support( 'editor-color-palette', array(array()));
```

You can use [twentytwenty-copy-empty-array.zip](https://github.com/wordpress-mobile/WordPress-FluxC-Android/files/4997581/twentytwenty-copy-empty-array.zip) which is already setup.

2.) In the demo app log into your site
3.) Select "Editor Theme"
4.) Select "Fetch Theme from first site"

Expect app not crash.

This can also be tested in WPAndroid with the build here: 

