### PR TITLE
Add support for JDK 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,9 @@ commands:
 
 jobs:
   Lint:
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "27"
     steps:
       - checkout
       - android/restore-gradle-cache
@@ -60,8 +61,9 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Unit Tests:
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "27"
     steps:
       - checkout
       - android/restore-gradle-cache
@@ -85,8 +87,9 @@ jobs:
         type: boolean
       device:
         type: string
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "27"
     steps:
       - checkout
       - android/restore-gradle-cache:
@@ -135,8 +138,9 @@ jobs:
                 success_message: '${SLACK_SUCCESS_MESSAGE}'
                 webhook: '${SLACK_STATUS_WEBHOOK}'
   WooCommerce API Tests:
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "27"
     steps:
       - checkout
       - android/restore-gradle-cache

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -123,7 +123,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation 'org.robolectric:robolectric:3.6.1'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
     testImplementation 'org.assertj:assertj-core:3.11.1'


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1672

CircleCI Android docker images were updated to JDK 11 on August 17. Since the project was failing we decided to pinpoint a docker image which was still using JDK8 as a temporary workaround. This PR fixes the root cause of the failures on JDK11 and reverts this temporary workaround.

I updated Robolectric to v4.3.1 even though v4.4 is available. There is an issue in v4.4 -> the jetifier fails during the build. There are some workarounds available but I think it's better to stay on 4.3.1 until the issue is fixed in the next release.

To test
- CircleCI pass
- run `./gradlew cAT` (`testAuthenticatedCallToSelfSignedSslSite` is failing for me. However, since it's failing even on JDK8 I assume it's not related to these changes and it's probably an issue with my setup)