### PR TITLE
Default to site settings value if currency code argument is empty

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
@@ -179,6 +179,9 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
 
             val formattedCurrencyDifferentCurrency = formatCurrencyForDisplay(1234.12, siteModel, "EUR", true)
             assertEquals("€1,234.12", formattedCurrencyDifferentCurrency)
+
+            val formattedCurrencyEmptyCodeUseSite = formatCurrencyForDisplay(1234.12, siteModel, "", true)
+            assertEquals("CA$1,234.12", formattedCurrencyUseSiteCurrency)
         }
 
         // -- Site using EUR

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -165,7 +165,7 @@ open class WooCommerceStore @Inject constructor(
         val siteSettings = getSiteSettings(site)
 
         // Resolve the currency code to a localized symbol
-        val resolvedCurrencyCode = currencyCode ?: siteSettings?.currencyCode
+        val resolvedCurrencyCode = currencyCode?.takeIf { it.isNotEmpty() } ?: siteSettings?.currencyCode
         val currencySymbol = resolvedCurrencyCode?.let {
             WCCurrencyUtils.getLocalizedCurrencySymbolForCode(it, LanguageUtils.getCurrentDeviceLanguage(appContext))
         } ?: ""


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-android/issues/2733. There are several parts of the WCAndroid app that will send an empty string for the `currencyCode` argument, but in `WooCommerceStore.formatCurrencyForDisplay()` we only check if it is `null`. Adding an additional check for empty so the currency code in `WCSettingsModel` will be used when no value is present. 

Also updated the `MockedStack_WCBaseStoreTest.testFormatCurrencyForDisplay()` test to verify this fix. 

### To Test
Run `MockedStack_WCBaseStoreTest.testFormatCurrencyForDisplay()` and verify it’s successful.