### PR TITLE
Pinpoint Android executor to the last JDK 8 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,8 @@ commands:
 
 jobs:
   Lint:
-    executor:
-      name: android/default
-      api-version: "27"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - checkout
       - android/restore-gradle-cache
@@ -61,9 +60,8 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Unit Tests:
-    executor:
-      name: android/default
-      api-version: "27"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - checkout
       - android/restore-gradle-cache
@@ -87,9 +85,8 @@ jobs:
         type: boolean
       device:
         type: string
-    executor:
-      name: android/default
-      api-version: "27"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - checkout
       - android/restore-gradle-cache:
@@ -138,9 +135,8 @@ jobs:
                 success_message: '${SLACK_SUCCESS_MESSAGE}'
                 webhook: '${SLACK_STATUS_WEBHOOK}'
   WooCommerce API Tests:
-    executor:
-      name: android/default
-      api-version: "27"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - checkout
       - android/restore-gradle-cache


### PR DESCRIPTION
Yesterday CircleCI Android docker images have been updated to JDK 11. This caused failures on some of our Android projects.
As a temporary workaround for the issue, this PR pinpoints the docker image we use to the last one which shipped JDK 8.
We should revert this PR as soon as we update our project to be compatible with JDK 11.

To Test: 
- Verify that the CI is green. 