### PR TITLE
Migrated all v4 endpoints to v3 in API tests

### DIFF
--- a/tests/api/src/test/java/APITesting_WCGateway.java
+++ b/tests/api/src/test/java/APITesting_WCGateway.java
@@ -35,7 +35,7 @@ public class APITesting_WCGateway {
     public void canGetAllPaymentGateways() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/payment_gateways").
+            queryParam("path", "/wc/v3/payment_gateways").
         when().
             get().
         then().
@@ -49,7 +49,7 @@ public class APITesting_WCGateway {
     public void canGetSinglePaymentGateway() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/payment_gateways/stripe").
+            queryParam("path", "/wc/v3/payment_gateways/stripe").
         when().
             get().
         then().

--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -41,7 +41,7 @@ public class APITesting_WCOrder {
     public void canGetAllOrders() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&_fields=" + mOrderFields).
+            queryParam("path", "/wc/v3/orders&per_page=50&offset=0&_fields=" + mOrderFields).
         when().
             get().
         then().
@@ -53,7 +53,7 @@ public class APITesting_WCOrder {
     public void canGetOrderListSummary() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&status=failed&_fields=id,"
+            queryParam("path", "/wc/v3/orders&per_page=50&offset=0&status=failed&_fields=id,"
                 + "date_created_gmt,date_modified_gmt").
         when().
             get().
@@ -66,7 +66,7 @@ public class APITesting_WCOrder {
     public void canGetOrdersByID() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders&per_page=50&include=625,628,618").
+            queryParam("path", "/wc/v3/orders&per_page=50&include=625,628,618").
         when().
             get().
         then().
@@ -93,7 +93,7 @@ public class APITesting_WCOrder {
     public void canSearchOrders() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders&per_page=50&offset=0&status=failed&search=belt&_fields=" + mOrderFields).
+            queryParam("path", "/wc/v3/orders&per_page=50&offset=0&status=failed&search=belt&_fields=" + mOrderFields).
         when().
             get().
         then().
@@ -107,7 +107,7 @@ public class APITesting_WCOrder {
     public void canGetSingleOrder() {
         given().
             spec(this.mRequestSpec).
-                queryParam("path", "/wc/v4/orders/609&_fields=" + mOrderFields).
+                queryParam("path", "/wc/v3/orders/609&_fields=" + mOrderFields).
         when().
             get().
         then().
@@ -133,7 +133,7 @@ public class APITesting_WCOrder {
     public void canGetHasOrders() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders&per_page=1&offset=0&status=processing").
+            queryParam("path", "/wc/v3/orders&per_page=1&offset=0&status=processing").
         when().
             get().
         then().
@@ -145,7 +145,7 @@ public class APITesting_WCOrder {
 
     @Test
     public void canUpdateOrderStatus() {
-        String path = "/wc/v4/orders/607/";
+        String path = "/wc/v3/orders/607/";
         String method = "put";
 
         JSONObject jsonBody = new JSONObject();
@@ -200,7 +200,7 @@ public class APITesting_WCOrder {
     public void canGetOrderNotes() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders/591/notes").
+            queryParam("path", "/wc/v3/orders/591/notes").
         when().
             get().
         then().
@@ -212,7 +212,7 @@ public class APITesting_WCOrder {
 
     @Test
     public void canAddOrderNote() {
-        String path = "/wc/v4/orders/565/notes";
+        String path = "/wc/v3/orders/565/notes";
         String method = "post";
 
         JSONObject jsonBody = new JSONObject();

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -38,7 +38,7 @@ public class APITesting_WCProduct {
     public void canGetAllProducts() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/products&per_page=50&offset=0").
+            queryParam("path", "/wc/v3/products&per_page=50&offset=0").
         when().
             get().
         then().
@@ -50,7 +50,7 @@ public class APITesting_WCProduct {
     public void canGetSingleProduct() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/products/12").
+            queryParam("path", "/wc/v3/products/12").
         when().
             get().
         then().
@@ -70,7 +70,7 @@ public class APITesting_WCProduct {
     public void canGetProductVariations() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/products/12/variations").
+            queryParam("path", "/wc/v3/products/12/variations").
         when().
             get().
         then().
@@ -84,7 +84,7 @@ public class APITesting_WCProduct {
     public void canGetProductSkuAvailability() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/products/&_fields=sku&sku=woo-belt").
+            queryParam("path", "/wc/v3/products/&_fields=sku&sku=woo-belt").
         when().
             get().
         then().
@@ -97,7 +97,7 @@ public class APITesting_WCProduct {
     public void canGetProductShippingClasses() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/products/shipping_classes").
+            queryParam("path", "/wc/v3/products/shipping_classes").
         when().
             get().
         then().
@@ -111,7 +111,7 @@ public class APITesting_WCProduct {
     public void canGetProductShippingClassbyID() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/products/shipping_classes/35").
+            queryParam("path", "/wc/v3/products/shipping_classes/35").
         when().
             get().
         then().
@@ -123,7 +123,7 @@ public class APITesting_WCProduct {
     public void canGetProductReviews() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/products/reviews").
+            queryParam("path", "/wc/v3/products/reviews").
         when().
             get().
         then().
@@ -137,7 +137,7 @@ public class APITesting_WCProduct {
     public void canGetSingleProductReview() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/products/reviews/1088").
+            queryParam("path", "/wc/v3/products/reviews/1088").
         when().
             get().
         then().
@@ -203,7 +203,7 @@ public class APITesting_WCProduct {
 
     @Test
     public void canUpdateProductImages() {
-        String path = "/wc/v4/products/13";
+        String path = "/wc/v3/products/13";
         String method = "put";
 
         JSONObject jsonBody = new JSONObject();
@@ -306,7 +306,7 @@ public class APITesting_WCProduct {
 
     @Test
     public void canUpdateProduct() {
-        String path = "/wc/v4/products/19";
+        String path = "/wc/v3/products/19";
         String method = "put";
 
         JSONObject jsonBody = new JSONObject();

--- a/tests/api/src/test/java/APITesting_WCRefund.java
+++ b/tests/api/src/test/java/APITesting_WCRefund.java
@@ -37,7 +37,7 @@ public class APITesting_WCRefund {
     public void canGetAllRefunds() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders/161/refunds").
+            queryParam("path", "/wc/v3/orders/161/refunds").
         when().
             get().
         then().
@@ -51,7 +51,7 @@ public class APITesting_WCRefund {
     public void canGetSingleRefund() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/orders/161/refunds/638").
+            queryParam("path", "/wc/v3/orders/161/refunds/638").
         when().
             get().
         then().

--- a/tests/api/src/test/java/APITesting_WCSettings.java
+++ b/tests/api/src/test/java/APITesting_WCSettings.java
@@ -35,7 +35,7 @@ public class APITesting_WCSettings {
     public void canGetGeneralSettings() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/settings/general").
+            queryParam("path", "/wc/v3/settings/general").
         when().
             get().
         then().
@@ -50,7 +50,7 @@ public class APITesting_WCSettings {
     public void canGetProductSettings() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/settings/products").
+            queryParam("path", "/wc/v3/settings/products").
         when().
             get().
         then().

--- a/tests/api/src/test/java/APITesting_WCTax.java
+++ b/tests/api/src/test/java/APITesting_WCTax.java
@@ -36,7 +36,7 @@ public class APITesting_WCTax {
     public void canGetTaxClasses() {
         given().
             spec(this.mRequestSpec).
-            queryParam("path", "/wc/v4/taxes/classes").
+            queryParam("path", "/wc/v3/taxes/classes").
         when().
             get().
         then().


### PR DESCRIPTION
There are some WooCommerce API tests that are failing since they are pointing to `v4` endpoint, which is no longer used. This PR changes all the API test endpoints to use `v3` instead of `v4`.

#### To test
To run the tests locally, you need to set the `API_TEST_OAUTH_KEY` and `API_TEST_SITE_URL` env variables and then run the tests using `./gradlew :tests:api:test` Values for the env variables can be found in `ss Mobile API Test key`.