### PR TITLE
Update kotlin to 1.4.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlinVersion = '1.3.70'
-    ext.kotlinCoroutinesVersion = '1.2.2'
+    ext.kotlinVersion = '1.4.10'
+    ext.kotlinCoroutinesVersion = '1.3.9'
 
     repositories {
         google()

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PostsFragment.kt
@@ -11,7 +11,6 @@ import kotlinx.android.synthetic.main.fragment_posts.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.PostAction
 import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged
 import org.wordpress.android.fluxc.model.SiteModel
@@ -87,7 +86,7 @@ class PostsFragment : Fragment() {
             if (event.causeOfChange is CauseOfOnPostChanged.FetchPosts ||
                 event.causeOfChange is CauseOfOnPostChanged.FetchPages) {
                 prependToLog("Fetched " + event.rowsAffected + " posts from: " + firstSite.name)
-            } else if (event.causeOfChange == PostAction.DELETE_POST) {
+            } else if (event.causeOfChange is CauseOfOnPostChanged.DeletePost) {
                 prependToLog("Post trashed!")
             }
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/CoroutinesTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/CoroutinesTestUtils.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -11,4 +10,4 @@ fun <T> test(context: CoroutineContext = EmptyCoroutineContext, block: suspend C
     runBlocking(context, block)
 }
 
-@ExperimentalCoroutinesApi val TEST_SCOPE = CoroutineScope(Dispatchers.Unconfined)
+val TEST_SCOPE = CoroutineScope(Dispatchers.Unconfined)

--- a/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/list/PagedListWrapperTest.kt
@@ -10,7 +10,6 @@ import com.nhaarman.mockitokotlin2.firstValue
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -33,7 +32,6 @@ import org.wordpress.android.fluxc.store.ListStore.OnListDataInvalidated
 import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
 
-@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class PagedListWrapperTest {
     @get:Rule

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.yarolegovich.wellsql.SelectQuery
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -39,7 +38,6 @@ class ActivityLogStoreTest {
     @Mock private lateinit var siteModel: SiteModel
     private lateinit var activityLogStore: ActivityLogStore
 
-    @ExperimentalCoroutinesApi
     @Before
     fun setUp() {
         activityLogStore = ActivityLogStore(activityLogRestClient, activityLogSqlUtils,

--- a/example/src/test/java/org/wordpress/android/fluxc/store/PlanOffersStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/PlanOffersStoreTest.kt
@@ -4,7 +4,6 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,7 +32,6 @@ class PlanOffersStoreTest {
     @Mock private lateinit var dispatcher: Dispatcher
     private lateinit var planOffersStore: PlanOffersStore
 
-    @ExperimentalCoroutinesApi
     @Before
     fun setUp() {
         planOffersStore = PlanOffersStore(planOffersRestClient, planOffersSqlUtils, initCoroutineEngine(), dispatcher)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -37,7 +36,6 @@ class StatsStoreTest {
     @Mock lateinit var statsSqlUtils: StatsSqlUtils
     private lateinit var store: StatsStore
 
-    @ExperimentalCoroutinesApi
     @Before
     fun setUp() {
         store = StatsStore(

--- a/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.store
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,7 +36,6 @@ class TransactionsStoreTest {
         private const val TEST_DOMAIN_PRODUCT_ID = 76
     }
 
-    @ExperimentalCoroutinesApi
     @Before
     fun setUp() {
         transactionsStore = TransactionsStore(transactionsRestClient, initCoroutineEngine(), dispatcher)


### PR DESCRIPTION
This is a pretty straightforward PR updating Kotlin and Coroutines versions to the latest stable. This allows us to remote the `ExperimentalCoroutinesApi`. 

For some reason this exposed a bug in a test where `event.causeOfChange == PostAction.DELETE_POST` was comparing two different types and could never succeed.

Matching WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/12973