### PR TITLE
Issue/1723 woo linked products

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -627,6 +627,8 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             virtual = true
             images = generateTestImageListJsonString()
             groupedProductIds = "[10, 11]"
+            crossSellIds = "[1, 2, 3]"
+            upsellIds = "[1, 2, 3, 4]"
             type = "simple"
         }
         productRestClient.updateProduct(siteModel, testProduct, updatedProduct)
@@ -645,6 +647,8 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(updatedProduct.virtual, product.virtual)
             assertEquals(updatedProduct.getImageList().size, 2)
             assertEquals(updatedProduct.getGroupedProductIdList().size, 2)
+            assertEquals(updatedProduct.getCrossSellProductIdList().size, 3)
+            assertEquals(updatedProduct.getUpsellProductIdList().size, 4)
             assertEquals(updatedProduct.type, product.type)
         }
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -577,6 +577,12 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         val updatedGroupedProductIds = "[770,771]"
         productModel.groupedProductIds = updatedGroupedProductIds
 
+        val updatedCrossSellProductIds = "[1,2,3]"
+        productModel.crossSellIds = updatedCrossSellProductIds
+
+        val updatedUpsellProductIds = "[1,2,3,4]"
+        productModel.upsellIds = updatedUpsellProductIds
+
         val updatedProductType = "grouped"
         productModel.type = updatedProductType
 
@@ -601,6 +607,8 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         assertEquals(updateProductPurchaseNote, updatedProduct?.purchaseNote)
         assertEquals(updatedProductMenuOrder, updatedProduct?.menuOrder)
         assertEquals(updatedGroupedProductIds, updatedProduct?.groupedProductIds)
+        assertEquals(updatedCrossSellProductIds, updatedProduct?.crossSellIds)
+        assertEquals(updatedUpsellProductIds, updatedProduct?.upsellIds)
     }
 
     @Throws(InterruptedException::class)

--- a/example/src/androidTest/resources/wc-fetch-product-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-success.json
@@ -57,6 +57,7 @@
       }
     ],
     "cross_sell_ids": [
+      1, 2, 3, 4
     ],
     "date_created": "2018-11-02T14:02:28",
     "date_created_gmt": "2018-11-02T18:02:28",
@@ -219,6 +220,7 @@
     "total_sales": 11,
     "type": "simple",
     "upsell_ids": [
+      1, 2, 3
     ],
     "variations": [192, 193],
     "virtual": true,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -178,6 +178,40 @@ class WooUpdateProductFragment : Fragment() {
             }
         }
 
+        cross_sell_product_ids.isEnabled = false
+        select_cross_sell_product_ids.setOnClickListener {
+            showSingleLineDialog(activity, "Enter a remoteProductId:") { editText ->
+                editText.text.toString().toLongOrNull()?.let { id ->
+                    val storedCrossSellIds =
+                            selectedProductModel?.getCrossSellProductIdList()?.toMutableList() ?: mutableListOf()
+                    storedCrossSellIds.add(id)
+                    selectedProductModel?.crossSellIds = storedCrossSellIds.joinToString(
+                            separator = ",",
+                            prefix = "[",
+                            postfix = "]"
+                    )
+                    selectedProductModel?.crossSellIds?.let { updateCrossSellProductIds(it) }
+                } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+            }
+        }
+
+        upsell_product_ids.isEnabled = false
+        select_upsell_product_ids.setOnClickListener {
+            showSingleLineDialog(activity, "Enter a remoteProductId:") { editText ->
+                editText.text.toString().toLongOrNull()?.let { id ->
+                    val storedUpsellIds =
+                            selectedProductModel?.getUpsellProductIdList()?.toMutableList() ?: mutableListOf()
+                    storedUpsellIds.add(id)
+                    selectedProductModel?.upsellIds = storedUpsellIds.joinToString(
+                            separator = ",",
+                            prefix = "[",
+                            postfix = "]"
+                    )
+                    selectedProductModel?.upsellIds?.let { updateUpsellProductIds(it) }
+                } ?: prependToLog("No valid remoteProductId defined...doing nothing")
+            }
+        }
+
         product_name.onTextChanged { selectedProductModel?.name = it }
         product_description.onTextChanged { selectedProductModel?.description = it }
         product_sku.onTextChanged { selectedProductModel?.sku = it }
@@ -422,6 +456,14 @@ class WooUpdateProductFragment : Fragment() {
         grouped_product_ids.setText(storedGroupedProductIds)
     }
 
