### PR TITLE
Fix the failing Products API test

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -9,7 +9,16 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -43,7 +43,7 @@ public class APITesting_WCProduct {
             get().
         then().
             statusCode(200).
-            body("data", hasSize(18));
+            body("data", hasSize(25));
     }
 
     @Test

--- a/tests/api/src/test/java/APITesting_WCProduct.java
+++ b/tests/api/src/test/java/APITesting_WCProduct.java
@@ -369,9 +369,40 @@ public class APITesting_WCProduct {
     @Test
     public void canAddProduct() {
         String path = "/wc/v3/products";
-        String method = "post";
+
+        // Get previous product
+        Integer id = given().
+            spec(this.mRequestSpec).
+            queryParam("path", path).
+            when().
+                get().
+            then().
+                statusCode(200).
+            extract().
+            path("data[0].id");
+
+        // Delete previous product
+        String deleteMethod = "delete";
+        JSONObject deleteJsonObj = new JSONObject();
+        deleteJsonObj.put("json", "true");
+        deleteJsonObj.put("force", "true");
+
+        if (id != null) {
+            String deletePath = path + "/" + id + "&_method=" + deleteMethod;
+            deleteJsonObj.put("path", deletePath);
+            given().
+               spec(this.mRequestSpec).
+               header("Content-Type", ContentType.JSON).
+               queryParam("path", deletePath).
+               body(deleteJsonObj.toString()).
+           when().
+               post().
+           then().
+               statusCode(200);
+        }
 
         // New Product
+        String method = "post";
         JSONObject jsonBody = new JSONObject();
         jsonBody.put("name", "New product");
         jsonBody.put("type", "simple");


### PR DESCRIPTION
Recently-added `canAddProduct()` test had an adverse effect on `canGetAllProducts()` and made it fail, because it changed the number of products on the site. This PR makes sure to delete the last product before creating a new one so that the total number stays the same.

**To test:** Run the `APITesting_WCProduct` tests and make sure all of them pass.