### PR TITLE
Add Proguard Rules for Encrypted Logging

### DIFF
--- a/fluxc/proguard-rules.pro
+++ b/fluxc/proguard-rules.pro
@@ -15,3 +15,9 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+## Encrypted Logging Start
+-dontwarn java.awt.*
+-keep class com.sun.jna.* { *; }
+-keepclassmembers class * extends com.sun.jna.* { public *; }
+## Encrypted Logging End


### PR DESCRIPTION
Adds proguard rules to support encrypted logging – prevents a crash from happening on release builds.

Added per the docs at https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android