### PR TITLE
Issue/1685 fix get start day of current week for site

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -6,11 +6,13 @@ import org.wordpress.android.fluxc.utils.DateUtils
 import org.wordpress.android.fluxc.utils.SiteUtils
 import java.text.SimpleDateFormat
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.temporal.WeekFields
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 import kotlin.test.assertEquals
 
 class DateUtilsTest {
@@ -226,17 +228,28 @@ class DateUtilsTest {
     fun testGetStartDayOfCurrentWeekForSite() {
         val site = SiteModel().apply { id = 1 }
 
-        val fieldISO = WeekFields.of(Locale.ROOT).dayOfWeek()
-        val timezone = SiteUtils.getNormalizedTimezone(site.timezone)
-        val expectedDate = LocalDate.now()
-                .with(fieldISO, 1)
-                .atStartOfDay(timezone.toZoneId())
-                .toInstant()
-        val expectedDateString = DateUtils.formatDate(DATE_TIME_FORMAT_START, Date.from(expectedDate))
-
         // test get start date for current day
-        for (i in -20..20) {
-            site.timezone = i.toString()
+        for (offset in -20..20) {
+            site.timezone = offset.toString()
+
+            val fieldISO = WeekFields.of(Locale.ROOT).dayOfWeek()
+
+            // Setting a zone id where the start of the week is always Sunday
+            val zoneId = ZoneId.of("America/New_York")
+
+            val expectedDate = LocalDateTime.now()
+                    // Adds the offset that are being tested minus the local offset
+                    // This is a way to add the offset using LocalDateTime without changing the zone
+                    .plusHours(offset.toLong())
+                    .plusSeconds(TimeZone.getDefault().rawOffset.toLong() / 1000*-1)
+                    .atZone(zoneId)
+                    .with(fieldISO, 1)
+                    .toLocalDate()
+                    .atStartOfDay()
+                    .atZone(zoneId)
+                    .toInstant()
+
+            val expectedDateString = DateUtils.formatDate(DATE_TIME_FORMAT_START, Date.from(expectedDate))
             // format the current date to string
             // get the formatted date string for the site in the format yyyy-MM-ddThh:mm:ss
             // get the expected start date string for the site in the format yyyy-MM-ddThh:mm:ss

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -12,7 +12,6 @@ import java.time.temporal.WeekFields
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import java.util.TimeZone
 import kotlin.test.assertEquals
 
 class DateUtilsTest {
@@ -237,11 +236,10 @@ class DateUtilsTest {
             // Setting a zone id where the start of the week is always Sunday
             val zoneId = ZoneId.of("America/New_York")
 
-            val expectedDate = LocalDateTime.now()
-                    // Adds the offset that are being tested minus the local offset
+            val expectedDate = LocalDateTime.now(ZoneId.of("UTC"))
+                    // Adds the offset that are being tested
                     // This is a way to add the offset using LocalDateTime without changing the zone
                     .plusHours(offset.toLong())
-                    .plusSeconds(TimeZone.getDefault().rawOffset.toLong() / 1000*-1)
                     .atZone(zoneId)
                     .with(fieldISO, 1)
                     .toLocalDate()


### PR DESCRIPTION
Fixes #1685 

### Description

Fixes the test `testGetStartDayOfCurrentWeekForSite()` in `DateUtilsTest.kt` by handling correctly each site timezone while not using local timezone.

### To test

Run `testGetStartDayOfCurrentWeekForSite()` and print the expected and actual dates and check if it's correct. Here are the results performed locally:

> Current time 2020-09-27T13:13:25.766-03:00[America/Sao_Paulo]
Testing timezone -20. Expected: 2020-09-20T00:00:00 Actual: 2020-09-20T00:00:00
Testing timezone -19. Expected: 2020-09-20T00:00:00 Actual: 2020-09-20T00:00:00
Testing timezone -18. Expected: 2020-09-20T00:00:00 Actual: 2020-09-20T00:00:00
Testing timezone -17. Expected: 2020-09-20T00:00:00 Actual: 2020-09-20T00:00:00
Testing timezone -16. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -15. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -14. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -13. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -12. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -11. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -10. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -9. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -8. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -7. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -6. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -5. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -4. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -3. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -2. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone -1. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 0. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 1. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 2. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 3. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 4. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 5. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 6. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 7. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 8. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 9. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 10. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 11. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 12. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 13. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 14. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 15. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 16. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 17. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 18. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 19. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00
Testing timezone 20. Expected: 2020-09-27T00:00:00 Actual: 2020-09-27T00:00:00

From timezone -17 to -20 the expected is 2020-09-20 because the current date is 2020-09-26, and in the rest of the timezones the current date is 2020-09-27.

### Notes

The production code in `DateUtils` seems to be not localized and the start of the week seems to be always Sunday. There are some countries that the start of the week is on Monday, and I am not sure if `getFirstDayOfCurrentWeekBySite(site)` takes that into account.