### PR TITLE
Fixed migration logic for shipping labels only for WooCommerce

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1260,7 +1260,7 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "LOCALIZED INTEGER,RESPONSE_LOCALE TEXT NOT NULL,DETAILS_URL TEXT)"
                     )
                 }
-                113 -> migrate(version) {
+                113 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCShippingLabelModel ADD DATE_CREATED TEXT")
                 }
             }


### PR DESCRIPTION
Fixes the below crash issue when updating the migration script for WooCommerce Shipping Labels table. The fix is to ensure that the table `WCShippingLabelModel` is to be available only for the Woo apps. 

#### Testing
- I updated the FluxC hash from the latest `develop` branch to the WordPress apps and was able to reproduce the crash.
- Pull changes from this PR and try again. The app should not crash.