### PR TITLE
Exclude Flipper's okhttp import

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -141,7 +141,12 @@ dependencies {
     // Debug dependencies
     debugImplementation 'com.facebook.flipper:flipper:0.51.0'
     debugImplementation 'com.facebook.soloader:soloader:0.9.0'
-    debugImplementation 'com.facebook.flipper:flipper-network-plugin:0.51.0'
+    debugImplementation ('com.facebook.flipper:flipper-network-plugin:0.51.0') {
+        // Force Flipper to use the okhttp version defined in the fluxc module
+        // okhttp versions higher than 3.9.0 break handling for self-signed SSL sites
+        // See https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
+        exclude group: 'com.squareup.okhttp3'
+    }
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"


### PR DESCRIPTION
I noticed that the live tests on self-signed SSL sites started to fail. It turns out that Flipper's network plugin (added in #1602) [relies on okhttp3 3.14.1](https://github.com/facebook/flipper/blob/10f9a485401559be73b976cbe3b5eb0e1b2cc95c/build.gradle#L91), which is too high for us. See https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919 for background, but basically any okhttp version over `3.9.0` will break FluxC's self-signed SSL site support.

The fix was to just exclude the `okhttp3` dependency when importing the Flipper network plugin. This fixes the SSL tests and the Flipper network sniffer seems to still be working.

### To test:
1. Run the connected tests and confirm they pass, in particular:
* `ReleaseStack_SiteTestXMLRPC#testXMLRPCSelfSignedSSLFetchSites` and
* `ReleaseStack_ReactNativeWPAPIRequestTest#testAuthenticatedCallToSelfSignedSslSite`
2. Install Flipper (see #1602 for instructions) and confirm you can still inspect network requests from the example app