### PR TITLE
Add missing "video/x-msvideo" mime type

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
@@ -24,6 +24,7 @@ class MimeTypesTest {
                         "video/quicktime",
                         "video/x-ms-wmv",
                         "video/avi",
+                        "video/x-msvideo",
                         "video/mpeg",
                         "video/mp2p",
                         "video/ogg",

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
@@ -25,6 +25,7 @@ class MimeTypesTest {
                         "video/x-ms-wmv",
                         "video/avi",
                         "video/x-msvideo",
+                        "video/msvideo",
                         "video/mpeg",
                         "video/mp2p",
                         "video/ogg",

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeType.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeType.kt
@@ -22,6 +22,7 @@ data class MimeType(val type: Type, val subtypes: List<Subtype>, val extensions:
         QUICKTIME("quicktime"),
         X_MS_WMV("x-ms-wmv"),
         AVI("avi"),
+        X_MSVIDEO("x-msvideo"),
         MP2P("mp2p"),
         THREE_GPP("3gpp"),
         THREE_GPP_2("3gpp2"),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeType.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeType.kt
@@ -23,6 +23,7 @@ data class MimeType(val type: Type, val subtypes: List<Subtype>, val extensions:
         X_MS_WMV("x-ms-wmv"),
         AVI("avi"),
         X_MSVIDEO("x-msvideo"),
+        MSVIDEO("msvideo"),
         MP2P("mp2p"),
         THREE_GPP("3gpp"),
         THREE_GPP_2("3gpp2"),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -42,6 +42,7 @@ class MimeTypes {
             MimeType(VIDEO, Subtype.QUICKTIME, listOf("mov")),
             MimeType(VIDEO, Subtype.X_MS_WMV, listOf("wmv")),
             MimeType(VIDEO, Subtype.AVI, listOf("avi")),
+            MimeType(VIDEO, Subtype.X_MSVIDEO, listOf("avi")),
             MimeType(VIDEO, Subtype.MPEG, listOf("mpg")),
             MimeType(VIDEO, Subtype.MP2P, listOf("mpg")),
             MimeType(VIDEO, Subtype.OGG, listOf("ogv")),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -31,7 +31,7 @@ class MimeTypes {
      * .mp4, .m4v (MPEG-4) - "video/mp4"
      * .mov - missing - using "video/quicktime"
      * .wmv - "video/x-ms-wmv"
-     * .avi - "video/avi"
+     * .avi - "video/avi", "video/x-msvideo"
      * .mpg - "video/mpeg", "video/mp2p"
      * .ogv (Ogg) - missing - using "video/ogg"
      * .3gp (3GPP) - "video/3gpp"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -31,7 +31,7 @@ class MimeTypes {
      * .mp4, .m4v (MPEG-4) - "video/mp4"
      * .mov - missing - using "video/quicktime"
      * .wmv - "video/x-ms-wmv"
-     * .avi - "video/avi", "video/x-msvideo"
+     * .avi - "video/avi", "video/x-msvideo", "video/msvideo"
      * .mpg - "video/mpeg", "video/mp2p"
      * .ogv (Ogg) - missing - using "video/ogg"
      * .3gp (3GPP) - "video/3gpp"
@@ -43,6 +43,7 @@ class MimeTypes {
             MimeType(VIDEO, Subtype.X_MS_WMV, listOf("wmv")),
             MimeType(VIDEO, Subtype.AVI, listOf("avi")),
             MimeType(VIDEO, Subtype.X_MSVIDEO, listOf("avi")),
+            MimeType(VIDEO, Subtype.MSVIDEO, listOf("avi")),
             MimeType(VIDEO, Subtype.MPEG, listOf("mpg")),
             MimeType(VIDEO, Subtype.MP2P, listOf("mpg")),
             MimeType(VIDEO, Subtype.OGG, listOf("ogv")),


### PR DESCRIPTION
This PR adds support for the AVI files with the mime type `video/x-msvideo`. This could be tested on the corresponding WPAndroid PR