### PR TITLE
Remove unnecessary uploadNext calls from uploadEncryptedLog method

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -154,10 +154,8 @@ class EncryptedLogStore @Inject constructor(
                 is LogUploaded -> handleSuccessfulUpload(encryptedLog)
                 is LogUploadFailed -> handleFailedUpload(encryptedLog, result.error)
             }
-            uploadNextWithDelay()
         } catch (e: UnsatisfiedLinkError) {
             handleFailedUpload(encryptedLog, UnsatisfiedLinkException)
-            uploadNext()
         }
     }
 


### PR DESCRIPTION
This PR fixes the compilation issue in `develop` which was created due to #1656 and #1673 being merged one after another and `git` not being able to detect the merge conflict. Neither of these upload next calls are necessary anymore since they are triggered from `handleSuccessfulUpload` and `handleFailedUpload`.