### PR TITLE
Woo/order detail changes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -268,11 +268,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     fun testOrderNotesFetchSuccess() {
         interceptor.respondWith("wc-order-notes-response-success.json")
         orderRestClient.fetchOrderNotes(
-                WCOrderModel().apply {
-                    localSiteId = 5
-                    id = 8
-                    remoteOrderId = 88
-                }, siteModel
+                localOrderId = 8,
+                remoteOrderId = 88,
+                site = siteModel
         )
 
         countDownLatch = CountDownLatch(1)
@@ -316,11 +314,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     fun testOrderNotesFetchError() {
         interceptor.respondWithError("wc-order-notes-response-failure-invalid-id.json", 404)
         orderRestClient.fetchOrderNotes(
-                WCOrderModel().apply {
-                    localSiteId = 5
-                    id = 8
-                    remoteOrderId = 88
-                }, siteModel
+                localOrderId = 8,
+                remoteOrderId = 88,
+                site = siteModel
         )
 
         countDownLatch = CountDownLatch(1)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -346,7 +346,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWith("wc-order-note-post-response-success.json")
-        orderRestClient.postOrderNote(orderModel, siteModel, originalNote)
+        orderRestClient.postOrderNote(orderModel.id, orderModel.remoteOrderId, siteModel, originalNote)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
@@ -379,7 +379,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWithError(errorJson, 400)
-        orderRestClient.postOrderNote(orderModel, siteModel, originalNote)
+        orderRestClient.postOrderNote(orderModel.id, orderModel.remoteOrderId, siteModel, originalNote)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -218,7 +218,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWith("wc-order-update-response-success.json")
-        orderRestClient.updateOrderStatus(originalOrder, siteModel, CoreOrderStatus.REFUNDED.value)
+        orderRestClient.updateOrderStatus(
+                originalOrder.id, originalOrder.remoteOrderId, siteModel, CoreOrderStatus.REFUNDED.value
+        )
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -250,7 +252,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWithError(errorJson, 400)
-        orderRestClient.updateOrderStatus(originalOrder, siteModel, CoreOrderStatus.REFUNDED.value)
+        orderRestClient.updateOrderStatus(
+                originalOrder.id, originalOrder.remoteOrderId, siteModel, CoreOrderStatus.REFUNDED.value
+        )
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -461,7 +461,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             dateShipped = "2019-04-18"
         }
         interceptor.respondWith("wc-post-order-shipment-tracking-success.json")
-        orderRestClient.addOrderShipmentTrackingForOrder(siteModel, orderModel, trackingModel, isCustomProvider = false)
+        orderRestClient.addOrderShipmentTrackingForOrder(
+                siteModel, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = false
+        )
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
@@ -492,7 +494,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             dateShipped = "2019-04-19"
         }
         interceptor.respondWith("wc-post-order-shipment-tracking-custom-success.json")
-        orderRestClient.addOrderShipmentTrackingForOrder(siteModel, orderModel, trackingModel, isCustomProvider = true)
+        orderRestClient.addOrderShipmentTrackingForOrder(
+                siteModel, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = true
+        )
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -523,7 +523,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWith("wc-delete-order-shipment-tracking-success.json")
-        orderRestClient.deleteShipmentTrackingForOrder(siteModel, orderModel, trackingModel)
+        orderRestClient.deleteShipmentTrackingForOrder(
+                siteModel, orderModel.id, orderModel.remoteOrderId, trackingModel
+        )
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -427,7 +427,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     fun testOrderShipmentTrackingsFetchSuccess() {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         interceptor.respondWith("wc-order-shipment-trackings-success.json")
-        orderRestClient.fetchOrderShipmentTrackings(siteModel, orderModel)
+        orderRestClient.fetchOrderShipmentTrackings(siteModel, orderModel.id, orderModel.remoteOrderId)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -76,10 +76,12 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
             localSiteId = sSite.id
         }
         mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(sSite, orderModel)))
+                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
-        val trackings = orderStore.getShipmentTrackingsForOrder(orderModel)
+        val trackings = orderStore.getShipmentTrackingsForOrder(
+                sSite, orderModel.id
+        )
         assertTrue(trackings.isNotEmpty())
     }
 
@@ -100,10 +102,12 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
             localSiteId = sSite.id
         }
         mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(sSite, orderModel)))
