### PR TITLE
Shipping labels: Address verification

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
 import org.wordpress.android.fluxc.example.ui.products.WooUpdateVariationFragment
 import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
 import org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment
+import org.wordpress.android.fluxc.example.ui.shippinglabels.WooVerifyAddressFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
@@ -109,6 +110,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooShippingLabelFragmentInjector(): WooShippingLabelFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooVerifyAddressFragment(): WooVerifyAddressFragment
 
     @ContributesAndroidInjector
     abstract fun provideWooLeaderboardsFragmentInjector(): WooLeaderboardsFragment

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -22,7 +22,11 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.products.WooProductTagsFragment
+import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
+import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment.Companion
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -176,6 +180,17 @@ class WooShippingLabelFragment : Fragment() {
                         }
                     }
                 }
+            }
+        }
+
+        verify_address.setOnClickListener {
+            selectedSite?.let { site ->
+                replaceFragment(
+                        WooVerifyAddressFragment.newInstance(
+                                fragment = this,
+                                site
+                        )
+                )
             }
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -24,9 +24,6 @@ import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
-import org.wordpress.android.fluxc.example.ui.products.WooProductTagsFragment
-import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment
-import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment.Companion
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -185,12 +182,7 @@ class WooShippingLabelFragment : Fragment() {
 
         verify_address.setOnClickListener {
             selectedSite?.let { site ->
-                replaceFragment(
-                        WooVerifyAddressFragment.newInstance(
-                                fragment = this,
-                                site
-                        )
-                )
+                replaceFragment(WooVerifyAddressFragment.newInstance(site))
             }
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
@@ -66,7 +66,7 @@ class WooVerifyAddressFragment : Fragment() {
                                 address_city.getText(),
                                 address_zip.getText()
                         ),
-                        ORIGIN
+                        if (destination.isChecked) DESTINATION else ORIGIN
                 )
                 Log.d("ONKO", result.toString())
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
@@ -16,7 +16,8 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Invalid
+import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidRequest
+import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Valid
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.DESTINATION
@@ -77,8 +78,11 @@ class WooVerifyAddressFragment : Fragment() {
                     result.model is Valid -> {
                         prependToLog("${(result.model as Valid).suggestedAddress}")
                     }
-                    result.model is Invalid -> {
-                        prependToLog((result.model as Invalid).message)
+                    result.model is InvalidAddress -> {
+                        prependToLog("Address error: ${(result.model as InvalidAddress).message}")
+                    }
+                    result.model is InvalidRequest -> {
+                        prependToLog("Request error: ${(result.model as InvalidRequest).message}")
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
@@ -1,46 +1,26 @@
 package org.wordpress.android.fluxc.example.ui.shippinglabels
 
 import android.content.Context
-import android.content.Intent
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
-import android.os.Environment
-import android.util.Base64
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.RequiresApi
-import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.fragment_woo_shippinglabels.*
 import kotlinx.android.synthetic.main.fragment_woo_shippinglabels.verify_address
 import kotlinx.android.synthetic.main.fragment_woo_verify_address.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
-import org.wordpress.android.fluxc.example.prependToLog
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
-import org.wordpress.android.fluxc.example.ui.products.WooProductTagsFragment
-import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment.ProductTag
-import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.DESTINATION
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.ORIGIN
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
 
 class WooVerifyAddressFragment : Fragment() {
@@ -53,16 +33,9 @@ class WooVerifyAddressFragment : Fragment() {
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     companion object {
-        const val SHIPPING_LABEL_REQUEST_CODE = 1000
-        const val ARG_RESULT_CODE = "ARG_RESULT_CODE"
-        const val ARG_ADDRESS = "ARG_ADDRESS"
-        const val ARG_SELECTED_PRODUCT_TAGS = "ARG_SELECTED_PRODUCT_TAGS"
-
         fun newInstance(
-            fragment: Fragment,
             site: SiteModel
         ) = WooVerifyAddressFragment().apply {
-            this.setTargetFragment(fragment, SHIPPING_LABEL_REQUEST_CODE)
             this.selectedSite = site
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.example.ui.shippinglabels
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -22,7 +21,6 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationRes
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.DESTINATION
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.ORIGIN
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
@@ -15,10 +15,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Invalid
+import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Valid
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.DESTINATION
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.ORIGIN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -68,7 +72,17 @@ class WooVerifyAddressFragment : Fragment() {
                         ),
                         if (destination.isChecked) DESTINATION else ORIGIN
                 )
-                Log.d("ONKO", result.toString())
+                when {
+                    result.isError -> {
+                        prependToLog("${result.error.message}")
+                    }
+                    result.model is Valid -> {
+                        prependToLog("${(result.model as Valid).suggestedAddress}")
+                    }
+                    result.model is Invalid -> {
+                        prependToLog((result.model as Invalid).message)
+                    }
+                }
             }
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
@@ -55,34 +55,38 @@ class WooVerifyAddressFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         verify_address.setOnClickListener {
-            coroutineScope.launch {
-                val result = wcShippingLabelStore.verifyAddress(
-                        selectedSite,
-                        ShippingLabelAddress(
-                                address_company.getText(),
-                                address_name.getText(),
-                                address_phone.getText(),
-                                address_country.getText(),
-                                address_state.getText(),
-                                address_address1.getText(),
-                                address_address2.getText(),
-                                address_city.getText(),
-                                address_zip.getText()
-                        ),
-                        if (destination.isChecked) DESTINATION else ORIGIN
-                )
-                when {
-                    result.isError -> {
-                        prependToLog("${result.error.message}")
-                    }
-                    result.model is Valid -> {
-                        prependToLog("${(result.model as Valid).suggestedAddress}")
-                    }
-                    result.model is InvalidAddress -> {
-                        prependToLog("Address error: ${(result.model as InvalidAddress).message}")
-                    }
-                    result.model is InvalidRequest -> {
-                        prependToLog("Request error: ${(result.model as InvalidRequest).message}")
+            if (address_country.getText().isBlank()) {
+                prependToLog("Validation error: Country is required (2-letter acronym) ")
+            } else {
+                coroutineScope.launch {
+                    val result = wcShippingLabelStore.verifyAddress(
+                            selectedSite,
+                            ShippingLabelAddress(
+                                    address_company.getText(),
+                                    address_name.getText(),
+                                    address_phone.getText(),
+                                    address_country.getText(),
+                                    address_state.getText(),
+                                    address_address1.getText(),
+                                    address_address2.getText(),
+                                    address_city.getText(),
+                                    address_zip.getText()
+                            ),
+                            if (destination.isChecked) DESTINATION else ORIGIN
+                    )
+                    when {
+                        result.isError -> {
+                            prependToLog("${result.error.message}")
+                        }
+                        result.model is Valid -> {
+                            prependToLog("${(result.model as Valid).suggestedAddress}")
+                        }
+                        result.model is InvalidAddress -> {
+                            prependToLog("Address error: ${(result.model as InvalidAddress).message}")
+                        }
+                        result.model is InvalidRequest -> {
+                            prependToLog("Request error: ${(result.model as InvalidRequest).message}")
+                        }
                     }
                 }
             }

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -59,5 +59,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Print Shipping Label"/>
+
+        <Button
+            android:id="@+id/verify_address"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Verify address"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woo_verify_address.xml
+++ b/example/src/main/res/layout/fragment_woo_verify_address.xml
@@ -1,0 +1,77 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context="org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="Name" />
+
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_company"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="Company" />
+
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_phone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="Phone" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_address1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="Address" />
+
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_address2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="Address 2" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_city"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="City" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_state"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="State" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_zip"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="ZIP Code" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/address_country"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:textHint="Country" />
+
+        <Button
+            android:id="@+id/verify_address"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Verify address"/>
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woo_verify_address.xml
+++ b/example/src/main/res/layout/fragment_woo_verify_address.xml
@@ -68,6 +68,24 @@
             android:layout_height="wrap_content"
             app:textHint="Country" />
 
+        <RadioGroup
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" >
+
+            <RadioButton
+                android:id="@+id/origin"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Origin" />
+
+            <RadioButton
+                android:id="@+id/destination"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Destination" />
+        </RadioGroup>
+
         <Button
             android:id="@+id/verify_address"
             android:layout_width="wrap_content"

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -42,4 +42,6 @@
 /connect/label/<order_id>/<shippingLabelId>/
 /connect/label/<order_id>/<shippingLabelId>/refund
 
+/connect/normalize-address
+
 /leaderboards

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/JsonExt.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/JsonExt.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.network.utils
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+// Convert an object of type T to type R
+inline fun <T, reified R> T.convert(): R {
+    val gson = Gson()
+    val json = gson.toJson(this)
+    return gson.fromJson(json, object : TypeToken<R>() {}.type)
+}
+
+// Convert an object to a Map
+fun <T> T.toMap(): Map<String, Any> {
+    return convert()
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAddressVerificationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAddressVerificationResult.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
+
+sealed class WCAddressVerificationResult {
+    class Valid(val suggestedAddress: ShippingLabelAddress) : WCAddressVerificationResult()
+    class Invalid(val message: String) : WCAddressVerificationResult()
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAddressVerificationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAddressVerificationResult.kt
@@ -4,5 +4,6 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.Shi
 
 sealed class WCAddressVerificationResult {
     class Valid(val suggestedAddress: ShippingLabelAddress) : WCAddressVerificationResult()
-    class Invalid(val message: String) : WCAddressVerificationResult()
+    class InvalidAddress(val message: String) : WCAddressVerificationResult()
+    class InvalidRequest(val message: String) : WCAddressVerificationResult()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAddressVerificationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAddressVerificationResult.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.model.shippinglabels
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 
 sealed class WCAddressVerificationResult {
-    class Valid(val suggestedAddress: ShippingLabelAddress) : WCAddressVerificationResult()
-    class InvalidAddress(val message: String) : WCAddressVerificationResult()
-    class InvalidRequest(val message: String) : WCAddressVerificationResult()
+    data class Valid(val suggestedAddress: ShippingLabelAddress) : WCAddressVerificationResult()
+    data class InvalidAddress(val message: String) : WCAddressVerificationResult()
+    data class InvalidRequest(val message: String) : WCAddressVerificationResult()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -116,16 +116,21 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
         @SerializedName("selected_packages") val selectedPackage: SelectedPackage? = null
     }
 
-    class ShippingLabelAddress {
-        val company: String? = null
-        val name: String? = null
-        val phone: String? = null
-        val country: String? = null
-        val state: String? = null
-        val address: String? = null
-        val address2: String? = null
-        val city: String? = null
+    data class ShippingLabelAddress(
+        val company: String? = null,
+        val name: String? = null,
+        val phone: String? = null,
+        val country: String? = null,
+        val state: String? = null,
+        val address: String? = null,
+        val address2: String? = null,
+        val city: String? = null,
         val postcode: String? = null
+    ) {
+        enum class Type {
+            ORIGIN,
+            DESTINATION
+        }
     }
 
     class SelectedPackage {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -123,7 +123,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
         val country: String? = null,
         val state: String? = null,
         val address: String? = null,
-        val address2: String? = null,
+        @SerializedName("address_2") val address2: String? = null,
         val city: String? = null,
         val postcode: String? = null
     ) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -143,7 +143,7 @@ constructor(
     data class VerifyAddressResponse(
         @SerializedName("success") val isSuccess: Boolean,
         @SerializedName("is_trivial_normalization") val isTrivialNormalization: Boolean,
-        @SerializedName("normalized") val suggestedAddress : ShippingLabelAddress?,
+        @SerializedName("normalized") val suggestedAddress: ShippingLabelAddress?,
         @SerializedName("field_errors") val error: Error?
     ) {
         data class Error(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -141,11 +141,13 @@ constructor(
 
     data class VerifyAddressResponse(
         @SerializedName("success") val isSuccess: Boolean,
+        @SerializedName("is_trivial_normalization") val isTrivialNormalization: Boolean,
         @SerializedName("normalized") val suggestedAddress : ShippingLabelAddress?,
         @SerializedName("field_errors") val error: Error?
     ) {
         data class Error(
-            @SerializedName("general") val message: String
+            @SerializedName("general") val message: String,
+            @SerializedName("address") val address: String
         )
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -2,9 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
 
 import android.content.Context
 import com.android.volley.RequestQueue
-import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
-import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.android.volley.RequestQueue
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
@@ -16,6 +17,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.network.utils.toMap
+import java.util.Locale
 import javax.inject.Singleton
 
 @Singleton
@@ -112,8 +115,8 @@ constructor(
     ): WooPayload<VerifyAddressResponse> {
         val url = WOOCOMMERCE.connect.normalize_address.pathV1
         val params = mapOf(
-                "address" to Gson().toJson(address).toString(),
-                "type" to type.name
+                "address" to address.toMap(),
+                "type" to type.name.toLowerCase(Locale.ROOT)
         )
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -149,8 +149,8 @@ constructor(
         @SerializedName("field_errors") val error: Error?
     ) {
         data class Error(
-            @SerializedName("general") val message: String,
-            @SerializedName("address") val address: String
+            @SerializedName("general") val message: String?,
+            @SerializedName("address") val address: String?
         )
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -116,7 +116,7 @@ constructor(
                 "type" to type.name
         )
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,
                 site,
                 url,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -110,7 +110,7 @@ class WCShippingLabelStore @Inject constructor(
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "verifyAddress") {
             val response = restClient.verifyAddress(site, address, type)
             return@withDefaultContext if (response.isError) {
-                WooResult(response.error.apply { message = message?: "" })
+                WooResult(response.error.apply { message = message ?: "" })
             } else if (response.result?.error != null) {
                 if (!response.result.error.address.isNullOrBlank()) {
                     WooResult(InvalidAddress(response.result.error.address))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.store
 
-import android.text.TextUtils
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Invalid

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -2,7 +2,8 @@ package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult
-import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Invalid
+import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidAddress
+import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidRequest
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Valid
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelMapper
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
@@ -111,7 +112,11 @@ class WCShippingLabelStore @Inject constructor(
             return@withDefaultContext if (response.isError) {
                 WooResult(response.error)
             } else if (response.result?.error != null) {
-                WooResult(Invalid(response.result.error.address + response.error.message))
+                if (!response.result.error.address.isNullOrBlank()) {
+                    WooResult(InvalidAddress(response.result.error.address))
+                } else {
+                    WooResult(InvalidRequest(response.result.error.message ?: ""))
+                }
             } else if (response.result?.suggestedAddress != null && response.result.isSuccess) {
                 WooResult(Valid(response.result.suggestedAddress))
             } else {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.store
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelMapper
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -91,6 +92,25 @@ class WCShippingLabelStore @Inject constructor(
                 }
                 response.result?.success == true -> {
                     WooResult(response.result.b64Content)
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
+    suspend fun verifyAddress(
+        site: SiteModel,
+        address: ShippingLabelAddress,
+        type: ShippingLabelAddress.Type
+    ): WooResult<ShippingLabelAddress> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "verifyAddress") {
+            val response = restClient.verifyAddress(site, address, type)
+            return@withDefaultContext when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+                response.result?.isSuccess == true -> {
+                    WooResult(response.result.suggestedAddress)
                 }
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -110,7 +110,7 @@ class WCShippingLabelStore @Inject constructor(
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "verifyAddress") {
             val response = restClient.verifyAddress(site, address, type)
             return@withDefaultContext if (response.isError) {
-                WooResult(response.error)
+                WooResult(response.error.apply { message = message?: "" })
             } else if (response.result?.error != null) {
                 if (!response.result.error.address.isNullOrBlank()) {
                     WooResult(InvalidAddress(response.result.error.address))
@@ -120,7 +120,7 @@ class WCShippingLabelStore @Inject constructor(
             } else if (response.result?.suggestedAddress != null && response.result.isSuccess) {
                 WooResult(Valid(response.result.suggestedAddress))
             } else {
-                WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+                WooResult(WooError(GENERIC_ERROR, UNKNOWN, "Unknown error"))
             }
         }
     }


### PR DESCRIPTION
Fixes #1716.

This PR adds client support for the address verification endpoint.

**To test:**

1. Authenticate
2. Go to Woo -> Shipping labels
3. Select site with shipping labels
4. Tap on the Verify address button
5. Fill out the form with a valid address
6. Tap on the Verify address button
7. Notice a normalized address object is returned
8. Fill out an invalid address
9. Notice an error is displayed