### PR TITLE
Remove MultiplePages flag in PostList tests to fix flakiness

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestWpCom.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestWpCom.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.release.AuthorTestFilter.EVERYONE
 import org.wordpress.android.fluxc.release.AuthorTestFilter.SPECIFIC_AUTHOR
 import org.wordpress.android.fluxc.release.utils.ListStoreConnectedTestHelper
 import org.wordpress.android.fluxc.release.utils.ListStoreConnectedTestMode
-import org.wordpress.android.fluxc.release.utils.ListStoreConnectedTestMode.MultiplePages
 import org.wordpress.android.fluxc.release.utils.ListStoreConnectedTestMode.SinglePage
 import org.wordpress.android.fluxc.release.utils.TEST_LIST_CONFIG
 import org.wordpress.android.fluxc.release.utils.TestPostListDataSource
@@ -63,12 +62,12 @@ internal class ReleaseStack_PostListTestWpCom(
                  They are very easy to extend on, so if we start running them on an account with pre-setup, they can
                  made to be a lot more demanding by ensuring that each post list type returns some data.
                  */
-                RestPostListTestCase(testMode = MultiplePages),
+                RestPostListTestCase(),
                 RestPostListTestCase(statusList = listOf(DRAFT)),
                 RestPostListTestCase(statusList = listOf(SCHEDULED)),
                 RestPostListTestCase(statusList = listOf(TRASHED)),
-                RestPostListTestCase(order = ListOrder.ASC, testMode = MultiplePages),
-                RestPostListTestCase(orderBy = PostListOrderBy.ID, testMode = MultiplePages),
+                RestPostListTestCase(order = ListOrder.ASC),
+                RestPostListTestCase(orderBy = PostListOrderBy.ID),
                 RestPostListTestCase(searchQuery = TEST_POST_LIST_SEARCH_QUERY),
                 RestPostListTestCase(
                         author = SPECIFIC_AUTHOR,

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestXMLRPC.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostListTestXMLRPC.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
 import org.wordpress.android.fluxc.model.post.PostStatus.TRASHED
 import org.wordpress.android.fluxc.release.utils.ListStoreConnectedTestHelper
 import org.wordpress.android.fluxc.release.utils.ListStoreConnectedTestMode
-import org.wordpress.android.fluxc.release.utils.ListStoreConnectedTestMode.MultiplePages
 import org.wordpress.android.fluxc.release.utils.ListStoreConnectedTestMode.SinglePage
 import org.wordpress.android.fluxc.release.utils.TEST_LIST_CONFIG
 import org.wordpress.android.fluxc.release.utils.TestPostListDataSource
@@ -55,12 +54,12 @@ internal class ReleaseStack_PostListTestXMLRPC(
                  They are very easy to extend on, so if we start running them on an account with pre-setup, they can
                  made to be a lot more demanding by ensuring that each post list type returns some data.
                  */
-                XmlRpcPostListTestCase(testMode = MultiplePages),
+                XmlRpcPostListTestCase(),
                 XmlRpcPostListTestCase(statusList = listOf(DRAFT)),
                 XmlRpcPostListTestCase(statusList = listOf(SCHEDULED)),
                 XmlRpcPostListTestCase(statusList = listOf(TRASHED)),
-                XmlRpcPostListTestCase(order = ListOrder.ASC, testMode = MultiplePages),
-                XmlRpcPostListTestCase(orderBy = PostListOrderBy.ID, testMode = MultiplePages),
+                XmlRpcPostListTestCase(order = ListOrder.ASC),
+                XmlRpcPostListTestCase(orderBy = PostListOrderBy.ID),
                 XmlRpcPostListTestCase(searchQuery = TEST_POST_LIST_SEARCH_QUERY)
         )
     }


### PR DESCRIPTION
Follow up for https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1651. 

We tried to re-enable the PostList tests but they are still flaky. It seems that only tests with "MultiplePages" parameter are failing. This PR removes that parameter so we can verify the flakiness is really related just to the MultiPages tests. We plan to look into the root of the issue and fix it once and for all when we gather more information.

No need to test anything.