### PR TITLE
issue/1707-wc-trashed-product-status 

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStatus.kt
@@ -4,7 +4,8 @@ enum class CoreProductStatus(val value: String) {
     DRAFT("draft"),
     PENDING("pending"),
     PRIVATE("private"),
-    PUBLISH("publish");
+    PUBLISH("publish"),
+    TRASH("trash");
 
     companion object {
         private val valueMap = values().associateBy(CoreProductStatus::value)


### PR DESCRIPTION
Resolves #1707 - this simple PR adds the missing `TRASH` status to `CoreProductStatus`. To test:

* Open the example app
* Go to Woo > Products > Fetch products with filters
* Choose Filter by status and verify that Trash is one of the selections
* Verify that only trashed products are returned when you apply the Trash filter