### PR TITLE
Update harmless libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,5 +77,5 @@ ext {
     arch_lifecycle_version = '1.1.1'
     arch_core_version = '2.0.1'
     appcompat_version = '1.0.2'
-    mockitoVersion = '2.28.2'
+    mockitoVersion = '3.3.3'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.example"
-        minSdkVersion 16
+        minSdkVersion 18
         // Keep the targetSdkVersion 22 so we don't need to grant runtime permissions to the tests and the example app
         // An alternative would be granting the permissions via adb before running the test, like here:
         // https://afterecho.uk/blog/granting-marshmallow-permissions-for-testing-flavoured-builds.html

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -121,12 +121,12 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
+    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
+    testImplementation 'org.assertj:assertj-core:3.15.0'
     testImplementation "androidx.arch.core:core-testing:$arch_core_version"
 
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -87,8 +87,8 @@ dependencies {
 
     // External libs
     api 'org.greenrobot:eventbus:3.1.1'
-    api 'com.squareup.okhttp3:okhttp:3.14.9'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.12.1'
+    api 'com.squareup.okhttp3:okhttp:3.9.0'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.9.0'
     api 'com.android.volley:volley:1.1.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-text:1.1'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -87,8 +87,8 @@ dependencies {
 
     // External libs
     api 'org.greenrobot:eventbus:3.1.1'
-    api 'com.squareup.okhttp3:okhttp:3.9.0'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.9.0'
+    api 'com.squareup.okhttp3:okhttp:3.14.9'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.12.1'
     api 'com.android.volley:volley:1.1.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-text:1.1'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -26,7 +26,7 @@ android {
     defaultConfig {
         versionCode 4
         versionName "0.1"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 29
     }
     buildTypes {
@@ -71,7 +71,7 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:1.0.0"
 
     // WordPress libs
-    implementation ('org.wordpress:utils:1.20.0') {
+    implementation ('org.wordpress:utils:1.26') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -20,7 +20,7 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.instaflux"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         versionCode 1
         versionName "0.1"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 29
     }
     buildTypes {


### PR DESCRIPTION
This PR updates:
- test libraries - this should be OK if all the tests pass
- WordPress Utils + minSdkVersion - I don't think there was a reason why we had min SDK set to 16. WP Utils requires at least 18