### PR TITLE
Parcelizes FETCH_BLOCK_LAYOUTS response

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/BlockLayoutsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/BlockLayoutsResponse.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.network.Response
 
 data class BlockLayoutsResponse(
@@ -7,17 +9,19 @@ data class BlockLayoutsResponse(
     val categories: List<GutenbergLayoutCategory>
 ) : Response
 
+@Parcelize
 data class GutenbergLayout(
     val slug: String,
     val title: String,
     val preview: String,
     val content: String,
     val categories: List<GutenbergLayoutCategory>
-)
+) : Parcelable
 
+@Parcelize
 data class GutenbergLayoutCategory(
     val slug: String,
     val title: String,
     val description: String,
     val emoji: String
-)
+) : Parcelable


### PR DESCRIPTION
**Partially Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2452

**Depends on:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1703

**Description**
Makes  `GutenbergLayout` and `GutenbergLayoutCategory` `Parcelable` to able to save state for https://github.com/wordpress-mobile/WordPress-Android/pull/13022