+                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
-        val trackings = orderStore.getShipmentTrackingsForOrder(orderModel)
+        val trackings = orderStore.getShipmentTrackingsForOrder(
+                sSite, orderModel.id
+        )
         assertTrue(trackings.isEmpty())
     }
 
@@ -140,7 +144,9 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
                 AddOrderShipmentTrackingPayload(sSite, orderModel, trackingModel, isCustomProvider = false)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
-        var trackings = orderStore.getShipmentTrackingsForOrder(orderModel)
+        var trackings = orderStore.getShipmentTrackingsForOrder(
+                sSite, orderModel.id
+        )
         assertTrue(trackings.isNotEmpty())
 
         var trackingResult: WCOrderShipmentTrackingModel? = null
@@ -169,7 +175,7 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
 
         // Verify the tracking record is no longer in the database
         var currentCount = trackings.size
-        trackings = orderStore.getShipmentTrackingsForOrder(orderModel)
+        trackings = orderStore.getShipmentTrackingsForOrder(sSite, orderModel.id)
         assertTrue(trackings.size == --currentCount)
     }
 
@@ -208,7 +214,9 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
                 AddOrderShipmentTrackingPayload(sSite, orderModel, trackingModel, isCustomProvider = true)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
-        var trackings = orderStore.getShipmentTrackingsForOrder(orderModel)
+        var trackings = orderStore.getShipmentTrackingsForOrder(
+                sSite, orderModel.id
+        )
         assertTrue(trackings.isNotEmpty())
 
         var trackingResult: WCOrderShipmentTrackingModel? = null
@@ -238,7 +246,7 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
 
         // Verify the tracking record is no longer in the database
         var currentCount = trackings.size
-        trackings = orderStore.getShipmentTrackingsForOrder(orderModel)
+        trackings = orderStore.getShipmentTrackingsForOrder(sSite, orderModel.id)
         assertTrue(trackings.size == --currentCount)
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -141,7 +141,9 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
             dateShipped = testDateShipped
         }
         mDispatcher.dispatch(WCOrderActionBuilder.newAddOrderShipmentTrackingAction(
-                AddOrderShipmentTrackingPayload(sSite, orderModel, trackingModel, isCustomProvider = false)))
+                AddOrderShipmentTrackingPayload(
+                        sSite, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = false))
+        )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         var trackings = orderStore.getShipmentTrackingsForOrder(
@@ -211,7 +213,9 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
             trackingLink = testTrackingLink
         }
         mDispatcher.dispatch(WCOrderActionBuilder.newAddOrderShipmentTrackingAction(
-                AddOrderShipmentTrackingPayload(sSite, orderModel, trackingModel, isCustomProvider = true)))
+                AddOrderShipmentTrackingPayload(
+                        sSite, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = true))
+        )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         var trackings = orderStore.getShipmentTrackingsForOrder(

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -172,7 +172,7 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
 
         mDispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(
-                DeleteOrderShipmentTrackingPayload(sSite, orderModel, trackingResult!!)))
+                DeleteOrderShipmentTrackingPayload(sSite, orderModel.id, orderModel.remoteOrderId, trackingResult!!)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         // Verify the tracking record is no longer in the database
@@ -245,7 +245,7 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
 
         mDispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(
-                DeleteOrderShipmentTrackingPayload(sSite, orderModel, trackingResult!!)))
+                DeleteOrderShipmentTrackingPayload(sSite, orderModel.id, orderModel.remoteOrderId, trackingResult!!)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         // Verify the tracking record is no longer in the database

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -187,11 +187,13 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         val firstOrder = orderStore.getOrdersForSite(sSite)[0]
         nextEvent = TestEvent.FETCHED_ORDER_NOTES
         mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderNotesAction(FetchOrderNotesPayload(firstOrder, sSite)))
+        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderNotesAction(
+                FetchOrderNotesPayload(firstOrder.id, firstOrder.remoteOrderId, sSite)
+        ))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         // Verify results
-        val fetchedNotes = orderStore.getOrderNotesForOrder(firstOrder)
+        val fetchedNotes = orderStore.getOrderNotesForOrder(firstOrder.id)
         assertTrue(fetchedNotes.isNotEmpty())
     }
 
