### PR TITLE
issue/1700-wc-add-delete-product-db-only

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -9,16 +9,7 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -920,6 +920,18 @@ class WCProductStore @Inject constructor(
         }
     }
 
+    /**
+     * Adds a product to the database only
+     */
+    fun addProductToDb(product: WCProductModel) =
+            ProductSqlUtils.insertOrUpdateProduct(product) > 0
+
+    /**
+     * Deletes a product from the database only
+     */
+    fun removeProductFromDb(site: SiteModel, remoteProductId: Long) =
+            ProductSqlUtils.deleteProduct(site, remoteProductId) > 0
+
     private fun handleFetchSingleProductCompleted(payload: RemoteProductPayload) {
         val onProductChanged: OnProductChanged
 


### PR DESCRIPTION
Closes #1700 - this simple PR enables adding or removing a product from the database only. This is to be used by WCAndroid when we give users the ability to trash a product and then restore it.

Note that I haven't added tests for this PR because it's simply a wrapper for two functions in `ProductSqlUtils` that are already heavily tested.