### PR TITLE
Woo: Parse product attributes in order detail

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
@@ -60,6 +60,34 @@ class WCOrderModelTest {
     }
 
     @Test
+    fun testGetLineItemAttributes() {
+        val model = OrderTestUtils.generateSampleOrder(61).apply {
+            lineItems = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/lineitems.json")
+        }
+        val renderedLineItems = model.getLineItemList()
+        assertEquals(2, renderedLineItems.size)
+
+        with(renderedLineItems[0]) {
+            val attributes = getAttributeList()
+            assertEquals(2, attributes.size)
+
+            assertEquals("color", attributes[0].key)
+            assertEquals("Red", attributes[0].value)
+
+            assertEquals("size", attributes[1].key)
+            assertEquals("Medium", attributes[1].value)
+        }
+
+        with(renderedLineItems[1]) {
+            val attributes = getAttributeList()
+            assertEquals(1, attributes.size)
+
+            assertEquals("size", attributes[0].key)
+            assertEquals("Medium", attributes[0].value)
+        }
+    }
+
+    @Test
     fun testGetSubtotal() {
         val model = OrderTestUtils.generateSampleOrder(61).apply {
             lineItems = "[{\"subtotal\": \"12.26\"},{\"subtotal\": \"15.39\"}]"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
@@ -76,6 +76,9 @@ class WCOrderModelTest {
 
             assertEquals("size", attributes[1].key)
             assertEquals("Medium", attributes[1].value)
+
+            val asList = getAttributesAsString()
+            assertEquals("Red, Medium", asList)
         }
 
         with(renderedLineItems[1]) {

--- a/example/src/test/resources/wc/lineitems.json
+++ b/example/src/test/resources/wc/lineitems.json
@@ -10,7 +10,22 @@
     "total":"10.00",
     "total_tax":"0.00",
     "taxes":[],
-    "meta_data":[],
+    "meta_data":[
+      {
+        "id":45512,
+        "key":"pa_color",
+        "value":"red",
+        "display_key":"color",
+        "display_value":"Red"
+      },
+      {
+        "id":45513,
+        "key":"pa_size",
+        "value":"medium",
+        "display_key":"size",
+        "display_value":"Medium"
+      }
+    ],
     "sku":null,
     "price":10
   },
@@ -26,7 +41,15 @@
     "total":"20.00",
     "total_tax":"0.00",
     "taxes":[],
-    "meta_data":[],
+    "meta_data":[
+      {
+        "id":45513,
+        "key":"pa_size",
+        "value":"medium",
+        "display_key":"size",
+        "display_value":"Medium"
+      }
+    ],
     "sku":"blabla",
     "price":20
   }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 119
+        return 120
     }
 
     override fun getDbName(): String {
@@ -1315,6 +1315,9 @@ open class WellSqlConfig : DefaultWellConfig {
                             "LAYOUT_ID INTEGER," +
                             "CATEGORY_ID INTEGER," +
                             "SITE_ID INTEGER)")
+                }
+                119 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DELETE FROM WCOrderModel")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -102,6 +102,13 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
             val responseType = object : TypeToken<List<Attribute>>() {}.type
             return gson.fromJson(attributes, responseType) as? List<Attribute> ?: emptyList()
         }
+
+        /**
+         * @return a comma-separated list of attribute values for display
+         */
+        fun getAttributesAsString(): String {
+            return getAttributeList().joinToString { it.value ?: "" }
+        }
     }
 
     override fun getId() = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -157,5 +157,5 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         return gson.fromJson(shippingLines, responseType) as? List<ShippingLine> ?: emptyList()
     }
 
-    fun isMultiShippingLinesAvailable() = getShippingLineList()?.size > 1
+    fun isMultiShippingLinesAvailable() = getShippingLineList().size > 1
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model
 
 import com.google.gson.Gson
+import com.google.gson.JsonArray
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.yarolegovich.wellsql.core.Identifiable
@@ -86,6 +87,21 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         val totalTax: String? = null
         val sku: String? = null
         val price: String? = null // The per-item price
+
+        @SerializedName("meta_data")
+        private val attributes:JsonArray? = null
+
+        class Attribute {
+            @SerializedName("display_key")
+            val key: String? = null
+            @SerializedName("display_value")
+            val value: String? = null
+        }
+
+        fun getAttributeList(): List<Attribute> {
+            val responseType = object : TypeToken<List<Attribute>>() {}.type
+            return gson.fromJson(attributes, responseType) as? List<Attribute> ?: emptyList()
+        }
     }
 
     override fun getId() = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -89,7 +89,7 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         val price: String? = null // The per-item price
 
         @SerializedName("meta_data")
-        private val attributes:JsonArray? = null
+        private val attributes: JsonArray? = null
 
         class Attribute {
             @SerializedName("display_key")


### PR DESCRIPTION
Closes #1725 by adding a way to parse the new product attributes from the line item metadata of the order detail response. This includes the following:
- Added new `Attribute` subclass to `WCOrderModel.LineItem` along with a couple helper methods for parsing the attribute data from json. 
- Added new unit test to `WCOrderModelTest` called `testGetLineItemAttributes()`
- Dumps the contents of the `WCOrderModel` table on database upgrade to this latest version. This was added to ensure this new metadata would be pulled from the API since it was just added in WooCommerce version 4.7.0 [in this PR](https://github.com/woocommerce/woocommerce-rest-api/pull/229). 

### To Test
- Run the new `WCOrderModelTest.testGetLineItemAttributes()`
- Make sure there are no issues fetching orders in the Example app. 
