### PR TITLE
Fixed failing test by adding type field when updating a product

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -572,6 +572,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         val updatedGroupedProductIds = "[770,771]"
         productModel.groupedProductIds = updatedGroupedProductIds
 
+        val updatedProductType = "grouped"
+        productModel.type = updatedProductType
+
         nextEvent = TestEvent.UPDATED_PRODUCT
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(


### PR DESCRIPTION
This PR introduced the option to update the product type. The `testUpdateProduct` test in `ReleaseStack_WCProductTest` was not updated after this change and this was causing the test to fail. This PR updates the test, which should fix the failing test. 

#### To test
- Run `testUpdateProduct` in `ReleaseStack_WCProductTest` and verify that the test is passing.