### PR TITLE
Make sure methods with "get" prefix do not collide with field names

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -87,13 +87,13 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         with(payload) {
             assertNull(error)
             assertEquals(remoteProductId, product.remoteProductId)
-            assertEquals(product.getCategoriesList().size, 2)
-            assertEquals(product.getTagsList().size, 2)
-            assertEquals(product.getImagesList().size, 2)
+            assertEquals(product.getCategoryList().size, 2)
+            assertEquals(product.getTagList().size, 2)
+            assertEquals(product.getImageList().size, 2)
             assertNotNull(product.getFirstImageUrl())
-            assertEquals(product.getAttributesList().size, 2)
-            assertEquals(product.getAttributesList().get(0).options.size, 3)
-            assertEquals(product.getAttributesList().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
+            assertEquals(product.getAttributeList().size, 2)
+            assertEquals(product.getAttributeList().get(0).options.size, 3)
+            assertEquals(product.getAttributeList().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
             assertEquals(product.getNumVariations(), 2)
         }
 
@@ -105,13 +105,13 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertNotNull(productFromDb)
         productFromDb?.let { product ->
             assertEquals(product.remoteProductId, remoteProductId)
-            assertEquals(product.getCategoriesList().size, 2)
-            assertEquals(product.getTagsList().size, 2)
-            assertEquals(product.getImagesList().size, 2)
+            assertEquals(product.getCategoryList().size, 2)
+            assertEquals(product.getTagList().size, 2)
+            assertEquals(product.getImageList().size, 2)
             assertNotNull(product.getFirstImageUrl())
-            assertEquals(product.getAttributesList().size, 2)
-            assertEquals(product.getAttributesList().get(0).options.size, 3)
-            assertEquals(product.getAttributesList().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
+            assertEquals(product.getAttributeList().size, 2)
+            assertEquals(product.getAttributeList().get(0).options.size, 3)
+            assertEquals(product.getAttributeList().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
             assertEquals(product.getNumVariations(), 2)
         }
     }
@@ -582,7 +582,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         with(payload) {
             assertNull(error)
             assertEquals(remoteProductId, product.remoteProductId)
-            assertEquals(product.getImagesList().size, 2)
+            assertEquals(product.getImageList().size, 2)
         }
     }
 
@@ -627,8 +627,8 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(updatedProduct.name, product.name)
             assertEquals(updatedProduct.sku, product.sku)
             assertEquals(updatedProduct.virtual, product.virtual)
-            assertEquals(updatedProduct.getImagesList().size, 2)
-            assertEquals(updatedProduct.getGroupedProductIdsList().size, 2)
+            assertEquals(updatedProduct.getImageList().size, 2)
+            assertEquals(updatedProduct.getGroupedProductIdList().size, 2)
             assertEquals(updatedProduct.type, product.type)
         }
     }
@@ -664,7 +664,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         // make sure two images are attached to the product
         val productBefore = ProductSqlUtils.getProductByRemoteId(siteModel, remoteProductId)
         assertNotNull(productBefore)
-        assertEquals(productBefore!!.getImagesList().size, 2)
+        assertEquals(productBefore!!.getImageList().size, 2)
 
         // remove one of the images
         val didDelete = ProductSqlUtils.deleteProductImage(siteModel, remoteProductId, 1)
@@ -673,7 +673,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         // now make sure only one image is attached to the product
         val productAfter = ProductSqlUtils.getProductByRemoteId(siteModel, remoteProductId)
         assertNotNull(productAfter)
