### PR TITLE
Adding list of video and image supported types only

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
@@ -54,4 +54,26 @@ class MimeTypesTest {
                 )
         )
     }
+
+    @Test
+    fun `returns image and video only mime types as strings`() {
+        val allTypes = mimeTypes.getVideoAndImageTypesOnly()
+
+        assertThat(allTypes).isEqualTo(
+                arrayOf(
+                        "video/mp4",
+                        "video/quicktime",
+                        "video/x-ms-wmv",
+                        "video/avi",
+                        "video/mpeg",
+                        "video/mp2p",
+                        "video/ogg",
+                        "video/3gpp",
+                        "video/3gpp2",
+                        "image/jpeg",
+                        "image/png",
+                        "image/gif"
+                )
+        )
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
@@ -76,4 +76,36 @@ class MimeTypesTest {
                 )
         )
     }
+
+    @Test
+    fun `returns image only mime types as strings`() {
+        val allTypes = mimeTypes.getImageTypesOnly()
+
+        assertThat(allTypes).isEqualTo(
+                arrayOf(
+                        "image/jpeg",
+                        "image/png",
+                        "image/gif"
+                )
+        )
+    }
+
+    @Test
+    fun `returns video only mime types as strings`() {
+        val allTypes = mimeTypes.getVideoTypesOnly()
+
+        assertThat(allTypes).isEqualTo(
+                arrayOf(
+                        "video/mp4",
+                        "video/quicktime",
+                        "video/x-ms-wmv",
+                        "video/avi",
+                        "video/mpeg",
+                        "video/mp2p",
+                        "video/ogg",
+                        "video/3gpp",
+                        "video/3gpp2"
+                )
+        )
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -141,6 +141,12 @@ class MimeTypes {
                 .toTypedArray()
     }
 
+    fun getVideoAndImageTypesOnly(): Array<String> {
+        return (videoTypes.toStrings() + imageTypes.toStrings())
+                .toSet()
+                .toTypedArray()
+    }
+
     private fun List<MimeType>.toStrings(): List<String> {
         return this.map { mimeType -> mimeType.subtypes.map { print(mimeType.type, it) } }.flatten()
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -147,6 +147,18 @@ class MimeTypes {
                 .toTypedArray()
     }
 
+    fun getVideoTypesOnly(): Array<String> {
+        return (videoTypes.toStrings())
+                .toSet()
+                .toTypedArray()
+    }
+
+    fun getImageTypesOnly(): Array<String> {
+        return (imageTypes.toStrings())
+                .toSet()
+                .toTypedArray()
+    }
+
     private fun List<MimeType>.toStrings(): List<String> {
         return this.map { mimeType -> mimeType.subtypes.map { print(mimeType.type, it) } }.flatten()
     }


### PR DESCRIPTION
Title has it - this PR only adds utility methods in `MimeTypes` that provides a list of `image/* ` and `video/*` mime types (in conjunction or separately) to be used elsewhere for example as filters when picking media from the device.

#### To test
See the WPAndroid related PR https://github.com/wordpress-mobile/WordPress-Android/pull/12861