### PR TITLE
Feat/2707 add product

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddNewProductPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload
@@ -822,17 +822,17 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testAddNewProductSuccess() {
+    fun testAddProductSuccess() {
         interceptor.respondWith("wc-fetch-product-response-success.json")
 
         val testProduct = generateTestProduct()
-        productRestClient.createNewProduct(siteModel, testProduct)
+        productRestClient.addProduct(siteModel, testProduct)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
-        assertEquals(WCProductAction.ADDED_NEW_PRODUCT, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteAddNewProductPayload
+        assertEquals(WCProductAction.ADDED_PRODUCT, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteAddProductPayload
         with(payload) {
             assertNull(error)
             assertEquals(remoteProductId, product.remoteProductId)
@@ -842,16 +842,16 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testAddNewProductFailed() {
+    fun testAddProductFailed() {
         interceptor.respondWithError("wc-response-failure-invalid-param.json")
         val testProduct = generateTestProduct()
-        productRestClient.createNewProduct(siteModel, testProduct)
+        productRestClient.addProduct(siteModel, testProduct)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
-        assertEquals(WCProductAction.ADDED_NEW_PRODUCT, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteAddNewProductPayload
+        assertEquals(WCProductAction.ADDED_PRODUCT, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteAddProductPayload
         assertTrue(payload.isError)
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -930,7 +930,6 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         }
     }
 
-
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onProductCreated(event: OnProductCreated) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -48,7 +48,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.OnProductTagChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductUpdated
 import org.wordpress.android.fluxc.store.WCProductStore.OnVariationChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnVariationUpdated
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddNewProductPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload
@@ -81,8 +81,8 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         ADDED_PRODUCT_TAGS,
         FETCHED_SINGLE_VARIATION,
         UPDATED_VARIATION,
-        ADD_NEW_PRODUCT,
-        ADDED_NEW_PRODUCT
+        ADD_PRODUCT,
+        ADDED_PRODUCT
     }
 
     @Inject internal lateinit var productStore: WCProductStore
@@ -701,11 +701,11 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         val newProductImages = "[image1,image2]"
         productModel.images = newProductImages
 
-        nextEvent = TestEvent.ADDED_NEW_PRODUCT
+        nextEvent = TestEvent.ADDED_PRODUCT
         mCountDownLatch = CountDownLatch(1)
 
         mDispatcher.dispatch(
-                WCProductActionBuilder.newAddedNewProductAction(RemoteAddNewProductPayload(sSite, productModel))
+                WCProductActionBuilder.newAddedProductAction(RemoteAddProductPayload(sSite, productModel))
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
     }
@@ -940,8 +940,8 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         lastAddNewProductEvent = event
 
         when (event.causeOfChange) {
-            WCProductAction.ADD_NEW_PRODUCT -> {
-                assertEquals(TestEvent.ADDED_NEW_PRODUCT, nextEvent)
+            WCProductAction.ADD_PRODUCT -> {
+                assertEquals(TestEvent.ADDED_PRODUCT, nextEvent)
                 assertEquals(event.remoteProductId, productModel.remoteProductId)
                 mCountDownLatch.countDown()
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -387,6 +387,10 @@ class WooProductsFragment : Fragment() {
         update_variation.setOnClickListener {
             replaceFragment(WooUpdateVariationFragment.newInstance(selectedPos))
         }
+
+        add_new_product.setOnClickListener {
+            replaceFragment(WooUpdateProductFragment.newInstance(selectedPos, isAddNewProduct = true))
+        }
     }
 
     /**

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -41,7 +41,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductTaxS
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductVisibility
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCProductStore.AddNewProductPayload
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductCreated
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductPasswordChanged
@@ -248,8 +248,8 @@ class WooUpdateProductFragment : Fragment() {
                                 it.map { it.toProductTriplet().toJson() }.toString()
                     }
 
-                    val payload = AddNewProductPayload(site, selectedProductModel!!)
-                    dispatcher.dispatch(WCProductActionBuilder.newAddNewProductAction(payload))
+                    val payload = AddProductPayload(site, selectedProductModel!!)
+                    dispatcher.dispatch(WCProductActionBuilder.newAddProductAction(payload))
                 } else if (selectedProductModel?.remoteProductId != null) {
                     // update categories only if new categories has been selected
                     selectedCategories?.let {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -41,7 +41,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductTaxS
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductVisibility
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.AddNewProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductCreated
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductPasswordChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductUpdated
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload
@@ -63,6 +65,7 @@ class WooUpdateProductFragment : Fragment() {
     private var password: String? = null
     private var selectedCategories: List<ProductCategory>? = null
     private var selectedTags: List<ProductTag>? = null
+    private var isAddNewProduct: Boolean = false
 
     companion object {
         const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
@@ -77,11 +80,13 @@ class WooUpdateProductFragment : Fragment() {
         const val LIST_RESULT_CODE_CATEGORIES = 106
         const val LIST_RESULT_CODE_TAGS = 107
         const val LIST_RESULT_CODE_PRODUCT_TYPE = 108
+        const val IS_ADD_NEW_PRODUCT = "IS_ADD_NEW_PRODUCT"
 
-        fun newInstance(selectedSitePosition: Int): WooUpdateProductFragment {
+        fun newInstance(selectedSitePosition: Int, isAddNewProduct: Boolean = false): WooUpdateProductFragment {
             val fragment = WooUpdateProductFragment()
             val args = Bundle()
             args.putInt(ARG_SELECTED_SITE_POS, selectedSitePosition)
+            args.putBoolean(IS_ADD_NEW_PRODUCT, isAddNewProduct)
             fragment.arguments = args
             return fragment
         }
@@ -92,6 +97,7 @@ class WooUpdateProductFragment : Fragment() {
 
         arguments?.let {
             selectedSitePosition = it.getInt(ARG_SELECTED_SITE_POS, 0)
+            isAddNewProduct = it.getBoolean(IS_ADD_NEW_PRODUCT, false)
         }
     }
 
@@ -124,13 +130,19 @@ class WooUpdateProductFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        product_enter_product_id.setOnClickListener {
-            showSingleLineDialog(activity, "Enter the remoteProductId of product to fetch:") { editText ->
-                selectedRemoteProductId = editText.text.toString().toLongOrNull()
-                selectedRemoteProductId?.let { id ->
-                    updateSelectedProductId(id)
-                } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+        if (!isAddNewProduct) {
+            product_enter_product_id.setOnClickListener {
+                showSingleLineDialog(activity, "Enter the remoteProductId of product to fetch:") { editText ->
+                    selectedRemoteProductId = editText.text.toString().toLongOrNull()
+                    selectedRemoteProductId?.let { id ->
+                        updateSelectedProductId(id)
+                    } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+                }
             }
+        } else {
+            selectedProductModel = WCProductModel()
+            product_enter_product_id.visibility = View.GONE
+            product_entered_product_id.visibility = View.GONE
         }
 
         grouped_product_ids.isEnabled = false
@@ -162,7 +174,9 @@ class WooUpdateProductFragment : Fragment() {
         product_length.onTextChanged { selectedProductModel?.length = it }
         product_weight.onTextChanged { selectedProductModel?.weight = it }
         product_stock_quantity.onTextChanged {
-            if (it.isNotEmpty()) { selectedProductModel?.stockQuantity = it.toInt() }
+            if (it.isNotEmpty()) {
+                selectedProductModel?.stockQuantity = it.toInt()
+            }
         }
 
         product_sold_individually.setOnCheckedChangeListener { _, isChecked ->
@@ -223,13 +237,30 @@ class WooUpdateProductFragment : Fragment() {
 
         product_update.setOnClickListener {
             getWCSite()?.let { site ->
-                if (selectedProductModel?.remoteProductId != null) {
-                    // update categories only if new categories has been selected
-                    selectedCategories?.let { selectedProductModel?.categories =
-                            it.map { it.toProductTriplet().toJson() }.toString() }
+                if (isAddNewProduct) {
+                    selectedCategories?.let {
+                        selectedProductModel?.categories =
+                                it.map { it.toProductTriplet().toJson() }.toString()
+                    }
 
-                    selectedTags?.let { selectedProductModel?.tags =
-                            it.map { it.toProductTriplet().toJson() }.toString() }
+                    selectedTags?.let {
+                        selectedProductModel?.tags =
+                                it.map { it.toProductTriplet().toJson() }.toString()
+                    }
+
+                    val payload = AddNewProductPayload(site, selectedProductModel!!)
+                    dispatcher.dispatch(WCProductActionBuilder.newAddNewProductAction(payload))
+                } else if (selectedProductModel?.remoteProductId != null) {
+                    // update categories only if new categories has been selected
+                    selectedCategories?.let {
+                        selectedProductModel?.categories =
+                                it.map { it.toProductTriplet().toJson() }.toString()
+                    }
+
+                    selectedTags?.let {
+                        selectedProductModel?.tags =
+                                it.map { it.toProductTriplet().toJson() }.toString()
+                    }
 
                     val payload = UpdateProductPayload(site, selectedProductModel!!)
                     dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
@@ -270,12 +301,14 @@ class WooUpdateProductFragment : Fragment() {
                 val selectedProductCategories = selectedCategories ?: selectedProductModel?.getCategories()
                         ?.map { it.toProductCategory() }
 
-                replaceFragment(WooProductCategoriesFragment.newInstance(
-                        fragment = this,
-                        productCategories = categories,
-                        resultCode = LIST_RESULT_CODE_CATEGORIES,
-                        selectedProductCategories = selectedProductCategories?.toMutableList()
-                ))
+                replaceFragment(
+                        WooProductCategoriesFragment.newInstance(
+                                fragment = this,
+                                productCategories = categories,
+                                resultCode = LIST_RESULT_CODE_CATEGORIES,
+                                selectedProductCategories = selectedProductCategories?.toMutableList()
+                        )
+                )
             }
         }
 
@@ -287,12 +320,14 @@ class WooUpdateProductFragment : Fragment() {
                 val selectedProductTags = selectedTags ?: selectedProductModel?.getTags()
                         ?.map { it.toProductTag() }
 
-                replaceFragment(WooProductTagsFragment.newInstance(
-                        fragment = this,
-                        productTags = tags,
-                        resultCode = LIST_RESULT_CODE_TAGS,
-                        selectedProductTags = selectedProductTags?.toMutableList()
-                ))
+                replaceFragment(
+                        WooProductTagsFragment.newInstance(
+                                fragment = this,
+                                productTags = tags,
+                                resultCode = LIST_RESULT_CODE_TAGS,
+                                selectedProductTags = selectedProductTags?.toMutableList()
+                        )
+                )
             }
         }
 
@@ -448,8 +483,10 @@ class WooUpdateProductFragment : Fragment() {
             DateUtils.getCurrentDateString()
         } else dateString
         val calendar = DateUtils.getCalendarInstance(date)
-        DatePickerDialog(requireActivity(), listener, calendar.get(Calendar.YEAR),
-                calendar.get(Calendar.MONTH), calendar.get(Calendar.DATE))
+        DatePickerDialog(
+                requireActivity(), listener, calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH), calendar.get(Calendar.DATE)
+        )
                 .show()
     }
 
@@ -494,6 +531,16 @@ class WooUpdateProductFragment : Fragment() {
                 password = event.password
             }
         }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductCreated(event: OnProductCreated) {
+        if (event.isError) {
+            prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
+            return
+        }
+        prependToLog("Product created! ${event.rowsAffected} - new product id is: ${event.remoteProductId}")
     }
 
     @Parcelize

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -199,5 +199,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Update Variation"/>
+
+        <Button
+            android:id="@+id/add_new_product"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Add new product"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -18,7 +18,7 @@ import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddNewProductPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload
 import kotlin.test.assertEquals
@@ -213,7 +213,7 @@ class WCProductStoreTest {
     }
 
     @Test
-    fun `test AddNewProductAction triggered correctly`() {
+    fun `test AddProduct Action triggered correctly`() {
         // given
         val productModel = ProductTestUtils.generateSampleProduct(remoteId = 0).apply {
             name = "test new product"
@@ -223,8 +223,8 @@ class WCProductStoreTest {
 
         // when
         ProductSqlUtils.insertOrUpdateProduct(productModel)
-        val payload = RemoteAddNewProductPayload(site, productModel)
-        productStore.onAction(WCProductActionBuilder.newAddedNewProductAction(payload))
+        val payload = RemoteAddProductPayload(site, productModel)
+        productStore.onAction(WCProductActionBuilder.newAddedProductAction(payload))
 
         // then
         with(productStore.getProductByRemoteId(site, productModel.remoteProductId)) {

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCProductStore.AddNewProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddNewProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
+import org.wordpress.android.fluxc.store.WCProductStore.AddNewProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload;
@@ -18,6 +19,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayloa
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleVariationPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddNewProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
@@ -86,6 +88,8 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_TAGS,
     @Action(payloadType = AddProductTagsPayload.class)
     ADD_PRODUCT_TAGS,
+    @Action(payloadType = AddNewProductPayload.class)
+    ADD_NEW_PRODUCT,
 
 
     // Remote responses
@@ -128,5 +132,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteProductTagsPayload.class)
     FETCHED_PRODUCT_TAGS,
     @Action(payloadType = RemoteAddProductTagsResponsePayload.class)
-    ADDED_PRODUCT_TAGS
+    ADDED_PRODUCT_TAGS,
+    @Action(payloadType = RemoteAddNewProductPayload.class)
+    ADDED_NEW_PRODUCT
 }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.store.WCProductStore.AddNewProductPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload;
@@ -19,7 +19,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayloa
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleVariationPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddNewProductPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
@@ -88,8 +88,8 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_TAGS,
     @Action(payloadType = AddProductTagsPayload.class)
     ADD_PRODUCT_TAGS,
-    @Action(payloadType = AddNewProductPayload.class)
-    ADD_NEW_PRODUCT,
+    @Action(payloadType = AddProductPayload.class)
+    ADD_PRODUCT,
 
 
     // Remote responses
@@ -133,6 +133,6 @@ public enum WCProductAction implements IAction {
     FETCHED_PRODUCT_TAGS,
     @Action(payloadType = RemoteAddProductTagsResponsePayload.class)
     ADDED_PRODUCT_TAGS,
-    @Action(payloadType = RemoteAddNewProductPayload.class)
-    ADDED_NEW_PRODUCT
+    @Action(payloadType = RemoteAddProductPayload.class)
+    ADDED_PRODUCT
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -51,7 +51,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddNewProductPayload
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload
@@ -967,14 +967,14 @@ class ProductRestClient(
     }
 
     /**
-     * Makes a POST request to `/wp-json/wc/v3/products` to create a product
+     * Makes a POST request to `/wp-json/wc/v3/products` to add a product
      *
-     * Dispatches a [WCProductAction.ADDED_NEW_PRODUCT] action with the result
+     * Dispatches a [WCProductAction.ADDED_PRODUCT] action with the result
      *
      * @param [site] The site to fetch product reviews for
      * @param [newModel] the new product model
      */
-    fun createNewProduct(
+    fun addProduct(
         site: SiteModel,
         productModel: WCProductModel
     ) {
@@ -994,19 +994,19 @@ class ProductRestClient(
                             id = product.id?.toInt() ?: 0
                             localSiteId = site.id
                         }
-                        val payload = RemoteAddNewProductPayload(site, newModel)
-                        dispatcher.dispatch(WCProductActionBuilder.newAddedNewProductAction(payload))
+                        val payload = RemoteAddProductPayload(site, newModel)
+                        dispatcher.dispatch(WCProductActionBuilder.newAddedProductAction(payload))
                     }
                 },
                 errorListener = WPComErrorListener { networkError ->
                     // error
                     val productError = networkErrorToProductError(networkError)
-                    val payload = RemoteAddNewProductPayload(
+                    val payload = RemoteAddProductPayload(
                             productError,
                             site,
                             WCProductModel()
                     )
-                    dispatcher.dispatch(WCProductActionBuilder.newAddedNewProductAction(payload))
+                    dispatcher.dispatch(WCProductActionBuilder.newAddedProductAction(payload))
                 }
         )
         add(request)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -992,6 +992,7 @@ class ProductRestClient(
                     // success
                     response?.let { product ->
                         val newModel = product.asProductModel().apply {
+                            id = product.id?.toInt() ?: 0
                             localSiteId = site.id
                         }
                         val payload = RemoteAddNewProductPayload(site, newModel)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -6,7 +6,6 @@ import com.google.gson.JsonArray
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction
-import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
@@ -970,10 +969,10 @@ class ProductRestClient(
     /**
      * Makes a POST request to `/wp-json/wc/v3/products` to create a product
      *
-     * Dispatches a WCProductAction.ADD_NEW_PRODUCT action with the result
+     * Dispatches a [WCProductAction.ADDED_NEW_PRODUCT] action with the result
      *
      * @param [site] The site to fetch product reviews for
-     * @param [newProductModel] the new product model
+     * @param [newModel] the new product model
      */
     fun createNewProduct(
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -172,7 +172,7 @@ class WCProductStore @Inject constructor(
         val tags: List<String>
     ) : Payload<BaseNetworkError>()
 
-    class AddNewProductPayload(
+    class AddProductPayload(
         var site: SiteModel,
         val product: WCProductModel
     ) : Payload<BaseNetworkError>()
@@ -464,7 +464,7 @@ class WCProductStore @Inject constructor(
         ) : this(site, addedTags) { this.error = error }
     }
 
-    class RemoteAddNewProductPayload(
+    class RemoteAddProductPayload(
         var site: SiteModel,
         val product: WCProductModel
     ) : Payload<ProductError>() {
@@ -729,8 +729,8 @@ class WCProductStore @Inject constructor(
                 fetchProductTags(action.payload as FetchProductTagsPayload)
             WCProductAction.ADD_PRODUCT_TAGS ->
                 addProductTags(action.payload as AddProductTagsPayload)
-            WCProductAction.ADD_NEW_PRODUCT ->
-                createNewProduct(action.payload as AddNewProductPayload)
+            WCProductAction.ADD_PRODUCT ->
+                addProduct(action.payload as AddProductPayload)
 
             // remote responses
             WCProductAction.FETCHED_SINGLE_PRODUCT ->
@@ -773,8 +773,8 @@ class WCProductStore @Inject constructor(
                 handleFetchProductTagsCompleted(action.payload as RemoteProductTagsPayload)
             WCProductAction.ADDED_PRODUCT_TAGS ->
                 handleAddProductTags(action.payload as RemoteAddProductTagsResponsePayload)
-            WCProductAction.ADDED_NEW_PRODUCT ->
-                handleAddNewProduct(action.payload as RemoteAddNewProductPayload)
+            WCProductAction.ADDED_PRODUCT ->
+                handleAddNewProduct(action.payload as RemoteAddProductPayload)
         }
     }
 
@@ -878,9 +878,9 @@ class WCProductStore @Inject constructor(
         }
     }
 
-    private fun createNewProduct(payload: AddNewProductPayload) {
+    private fun addProduct(payload: AddProductPayload) {
         with(payload) {
-            wcProductRestClient.createNewProduct(site, product)
+            wcProductRestClient.addProduct(site, product)
         }
     }
 
@@ -1205,7 +1205,7 @@ class WCProductStore @Inject constructor(
         emitChange(onProductTagsChanged)
     }
 
-    private fun handleAddNewProduct(payload: RemoteAddNewProductPayload) {
+    private fun handleAddNewProduct(payload: RemoteAddProductPayload) {
         val onProductCreated: OnProductCreated
 
         if (payload.isError) {
@@ -1215,7 +1215,7 @@ class WCProductStore @Inject constructor(
             onProductCreated = OnProductCreated(rowsAffected, payload.product.remoteProductId)
         }
 
-        onProductCreated.causeOfChange = WCProductAction.ADDED_NEW_PRODUCT
+        onProductCreated.causeOfChange = WCProductAction.ADDED_PRODUCT
         emitChange(onProductCreated)
     }
 }

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -6,9 +6,9 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
-import io.restassured.builder.RequestSpecBuilder;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.oauth2;
@@ -364,5 +364,62 @@ public class APITesting_WCProduct {
                 "data.slug", equalTo("hot-sunglasses"),
                 "data.short_description", equalTo("Really hot sunglasses")
             );
+    }
+
+    @Test
+    public void canAddNewProduct() {
+        String path = "/wc/v3/products";
+        String method = "post";
+
+        // New Product
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("name", "New product");
+        jsonBody.put("type", "simple");
+        jsonBody.put("regular_price", "90");
+        jsonBody.put("description", "New product description that is long");
+        jsonBody.put("short_description", "New product short desc");
+
+        // for categories
+        JSONArray jsonCategories = new JSONArray();
+        JSONObject jsonCategory1 = new JSONObject();
+        jsonCategory1.put("id", 1);
+        JSONObject jsonCategory2 = new JSONObject();
+        jsonCategory2.put("id", 2);
+        jsonCategories.put(0, jsonCategory1);
+        jsonCategories.put(1, jsonCategory2);
+        jsonBody.put("categories", jsonCategories);
+
+        // for images
+        JSONArray jsonImagesArray = new JSONArray();
+        JSONObject jsonImage = new JSONObject();
+        jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content" + "/uploads/2020/02/hoodie-2.jpg");
+        jsonImagesArray.put(0, jsonImage);
+        jsonBody.put("images", jsonCategories);
+
+
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("body", jsonBody.toString());
+        jsonObj.put("path", path);
+        jsonObj.put("method", method);
+        jsonObj.put("json", "true");
+
+        given()
+                .spec(this.mRequestSpec)
+               .header("Content-Type", ContentType.JSON)
+               .queryParam("path", path)
+               .queryParam("_method", method)
+               .body(jsonObj.toString())
+       .when()
+               .post()
+       .then()
+               .statusCode(200)
+               .body("data.name", equalTo("New product"),
+                       "data.type", equalTo("simple"),
+                       "data.regular_price", equalTo("90"),
+                       "data.description", equalTo("New product description that is long"),
+                       "data.short_description", equalTo("New product short desc"),
+                       "data.categories", hasSize(2),
+                       "data.images", hasSize(1)
+                    );
     }
 }

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -392,7 +392,8 @@ public class APITesting_WCProduct {
         // for images
         JSONArray jsonImagesArray = new JSONArray();
         JSONObject jsonImage = new JSONObject();
-        jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content" + "/uploads/2020/02/hoodie-2.jpg");
+        jsonImage.put("src", "https://woomobileapitesting.mystagingwebsite.com/wp-content"
+                             + "/uploads/2020/02/hoodie-2.jpg");
         jsonImagesArray.put(0, jsonImage);
         jsonBody.put("images", jsonCategories);
 

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -367,7 +367,7 @@ public class APITesting_WCProduct {
     }
 
     @Test
-    public void canAddNewProduct() {
+    public void canAddProduct() {
         String path = "/wc/v3/products";
         String method = "post";
 


### PR DESCRIPTION
## RESOURCES
[The api definition](https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-product)

## CHANGES / DESCRIPTION

This PR will contain the work to allow a remote communication for the **creation of a new product**. This chunk of work meant:
- add new product actions in `WCProductAction`
- handle of new actions and new event `OnProductCreated` in `WCProductStore`
- add new product function in `ProductRestClient`
- added tests to the new request in **APITesting_WCProduct**, **ReleaseStack_WCProductTest** and **WCProductStoreTest.kt**

Following the `README`, I added the initial action in the `WCProductAction`; I called them:
- **ADD_NEW_PRODUCT** 
- **ADDED_NEW_PRODUCT**

In the `WCProductStore`, the `onAction` method will be listening to these actions that, upon trigger will behave as such:

**1)** `ADD_NEW_PRODUCT`
Will call the `createNewProduct` of the `ProductRestClient` that will make the remote connection and respond with success/error, mapping the response model accordingly. This done, it will trigger the correct action for completion, with the data;

**2)** `ADDED_NEW_PRODUCT`
Will call the `handleAddNewProduct`, from a previous completion of a request, and create the success/error scenarios accordingly, using the `OnProductCreated` for proper communication of the result.

This will get emitted to whoever is listening and trigger the UI updates (example app has this integration 👍 also, in screenshots bellow)

Let me know your thoughts on it 🙏 

## SCREENSHOTS
Product created
-
 <img width="315" src="https://user-images.githubusercontent.com/7058393/91237752-54c89000-e733-11ea-8c5b-29aa8fee387c.png"/>

New Product fetched
-
<img width="315" src="https://user-images.githubusercontent.com/7058393/91237755-55612680-e733-11ea-8357-79d4c54264d4.png"/><img width="315" src="https://user-images.githubusercontent.com/7058393/91237756-55612680-e733-11ea-9505-d8be39e1d45f.png"/>

Tests
-
<img width="415" alt="Screenshot 2020-08-25 at 23 56 17" src="https://user-images.githubusercontent.com/7058393/91237742-51350900-e733-11ea-98e3-519ad3d2ee62.png"> 


