### PR TITLE
Woo/add grouped product fixes

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -372,7 +372,8 @@ class ProductRestClient(
                                 offset,
                                 loadedMore,
                                 canLoadMore,
-                                remoteProductIds
+                                remoteProductIds,
+                                excludedProductIds
                         )
                         dispatcher.dispatch(WCProductActionBuilder.newFetchedProductsAction(payload))
                     } else {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -323,7 +323,8 @@ class ProductRestClient(
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         searchQuery: String? = null,
         remoteProductIds: List<Long>? = null,
-        filterOptions: Map<ProductFilterOption, String>? = null
+        filterOptions: Map<ProductFilterOption, String>? = null,
+        excludedProductIds: List<Long>? = null
     ) {
         // orderby (string) Options: date, id, include, title and slug. Default is date.
         val orderBy = when (sortType) {
@@ -350,6 +351,10 @@ class ProductRestClient(
 
         filterOptions?.let { filters ->
             filters.map { params.put(it.key.toString(), it.value) }
+        }
+
+        excludedProductIds?.let { excludedIds ->
+            params.put("exclude", excludedIds.map { it }.joinToString())
         }
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
@@ -401,9 +406,10 @@ class ProductRestClient(
         searchQuery: String,
         pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         offset: Int = 0,
-        sorting: ProductSorting = DEFAULT_PRODUCT_SORTING
+        sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
+        excludedProductIds: List<Long>? = null
     ) {
-        fetchProducts(site, pageSize, offset, sorting, searchQuery)
+        fetchProducts(site, pageSize, offset, sorting, searchQuery, excludedProductIds = excludedProductIds)
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -99,7 +99,8 @@ object ProductSqlUtils {
     fun getProductsByFilterOptions(
         site: SiteModel,
         filterOptions: Map<ProductFilterOption, String>,
-        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING
+        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
+        excludedProductIds: List<Long>? = null
     ): List<WCProductModel> {
         val queryBuilder = WellSql.select(WCProductModel::class.java)
                 .where().beginGroup()
@@ -113,6 +114,10 @@ object ProductSqlUtils {
         }
         if (filterOptions.containsKey(ProductFilterOption.TYPE)) {
             queryBuilder.equals(WCProductModelTable.TYPE, filterOptions[ProductFilterOption.TYPE])
+        }
+
+        excludedProductIds?.let {
+            queryBuilder.isNotIn(WCProductModelTable.REMOTE_PRODUCT_ID, excludedProductIds)
         }
 
         val sortOrder = when (sortType) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -609,9 +609,10 @@ class WCProductStore @Inject constructor(
     fun getProductsByFilterOptions(
         site: SiteModel,
         filterOptions: Map<ProductFilterOption, String>,
-        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING
+        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
+        excludedProductIds: List<Long>? = null
     ): List<WCProductModel> =
-            ProductSqlUtils.getProductsByFilterOptions(site, filterOptions, sortType)
+            ProductSqlUtils.getProductsByFilterOptions(site, filterOptions, sortType, excludedProductIds)
 
     fun getProductsForSite(site: SiteModel, sortType: ProductSorting = DEFAULT_PRODUCT_SORTING) =
             ProductSqlUtils.getProductsForSite(site, sortType)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -279,7 +279,8 @@ class WCProductStore @Inject constructor(
         var offset: Int = 0,
         var loadedMore: Boolean = false,
         var canLoadMore: Boolean = false,
-        val remoteProductIds: List<Long>? = null
+        val remoteProductIds: List<Long>? = null,
+        val excludedProductIds: List<Long>? = null
     ) : Payload<ProductError>() {
         constructor(
             error: ProductError,
@@ -910,9 +911,10 @@ class WCProductStore @Inject constructor(
         if (payload.isError) {
             onProductChanged = OnProductChanged(0).also { it.error = payload.error }
         } else {
-            // remove the existing products for this site if this is the first page of results, otherwise
+            // remove the existing products for this site if this is the first page of results
+            // or if the remoteProductIds or excludedProductIds are null, otherwise
             // products deleted outside of the app will persist
-            if (payload.offset == 0 && payload.remoteProductIds == null) {
+            if (payload.offset == 0 && payload.remoteProductIds == null && payload.excludedProductIds == null) {
                 ProductSqlUtils.deleteProductsForSite(payload.site)
             }
             val rowsAffected = ProductSqlUtils.insertOrUpdateProducts(payload.products)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -74,7 +74,8 @@ class WCProductStore @Inject constructor(
         var offset: Int = 0,
         var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
         var remoteProductIds: List<Long>? = null,
-        var filterOptions: Map<ProductFilterOption, String>? = null
+        var filterOptions: Map<ProductFilterOption, String>? = null,
+        var excludedProductIds: List<Long>? = null
     ) : Payload<BaseNetworkError>()
 
     class SearchProductsPayload(
@@ -82,7 +83,8 @@ class WCProductStore @Inject constructor(
         var searchQuery: String,
         var pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         var offset: Int = 0,
-        var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING
+        var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
+        var excludedProductIds: List<Long>? = null
     ) : Payload<BaseNetworkError>()
 
     class FetchProductVariationsPayload(
@@ -768,7 +770,8 @@ class WCProductStore @Inject constructor(
             wcProductRestClient.fetchProducts(
                     site, pageSize, offset, sorting,
                     remoteProductIds = remoteProductIds,
-                    filterOptions = filterOptions
+                    filterOptions = filterOptions,
+                    excludedProductIds = excludedProductIds
                     )
         }
     }
@@ -779,7 +782,9 @@ class WCProductStore @Inject constructor(
             }
 
     private fun searchProducts(payload: SearchProductsPayload) {
-        with(payload) { wcProductRestClient.searchProducts(site, searchQuery, pageSize, offset, sorting) }
+        with(payload) { wcProductRestClient.searchProducts(
+                site, searchQuery, pageSize, offset, sorting, excludedProductIds
+        ) }
     }
 
     private fun fetchProductVariations(payload: FetchProductVariationsPayload) {


### PR DESCRIPTION
Adds support for woocommerce/woocommerce-android#2630 by adding the option to exclude `remoteProductIds` when fetching and searching for a product.

#### Changes
- Added `excludedProductIds` list when fetching products and searching for products from the request API.
- Added `excludedProductIds` list when fetching products and searching for products from the local db.
- Added logic to delete the products stored locally only if `excludedProductIds` is null. This prevents the excluded products from being deleted from the local db. (This was causing the excluded products to disappear from the Products tab in the Woo app).

#### Testing
- Smoke test fetching products and searching products to ensure that everything is working correctly.
- Run `ProductSqlUtilsTest`. 