-        assertEquals(productAfter!!.getImagesList().size, 1)
+        assertEquals(productAfter!!.getImageList().size, 1)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -87,13 +87,13 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         with(payload) {
             assertNull(error)
             assertEquals(remoteProductId, product.remoteProductId)
-            assertEquals(product.getCategories().size, 2)
-            assertEquals(product.getTags().size, 2)
-            assertEquals(product.getImages().size, 2)
+            assertEquals(product.getCategoriesList().size, 2)
+            assertEquals(product.getTagsList().size, 2)
+            assertEquals(product.getImagesList().size, 2)
             assertNotNull(product.getFirstImageUrl())
-            assertEquals(product.getAttributes().size, 2)
-            assertEquals(product.getAttributes().get(0).options.size, 3)
-            assertEquals(product.getAttributes().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
+            assertEquals(product.getAttributesList().size, 2)
+            assertEquals(product.getAttributesList().get(0).options.size, 3)
+            assertEquals(product.getAttributesList().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
             assertEquals(product.getNumVariations(), 2)
         }
 
@@ -105,13 +105,13 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertNotNull(productFromDb)
         productFromDb?.let { product ->
             assertEquals(product.remoteProductId, remoteProductId)
-            assertEquals(product.getCategories().size, 2)
-            assertEquals(product.getTags().size, 2)
-            assertEquals(product.getImages().size, 2)
+            assertEquals(product.getCategoriesList().size, 2)
+            assertEquals(product.getTagsList().size, 2)
+            assertEquals(product.getImagesList().size, 2)
             assertNotNull(product.getFirstImageUrl())
-            assertEquals(product.getAttributes().size, 2)
-            assertEquals(product.getAttributes().get(0).options.size, 3)
-            assertEquals(product.getAttributes().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
+            assertEquals(product.getAttributesList().size, 2)
+            assertEquals(product.getAttributesList().get(0).options.size, 3)
+            assertEquals(product.getAttributesList().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
             assertEquals(product.getNumVariations(), 2)
         }
     }
@@ -582,7 +582,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         with(payload) {
             assertNull(error)
             assertEquals(remoteProductId, product.remoteProductId)
-            assertEquals(product.getImages().size, 2)
+            assertEquals(product.getImagesList().size, 2)
         }
     }
 
@@ -627,8 +627,8 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(updatedProduct.name, product.name)
             assertEquals(updatedProduct.sku, product.sku)
             assertEquals(updatedProduct.virtual, product.virtual)
-            assertEquals(updatedProduct.getImages().size, 2)
-            assertEquals(updatedProduct.getGroupedProductIds().size, 2)
+            assertEquals(updatedProduct.getImagesList().size, 2)
+            assertEquals(updatedProduct.getGroupedProductIdsList().size, 2)
             assertEquals(updatedProduct.type, product.type)
         }
     }
@@ -664,7 +664,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         // make sure two images are attached to the product
         val productBefore = ProductSqlUtils.getProductByRemoteId(siteModel, remoteProductId)
         assertNotNull(productBefore)
-        assertEquals(productBefore!!.getImages().size, 2)
+        assertEquals(productBefore!!.getImagesList().size, 2)
 
         // remove one of the images
         val didDelete = ProductSqlUtils.deleteProductImage(siteModel, remoteProductId, 1)
@@ -673,7 +673,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         // now make sure only one image is attached to the product
         val productAfter = ProductSqlUtils.getProductByRemoteId(siteModel, remoteProductId)
         assertNotNull(productAfter)
-        assertEquals(productAfter!!.getImages().size, 1)
+        assertEquals(productAfter!!.getImagesList().size, 1)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -433,7 +433,7 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
             assertEquals("2019-07-01", startInterval)
             assertEquals("2019-07-07", endInterval)
 
-            val total = getTotal()
+            val total = parseTotal()
             assertNotNull(total)
             assertEquals(11, total?.ordersCount)
             assertEquals(301.99, total?.totalSales)
@@ -464,7 +464,7 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
             assertEquals(StatsGranularity.DAYS.toString(), interval)
 
             val intervals = getIntervalList()
-            val total = getTotal()
+            val total = parseTotal()
             assertEquals(0, intervals.size)
             assertNull(total)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -533,7 +533,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         val updatedProduct = productStore.getProductByRemoteId(sSite, productModel.remoteProductId)
         assertNotNull(updatedProduct)
 