+    private fun updateCrossSellProductIds(storedCrossSellProductIds: String) {
+        cross_sell_product_ids.setText(storedCrossSellProductIds)
+    }
+
+    private fun updateUpsellProductIds(storedUpsellProductIds: String) {
+        upsell_product_ids.setText(storedUpsellProductIds)
+    }
+
     private fun updateSelectedProductId(remoteProductId: Long) {
         getWCSite()?.let { siteModel ->
             enableProductDependentButtons()
@@ -470,6 +512,8 @@ class WooUpdateProductFragment : Fragment() {
         product_external_url.setText(it.externalUrl)
         product_button_text.setText(it.buttonText)
         updateGroupedProductIds(it.groupedProductIds)
+        updateCrossSellProductIds(it.crossSellIds)
+        updateUpsellProductIds(it.upsellIds)
         product_categories.setText(
                 selectedCategories?.joinToString(", ") { it.name }
                         ?: it.getCommaSeparatedCategoryNames()

--- a/example/src/main/res/layout/fragment_woo_update_product.xml
+++ b/example/src/main/res/layout/fragment_woo_update_product.xml
@@ -541,5 +541,57 @@
             app:layout_constraintStart_toEndOf="@+id/grouped_product_ids"
             app:layout_constraintTop_toBottomOf="@+id/product_password" />
 
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/cross_sell_product_ids"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="text"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            app:layout_constraintEnd_toStartOf="@+id/select_cross_sell_product_ids"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/grouped_product_ids"
+            app:textHint="Cross-sell Product IDs" />
+
+        <Button
+            android:id="@+id/select_cross_sell_product_ids"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Add product IDs"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/cross_sell_product_ids"
+            app:layout_constraintTop_toBottomOf="@+id/grouped_product_ids" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/upsell_product_ids"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:inputType="text"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            app:layout_constraintEnd_toStartOf="@+id/select_upsell_product_ids"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/cross_sell_product_ids"
+            app:textHint="Upsell Product IDs" />
+
+        <Button
+            android:id="@+id/select_upsell_product_ids"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="false"
+            android:text="Add product IDs"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/upsell_product_ids"
+            app:layout_constraintTop_toBottomOf="@+id/cross_sell_product_ids" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -239,25 +239,14 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         }
     }
 
-    fun getGroupedProductIdList(): List<Long> {
-        val groupedIds = ArrayList<Long>()
-        try {
-            if (groupedProductIds.isNotEmpty()) {
-                Gson().fromJson(groupedProductIds, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
-                    jsonElement.asLong.let { groupedIds.add(it) }
-                }
-            }
-        } catch (e: JsonParseException) {
-            AppLog.e(T.API, e)
-        }
-        return groupedIds
-    }
-
-    fun getUpsellProductIdList(): List<Long> {
+    /**
+     * Returns a list of product IDs from the passed string, assumed to be a JSON array of IDs
+     */
+    private fun parseProductIds(jsonString: String): List<Long> {
         val productIds = ArrayList<Long>()
         try {
-            if (upsellIds.isNotEmpty()) {
-                Gson().fromJson(upsellIds, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+            if (jsonString.isNotEmpty()) {
+                Gson().fromJson(jsonString, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
                     jsonElement.asLong.let { productIds.add(it) }
                 }
             }
@@ -267,19 +256,11 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return productIds
     }
 
-    fun getCrossSellProductIdList(): List<Long> {
-        val productIds = ArrayList<Long>()
-        try {
-            if (crossSellIds.isNotEmpty()) {
-                Gson().fromJson(crossSellIds, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
-                    jsonElement.asLong.let { productIds.add(it) }
-                }
-            }
-        } catch (e: JsonParseException) {
-            AppLog.e(T.API, e)
-        }
-        return productIds
-    }
+    fun getGroupedProductIdList() = parseProductIds(groupedProductIds)
+
+    fun getUpsellProductIdList() = parseProductIds(upsellIds)
+
+    fun getCrossSellProductIdList() = parseProductIds(crossSellIds)
 
     fun getCategoryList() = getTriplets(categories)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -253,6 +253,34 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return groupedIds
     }
 
+    fun getUpsellProductIdList(): List<Long> {
+        val productIds = ArrayList<Long>()
+        try {
+            if (upsellIds.isNotEmpty()) {
+                Gson().fromJson(upsellIds, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+                    jsonElement.asLong.let { productIds.add(it) }
+                }
+            }
+        } catch (e: JsonParseException) {
+            AppLog.e(T.API, e)
+        }
+        return productIds
+    }
+
+    fun getCrossSellProductIdList(): List<Long> {
+        val productIds = ArrayList<Long>()
+        try {
+            if (crossSellIds.isNotEmpty()) {
+                Gson().fromJson(crossSellIds, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+                    jsonElement.asLong.let { productIds.add(it) }
+                }
+            }
+        } catch (e: JsonParseException) {
+            AppLog.e(T.API, e)
+        }
+        return productIds
+    }
+
     fun getCategoryList() = getTriplets(categories)
 
     fun getCommaSeparatedCategoryNames() = getCommaSeparatedTripletNames(getCategoryList())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1207,7 +1207,7 @@ class ProductRestClient(
             body["cross_sell_ids"] = updatedProductModel.getCrossSellProductIdList()
         }
         if (storedWCProductModel.upsellIds != updatedProductModel.upsellIds) {
-            body["up_sell_ids"] = updatedProductModel.getUpsellProductIdList()
+            body["upsell_ids"] = updatedProductModel.getUpsellProductIdList()
         }
         return body
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1203,6 +1203,12 @@ class ProductRestClient(
         if (storedWCProductModel.groupedProductIds != updatedProductModel.groupedProductIds) {
             body["grouped_products"] = updatedProductModel.getGroupedProductIdList()
         }
+        if (storedWCProductModel.crossSellIds != updatedProductModel.crossSellIds) {
+            body["cross_sell_ids"] = updatedProductModel.getCrossSellProductIdList()
+        }
+        if (storedWCProductModel.upsellIds != updatedProductModel.upsellIds) {
+            body["up_sell_ids"] = updatedProductModel.getUpsellProductIdList()
+        }
         return body
     }
 


### PR DESCRIPTION
Closes #1723 - this PR adds support for product cross-sells and upsells. Previously these were already part of the product model, but there wasn't a way to get a list of the linked IDs, nor did `ProductRestClient` support updating these IDs.

To test:

- Verify in the product screen of the example app that both cross-sell IDs and upsell IDs show correctly
- Verify in the product screen of the example app that both cross-sell IDs and upsell IDs are updated correctly
- Run `ReleaseStack_WCProductTest.testUpdateProduct` and verify that it succeeds
- Run `MockedStack_WCProductsTest.testUpdateProductSuccess` and verify that it succeeds

![linked](https://user-images.githubusercontent.com/3903757/96497664-0ad2c680-1219-11eb-8009-748fb6dc0751.png)

