### PR TITLE
Improves encrypted log upload delay handling

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-private const val NUMBER_OF_LOGS_TO_UPLOAD = 3
+private const val NUMBER_OF_LOGS_TO_UPLOAD = 2
 private const val TEST_UUID_PREFIX = "TEST-UUID-"
 private const val INVALID_UUID = "INVALID_UUID" // Underscore is not allowed
 


### PR DESCRIPTION
This PR improves the delay handling for encrypted logging upload requests. Here is the new logic:

* If the previous upload was successful, try and upload the next one immediately
* If the previous upload had a final failure, try and upload the next one immediately - This is because it wasn't a temporary failure and we won't be trying to upload the same log again, so there is no reason to delay the next upload. The only case this might be a bit concerning is if we hit the max number of failures for a specific log due to a server error. However, we have pretty good error handling that distinguishes server issues, so if this becomes a thing, it'll be something we'll want to fix regardless of this logic.
* If the previous upload failed for a temporary reason, add a delay to the current date and save it in preferences. For `too_many_requests` errors, we add 1 hour delay since that's what the server uses. For other errors, we use a one minute delay.

One downside of these changes is that if the connected tests hit the `too_many_requests` error, it'll start to fail after the first run. There are hacky way around this, but since this is unlikely to occur in our typical tests (one run a day) it hopefully won't cause any issues. For now, I decreased the `NUMBER_OF_LOGS_TO_UPLOAD` to 2, so it's less likely for us to hit `too_many_requests` error. I'll keep an eye for this error and address it if necessary.

@jkmassel I asssume this is the type of solution you had in mind when we discussed it in #1650. I am still not 100% happy with this implementation, but it feels a good step forward. Let me know what you think!