-        val updatedImageList = updatedProduct!!.getImagesList()
+        val updatedImageList = updatedProduct!!.getImageList()
         assertNotNull(updatedImageList)
         assertEquals(updatedImageList.size, 1)
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -533,7 +533,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         val updatedProduct = productStore.getProductByRemoteId(sSite, productModel.remoteProductId)
         assertNotNull(updatedProduct)
 
-        val updatedImageList = updatedProduct!!.getImages()
+        val updatedImageList = updatedProduct!!.getImagesList()
         assertNotNull(updatedImageList)
         assertEquals(updatedImageList.size, 1)
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -166,7 +166,7 @@ class WooUpdateProductFragment : Fragment() {
                 editText.text.toString().toLongOrNull()?.let { id ->
 
                     val storedGroupedProductIds =
-                            selectedProductModel?.getGroupedProductIds()?.toMutableList() ?: mutableListOf()
+                            selectedProductModel?.getGroupedProductIdsList()?.toMutableList() ?: mutableListOf()
                     storedGroupedProductIds.add(id)
                     selectedProductModel?.groupedProductIds = storedGroupedProductIds.joinToString(
                             separator = ",",
@@ -305,7 +305,7 @@ class WooUpdateProductFragment : Fragment() {
                 val categories = wcProductStore.getProductCategoriesForSite(it)
                         .map { ProductCategory(it.remoteCategoryId, it.name, it.slug) }
 
-                val selectedProductCategories = selectedCategories ?: selectedProductModel?.getCategories()
+                val selectedProductCategories = selectedCategories ?: selectedProductModel?.getCategoriesList()
                         ?.map { it.toProductCategory() }
 
                 replaceFragment(
@@ -324,7 +324,7 @@ class WooUpdateProductFragment : Fragment() {
                 val tags = wcProductStore.getTagsForSite(it)
                         .map { ProductTag(it.remoteTagId, it.name, it.slug) }
 
-                val selectedProductTags = selectedTags ?: selectedProductModel?.getTags()
+                val selectedProductTags = selectedTags ?: selectedProductModel?.getTagsList()
                         ?.map { it.toProductTag() }
 
                 replaceFragment(

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -166,7 +166,7 @@ class WooUpdateProductFragment : Fragment() {
                 editText.text.toString().toLongOrNull()?.let { id ->
 
                     val storedGroupedProductIds =
-                            selectedProductModel?.getGroupedProductIdsList()?.toMutableList() ?: mutableListOf()
+                            selectedProductModel?.getGroupedProductIdList()?.toMutableList() ?: mutableListOf()
                     storedGroupedProductIds.add(id)
                     selectedProductModel?.groupedProductIds = storedGroupedProductIds.joinToString(
                             separator = ",",
@@ -305,7 +305,7 @@ class WooUpdateProductFragment : Fragment() {
                 val categories = wcProductStore.getProductCategoriesForSite(it)
                         .map { ProductCategory(it.remoteCategoryId, it.name, it.slug) }
 
-                val selectedProductCategories = selectedCategories ?: selectedProductModel?.getCategoriesList()
+                val selectedProductCategories = selectedCategories ?: selectedProductModel?.getCategoryList()
                         ?.map { it.toProductCategory() }
 
                 replaceFragment(
@@ -324,7 +324,7 @@ class WooUpdateProductFragment : Fragment() {
                 val tags = wcProductStore.getTagsForSite(it)
                         .map { ProductTag(it.remoteTagId, it.name, it.slug) }
 
-                val selectedProductTags = selectedTags ?: selectedProductModel?.getTagsList()
+                val selectedProductTags = selectedTags ?: selectedProductModel?.getTagList()
                         ?.map { it.toProductTag() }
 
                 replaceFragment(

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -177,7 +177,7 @@ class WooRevenueStatsFragment : Fragment() {
                         event.startDate!!,
                         event.endDate!!)
                 wcRevenueStatsModel?.let {
-                    val revenueSum = it.getTotal()?.totalSales
+                    val revenueSum = it.parseTotal()?.totalSales
                     prependToLog("Fetched stats with total " + revenueSum + " for granularity " +
                             event.granularity.toString().toLowerCase() + " from " + site.name +
                             " between " + event.startDate + " and " + event.endDate)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
@@ -97,7 +97,7 @@ class WCShippingLabelSqlUtilsTest {
         // Get shipping label list for site and order and verify
         val savedShippingLabelListExists = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
         assertEquals(shippingLabels.size, savedShippingLabelListExists.size)
-        assertEquals(shippingLabels[0].getProductNamesList(), savedShippingLabelListExists[0].getProductNamesList())
+        assertEquals(shippingLabels[0].getProductNameList(), savedShippingLabelListExists[0].getProductNameList())
 
         // Get shipping label list for a site that does not exist
         val nonExistingSite = SiteModel().apply { id = 400 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
@@ -97,7 +97,7 @@ class WCShippingLabelSqlUtilsTest {
         // Get shipping label list for site and order and verify
         val savedShippingLabelListExists = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
         assertEquals(shippingLabels.size, savedShippingLabelListExists.size)
-        assertEquals(shippingLabels[0].getProductNames(), savedShippingLabelListExists[0].getProductNames())
+        assertEquals(shippingLabels[0].getProductNamesList(), savedShippingLabelListExists[0].getProductNamesList())
 
         // Get shipping label list for a site that does not exist
         val nonExistingSite = SiteModel().apply { id = 400 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -133,7 +133,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     /**
      * Parses the images json array into a list of product images
      */
-    fun getImages(): ArrayList<WCProductImageModel> {
+    fun getImagesList(): ArrayList<WCProductImageModel> {
         val imageList = ArrayList<WCProductImageModel>()
         if (images.isNotEmpty()) {
             try {
@@ -175,13 +175,13 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      */
     fun getImageUrls(): List<String> {
         val imageUrls = ArrayList<String>()
-        getImages().forEach {
+        getImagesList().forEach {
             imageUrls.add(it.src)
         }
         return imageUrls
     }
 
-    fun getAttributes(): List<ProductAttribute> {
+    fun getAttributesList(): List<ProductAttribute> {
         fun getAttributeOptions(jsonArray: JsonArray?): List<String> {
             val options = ArrayList<String>()
             try {
@@ -239,7 +239,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         }
     }
 
-    fun getGroupedProductIds(): List<Long> {
+    fun getGroupedProductIdsList(): List<Long> {
         val groupedIds = ArrayList<Long>()
         try {
             if (groupedProductIds.isNotEmpty()) {
@@ -253,13 +253,13 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return groupedIds
     }
 
-    fun getCategories() = getTriplets(categories)
+    fun getCategoriesList() = getTriplets(categories)
 
-    fun getCommaSeparatedCategoryNames() = getCommaSeparatedTripletNames(getCategories())
+    fun getCommaSeparatedCategoryNames() = getCommaSeparatedTripletNames(getCategoriesList())
 
-    fun getTags() = getTriplets(tags)
+    fun getTagsList() = getTriplets(tags)
 
-    fun getCommaSeparatedTagNames() = getCommaSeparatedTripletNames(getTags())
+    fun getCommaSeparatedTagNames() = getCommaSeparatedTripletNames(getTagsList())
 
     private fun getCommaSeparatedTripletNames(triplets: List<ProductTriplet>): String {
         if (triplets.isEmpty()) return ""
@@ -301,8 +301,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * lists contain the same images in the same order
      */
     fun hasSameImages(updatedProduct: WCProductModel): Boolean {
-        val updatedImages = updatedProduct.getImages()
-        val thisImages = getImages()
+        val updatedImages = updatedProduct.getImagesList()
+        val thisImages = getImagesList()
         if (thisImages.size != updatedImages.size) {
             return false
         }
@@ -319,8 +319,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * lists contain the same categories in the same order
      */
     fun hasSameCategories(updatedProduct: WCProductModel): Boolean {
-        val updatedCategories = updatedProduct.getCategories()
-        val storedCategories = getCategories()
+        val updatedCategories = updatedProduct.getCategoriesList()
+        val storedCategories = getCategoriesList()
         if (storedCategories.size != updatedCategories.size) {
             return false
         }
@@ -337,8 +337,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * lists contain the same tags in the same order
      */
     fun hasSameTags(updatedProduct: WCProductModel): Boolean {
-        val updatedTags = updatedProduct.getTags()
-        val storedTags = getTags()
+        val updatedTags = updatedProduct.getTagsList()
+        val storedTags = getTagsList()
         if (storedTags.size != updatedTags.size) {
             return false
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -133,7 +133,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     /**
      * Parses the images json array into a list of product images
      */
-    fun getImagesList(): ArrayList<WCProductImageModel> {
+    fun getImageList(): ArrayList<WCProductImageModel> {
         val imageList = ArrayList<WCProductImageModel>()
         if (images.isNotEmpty()) {
             try {
@@ -175,13 +175,13 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      */
     fun getImageUrls(): List<String> {
         val imageUrls = ArrayList<String>()
-        getImagesList().forEach {
+        getImageList().forEach {
             imageUrls.add(it.src)
         }
         return imageUrls
     }
 
-    fun getAttributesList(): List<ProductAttribute> {
+    fun getAttributeList(): List<ProductAttribute> {
         fun getAttributeOptions(jsonArray: JsonArray?): List<String> {
             val options = ArrayList<String>()
             try {
@@ -239,7 +239,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         }
     }
 
-    fun getGroupedProductIdsList(): List<Long> {
+    fun getGroupedProductIdList(): List<Long> {
         val groupedIds = ArrayList<Long>()
         try {
             if (groupedProductIds.isNotEmpty()) {
@@ -253,13 +253,13 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return groupedIds
     }
 
-    fun getCategoriesList() = getTriplets(categories)
+    fun getCategoryList() = getTriplets(categories)
 
-    fun getCommaSeparatedCategoryNames() = getCommaSeparatedTripletNames(getCategoriesList())
+    fun getCommaSeparatedCategoryNames() = getCommaSeparatedTripletNames(getCategoryList())
 
-    fun getTagsList() = getTriplets(tags)
+    fun getTagList() = getTriplets(tags)
 
-    fun getCommaSeparatedTagNames() = getCommaSeparatedTripletNames(getTagsList())
+    fun getCommaSeparatedTagNames() = getCommaSeparatedTripletNames(getTagList())
 
     private fun getCommaSeparatedTripletNames(triplets: List<ProductTriplet>): String {
         if (triplets.isEmpty()) return ""
@@ -301,8 +301,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * lists contain the same images in the same order
      */
     fun hasSameImages(updatedProduct: WCProductModel): Boolean {
-        val updatedImages = updatedProduct.getImagesList()
-        val thisImages = getImagesList()
+        val updatedImages = updatedProduct.getImageList()
+        val thisImages = getImageList()
         if (thisImages.size != updatedImages.size) {
             return false
         }
@@ -319,8 +319,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * lists contain the same categories in the same order
      */
     fun hasSameCategories(updatedProduct: WCProductModel): Boolean {
-        val updatedCategories = updatedProduct.getCategoriesList()
-        val storedCategories = getCategoriesList()
+        val updatedCategories = updatedProduct.getCategoryList()
+        val storedCategories = getCategoryList()
         if (storedCategories.size != updatedCategories.size) {
             return false
         }
@@ -337,8 +337,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * lists contain the same tags in the same order
      */
     fun hasSameTags(updatedProduct: WCProductModel): Boolean {
-        val updatedTags = updatedProduct.getTagsList()
-        val storedTags = getTagsList()
+        val updatedTags = updatedProduct.getTagList()
+        val storedTags = getTagList()
         if (storedTags.size != updatedTags.size) {
             return false
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -92,7 +92,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     /**
      * Parses the images json array into a list of product images
      */
-    fun getImage(): WCProductImageModel? {
+    fun getImageModel(): WCProductImageModel? {
         if (image.isNotBlank()) {
             try {
                 with(Gson().fromJson(image, JsonElement::class.java).asJsonObject) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -66,7 +66,7 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
      * To address this issue, we check if the [total] param is a JsonArray
      * and return a null response, if that's the case.
      */
-    fun getTotal(): Total? {
+    fun parseTotal(): Total? {
         val jsonElement = JsonParser().parse(total)
         return if (jsonElement.isJsonArray) {
             if (jsonElement.asJsonArray.size() > 0) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -80,7 +80,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
      * For instance: "[Belt, Cap, Herman Miller Chair Embody]" would be split into a list
      * ["Belt", "Cap", "Herman Miller Chair Embody"]
      */
-    fun getProductNamesList(): List<String> {
+    fun getProductNameList(): List<String> {
         return productNames
                 .trim() // remove extra spaces between commas
                 .removePrefix("[") // remove the String prefix

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -60,7 +60,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     /**
      * Returns the store details such as currency, country and dimensions wrapped in [StoreOptions]
      */
-    fun getStoreOptions(): StoreOptions? {
+    fun getStoreOptionsModel(): StoreOptions? {
         val responseType = object : TypeToken<StoreOptions>() {}.type
         return gson.fromJson(storeOptions, responseType) as? StoreOptions
     }
@@ -80,7 +80,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
      * For instance: "[Belt, Cap, Herman Miller Chair Embody]" would be split into a list
      * ["Belt", "Cap", "Herman Miller Chair Embody"]
      */
-    fun getProductNames(): List<String> {
+    fun getProductNamesList(): List<String> {
         return productNames
                 .trim() // remove extra spaces between commas
                 .removePrefix("[") // remove the String prefix
@@ -92,7 +92,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
      * Returns data related to the refund of a shipping label.
      * Will only be available in the API if a refund has been initiated
      */
-    fun getRefund(): WCShippingLabelRefundModel? {
+    fun getRefundModel(): WCShippingLabelRefundModel? {
         val responseType = object : TypeToken<WCShippingLabelRefundModel>() {}.type
         return gson.fromJson(refund, responseType) as? WCShippingLabelRefundModel
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1127,7 +1127,7 @@ class ProductRestClient(
             body["short_description"] = updatedProductModel.shortDescription
         }
         if (!storedWCProductModel.hasSameImages(updatedProductModel)) {
-            val updatedImages = updatedProductModel.getImagesList()
+            val updatedImages = updatedProductModel.getImageList()
             body["images"] = JsonArray().also {
                 for (image in updatedImages) {
                     it.add(image.toJson())
@@ -1147,7 +1147,7 @@ class ProductRestClient(
             body["menu_order"] = updatedProductModel.menuOrder
         }
         if (!storedWCProductModel.hasSameCategories(updatedProductModel)) {
-            val updatedCategories = updatedProductModel.getCategoriesList()
+            val updatedCategories = updatedProductModel.getCategoryList()
             body["categories"] = JsonArray().also {
                 for (category in updatedCategories) {
                     it.add(category.toJson())
@@ -1155,7 +1155,7 @@ class ProductRestClient(
             }
         }
         if (!storedWCProductModel.hasSameTags(updatedProductModel)) {
-            val updatedTags = updatedProductModel.getTagsList()
+            val updatedTags = updatedProductModel.getTagList()
             body["tags"] = JsonArray().also {
                 for (tag in updatedTags) {
                     it.add(tag.toJson())
@@ -1163,7 +1163,7 @@ class ProductRestClient(
             }
         }
         if (storedWCProductModel.groupedProductIds != updatedProductModel.groupedProductIds) {
-            body["grouped_products"] = updatedProductModel.getGroupedProductIdsList()
+            body["grouped_products"] = updatedProductModel.getGroupedProductIdList()
         }
         return body
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1127,7 +1127,7 @@ class ProductRestClient(
             body["short_description"] = updatedProductModel.shortDescription
         }
         if (!storedWCProductModel.hasSameImages(updatedProductModel)) {
-            val updatedImages = updatedProductModel.getImages()
+            val updatedImages = updatedProductModel.getImagesList()
             body["images"] = JsonArray().also {
                 for (image in updatedImages) {
                     it.add(image.toJson())
@@ -1147,7 +1147,7 @@ class ProductRestClient(
             body["menu_order"] = updatedProductModel.menuOrder
         }
         if (!storedWCProductModel.hasSameCategories(updatedProductModel)) {
-            val updatedCategories = updatedProductModel.getCategories()
+            val updatedCategories = updatedProductModel.getCategoriesList()
             body["categories"] = JsonArray().also {
                 for (category in updatedCategories) {
                     it.add(category.toJson())
@@ -1155,7 +1155,7 @@ class ProductRestClient(
             }
         }
         if (!storedWCProductModel.hasSameTags(updatedProductModel)) {
-            val updatedTags = updatedProductModel.getTags()
+            val updatedTags = updatedProductModel.getTagsList()
             body["tags"] = JsonArray().also {
                 for (tag in updatedTags) {
                     it.add(tag.toJson())
@@ -1163,7 +1163,7 @@ class ProductRestClient(
             }
         }
         if (storedWCProductModel.groupedProductIds != updatedProductModel.groupedProductIds) {
-            body["grouped_products"] = updatedProductModel.getGroupedProductIds()
+            body["grouped_products"] = updatedProductModel.getGroupedProductIdsList()
         }
         return body
     }
@@ -1251,7 +1251,7 @@ class ProductRestClient(
         }
         // TODO: Once removal is supported, we can remove the extra isNotBlank() condition
         if (storedVariationModel.image != updatedVariationModel.image && updatedVariationModel.image.isNotBlank()) {
-            body["image"] = updatedVariationModel.getImage()?.toJson() ?: ""
+            body["image"] = updatedVariationModel.getImageModel()?.toJson() ?: ""
         }
         if (storedVariationModel.menuOrder != updatedVariationModel.menuOrder) {
             body["menu_order"] = updatedVariationModel.menuOrder

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -373,12 +373,12 @@ object ProductSqlUtils {
 
         // build a new image list containing all the product images except the passed one
         val imageList = ArrayList<WCProductImageModel>()
-        product.getImagesList().forEach { image ->
+        product.getImageList().forEach { image ->
             if (image.id != remoteMediaId) {
                 imageList.add(image)
             }
         }
-        if (imageList.size == product.getImagesList().size) {
+        if (imageList.size == product.getImageList().size) {
             return false
         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -373,12 +373,12 @@ object ProductSqlUtils {
 
         // build a new image list containing all the product images except the passed one
         val imageList = ArrayList<WCProductImageModel>()
-        product.getImages().forEach { image ->
+        product.getImagesList().forEach { image ->
             if (image.id != remoteMediaId) {
                 imageList.add(image)
             }
         }
-        if (imageList.size == product.getImages().size) {
+        if (imageList.size == product.getImagesList().size) {
             return false
         }
 


### PR DESCRIPTION
This PR fixes "reference to xyz is ambiguous" error.

Corresponding PR in Woo: https://github.com/woocommerce/woocommerce-android/pull/2849

**What is the root cause of the issue:**
Some models have getters (methods with "get" prefix) which seem like they are getters for fields but their return type is not the same as the type of the fields.

**Example:**
A field is called "tags" and its type is "String". However, "getTags" method doesn't return "String" but it returns "ArrayList<WCProductImageModel>". This is not allowed in Java-Kotlin code. The reason is simple - the compiler doesn't know if you want to access the field or the method. It seems JDK8 uses a default behavior which accesses the field when "o.field" syntax is used and it accesses the method when "o.getField()" syntax is used.

**Why we need to update this code**
The issue isn't breaking the build on JDK8 - it's reported by AS as an error but it doesn't fail the build. However, with JDK11 this issue breaks the build. Since CircleCI dropped support for JDK8 we need to update all our projects to JDK11 and this issue is blocking the migration.

<img width="700" alt="Screenshot 2020-09-15 at 13 58 54" src="https://user-images.githubusercontent.com/2261188/93207917-f7d16000-f75b-11ea-989d-42b9eb764d60.png">



To Test:
Smoke test the Woo app - 

