### PR TITLE
Issue/1695 woo delete product

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -54,6 +54,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     private var countDownLatch: CountDownLatch by notNull()
 
     private val remoteProductId = 1537L
+    private val bogusProductId = -1L
     private val remoteShippingClassId = 34L
     private val searchQuery = "test"
 
@@ -667,6 +668,19 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         // now verify the db no longer contains the product
         val productFromDb = ProductSqlUtils.getProductByRemoteId(siteModel, remoteProductId)
         assertNull(productFromDb)
+    }
+
+    @Test
+    fun testDeleteProductFailed() {
+        interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
+        productRestClient.deleteProduct(siteModel, remoteProductId)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCProductAction.DELETED_PRODUCT, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteDeleteProductPayload
+        assertNotNull(payload.error)
     }
 
     @Test

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -13,6 +13,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_CATEGORY
 import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_TAGS
+import org.wordpress.android.fluxc.action.WCProductAction.DELETE_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_CATEGORIES
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_REVIEWS
@@ -37,6 +38,7 @@ import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload
+import org.wordpress.android.fluxc.store.WCProductStore.DeleteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload
@@ -391,6 +393,20 @@ class WooProductsFragment : Fragment() {
         add_new_product.setOnClickListener {
             replaceFragment(WooUpdateProductFragment.newInstance(selectedPos, isAddNewProduct = true))
         }
+
+        delete_product.setOnClickListener {
+            showSingleLineDialog(
+                    activity,
+                    "Enter the remoteProductId of the product to delete:"
+            ) { editTextProduct ->
+                editTextProduct.text.toString().toLongOrNull()?.let { productId ->
+                    selectedSite?.let { site ->
+                        val payload = DeleteProductPayload(site, productId)
+                        dispatcher.dispatch(WCProductActionBuilder.newDeleteProductAction(payload))
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -468,6 +484,9 @@ class WooProductsFragment : Fragment() {
                 }
                 UPDATE_PRODUCT_REVIEW_STATUS -> {
                     prependToLog("${event.rowsAffected} product reviews updated")
+                }
+                DELETE_PRODUCT -> {
+                    prependToLog("${event.rowsAffected} product deleted")
                 }
                 else -> prependToLog("Product store was updated from a " + event.causeOfChange)
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -13,7 +13,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_CATEGORY
 import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_TAGS
-import org.wordpress.android.fluxc.action.WCProductAction.DELETE_PRODUCT
+import org.wordpress.android.fluxc.action.WCProductAction.DELETED_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_CATEGORIES
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_REVIEWS
@@ -485,7 +485,7 @@ class WooProductsFragment : Fragment() {
                 UPDATE_PRODUCT_REVIEW_STATUS -> {
                     prependToLog("${event.rowsAffected} product reviews updated")
                 }
-                DELETE_PRODUCT -> {
+                DELETED_PRODUCT -> {
                     prependToLog("${event.rowsAffected} product deleted")
                 }
                 else -> prependToLog("Product store was updated from a " + event.causeOfChange)

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -206,5 +206,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Add new product"/>
+
+        <Button
+            android:id="@+id/delete_product"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Delete product"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -138,6 +138,23 @@ class ProductSqlUtilsTest {
     }
 
     @Test
+    fun testDeleteProduct() {
+        val remoteProductId = 40L
+        val productModel = ProductTestUtils.generateSampleProduct(remoteProductId)
+        val site = SiteModel().apply { id = productModel.localSiteId }
+
+        // Test inserting product
+        ProductSqlUtils.insertOrUpdateProduct(productModel)
+        val storedProductsCount = ProductSqlUtils.getProductCountForSite(site)
+        assertEquals(1, storedProductsCount)
+
+        // Test deleting product
+        val rowsAffected = ProductSqlUtils.deleteProduct(site, remoteProductId)
+        assertEquals(1, rowsAffected)
+        assertNull(ProductSqlUtils.getProductByRemoteId(site, remoteProductId))
+    }
+
+    @Test
     fun testInsertOrUpdateProductShippingClass() {
         val shippingClass = ProductTestUtils.generateProductList(site.id)[0]
         assertNotNull(shippingClass)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -3,9 +3,10 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.store.WCProductStore.AddProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.AddProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload;
+import org.wordpress.android.fluxc.store.WCProductStore.DeleteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
@@ -19,9 +20,10 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayloa
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleVariationPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload;
+import org.wordpress.android.fluxc.store.WCProductStore.RemoteDeleteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload;
@@ -90,7 +92,8 @@ public enum WCProductAction implements IAction {
     ADD_PRODUCT_TAGS,
     @Action(payloadType = AddProductPayload.class)
     ADD_PRODUCT,
-
+    @Action(payloadType = DeleteProductPayload.class)
+    DELETE_PRODUCT,
 
     // Remote responses
     @Action(payloadType = RemoteProductPayload.class)
@@ -134,5 +137,7 @@ public enum WCProductAction implements IAction {
     @Action(payloadType = RemoteAddProductTagsResponsePayload.class)
     ADDED_PRODUCT_TAGS,
     @Action(payloadType = RemoteAddProductPayload.class)
-    ADDED_PRODUCT
+    ADDED_PRODUCT,
+    @Action(payloadType = RemoteDeleteProductPayload.class)
+    DELETED_PRODUCT
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1036,7 +1036,7 @@ class ProductRestClient(
     ) {
         val url = WOOCOMMERCE.products.id(remoteProductId).pathV3
         val responseType = object : TypeToken<ProductApiResponse>() {}.type
-        val params= mapOf("force" to forceDelete.toString())
+        val params = mapOf("force" to forceDelete.toString())
         val request = JetpackTunnelGsonRequest.buildDeleteRequest(url, site.siteId, params, responseType,
                 { response: ProductApiResponse? ->
                     response?.let {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -385,6 +385,14 @@ object ProductSqlUtils {
         return updateProductImages(product, imageList) > 0
     }
 
+    fun deleteProduct(site: SiteModel, remoteProductId: Long): Int {
+        return WellSql.delete(WCProductModel::class.java)
+                .where()
+                .equals(WCProductModelTable.LOCAL_SITE_ID, site.id)
+                .equals(WCProductModelTable.REMOTE_PRODUCT_ID, remoteProductId)
+                .endWhere().execute()
+    }
+
     fun getProductShippingClassListForSite(
         localSiteId: Int
     ): List<WCProductShippingClassModel> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -838,7 +838,7 @@ class WCProductStore @Inject constructor(
     }
 
     suspend fun fetchProductListSynced(site: SiteModel, productIds: List<Long>) =
-            coroutineEngine?.withDefaultContext(AppLog.T.API, this, "fetchProductList") {
+            coroutineEngine?.withDefaultContext(T.API, this, "fetchProductList") {
                 wcProductRestClient.fetchProductsWithSyncRequest(site = site, remoteProductIds = productIds)?.result
             }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -594,13 +594,6 @@ class WCProductStore @Inject constructor(
         var causeOfChange: WCProductAction? = null
     }
 
-    class OnProductDeleted(
-        var rowsAffected: Int,
-        var remoteProductId: Long = 0L
-    ) : OnChanged<ProductError>() {
-        var causeOfChange: WCProductAction? = null
-    }
-
     /**
      * returns the corresponding product from the database as a [WCProductModel].
      */
@@ -1264,16 +1257,16 @@ class WCProductStore @Inject constructor(
     }
 
     private fun handleDeleteProduct(payload: RemoteDeleteProductPayload) {
-        val onProductDeleted: OnProductDeleted
+        val onProductChanged: OnProductChanged
 
         if (payload.isError) {
-            onProductDeleted = OnProductDeleted(0, payload.remoteProductId).also { it.error = payload.error }
+            onProductChanged = OnProductChanged(0).also { it.error = payload.error }
         } else {
             val rowsAffected = ProductSqlUtils.deleteProduct(payload.site, payload.remoteProductId)
-            onProductDeleted = OnProductDeleted(rowsAffected, payload.remoteProductId)
+            onProductChanged = OnProductChanged(rowsAffected, payload.remoteProductId)
         }
 
-        onProductDeleted.causeOfChange = WCProductAction.DELETED_PRODUCT
-        emitChange(onProductDeleted)
+        onProductChanged.causeOfChange = WCProductAction.DELETED_PRODUCT
+        emitChange(onProductChanged)
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -179,6 +179,12 @@ class WCProductStore @Inject constructor(
         val product: WCProductModel
     ) : Payload<BaseNetworkError>()
 
+    class DeleteProductPayload(
+        var site: SiteModel,
+        val product: WCProductModel,
+        val forceDelete: Boolean = false
+    ) : Payload<BaseNetworkError>()
+
     enum class ProductErrorType {
         INVALID_PARAM,
         INVALID_REVIEW_ID,
@@ -480,10 +486,23 @@ class WCProductStore @Inject constructor(
         }
     }
 
+    class RemoteDeleteProductPayload(
+        var site: SiteModel,
+        val remoteProductId: Long
+    ) : Payload<ProductError>() {
+        constructor(
+            error: ProductError,
+            site: SiteModel,
+            remoteProductId: Long
+        ) : this(site, remoteProductId) {
+            this.error = error
+        }
+    }
+
     // OnChanged events
     class OnProductChanged(
         var rowsAffected: Int,
-        var remoteProductId: Long = 0L, // only set for fetching a single product
+        var remoteProductId: Long = 0L, // only set for fetching or deleting a single product
         var canLoadMore: Boolean = false
     ) : OnChanged<ProductError>() {
         var causeOfChange: WCProductAction? = null


### PR DESCRIPTION
This PR adds the ability to delete/trash a WooCommerce product. The default is to trash, and WCAndroid will only be using that functionality, but I figured I'd support permanent deletion since the endpoint offers that.

Tests have been added, and the Example app has been updated with a "Delete Product" button.

![example](https://user-images.githubusercontent.com/3903757/94047417-1066f900-fda0-11ea-86c2-49947c98eb48.png)

Note: Only one reviewer is necessary.
