### PR TITLE
Woo/grouped products small fixes

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -136,7 +136,7 @@ class WooUpdateProductFragment : Fragment() {
         grouped_product_ids.isEnabled = false
         select_grouped_product_ids.setOnClickListener {
             showSingleLineDialog(activity, "Enter a remoteProductId:") { editText ->
-                editText.text.toString().toIntOrNull()?.let { id ->
+                editText.text.toString().toLongOrNull()?.let { id ->
 
                     val storedGroupedProductIds =
                             selectedProductModel?.getGroupedProductIds()?.toMutableList() ?: mutableListOf()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -239,11 +239,11 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         }
     }
 
-    fun getGroupedProductIds(): List<Int> {
-        val groupedIds = ArrayList<Int>()
+    fun getGroupedProductIds(): List<Long> {
+        val groupedIds = ArrayList<Long>()
         try {
             Gson().fromJson(groupedProductIds, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
-                jsonElement.asInt.let { groupedIds.add(it) }
+                jsonElement.asLong.let { groupedIds.add(it) }
             }
         } catch (e: JsonParseException) {
             AppLog.e(T.API, e)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -366,7 +366,8 @@ class ProductRestClient(
                                 productModels,
                                 offset,
                                 loadedMore,
-                                canLoadMore
+                                canLoadMore,
+                                remoteProductIds
                         )
                         dispatcher.dispatch(WCProductActionBuilder.newFetchedProductsAction(payload))
                     } else {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -276,7 +276,8 @@ class WCProductStore @Inject constructor(
         val products: List<WCProductModel> = emptyList(),
         var offset: Int = 0,
         var loadedMore: Boolean = false,
-        var canLoadMore: Boolean = false
+        var canLoadMore: Boolean = false,
+        val remoteProductIds: List<Long>? = null
     ) : Payload<ProductError>() {
         constructor(
             error: ProductError,
@@ -905,7 +906,7 @@ class WCProductStore @Inject constructor(
         } else {
             // remove the existing products for this site if this is the first page of results, otherwise
             // products deleted outside of the app will persist
-            if (payload.offset == 0) {
+            if (payload.offset == 0 || payload.remoteProductIds == null) {
                 ProductSqlUtils.deleteProductsForSite(payload.site)
             }
             val rowsAffected = ProductSqlUtils.insertOrUpdateProducts(payload.products)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -906,7 +906,7 @@ class WCProductStore @Inject constructor(
         } else {
             // remove the existing products for this site if this is the first page of results, otherwise
             // products deleted outside of the app will persist
-            if (payload.offset == 0 || payload.remoteProductIds == null) {
+            if (payload.offset == 0 && payload.remoteProductIds == null) {
                 ProductSqlUtils.deleteProductsForSite(payload.site)
             }
             val rowsAffected = ProductSqlUtils.insertOrUpdateProducts(payload.products)


### PR DESCRIPTION
While working on woocommerce/woocommerce-android#2630, I noticed a few issues when displaying a group of products. This PR attempts to fix those issues.

- The list of `groupedProductIds` should be `Long` since the `remoteProductId` is `Long` everywhere in the app. So modified `WCProductModel` to reflect this change in e2b7a4f.
- When fetching the product details for a list of `groupedProductIds`, I noticed that we delete the previously stored products from the local db before adding these products. This means in the woo app, the Products tab only displays the groupedProducts and we need to manually refresh the app to fetch the list of products again. So I have added logic to delete the locally stored products only if the `remoteProductIds` are null.

#### To test
- Verify that Fetching products, fetching a single product and updating grouped products works as expected.