### PR TITLE
Media upload error codes alignment - self-hosted

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -563,7 +563,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         if (exception instanceof XMLRPCFault) {
             switch (((XMLRPCFault) exception).getFaultCode()) {
                 case 401:
-                    mediaError.type = MediaErrorType.XMLRPC_UNAUTHORIZED;
+                    mediaError.type = MediaErrorType.XMLRPC_OPERATION_NOT_ALLOWED;
                     break;
                 case 403:
                     mediaError.type = MediaErrorType.NOT_AUTHENTICATED;
@@ -572,7 +572,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                     mediaError.type = MediaErrorType.NOT_FOUND;
                     break;
                 case 500:
-                    mediaError.type = MediaErrorType.XMLRPC_INTERNAL_SERVER_ERROR;
+                    mediaError.type = MediaErrorType.XMLRPC_UPLOAD_ERROR;
                     break;
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -562,11 +562,17 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mediaError.message = exception.getLocalizedMessage();
         if (exception instanceof XMLRPCFault) {
             switch (((XMLRPCFault) exception).getFaultCode()) {
-                case 404:
-                    mediaError.type = MediaErrorType.NOT_FOUND;
+                case 401:
+                    mediaError.type = MediaErrorType.XMLRPC_UNAUTHORIZED;
                     break;
                 case 403:
                     mediaError.type = MediaErrorType.NOT_AUTHENTICATED;
+                    break;
+                case 404:
+                    mediaError.type = MediaErrorType.NOT_FOUND;
+                    break;
+                case 500:
+                    mediaError.type = MediaErrorType.XMLRPC_INTERNAL_SERVER_ERROR;
                     break;
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -366,6 +366,8 @@ public class MediaStore extends Store {
         SERVER_ERROR, // this is also returned when PHP max_execution_time or memory_limit is reached
         TIMEOUT,
         BAD_REQUEST,
+        XMLRPC_UNAUTHORIZED,
+        XMLRPC_INTERNAL_SERVER_ERROR,
 
         // logic constraints errors
         INVALID_ID,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -366,8 +366,8 @@ public class MediaStore extends Store {
         SERVER_ERROR, // this is also returned when PHP max_execution_time or memory_limit is reached
         TIMEOUT,
         BAD_REQUEST,
-        XMLRPC_UNAUTHORIZED,
-        XMLRPC_INTERNAL_SERVER_ERROR,
+        XMLRPC_OPERATION_NOT_ALLOWED,
+        XMLRPC_UPLOAD_ERROR,
 
         // logic constraints errors
         INVALID_ID,


### PR DESCRIPTION
This PR does the following related to the self-hosted sites scenario:

- Adds 401 and 500 error codes. 
- Maps 401 and 500 xmlrpc error codes to MediaErrorType.

### To Test
Follow instructions in the companion WPAndroid PR

As for the #1657 we are adding a couple of MediaErrorType that could maybe be relevant for the Woo App. @ThomazFB would be great if you could have a quick look also into this, I can assume you are not using at all the XML-RPC self-hosted API so possibly it's a really quick check and no problem at all on Woo (thanks for confirming 🙇‍♂️)