### PR TITLE
Add unparsed referrers object to lower db load

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/stats/TimeStatsMapperTest.kt
@@ -59,7 +59,7 @@ class TimeStatsMapperTest {
 
     @Test
     fun `parses empty referrers`() {
-        val response = ReferrersResponse("DAYS", emptyMap())
+        val response = ReferrersResponse("DAYS", null, null, emptyList())
 
         val result = timeStatsMapper.map(response, LimitMode.Top(5))
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
@@ -30,7 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReportReferrerAsSpamResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.UnparsedReferrersResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.UnparsedReferrersResponse.UnparsedGroup
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.UnparsedReferrersResponse.UnparsedReferrerGroup
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
@@ -126,7 +126,7 @@ class ReferrersRestClientTest {
                 "\"results\":" +
                 "{\"views\":16}" +
                 "}"
-        val unparsedGroup = gson.fromJson(group, UnparsedGroup::class.java)
+        val unparsedGroup = gson.fromJson(group, UnparsedReferrerGroup::class.java)
 
         val parsedGroup = unparsedGroup.parse(gson)
 
@@ -151,11 +151,11 @@ class ReferrersRestClientTest {
                 "\"results\":" +
                 "[{\"name\":\"$firstReferrerName\",\"url\":\"$firstUrl\",\"views\":$firstViews}," +
                 "{\"name\":\"$secondReferrerName\",\"url\":\"$secondUrl\",\"views\":$secondViews}]}"
-        val unparsedGroup = gson.fromJson(group, UnparsedGroup::class.java)
+        val unparsedGroup = gson.fromJson(group, UnparsedReferrerGroup::class.java)
 
         val parsedGroup = unparsedGroup.parse(gson)
 
-        assertThat(parsedGroup.groupId).isEqualTo(groupId)
+        assertThat(parsedGroup.group).isEqualTo(groupId)
         assertThat(parsedGroup.views).isNull()
         assertThat(parsedGroup.referrers).hasSize(2)
         parsedGroup.referrers?.get(0)?.apply {

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
@@ -211,18 +211,14 @@ class ReferrersStoreTest {
         val groupResult = store.setSelectForSpam(REFERRERS_RESPONSE, "url_group_2.com", true)
 
         // Asserting group 1 is set with spam as false and group 2 is set with spam as true
-        assertThat(groupResult.groups.entries.toTypedArray()[0].value.groups[0].markedAsSpam!!).isFalse
-        assertThat(groupResult.groups.entries.toTypedArray()[0].value.groups[1].markedAsSpam!!).isTrue
+        assertThat(groupResult.groups[0].markedAsSpam).isFalse()
+        assertThat(groupResult.groups[1].markedAsSpam).isTrue()
 
         val referrerResult = store.setSelectForSpam(REFERRERS_RESPONSE, "john.com", true)
-        assertThat(
-                ((referrerResult.groups.entries.toTypedArray()[0].value.groups[0].referrers as List<*>)
-                [0] as ReferrersResponse.Referrer).markedAsSpam!!).isTrue
+        assertThat(referrerResult.groups[0].referrers!![0].markedAsSpam).isTrue()
 
         val childResult = store.setSelectForSpam(REFERRERS_RESPONSE, "child.com", true)
-        assertThat(
-                ((childResult.groups.entries.toTypedArray()[0].value.groups[0].referrers as List<*>)
-                        [0] as ReferrersResponse.Referrer).children?.get(0)?.markedAsSpam!!).isTrue
+        assertThat(childResult.groups[0].referrers!![0].children?.get(0)?.markedAsSpam).isTrue()
     }
 
     @Test
@@ -231,19 +227,15 @@ class ReferrersStoreTest {
         val groupResult = store.setSelectForSpam(groupResultWithSpam, "url_group_2.com", false)
 
         // Asserting group 1 and group 2 is set with spam to false
-        assertThat(groupResult.groups.entries.toTypedArray()[0].value.groups[0].markedAsSpam!!).isFalse
-        assertThat(groupResult.groups.entries.toTypedArray()[0].value.groups[1].markedAsSpam!!).isFalse
+        assertThat(groupResult.groups[0].markedAsSpam).isFalse()
+        assertThat(groupResult.groups[1].markedAsSpam).isFalse()
 
         val referrerResultWitSpam = store.setSelectForSpam(REFERRERS_RESPONSE, "john.com", true)
         val referrerResult = store.setSelectForSpam(referrerResultWitSpam, "john.com", false)
-        assertThat(
-                ((referrerResult.groups.entries.toTypedArray()[0].value.groups[0].referrers as List<*>)
-                [0] as ReferrersResponse.Referrer).markedAsSpam!!).isFalse
+        assertThat(referrerResult.groups[0].referrers!![0].markedAsSpam).isFalse()
 
         val childResultWithSpam = store.setSelectForSpam(REFERRERS_RESPONSE, "child.com", true)
         val childResult = store.setSelectForSpam(childResultWithSpam, "child.com", false)
-        assertThat(
-                ((childResult.groups.entries.toTypedArray()[0].value.groups[0].referrers as List<*>)
-                        [0] as ReferrersResponse.Referrer).children?.get(0)?.markedAsSpam!!).isFalse
+        assertThat(childResult.groups[0].referrers!![0].children?.get(0)?.markedAsSpam).isFalse()
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStoreTest.kt
@@ -211,14 +211,14 @@ class ReferrersStoreTest {
         val groupResult = store.setSelectForSpam(REFERRERS_RESPONSE, "url_group_2.com", true)
 
         // Asserting group 1 is set with spam as false and group 2 is set with spam as true
-        assertThat(groupResult.groups[0].markedAsSpam).isFalse()
-        assertThat(groupResult.groups[1].markedAsSpam).isTrue()
+        assertThat(groupResult.referrerGroups[0].markedAsSpam).isFalse()
+        assertThat(groupResult.referrerGroups[1].markedAsSpam).isTrue()
 
         val referrerResult = store.setSelectForSpam(REFERRERS_RESPONSE, "john.com", true)
-        assertThat(referrerResult.groups[0].referrers!![0].markedAsSpam).isTrue()
+        assertThat(referrerResult.referrerGroups[0].referrers!![0].markedAsSpam).isTrue()
 
         val childResult = store.setSelectForSpam(REFERRERS_RESPONSE, "child.com", true)
-        assertThat(childResult.groups[0].referrers!![0].children?.get(0)?.markedAsSpam).isTrue()
+        assertThat(childResult.referrerGroups[0].referrers!![0].markedAsSpam).isTrue()
     }
 
     @Test
@@ -227,15 +227,15 @@ class ReferrersStoreTest {
         val groupResult = store.setSelectForSpam(groupResultWithSpam, "url_group_2.com", false)
 
         // Asserting group 1 and group 2 is set with spam to false
-        assertThat(groupResult.groups[0].markedAsSpam).isFalse()
-        assertThat(groupResult.groups[1].markedAsSpam).isFalse()
+        assertThat(groupResult.referrerGroups[0].markedAsSpam).isFalse()
+        assertThat(groupResult.referrerGroups[1].markedAsSpam).isFalse()
 
         val referrerResultWitSpam = store.setSelectForSpam(REFERRERS_RESPONSE, "john.com", true)
         val referrerResult = store.setSelectForSpam(referrerResultWitSpam, "john.com", false)
-        assertThat(referrerResult.groups[0].referrers!![0].markedAsSpam).isFalse()
+        assertThat(referrerResult.referrerGroups[0].referrers!![0].markedAsSpam).isFalse()
 
         val childResultWithSpam = store.setSelectForSpam(REFERRERS_RESPONSE, "child.com", true)
         val childResult = store.setSelectForSpam(childResultWithSpam, "child.com", false)
-        assertThat(childResult.groups[0].referrers!![0].children?.get(0)?.markedAsSpam).isFalse()
+        assertThat(childResult.referrerGroups[0].referrers!![0].markedAsSpam).isFalse()
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -18,8 +18,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageView
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageViewsRestClient.PostAndPageViewsResponse.ViewsResponse.PostViewsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Child
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Group
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Referrer
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.ReferrerGroup
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse.SearchTerm
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestClient.VideoPlaysResponse
@@ -66,10 +66,10 @@ val REFERRER = Referrer(
         "john.jpg",
         "john.com",
         30,
-        listOf(Child("Child", 20, "child.jpg", "child.com", false)),
+        listOf(Child("child.com")),
         false
 )
-val GROUP_WITH_REFERRALS = Group(
+val GROUP_WITH_REFERRALS = ReferrerGroup(
         GROUP_ID_1,
         "Group 1",
         "icon_group_1.jpg",
@@ -78,7 +78,7 @@ val GROUP_WITH_REFERRALS = Group(
         referrers = listOf(REFERRER),
         markedAsSpam = false
 )
-val GROUP_WITH_EMPTY_REFERRALS = Group(
+val GROUP_WITH_EMPTY_REFERRALS = ReferrerGroup(
         GROUP_ID_2,
         "Group 2",
         "icon_group_2.jpg",

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/TimeStatsFixtures.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.PostAndPageView
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Child
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Group
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Groups
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.ReferrersRestClient.ReferrersResponse.Referrer
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.SearchTermsRestClient.SearchTermsResponse.SearchTerm
@@ -76,7 +75,6 @@ val GROUP_WITH_REFERRALS = Group(
         "icon_group_1.jpg",
         "url_group_1.com",
         50,
-        null,
         referrers = listOf(REFERRER),
         markedAsSpam = false
 )
@@ -87,18 +85,13 @@ val GROUP_WITH_EMPTY_REFERRALS = Group(
         "url_group_2.com",
         50,
         null,
-        referrers = null,
         markedAsSpam = false
 )
 val REFERRERS_RESPONSE = ReferrersResponse(
         null,
-        mapOf(
-                "2018-10-10" to Groups(
-                        10,
-                        20,
-                        listOf(GROUP_WITH_REFERRALS, GROUP_WITH_EMPTY_REFERRALS)
-                )
-        )
+        10,
+        20,
+        listOf(GROUP_WITH_REFERRALS, GROUP_WITH_EMPTY_REFERRALS)
 )
 val CLICK_GROUP = ClickGroup(GROUP_ID_1, "Click name", "click.jpg", "click.com", 20, null)
 val CLICKS_RESPONSE = ClicksResponse(null, mapOf("2018-10-10" to ClicksResponse.Groups(10, 15, listOf(CLICK_GROUP))))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/ReferrersModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/ReferrersModel.kt
@@ -8,13 +8,13 @@ data class ReferrersModel(val otherViews: Int, val totalViews: Int, val groups: 
         val url: String?,
         val total: Int?,
         val referrers: List<Referrer>,
-        var markedAsSpam: Boolean? = false
+        var markedAsSpam: Boolean = false
     )
     data class Referrer(
         val name: String,
         val views: Int,
         val icon: String?,
         val url: String?,
-        var markedAsSpam: Boolean? = false
+        var markedAsSpam: Boolean = false
     )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -54,7 +54,7 @@ class TimeStatsMapper
 
     fun map(response: ReferrersResponse, cacheMode: LimitMode): ReferrersModel {
         val groups =
-                response.groups.let {
+                response.referrerGroups.let {
                     if (cacheMode is LimitMode.Top) {
                         it.take(cacheMode.limit)
                     } else {
@@ -77,7 +77,7 @@ class TimeStatsMapper
                         }
                     }
                     ReferrersModel.Group(
-                            group.groupId,
+                            group.group,
                             group.name,
                             group.icon,
                             group.url,
@@ -86,7 +86,7 @@ class TimeStatsMapper
                             group.markedAsSpam
                     )
                 }
-        val hasMore = response.groups.size > groups.size
+        val hasMore = response.referrerGroups.size > groups.size
         return ReferrersModel(response.otherViews ?: 0, response.totalViews ?: 0, groups, hasMore)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -53,43 +53,41 @@ class TimeStatsMapper
     }
 
     fun map(response: ReferrersResponse, cacheMode: LimitMode): ReferrersModel {
-        val first = response.groups.values.firstOrNull()
-        val groups = first?.let {
-            first.groups.let {
-                if (cacheMode is LimitMode.Top) {
-                    it.take(cacheMode.limit)
-                } else {
-                    it
-                }
-            }.map { group ->
-                val children = group.referrers?.mapNotNull { result ->
-                    if (result.name != null && result.views != null) {
-                        val firstChildUrl = result.children?.firstOrNull()?.url
-                        Referrer(
-                                result.name,
-                                result.views,
-                                result.icon,
-                                firstChildUrl ?: result.url,
-                                result.markedAsSpam
-                        )
+        val groups =
+                response.groups.let {
+                    if (cacheMode is LimitMode.Top) {
+                        it.take(cacheMode.limit)
                     } else {
-                        AppLog.e(STATS, "ReferrersResponse: Missing fields on a referrer")
-                        null
+                        it
                     }
+                }.map { group ->
+                    val children = group.referrers?.mapNotNull { result ->
+                        if (result.name != null && result.views != null) {
+                            val firstChildUrl = result.children?.firstOrNull()?.url
+                            Referrer(
+                                    result.name,
+                                    result.views,
+                                    result.icon,
+                                    firstChildUrl ?: result.url,
+                                    result.markedAsSpam
+                            )
+                        } else {
+                            AppLog.e(STATS, "ReferrersResponse: Missing fields on a referrer")
+                            null
+                        }
+                    }
+                    ReferrersModel.Group(
+                            group.groupId,
+                            group.name,
+                            group.icon,
+                            group.url,
+                            group.total,
+                            children ?: listOf(),
+                            group.markedAsSpam
+                    )
                 }
-                ReferrersModel.Group(
-                        group.groupId,
-                        group.name,
-                        group.icon,
-                        group.url,
-                        group.total,
-                        children ?: listOf(),
-                        group.markedAsSpam
-                )
-            }
-        }
-        val hasMore = if (first != null && groups != null) first.groups.size > groups.size else false
-        return ReferrersModel(first?.otherViews ?: 0, first?.totalViews ?: 0, groups ?: listOf(), hasMore)
+        val hasMore = response.groups.size > groups.size
+        return ReferrersModel(response.otherViews ?: 0, response.totalViews ?: 0, groups, hasMore)
     }
 
     fun map(response: ClicksResponse, cacheMode: LimitMode): ClicksModel {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClient.kt
@@ -196,7 +196,7 @@ class ReferrersRestClient
         )
 
         data class Child(
-            @SerializedName("url") val url: String?,
+            @SerializedName("url") val url: String?
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 119
+        return 120
     }
 
     override fun getDbName(): String {
@@ -1315,6 +1315,12 @@ open class WellSqlConfig : DefaultWellConfig {
                             "LAYOUT_ID INTEGER," +
                             "CATEGORY_ID INTEGER," +
                             "SITE_ID INTEGER)")
+                }
+                119 -> migrate(version) {
+                    db.execSQL("DROP TABLE IF EXISTS StatsBlock")
+                    db.execSQL("CREATE TABLE StatsBlock (_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "LOCAL_SITE_ID INTEGER,BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT," +
+                            "POST_ID INTEGER,JSON TEXT NOT NULL)")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
@@ -109,9 +109,8 @@ class ReferrersStore
 
     fun setSelectForSpam(model: ReferrersResponse, domain: String, spam: Boolean): ReferrersResponse {
         val updatedGroups = model.groups.map { group ->
+            // Many groups has url as null, but they can still be spammed using their names as url
             val groupMarkedAsSpam = if (group.url == domain || group.name == domain) {
-                // Many groups has url as null, but they can still be spammed using their names as url
-                // Setting group.spam as true
                 spam
             } else {
                 group.markedAsSpam
@@ -119,14 +118,12 @@ class ReferrersStore
             val updatedReferrers = group.referrers?.map { referrer ->
                 val children = referrer.children?.map { child ->
                     if (child.url == domain) {
-                        // Setting child.spam as true
                         child.copy(markedAsSpam = spam)
                     } else {
                         child
                     }
                 }
                 val referrerMarkedAsSpam = if (referrer.url == domain) {
-                    // Setting referrer.spam as true
                     spam
                 } else {
                     referrer.markedAsSpam

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
@@ -108,7 +108,7 @@ class ReferrersStore
     }
 
     fun setSelectForSpam(model: ReferrersResponse, domain: String, spam: Boolean): ReferrersResponse {
-        val updatedGroups = model.groups.map { group ->
+        val updatedGroups = model.referrerGroups.map { group ->
             // Many groups has url as null, but they can still be spammed using their names as url
             val groupMarkedAsSpam = if (group.url == domain || group.name == domain) {
                 spam
@@ -116,22 +116,16 @@ class ReferrersStore
                 group.markedAsSpam
             }
             val updatedReferrers = group.referrers?.map { referrer ->
-                val children = referrer.children?.map { child ->
-                    if (child.url == domain) {
-                        child.copy(markedAsSpam = spam)
-                    } else {
-                        child
-                    }
-                }
-                val referrerMarkedAsSpam = if (referrer.url == domain) {
+                val referrerMarkedAsSpam = if (referrer.url == domain ||
+                        referrer.children?.any { it.url == domain } == true) {
                     spam
                 } else {
                     referrer.markedAsSpam
                 }
-                referrer.copy(markedAsSpam = referrerMarkedAsSpam, children = children)
+                referrer.copy(markedAsSpam = referrerMarkedAsSpam)
             }
             group.copy(markedAsSpam = groupMarkedAsSpam, referrers = updatedReferrers)
         }
-        return model.copy(groups = updatedGroups)
+        return model.copy(referrerGroups = updatedGroups)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/ReferrersStore.kt
@@ -98,35 +98,43 @@ class ReferrersStore
         limitMode: Top,
         spam: Boolean
     ) {
-        val select = sqlUtils.select(site, granularity, date)
-        if (select != null) {
-            val selectMarked = setSelectForSpam(select, domain, spam)
-            sqlUtils.insert(site, selectMarked, granularity, date, limitMode.limit)
+        val currentModel = sqlUtils.select(site, granularity, date)
+        if (currentModel != null) {
+            val updatedModel = setSelectForSpam(currentModel, domain, spam)
+            if (currentModel != updatedModel) {
+                sqlUtils.insert(site, updatedModel, granularity, date, limitMode.limit)
+            }
         }
     }
 
-    fun setSelectForSpam(select: ReferrersResponse, domain: String, spam: Boolean): ReferrersResponse {
-        select.groups.entries.forEach {
-            it.value.groups.forEach {
-                if (it.url == domain || it.name == domain) {
-                    // Many groups has url as null, but they can still be spammed using their names as url
-                    // Setting group.spam as true
-                    it.markedAsSpam = spam
-                }
-                it.referrers?.forEach {
-                    if (it.url == domain) {
-                        // Setting referrer.spam as true
-                        it.markedAsSpam = spam
-                    }
-                    it.children?.forEach {
-                        if (it.url == domain) {
-                            // Setting child.spam as true
-                            it.markedAsSpam = spam
-                        }
-                    }
-                }
+    fun setSelectForSpam(model: ReferrersResponse, domain: String, spam: Boolean): ReferrersResponse {
+        val updatedGroups = model.groups.map { group ->
+            val groupMarkedAsSpam = if (group.url == domain || group.name == domain) {
+                // Many groups has url as null, but they can still be spammed using their names as url
+                // Setting group.spam as true
+                spam
+            } else {
+                group.markedAsSpam
             }
+            val updatedReferrers = group.referrers?.map { referrer ->
+                val children = referrer.children?.map { child ->
+                    if (child.url == domain) {
+                        // Setting child.spam as true
+                        child.copy(markedAsSpam = spam)
+                    } else {
+                        child
+                    }
+                }
+                val referrerMarkedAsSpam = if (referrer.url == domain) {
+                    // Setting referrer.spam as true
+                    spam
+                } else {
+                    referrer.markedAsSpam
+                }
+                referrer.copy(markedAsSpam = referrerMarkedAsSpam, children = children)
+            }
+            group.copy(markedAsSpam = groupMarkedAsSpam, referrers = updatedReferrers)
         }
-        return select
+        return model.copy(groups = updatedGroups)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/10057

This is one of the steps to decrease the size of the Referrers JSON object saved into the database. Previously (because of our API) we were saving both the unparsed JSON object and the parsed referrers. This is fixed now by introducing an `UnparsedReferrersResponse` which gets parsed into `ReferrersResponse` which is now a little simplified. This should help reducing the DB load by half. As additional step I'll decrease the number of referrers loaded in the client. 

This PR can be tested using this WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/13183 

I've made some small changes like made some nullable fields non-null. Because I'm changing the response object, the Stats DB needs to be cleared.