### PR TITLE
Add attachment ViewsType

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/PostAndPageViewsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/PostAndPageViewsModel.kt
@@ -13,6 +13,7 @@ data class PostAndPageViewsModel(val views: List<ViewsModel>, val hasMore: Boole
         POST,
         PAGE,
         HOMEPAGE,
-        OTHER
+        OTHER,
+        ATTACHMENT
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/time/TimeStatsMapper.kt
@@ -38,6 +38,7 @@ class TimeStatsMapper
                 "post" -> ViewsType.POST
                 "page" -> ViewsType.PAGE
                 "homepage" -> ViewsType.HOMEPAGE
+                "attachment" -> ViewsType.ATTACHMENT
                 else -> {
                     ViewsType.OTHER
                 }


### PR DESCRIPTION
Parent Issue in WordPress-Android [13244](https://github.com/wordpress-mobile/WordPress-Android/issues/13244)

This PR 
- Adds ATTACHMENT to `ViewsType`
- Maps "attachment" postType to ATTACHMENT in `TimeStatsMapper`

Which will support handling of post type attachment while viewing stats.

Merge instructions
- Only after approval of WP Android [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13253) 