@@ -214,7 +216,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         // Verify results
-        val fetchedNotes = orderStore.getOrderNotesForOrder(orderModel)
+        val fetchedNotes = orderStore.getOrderNotesForOrder(orderModel.id)
         assertTrue(fetchedNotes.isNotEmpty())
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -210,7 +210,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
                 WCOrderActionBuilder.newPostOrderNoteAction(
-                        PostOrderNotePayload(orderModel, sSite, originalNote)
+                        PostOrderNotePayload(orderModel.id, orderModel.remoteOrderId, sSite, originalNote)
                 )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -254,10 +254,10 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
 
         mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(sSite, orderModel)))
+                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
-        val trackings = orderStore.getShipmentTrackingsForOrder(orderModel)
+        val trackings = orderStore.getShipmentTrackingsForOrder(sSite, orderModel.id)
         assertTrue(trackings.isEmpty())
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -224,7 +224,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                 wcOrderStore.getOrdersForSite(site).firstOrNull()?.let { order ->
                     showSingleLineDialog(activity, "Enter new order status") { editText ->
                         val status = editText.text.toString()
-                        val payload = UpdateOrderStatusPayload(order, site, status)
+                        val payload = UpdateOrderStatusPayload(order.id, order.remoteOrderId, site, status)
                         dispatcher.dispatch(WCOrderActionBuilder.newUpdateOrderStatusAction(payload))
                     }
                 } ?: showNoOrdersToast(site)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -511,7 +511,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
     ) {
         pendingAddShipmentTracking = tracking
         pendingAddShipmentTrackingRemoteOrderID = order.remoteOrderId
-        val payload = AddOrderShipmentTrackingPayload(site, order, tracking, isCustomProvider)
+        val payload = AddOrderShipmentTrackingPayload(site, order.id, order.remoteOrderId, tracking, isCustomProvider)
         dispatcher.dispatch(WCOrderActionBuilder.newAddOrderShipmentTrackingAction(payload))
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -242,7 +242,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                             prependToLog("Submitting request to fetch shipment trackings for " +
                                     "remoteOrderId: ${order.remoteOrderId}")
                             pendingShipmentTrackingOrder = order
-                            val payload = FetchOrderShipmentTrackingsPayload(site, order)
+                            val payload = FetchOrderShipmentTrackingsPayload(order.id, order.remoteOrderId, site)
                             dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(payload))
                         } ?: prependToLog("No order found in the db for remoteOrderId: $remoteOrderId, " +
                                 "please fetch orders first.")
@@ -280,7 +280,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                             prependToLog("Submitting request to fetch shipment trackings for " +
                                     "remoteOrderId: ${order.remoteOrderId}")
 
