### PR TITLE
Fix/use encoded media filename in upload

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
@@ -8,6 +8,8 @@ import org.wordpress.android.util.AppLog;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Map;
 
 import okhttp3.MediaType;
@@ -75,7 +77,13 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
         // add media file data
         File mediaFile = new File(media.getFilePath());
         RequestBody body = RequestBody.create(MediaType.parse(media.getMimeType()), mediaFile);
-        builder.addFormDataPart(MEDIA_DATA_KEY, media.getFileName(), body);
+        String fileName = media.getFileName();
+        try {
+            fileName = URLEncoder.encode(media.getFileName(), "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        builder.addFormDataPart(MEDIA_DATA_KEY, fileName, body);
 
         return builder.build();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
@@ -79,7 +79,7 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
         RequestBody body = RequestBody.create(MediaType.parse(media.getMimeType()), mediaFile);
         String fileName = media.getFileName();
         try {
-            fileName = URLEncoder.encode(media.getFileName(), "utf-8");
+            fileName = URLEncoder.encode(media.getFileName(), "UTF-8");
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/13194

In order to fix upload of files in different encodings (like Arabic) we need to encode the file names in UTF-8 to remove a crash in OKHTTP.

 This change could be tested with a related WPAndroid PR.