### PR TITLE
Use fixed referrer URL instead of fetched from unstable API

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestJetpack.kt
@@ -139,19 +139,9 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
     fun testReportReferrerAsSpam() {
         val site = authenticate()
 
-        val fetchedInsights = runBlocking {
-            referrersStore.fetchReferrers(
-                    site,
-                    YEARS,
-                    LIMIT_MODE,
-                    Date(),
-                    true
-            )
-        }
-
         runBlocking {
             // Retrieving the first domain in the referrer list
-            val domain = fetchedInsights.model?.groups?.first()?.referrers?.first()?.url!!
+            val domain = "https://wordpress.com/read/"
 
             // Always unreport first so report doesn't cause an already-spammed error
             referrersStore.unreportReferrerAsSpam(
@@ -176,6 +166,15 @@ class ReleaseStack_TimeStatsTestJetpack : ReleaseStack_Base() {
 
             // Asserting the second report twice now causes an already-spammed error
             val secondReponse = referrersStore.reportReferrerAsSpam(
+                    site,
+                    domain,
+                    YEARS,
+                    LIMIT_MODE,
+                    Date()
+            )
+
+            // Always unreport last to revert the change
+            referrersStore.unreportReferrerAsSpam(
                     site,
                     domain,
                     YEARS,


### PR DESCRIPTION
The previous test was failing because it marked a fetched referrer as a spam but didn't revert the change at the end of the test. This is now fixed and instead of fetched referrer we're marking as a spam a fixed URL. This way we can be sure we can always unmark the referrer and we don't have to rely on the API.