### PR TITLE
issue/1719-detect-deleted-products

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -132,6 +132,20 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
+    fun testFetchInvalidProductIdError() {
+        interceptor.respondWithError("wc-fetch-invalid-product-id.json")
+        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCProductAction.FETCHED_SINGLE_PRODUCT, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteProductPayload
+        assertNotNull(payload.error)
+        assertEquals(payload.error.type, ProductErrorType.INVALID_PRODUCT_ID)
+    }
+
+    @Test
     fun testFetchSingleProductManageStock() {
         // check that a product's manage stock field is correctly set to true
         interceptor.respondWith("wc-fetch-product-response-manage-stock-true.json")

--- a/example/src/androidTest/resources/wc-fetch-invalid-product-id.json
+++ b/example/src/androidTest/resources/wc-fetch-invalid-product-id.json
@@ -1,0 +1,4 @@
+{
+  "error": "woocommerce_rest_product_invalid_id",
+  "message": "Invalid ID."
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1415,6 +1415,7 @@ class ProductRestClient(
 
     private fun networkErrorToProductError(wpComError: WPComGsonNetworkError): ProductError {
         val productErrorType = when (wpComError.apiError) {
+            "woocommerce_rest_product_invalid_id" -> ProductErrorType.INVALID_PRODUCT_ID
             "rest_invalid_param" -> ProductErrorType.INVALID_PARAM
             "woocommerce_rest_review_invalid_id" -> ProductErrorType.INVALID_REVIEW_ID
             "woocommerce_product_invalid_image_id" -> ProductErrorType.INVALID_IMAGE_ID

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -186,6 +186,7 @@ class WCProductStore @Inject constructor(
     ) : Payload<BaseNetworkError>()
 
     enum class ProductErrorType {
+        INVALID_PRODUCT_ID,
         INVALID_PARAM,
         INVALID_REVIEW_ID,
         INVALID_IMAGE_ID,


### PR DESCRIPTION
Fixes #1719 - This PR adds `ProductErrorType.INVALID_PRODUCT_ID` to handle requests for products that no longer exists. Related test included.