-                            wcOrderStore.getShipmentTrackingsForOrder(order).firstOrNull()?.let { tracking ->
+                            wcOrderStore.getShipmentTrackingsForOrder(site, order.id).firstOrNull()?.let { tracking ->
                                 pendingDeleteShipmentTracking = tracking
                                 val payload = DeleteOrderShipmentTrackingPayload(site, order, tracking)
                                 dispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(payload))
@@ -422,7 +422,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                         with(orderList[0]) { prependToLog("Updated order status for $number to $status") }
                     FETCH_ORDER_SHIPMENT_TRACKINGS -> {
                         pendingShipmentTrackingOrder?.let {
-                            val trackings = wcOrderStore.getShipmentTrackingsForOrder(it)
+                            val trackings = wcOrderStore.getShipmentTrackingsForOrder(site, it.id)
                             trackings.forEach { tracking ->
                                 prependToLog("- shipped:${tracking.dateShipped}: ${tracking.trackingNumber}")
                             }
@@ -435,7 +435,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                     ADD_ORDER_SHIPMENT_TRACKING -> {
                         pendingAddShipmentTracking?.let {
                             getFirstWCOrder()?.let { order ->
-                                val trackingCount = wcOrderStore.getShipmentTrackingsForOrder(order).size
+                                val trackingCount = wcOrderStore.getShipmentTrackingsForOrder(site, order.id).size
                                 prependToLog("Shipment tracking added successfully to " +
                                         "remoteOrderId [$pendingAddShipmentTrackingRemoteOrderID]! " +
                                         "[$trackingCount] tracking records now exist for this order in the db.")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -198,7 +198,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
             getFirstWCSite()?.let { site ->
                 getFirstWCOrder()?.let { order ->
                     pendingNotesOrderModel = order
-                    val payload = FetchOrderNotesPayload(order, site)
+                    val payload = FetchOrderNotesPayload(order.id, order.remoteOrderId, site)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderNotesAction(payload))
                 }
             }
@@ -407,7 +407,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                         prependToLog("Store has orders: $hasOrders")
                     }
                     FETCH_ORDER_NOTES -> {
-                        val notes = wcOrderStore.getOrderNotesForOrder(pendingNotesOrderModel!!)
+                        val notes = wcOrderStore.getOrderNotesForOrder(pendingNotesOrderModel?.id!!)
                         prependToLog(
                                 "Fetched ${notes.size} order notes for order " +
                                         "${pendingNotesOrderModel!!.remoteOrderId}. ${event.rowsAffected} " +

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -282,7 +282,9 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
 
                             wcOrderStore.getShipmentTrackingsForOrder(site, order.id).firstOrNull()?.let { tracking ->
                                 pendingDeleteShipmentTracking = tracking
-                                val payload = DeleteOrderShipmentTrackingPayload(site, order, tracking)
+                                val payload = DeleteOrderShipmentTrackingPayload(
+                                        site, order.id, order.remoteOrderId, tracking
+                                )
                                 dispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(payload))
                             } ?: prependToLog("No shipment trackings in the db for remoteOrderId: $remoteOrderId, " +
                                     "please fetch records first for this order")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -212,7 +212,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                         val newNote = WCOrderNoteModel().apply {
                             note = editText.text.toString()
                         }
-                        val payload = PostOrderNotePayload(order, site, newNote)
+                        val payload = PostOrderNotePayload(order.id, order.remoteOrderId, site, newNote)
                         dispatcher.dispatch(WCOrderActionBuilder.newPostOrderNoteAction(payload))
                     }
                 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -299,7 +299,7 @@ class OrderSqlUtilsTest {
         assertEquals(1, rowsAffected)
 
         // Get all shipment trackings for a single order
-        val trackingsForOrder = OrderSqlUtils.getShipmentTrackingsForOrder(orderModel)
+        val trackingsForOrder = OrderSqlUtils.getShipmentTrackingsForOrder(siteModel, orderModel.id)
         assertEquals(3, trackingsForOrder.size)
     }
 
@@ -322,7 +322,7 @@ class OrderSqlUtilsTest {
         assertEquals(2, rowsAffected)
 
         // Verify no shipment trackings in db
-        val trackingsInDb = OrderSqlUtils.getShipmentTrackingsForOrder(orderModel)
+        val trackingsInDb = OrderSqlUtils.getShipmentTrackingsForOrder(siteModel, orderModel.id)
         assertEquals(0, trackingsInDb.size)
     }
 
@@ -341,12 +341,12 @@ class OrderSqlUtilsTest {
         assertEquals(2, rowsAffected)
 
         // Delete the first shipment tracking
-        var trackingsInDb = OrderSqlUtils.getShipmentTrackingsForOrder(orderModel)
-        rowsAffected = OrderSqlUtils.deleteOrderShipmentTrackingById(trackingsInDb.get(0))
+        var trackingsInDb = OrderSqlUtils.getShipmentTrackingsForOrder(siteModel, orderModel.id)
+        rowsAffected = OrderSqlUtils.deleteOrderShipmentTrackingById(trackingsInDb[0])
         assertEquals(1, rowsAffected)
 
         // Verify only a single shipment tracking row in db
-        trackingsInDb = OrderSqlUtils.getShipmentTrackingsForOrder(orderModel)
+        trackingsInDb = OrderSqlUtils.getShipmentTrackingsForOrder(siteModel, orderModel.id)
         assertEquals(1, trackingsInDb.size)
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -301,6 +301,13 @@ class OrderSqlUtilsTest {
         // Get all shipment trackings for a single order
         val trackingsForOrder = OrderSqlUtils.getShipmentTrackingsForOrder(siteModel, orderModel.id)
         assertEquals(3, trackingsForOrder.size)
+
+        // get a single shipment tracking by tracking number
+        val shipmentTracking = OrderSqlUtils.getShipmentTrackingByTrackingNumber(
+                siteModel, orderModel.id, trackingsForOrder[0].trackingNumber
+        )
+        assertNotNull(shipmentTracking)
+        assertEquals(trackingsForOrder[0].trackingNumber, shipmentTracking.trackingNumber)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -173,7 +173,7 @@ class WCOrderStoreTest {
         assertEquals(6, noteModels.size)
         OrderSqlUtils.insertOrIgnoreOrderNote(noteModels[0])
 
-        val retrievedNotes = orderStore.getOrderNotesForOrder(orderModel)
+        val retrievedNotes = orderStore.getOrderNotesForOrder(orderModel.id)
         assertEquals(1, retrievedNotes.size)
         assertEquals(noteModels[0], retrievedNotes[0])
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderIdentifier.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderIdentifier.kt
@@ -16,6 +16,11 @@ fun OrderIdentifier(localSiteId: Int, remoteOrderId: Long): OrderIdentifier {
     return "0-$remoteOrderId-$localSiteId"
 }
 
+@Suppress("FunctionName")
+fun OrderIdentifier(localOrderId: Int, localSiteId: Int, remoteOrderId: Long): OrderIdentifier {
+    return "$localOrderId-$remoteOrderId-$localSiteId"
+}
+
 fun OrderIdentifier.toIdSet(): OrderIdSet {
     val (id, remoteOrderId, localSiteId) = split("-")
     return OrderIdSet(id.toInt(), remoteOrderId.toLong(), localSiteId.toInt())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -245,6 +245,21 @@ object OrderSqlUtils {
                 .orderBy(WCOrderShipmentTrackingModelTable.DATE_SHIPPED, SelectQuery.ORDER_DESCENDING).asModel
     }
 
+    fun getShipmentTrackingByTrackingNumber(
+        site: SiteModel,
+        localOrderId: Int,
+        trackingNumber: String
+    ): WCOrderShipmentTrackingModel? {
+        return WellSql.select(WCOrderShipmentTrackingModel::class.java)
+                .where()
+                .beginGroup()
+                .equals(WCOrderShipmentTrackingModelTable.LOCAL_SITE_ID, site.id)
+                .equals(WCOrderShipmentTrackingModelTable.LOCAL_ORDER_ID, localOrderId)
+                .equals(WCOrderShipmentTrackingModelTable.TRACKING_NUMBER, trackingNumber)
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+    }
+
     fun deleteOrderShipmentTrackingById(tracking: WCOrderShipmentTrackingModel): Int =
             WellSql.delete(WCOrderShipmentTrackingModel::class.java).whereId(tracking.id)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -232,12 +232,15 @@ object OrderSqlUtils {
         }
     }
 
-    fun getShipmentTrackingsForOrder(order: WCOrderModel): List<WCOrderShipmentTrackingModel> {
+    fun getShipmentTrackingsForOrder(
+        site: SiteModel,
+        localOrderId: Int
+    ): List<WCOrderShipmentTrackingModel> {
         return WellSql.select(WCOrderShipmentTrackingModel::class.java)
                 .where()
                 .beginGroup()
-                .equals(WCOrderShipmentTrackingModelTable.LOCAL_SITE_ID, order.localSiteId)
-                .equals(WCOrderShipmentTrackingModelTable.LOCAL_ORDER_ID, order.id)
+                .equals(WCOrderShipmentTrackingModelTable.LOCAL_SITE_ID, site.id)
+                .equals(WCOrderShipmentTrackingModelTable.LOCAL_ORDER_ID, localOrderId)
                 .endGroup().endWhere()
                 .orderBy(WCOrderShipmentTrackingModelTable.DATE_SHIPPED, SelectQuery.ORDER_DESCENDING).asModel
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -143,7 +143,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     class UpdateOrderStatusPayload(
-        val order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         val site: SiteModel,
         val status: String
     ) : Payload<BaseNetworkError>()
@@ -466,7 +467,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     private fun updateOrderStatus(payload: UpdateOrderStatusPayload) {
-        with(payload) { wcOrderRestClient.updateOrderStatus(order, site, status) }
+        with(payload) { wcOrderRestClient.updateOrderStatus(localOrderId, remoteOrderId, site, status) }
     }
 
     private fun fetchOrderNotes(payload: FetchOrderNotesPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -174,18 +174,25 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     class PostOrderNotePayload(
-        val order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         val site: SiteModel,
         val note: WCOrderNoteModel
     ) : Payload<BaseNetworkError>()
 
     class RemoteOrderNotePayload(
-        val order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         val site: SiteModel,
         val note: WCOrderNoteModel
     ) : Payload<OrderError>() {
-        constructor(error: OrderError, order: WCOrderModel, site: SiteModel, note: WCOrderNoteModel) :
-                this(order, site, note) { this.error = error }
+        constructor(
+            error: OrderError,
+            localOrderId: Int,
+            remoteOrderId: Long,
+            site: SiteModel,
+            note: WCOrderNoteModel
+        ) : this(localOrderId, remoteOrderId, site, note) { this.error = error }
     }
 
     class FetchOrderStatusOptionsPayload(val site: SiteModel) : Payload<BaseNetworkError>()
@@ -475,7 +482,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     private fun postOrderNote(payload: PostOrderNotePayload) {
-        wcOrderRestClient.postOrderNote(payload.order, payload.site, payload.note)
+        with(payload) { wcOrderRestClient.postOrderNote(localOrderId, remoteOrderId, site, note) }
     }
 
     private fun fetchOrderStatusOptions(payload: FetchOrderStatusOptionsPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -221,22 +221,25 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     class AddOrderShipmentTrackingPayload(
         val site: SiteModel,
-        val order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         val tracking: WCOrderShipmentTrackingModel,
         val isCustomProvider: Boolean
     ) : Payload<BaseNetworkError>()
 
     class AddOrderShipmentTrackingResponsePayload(
         val site: SiteModel,
-        val order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         val tracking: WCOrderShipmentTrackingModel?
     ) : Payload<OrderError>() {
         constructor(
             error: OrderError,
             site: SiteModel,
-            order: WCOrderModel,
+            localOrderId: Int,
+            remoteOrderId: Long,
             tracking: WCOrderShipmentTrackingModel
-        ) : this(site, order, tracking) { this.error = error }
+        ) : this(site, localOrderId, remoteOrderId, tracking) { this.error = error }
     }
 
     class DeleteOrderShipmentTrackingPayload(
@@ -496,7 +499,11 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     private fun addOrderShipmentTracking(payload: AddOrderShipmentTrackingPayload) {
-        with(payload) { wcOrderRestClient.addOrderShipmentTrackingForOrder(site, order, tracking, isCustomProvider) }
+        with(payload) {
+            wcOrderRestClient.addOrderShipmentTrackingForOrder(
+                    site, localOrderId, remoteOrderId, tracking, isCustomProvider
+            )
+        }
     }
 
     private fun deleteOrderShipmentTracking(payload: DeleteOrderShipmentTrackingPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -156,16 +156,20 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     class FetchOrderNotesPayload(
-        var order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         var site: SiteModel
     ) : Payload<BaseNetworkError>()
 
     class FetchOrderNotesResponsePayload(
-        var order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         var site: SiteModel,
         var notes: List<WCOrderNoteModel> = emptyList()
     ) : Payload<OrderError>() {
-        constructor(error: OrderError, site: SiteModel, order: WCOrderModel) : this(order, site) { this.error = error }
+        constructor(error: OrderError, site: SiteModel, localOrderId: Int, remoteOrderId: Long) : this(
+                localOrderId, remoteOrderId, site
+        ) { this.error = error }
     }
 
     class PostOrderNotePayload(
@@ -336,8 +340,8 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     /**
      * Returns the notes belonging to supplied [WCOrderModel] as a list of [WCOrderNoteModel].
      */
-    fun getOrderNotesForOrder(order: WCOrderModel): List<WCOrderNoteModel> =
-            OrderSqlUtils.getOrderNotesForOrder(order.id)
+    fun getOrderNotesForOrder(orderId: Int): List<WCOrderNoteModel> =
+            OrderSqlUtils.getOrderNotesForOrder(orderId)
 
     /**
      * Returns the order status options available for the provided site [SiteModel] as a list of [WCOrderStatusModel].
@@ -464,7 +468,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     private fun fetchOrderNotes(payload: FetchOrderNotesPayload) {
-        wcOrderRestClient.fetchOrderNotes(payload.order, payload.site)
+        with(payload) { wcOrderRestClient.fetchOrderNotes(localOrderId, remoteOrderId, site) }
     }
 
     private fun postOrderNote(payload: PostOrderNotePayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -244,21 +244,24 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     class DeleteOrderShipmentTrackingPayload(
         val site: SiteModel,
-        val order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         val tracking: WCOrderShipmentTrackingModel
     ) : Payload<BaseNetworkError>()
 
     class DeleteOrderShipmentTrackingResponsePayload(
         val site: SiteModel,
-        val order: WCOrderModel,
+        var localOrderId: Int,
+        var remoteOrderId: Long,
         val tracking: WCOrderShipmentTrackingModel?
     ) : Payload<OrderError>() {
         constructor(
             error: OrderError,
             site: SiteModel,
-            order: WCOrderModel,
+            localOrderId: Int,
+            remoteOrderId: Long,
             tracking: WCOrderShipmentTrackingModel?
-        ) : this(site, order, tracking) { this.error = error }
+        ) : this(site, localOrderId, remoteOrderId, tracking) { this.error = error }
     }
 
     class FetchOrderShipmentProvidersPayload(
@@ -507,7 +510,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     }
 
     private fun deleteOrderShipmentTracking(payload: DeleteOrderShipmentTrackingPayload) {
-        with(payload) { wcOrderRestClient.deleteShipmentTrackingForOrder(site, order, tracking) }
+        with(payload) { wcOrderRestClient.deleteShipmentTrackingForOrder(site, localOrderId, remoteOrderId, tracking) }
     }
 
     private fun fetchOrderShipmentProviders(payload: FetchOrderShipmentProvidersPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -377,6 +377,9 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     fun getShipmentTrackingsForOrder(site: SiteModel, localOrderId: Int): List<WCOrderShipmentTrackingModel> =
             OrderSqlUtils.getShipmentTrackingsForOrder(site, localOrderId)
 
+    fun getShipmentTrackingByTrackingNumber(site: SiteModel, localOrderId: Int, trackingNumber: String) =
+            OrderSqlUtils.getShipmentTrackingByTrackingNumber(site, localOrderId, trackingNumber)
+
     /**
      * Returns the shipment providers as a list of [WCOrderShipmentProviderModel]
      */


### PR DESCRIPTION
This PR cleans up `OrderStore` and removes the use of `WCOrderModel` when fetching/adding order notes and order shipment trackings. This is needed for the Order Detail refactor to MVVM in woocommerce/woocommerce-android#2844

#### Changes
- Adds new method to `OrderIdentifier` to include the `localOrderId`.  baeb7db
- Removes redundant `WCOrderModel` when fetching order notes + fixes the unit tests. 4a1d6bf
- Removes redundant `WCOrderModel` when fetching order shipment + fixes the unit tests. afeb1f3
- Removed redundant `WCOrderModel` when updating order status + fixes the unit tests. e885049
- Removed redundant `WCOrderModel` when adding order note + fixes the unit tests. 1256f4d
- Removed redundant `WCOrderModel` when adding new shipment tracking + fixes the unit tests. 714b74a
- Removed redundant `WCOrderModel` when adding deleting shipment tracking + fixes the unit tests. 2ea0302
- Added new method to fetch shipment tracking from local db by tracking number. 709334c

#### To test
- Click on `Woo` -> `Orders` -> `Fetch Order Notes` and verify that the order notes are fetched successfully.
- Click on `Woo` -> `Orders` -> `Fetch Order Shipment Trackings` and verify that shipment trackings are fetched successfully.
- Click on `Woo` -> `Orders` -> `Update Latest Order Status`, enter an order status and verify that status is updated successfully.
- Click on `Woo` -> `Orders` -> `Post Order Note`, enter an order note and verify that note is added successfully.
- Click on `Woo` -> `Orders` -> `Add Shipment Tracking To First Order`, enter a tracking number and verify that shipment tracking is added successfully.
- Click on `Woo` -> `Orders` -> `Delete First Shipment Tracking For Order`, enter a tracking number and verify that shipment tracking is deleted successfully.
- Verify that all tests are passing in `WCOrderStoreTest`, `MockedStack_WCOrdersTest`, `ReleaseStack_WCOrderExtTest`, `ReleaseStack_WCOrderTest`, `OrderSqlUtilsTest`.
