### PR TITLE
Fix visibility of created sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -224,7 +224,7 @@ public class SiteRestClient extends BaseWPComRestClient {
         Map<String, Object> body = new HashMap<>();
         body.put("blog_name", siteName);
         body.put("lang_id", language);
-        body.put("public", visibility.toString());
+        body.put("public", String.valueOf(visibility.value()));
         body.put("validate", dryRun ? "1" : "0");
         body.put("client_id", mAppSecrets.getAppId());
         body.put("client_secret", mAppSecrets.getAppSecret());


### PR DESCRIPTION
This PR fixes an issue with the "Create new site" endpoint. We were sending `"public": "PUBLIC"` parameter instead of `"public":"1"`. 

Corresponding PR in WPAndroid is [here](https://github.com/wordpress-mobile/WordPress-Android/pull/13182).

More info p4a5px-2DW-p2