### PR TITLE
Added null check to groupedProductIds before parsing the json field

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -242,8 +242,10 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     fun getGroupedProductIds(): List<Long> {
         val groupedIds = ArrayList<Long>()
         try {
-            Gson().fromJson(groupedProductIds, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
-                jsonElement.asLong.let { groupedIds.add(it) }
+            if (groupedProductIds.isNotEmpty()) {
+                Gson().fromJson(groupedProductIds, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+                    jsonElement.asLong.let { groupedIds.add(it) }
+                }
             }
         } catch (e: JsonParseException) {
             AppLog.e(T.API, e)


### PR DESCRIPTION
@AmandaRiu noticed a crash when testing this PR to display/update grouped products. I wasn't able to reproduce the crash but this PR just adds a null check to the `groupedProductIds`, which was missed in previous implementations.