### PR TITLE
Implements FETCH_BLOCK_LAYOUTS response CACHING

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -16,6 +16,8 @@ import org.wordpress.android.fluxc.WellSqlTestUtils;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayout;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayoutCategory;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.PrivateAtomicCookie;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
@@ -29,6 +31,8 @@ import org.wordpress.android.fluxc.store.SiteStore.UpdateSitesResult;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -733,6 +737,25 @@ public class SiteStoreUnitTest {
             duplicate = true;
         }
         assertTrue(duplicate);
+    }
+
+    @Test
+    public void testInsertOrReplaceBlockLayouts() {
+        // Test data
+        SiteModel site = generateWPComSite();
+        GutenbergLayoutCategory cat1 = new GutenbergLayoutCategory("a", "About", "About", "👋");
+        GutenbergLayoutCategory cat2 = new GutenbergLayoutCategory("b", "Blog", "Blog", "📰");
+        List<GutenbergLayoutCategory> categories = Arrays.asList(cat1, cat2);
+        GutenbergLayout layout = new GutenbergLayout("l", "Layout", "img", "content", categories);
+        List<GutenbergLayout> layouts = Collections.singletonList(layout);
+        // Store
+        SiteSqlUtils.insertOrReplaceBlockLayouts(site, categories, layouts);
+        // Retrieve
+        List<GutenbergLayoutCategory> retrievedCategories = SiteSqlUtils.getBlockLayoutCategories(site);
+        List<GutenbergLayout> retrievedLayouts = SiteSqlUtils.getBlockLayouts(site);
+        // Check
+        assertEquals(categories, retrievedCategories);
+        assertEquals(layouts, retrievedLayouts);
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutCategoriesModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutCategoriesModel.kt
@@ -1,0 +1,42 @@
+package org.wordpress.android.fluxc.model.layouts
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayout
+
+@Table
+class GutenbergLayoutCategoriesModel(
+    @PrimaryKey @Column private var id: Int = 0,
+    @Column var layoutId: Int = 0, // Foreign key
+    @Column var categoryId: Int = 0, // Foreign key
+    @Column var siteId: Int = 0 // Foreign key
+) : Identifiable {
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}
+
+fun List<GutenbergLayout>.connections(site: SiteModel): List<GutenbergLayoutCategoriesModel> {
+    val connections = arrayListOf<GutenbergLayoutCategoriesModel>()
+    forEach { layout ->
+        getLayoutId(site.id, layout.slug)?.let { layoutId ->
+            layout.categories.forEach { category ->
+                getCategoryId(site.id, category.slug)?.let { categoryId ->
+                    connections.add(
+                            GutenbergLayoutCategoriesModel(
+                                    layoutId = layoutId,
+                                    categoryId = categoryId,
+                                    siteId = site.id
+                            )
+                    )
+                }
+            }
+        }
+    }
+    return connections
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutCategoryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutCategoryModel.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.fluxc.model.layouts
+
+import com.wellsql.generated.GutenbergLayoutCategoryModelTable
+import com.yarolegovich.wellsql.WellSql
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayoutCategory
+
+@Table
+class GutenbergLayoutCategoryModel(
+    @PrimaryKey @Column private var id: Int = 0,
+    @Column var slug: String = "",
+    @Column var siteId: Int = 0, // Foreign key
+    @Column var title: String = "",
+    @Column var description: String = "",
+    @Column var emoji: String = ""
+) : Identifiable {
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}
+
+fun GutenbergLayoutCategory.transform(site: SiteModel) = GutenbergLayoutCategoryModel(
+        slug = slug,
+        siteId = site.id,
+        title = title,
+        description = description,
+        emoji = emoji
+)
+
+fun GutenbergLayoutCategoryModel.transform() = GutenbergLayoutCategory(
+        slug = slug,
+        title = title,
+        description = description,
+        emoji = emoji
+)
+
+fun List<GutenbergLayoutCategoryModel>.transform() = map { it.transform() }
+
+fun List<GutenbergLayoutCategory>.transform(site: SiteModel) = map { it.transform(site) }
+
+fun getCategoryId(siteId: Int, categorySlug: String): Int? = WellSql.select(GutenbergLayoutCategoryModel::class.java)
+        .where()
+        .equals(GutenbergLayoutCategoryModelTable.SITE_ID, siteId)
+        .equals(GutenbergLayoutCategoryModelTable.SLUG, categorySlug)
+        .endWhere().asModel.firstOrNull()?.id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutModel.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.fluxc.model.layouts
+
+import com.wellsql.generated.GutenbergLayoutModelTable
+import com.yarolegovich.wellsql.WellSql
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayout
+
+@Table
+class GutenbergLayoutModel(
+    @PrimaryKey @Column private var id: Int = 0,
+    @Column var slug: String = "",
+    @Column var siteId: Int = 0, // Foreign key
+    @Column var title: String = "",
+    @Column var preview: String = "",
+    @Column var content: String = ""
+) : Identifiable {
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}
+
+fun GutenbergLayout.transform(site: SiteModel) = GutenbergLayoutModel(
+        slug = slug,
+        siteId = site.id,
+        title = title,
+        preview = preview,
+        content = content
+)
+
+fun GutenbergLayoutModel.transform(categories: List<GutenbergLayoutCategoryModel>) = GutenbergLayout(
+        slug = slug,
+        title = title,
+        preview = preview,
+        content = content,
+        categories = categories.transform()
+)
+
+fun List<GutenbergLayout>.transform(site: SiteModel) = map { it.transform(site) }
+
+fun getLayoutId(siteId: Int, layoutSlug: String): Int? = WellSql.select(GutenbergLayoutModel::class.java)
+        .where()
+        .equals(GutenbergLayoutModelTable.SITE_ID, siteId)
+        .equals(GutenbergLayoutModelTable.SLUG, layoutSlug)
+        .endWhere().asModel.firstOrNull()?.id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -6,6 +6,9 @@ import android.database.sqlite.SQLiteConstraintException;
 import androidx.annotation.NonNull;
 
 import com.wellsql.generated.AccountModelTable;
+import com.wellsql.generated.GutenbergLayoutCategoriesModelTable;
+import com.wellsql.generated.GutenbergLayoutCategoryModelTable;
+import com.wellsql.generated.GutenbergLayoutModelTable;
 import com.wellsql.generated.PostFormatModelTable;
 import com.wellsql.generated.RoleModelTable;
 import com.wellsql.generated.SiteModelTable;
@@ -17,10 +20,19 @@ import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.RoleModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.layouts.GutenbergLayoutCategoriesModel;
+import org.wordpress.android.fluxc.model.layouts.GutenbergLayoutCategoriesModelKt;
+import org.wordpress.android.fluxc.model.layouts.GutenbergLayoutCategoryModel;
+import org.wordpress.android.fluxc.model.layouts.GutenbergLayoutCategoryModelKt;
+import org.wordpress.android.fluxc.model.layouts.GutenbergLayoutModel;
+import org.wordpress.android.fluxc.model.layouts.GutenbergLayoutModelKt;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayout;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayoutCategory;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.UrlUtils;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -276,6 +288,62 @@ public class SiteSqlUtils {
             role.setSiteId(site.getId());
         }
         WellSql.insert(roles).execute();
+    }
+
+    public static List<GutenbergLayoutCategory> getBlockLayoutCategories(@NonNull SiteModel site) {
+        List<GutenbergLayoutCategoryModel> categories =
+                WellSql.select(GutenbergLayoutCategoryModel.class)
+                       .where()
+                       .equals(GutenbergLayoutCategoryModelTable.SITE_ID, site.getId())
+                       .endWhere().getAsModel();
+        return GutenbergLayoutCategoryModelKt.transform(categories);
+    }
+
+    public static List<GutenbergLayout> getBlockLayouts(@NonNull SiteModel site) {
+        ArrayList<GutenbergLayout> blockLayouts = new ArrayList();
+        List<GutenbergLayoutModel> layouts =
+                WellSql.select(GutenbergLayoutModel.class)
+                       .where()
+                       .equals(GutenbergLayoutModelTable.SITE_ID, site.getId())
+                       .endWhere().getAsModel();
+        for (GutenbergLayoutModel layout : layouts) {
+            List<GutenbergLayoutCategoriesModel> connections = WellSql.select(GutenbergLayoutCategoriesModel.class)
+                   .where()
+                   .equals(GutenbergLayoutCategoriesModelTable.SITE_ID, site.getId())
+                   .equals(GutenbergLayoutCategoriesModelTable.LAYOUT_ID, layout.getId())
+                   .endWhere().getAsModel();
+            for (GutenbergLayoutCategoriesModel connection : connections) {
+                List<GutenbergLayoutCategoryModel> categories = WellSql.select(GutenbergLayoutCategoryModel.class)
+                       .where()
+                       .equals(GutenbergLayoutCategoriesModelTable.ID, connection.getCategoryId())
+                       .endWhere().getAsModel();
+                blockLayouts.add(GutenbergLayoutModelKt.transform(layout, categories));
+            }
+        }
+        return blockLayouts;
+    }
+
+    public static void insertOrReplaceBlockLayouts(@NonNull SiteModel site,
+                                                   @NonNull List<GutenbergLayoutCategory> categories,
+                                                   @NonNull List<GutenbergLayout> layouts) {
+        // Update categories
+        WellSql.delete(GutenbergLayoutCategoryModel.class)
+               .where()
+               .equals(GutenbergLayoutCategoryModelTable.SITE_ID, site.getId())
+               .endWhere().execute();
+        WellSql.insert(GutenbergLayoutCategoryModelKt.transform(categories, site)).execute();
+        // Update layouts
+        WellSql.delete(GutenbergLayoutModel.class)
+               .where()
+               .equals(GutenbergLayoutModelTable.SITE_ID, site.getId())
+               .endWhere().execute();
+        WellSql.insert(GutenbergLayoutModelKt.transform(layouts, site)).execute();
+        // Update connections
+        WellSql.delete(GutenbergLayoutCategoriesModel.class)
+               .where()
+               .equals(GutenbergLayoutCategoriesModelTable.SITE_ID, site.getId())
+               .endWhere().execute();
+        WellSql.insert(GutenbergLayoutCategoriesModelKt.connections(layouts, site)).execute();
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -300,7 +300,7 @@ public class SiteSqlUtils {
     }
 
     public static List<GutenbergLayout> getBlockLayouts(@NonNull SiteModel site) {
-        ArrayList<GutenbergLayout> blockLayouts = new ArrayList();
+        ArrayList<GutenbergLayout> blockLayouts = new ArrayList<>();
         List<GutenbergLayoutModel> layouts =
                 WellSql.select(GutenbergLayoutModel.class)
                        .where()
@@ -312,13 +312,14 @@ public class SiteSqlUtils {
                    .equals(GutenbergLayoutCategoriesModelTable.SITE_ID, site.getId())
                    .equals(GutenbergLayoutCategoriesModelTable.LAYOUT_ID, layout.getId())
                    .endWhere().getAsModel();
+            ArrayList<GutenbergLayoutCategoryModel> categories = new ArrayList<>();
             for (GutenbergLayoutCategoriesModel connection : connections) {
-                List<GutenbergLayoutCategoryModel> categories = WellSql.select(GutenbergLayoutCategoryModel.class)
+                categories.addAll(WellSql.select(GutenbergLayoutCategoryModel.class)
                        .where()
                        .equals(GutenbergLayoutCategoriesModelTable.ID, connection.getCategoryId())
-                       .endWhere().getAsModel();
-                blockLayouts.add(GutenbergLayoutModelKt.transform(layout, categories));
+                       .endWhere().getAsModel());
             }
+            blockLayouts.add(GutenbergLayoutModelKt.transform(layout, categories));
         }
         return blockLayouts;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 118
+        return 119
     }
 
     override fun getDbName(): String {
@@ -1291,6 +1291,30 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("DROP TABLE IF EXISTS StockMediaPage")
                     db.execSQL("CREATE TABLE StockMediaPage (_id INTEGER PRIMARY KEY AUTOINCREMENT,PAGE INTEGER," +
                             "NEXT_PAGE INTEGER)")
+                }
+                118 -> migrate(version) {
+                    db.execSQL("DROP TABLE IF EXISTS GutenbergLayoutCategoryModel")
+                    db.execSQL("CREATE TABLE GutenbergLayoutCategoryModel (" +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "SLUG TEXT NOT NULL," +
+                            "SITE_ID INTEGER," +
+                            "TITLE TEXT NOT NULL," +
+                            "DESCRIPTION TEXT NOT NULL," +
+                            "EMOJI TEXT NOT NULL)")
+                    db.execSQL("DROP TABLE IF EXISTS GutenbergLayoutModel")
+                    db.execSQL("CREATE TABLE GutenbergLayoutModel (" +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "SLUG TEXT NOT NULL," +
+                            "SITE_ID INTEGER," +
+                            "TITLE TEXT NOT NULL," +
+                            "PREVIEW TEXT NOT NULL," +
+                            "CONTENT TEXT NOT NULL)")
+                    db.execSQL("DROP TABLE IF EXISTS GutenbergLayoutCategoriesModel")
+                    db.execSQL("CREATE TABLE GutenbergLayoutCategoriesModel (" +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "LAYOUT_ID INTEGER," +
+                            "CATEGORY_ID INTEGER," +
+                            "SITE_ID INTEGER)")
                 }
             }
         }


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2456

**Description**
This PR caches the fetch block layouts response

**To test**
This can be tested with https://github.com/wordpress-mobile/WordPress-Android/pull/13105
