### PR TITLE
Issue/1735 wc search product tags

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -323,10 +323,16 @@ class WooProductsFragment : Fragment() {
         }
 
         fetch_product_tags.setOnClickListener {
-            selectedSite?.let { site ->
-                prependToLog("Submitting request to fetch product tags for site ${site.id}")
-                val payload = FetchProductTagsPayload(site)
-                dispatcher.dispatch(WCProductActionBuilder.newFetchProductTagsAction(payload))
+            showSingleLineDialog(
+                    activity,
+                    "Enter a search query, leave blank for none:"
+            ) { editText ->
+                val searchQuery = editText.text.toString()
+                selectedSite?.let { site ->
+                    prependToLog("Submitting request to fetch product tags for site ${site.id}")
+                    val payload = FetchProductTagsPayload(site, searchQuery = searchQuery)
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchProductTagsAction(payload))
+                }
             }
         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -173,13 +173,15 @@ class ProductRestClient(
     fun fetchProductTags(
         site: SiteModel,
         pageSize: Int = DEFAULT_PRODUCT_TAGS_PAGE_SIZE,
-        offset: Int = 0
+        offset: Int = 0,
+        searchQuery: String?
     ) {
         val url = WOOCOMMERCE.products.tags.pathV3
         val responseType = object : TypeToken<List<ProductTagApiResponse>>() {}.type
         val params = mutableMapOf(
                 "per_page" to pageSize.toString(),
-                "offset" to offset.toString()
+                "offset" to offset.toString(),
+                "search" to (searchQuery ?: "")
         )
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
@@ -190,7 +192,7 @@ class ProductRestClient(
 
                     val loadedMore = offset > 0
                     val canLoadMore = tags.size == pageSize
-                    val payload = RemoteProductTagsPayload(site, tags, offset, loadedMore, canLoadMore)
+                    val payload = RemoteProductTagsPayload(site, tags, offset, loadedMore, canLoadMore, searchQuery)
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductTagsAction(payload))
                 },
                 WPComErrorListener { networkError ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -174,7 +174,7 @@ class ProductRestClient(
         site: SiteModel,
         pageSize: Int = DEFAULT_PRODUCT_TAGS_PAGE_SIZE,
         offset: Int = 0,
-        searchQuery: String?
+        searchQuery: String? = null
     ) {
         val url = WOOCOMMERCE.products.tags.pathV3
         val responseType = object : TypeToken<List<ProductTagApiResponse>>() {}.type

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -166,7 +166,8 @@ class WCProductStore @Inject constructor(
     class FetchProductTagsPayload(
         var site: SiteModel,
         var pageSize: Int = DEFAULT_PRODUCT_TAGS_PAGE_SIZE,
-        var offset: Int = 0
+        var offset: Int = 0,
+        var searchQuery: String? = null
     ) : Payload<BaseNetworkError>()
 
     class AddProductTagsPayload(
@@ -453,7 +454,8 @@ class WCProductStore @Inject constructor(
         val tags: List<WCProductTagModel> = emptyList(),
         var offset: Int = 0,
         var loadedMore: Boolean = false,
-        var canLoadMore: Boolean = false
+        var canLoadMore: Boolean = false,
+        var searchQuery: String? = null
     ) : Payload<ProductError>() {
         constructor(
             error: ProductError,
@@ -888,7 +890,7 @@ class WCProductStore @Inject constructor(
     }
 
     private fun fetchProductTags(payload: FetchProductTagsPayload) {
-        with(payload) { wcProductRestClient.fetchProductTags(site, pageSize, offset) }
+        with(payload) { wcProductRestClient.fetchProductTags(site, pageSize, offset, searchQuery) }
     }
 
     private fun addProductTags(payload: AddProductTagsPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1221,7 +1221,7 @@ class WCProductStore @Inject constructor(
         } else {
             // delete product tags for site if this is the first page of results, otherwise
             // tags deleted outside of the app will persist
-            if (payload.offset == 0) {
+            if (payload.offset == 0 && payload.searchQuery.isNullOrEmpty()) {
                 ProductSqlUtils.deleteProductTagsForSite(payload.site)
             }
 


### PR DESCRIPTION
Closes #1735 - adds the "search" parameter when fetching product tags so WCAndroid can enabling filtering the tag list.

To test:

- Open the example app
- Woo > Products > Fetch product tags
- Enter a search query
- Verify the resulting tags match that query