### PR TITLE
Woo/update product type

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -610,6 +610,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             virtual = true
             images = generateTestImageListJsonString()
             groupedProductIds = "[10, 11]"
+            type = "simple"
         }
         productRestClient.updateProduct(siteModel, testProduct, updatedProduct)
 
@@ -627,6 +628,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(updatedProduct.virtual, product.virtual)
             assertEquals(updatedProduct.getImages().size, 2)
             assertEquals(updatedProduct.getGroupedProductIds().size, 2)
+            assertEquals(updatedProduct.type, product.type)
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -38,6 +38,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductBack
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductTaxStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductVisibility
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload
@@ -75,6 +76,7 @@ class WooUpdateProductFragment : Fragment() {
         const val LIST_RESULT_CODE_STATUS = 105
         const val LIST_RESULT_CODE_CATEGORIES = 106
         const val LIST_RESULT_CODE_TAGS = 107
+        const val LIST_RESULT_CODE_PRODUCT_TYPE = 108
 
         fun newInstance(selectedSitePosition: Int): WooUpdateProductFragment {
             val fragment = WooUpdateProductFragment()
@@ -175,6 +177,13 @@ class WooUpdateProductFragment : Fragment() {
                     child.isEnabled = isChecked
                 }
             }
+        }
+
+        product_type.setOnClickListener {
+            showListSelectorDialog(
+                    CoreProductType.values().map { it.value }.toList(),
+                    LIST_RESULT_CODE_PRODUCT_TYPE, selectedProductModel?.type
+            )
         }
 
         product_tax_status.setOnClickListener {
@@ -347,6 +356,12 @@ class WooUpdateProductFragment : Fragment() {
                         selectedProductModel?.status = it
                     }
                 }
+                LIST_RESULT_CODE_PRODUCT_TYPE -> {
+                    selectedItem?.let {
+                        product_type.text = it
+                        selectedProductModel?.type = it
+                    }
+                }
                 LIST_RESULT_CODE_VISIBILITY -> {
                     selectedItem?.let {
                         product_catalog_visibility.text = it
@@ -387,6 +402,7 @@ class WooUpdateProductFragment : Fragment() {
                 product_length.setText(it.length)
                 product_weight.setText(it.weight)
                 product_tax_status.text = it.taxStatus
+                product_type.text = it.type
                 product_sold_individually.isChecked = it.soldIndividually
                 product_from_date.text = it.dateOnSaleFromGmt.split('T')[0]
                 product_to_date.text = it.dateOnSaleToGmt.split('T')[0]

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -94,6 +94,26 @@
             app:layout_constraintTop_toBottomOf="@+id/product_description"
             app:textHint="Product SKU" />
 
+        <TextView
+            android:id="@+id/product_type_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_sku"
+            android:text="Product type" />
+
+        <Button
+            android:id="@+id/product_type"
+            style="?android:attr/spinnerStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_type_title"
+            android:text="Product type" />
+
         <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
             android:id="@+id/product_slug"
             android:layout_width="0dp"
@@ -102,7 +122,7 @@
             android:inputType="text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_sku"
+            app:layout_constraintTop_toBottomOf="@+id/product_type"
             app:textHint="Product slug" />
 
         <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductType.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductType.kt
@@ -4,8 +4,7 @@ enum class CoreProductType(val value: String) {
     SIMPLE("simple"),
     GROUPED("grouped"),
     EXTERNAL("external"),
-    VARIABLE("variable"),
-    VARIATION("variation");
+    VARIABLE("variable");
 
     companion object {
         private val valueMap = values().associateBy(CoreProductType::value)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -902,6 +902,9 @@ class ProductRestClient(
         if (storedWCProductModel.name != updatedProductModel.name) {
             body["name"] = updatedProductModel.name
         }
+        if (storedWCProductModel.type != updatedProductModel.type) {
+            body["type"] = updatedProductModel.type
+        }
         if (storedWCProductModel.sku != updatedProductModel.sku) {
             body["sku"] = updatedProductModel.sku
         }


### PR DESCRIPTION
Adds FluxC support for woocommerce/woocommerce-android#2322 to update the product type of a product.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/89755209-3b510280-dafc-11ea-84a3-104b036f328c.png" width="300"/>

#### Testing
- Run `MockedStack_WCProductsTest`
- In the example app:
  - Click on `Woo` -> `Products` -> `Select Site`.
  - Click on `Update Product` -> `Enter product Id`
  - Notice the product type section is displayed.
  - Click on the product type and select a different product type.
  - Click on the `Tick` icon at the top of the screen.
  - Notice that the product type is updated successfully.