### PR TITLE
Update ReactNative API requests to respond with all available information (body, headers, status)

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
@@ -185,12 +185,11 @@ class ReactNativeWPAPIRestClientTest {
         expectedRestCallResponse: WPAPIResponse<JsonElement>,
         expected: ReactNativeFetchResponse
     ) {
-        whenever(wpApiGsonRequestBuilder.syncGetRequest(
+        whenever(wpApiGsonRequestBuilder.syncReactNativeGetRequest(
                 subject,
                 url,
                 params,
                 emptyMap(),
-                JsonElement::class.java,
                 true)
         ).thenReturn(expectedRestCallResponse)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
@@ -85,11 +85,10 @@ class ReactNativeWPComRestClientTest {
         expectedRestCallResponse: WPComGsonRequestBuilder.Response<JsonElement>,
         expected: ReactNativeFetchResponse
     ) {
-        whenever(wpComGsonRequestBuilder.syncGetRequest(
+        whenever(wpComGsonRequestBuilder.syncReactNativeGetRequest(
                 subject,
                 url,
                 params,
-                JsonElement::class.java,
                 true)
         ).thenReturn(expectedRestCallResponse)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/ReactNativeRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/ReactNativeRequest.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.fluxc.network.rest
+
+import com.android.volley.NetworkResponse
+import com.android.volley.Response
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+
+object ReactNativeRequest {
+    object ResponseKey {
+        const val body = "body"
+        const val headers = "headers"
+        const val networkTimeMs = "networkTimeMs"
+        const val notModified = "notModified"
+        const val statusCode = "statusCode"
+    }
+
+    fun parseNetworkResponse(
+        networkResponse: NetworkResponse?,
+        response: Response<JsonElement>
+    ): Response<JsonElement> =
+            // If response has a result, update the response to have the result under the "body" key and include
+            // additional information regarding the network response under relevant keys
+            if (response.result == null || networkResponse == null) {
+                response
+            } else {
+                val json = JsonObject().apply {
+                    add(ResponseKey.body, response.result)
+                    add(ResponseKey.headers, parseHeaders(networkResponse.headers))
+                    addProperty(ResponseKey.networkTimeMs, networkResponse.networkTimeMs)
+                    addProperty(ResponseKey.notModified, networkResponse.notModified)
+                    addProperty(ResponseKey.statusCode, networkResponse.statusCode)
+                }
+                Response.success(json, response.cacheEntry)
+            }
+
+    private fun parseHeaders(headers: Map<String, String>): JsonObject =
+            Gson().toJsonTree(headers).asJsonObject
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIGsonRequest.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.reactnative
+
+import com.android.volley.NetworkResponse
+import com.android.volley.Response
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.network.rest.ReactNativeRequest
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
+
+class ReactNativeWPAPIGsonRequest(
+    method: Int,
+    url: String,
+    body: Map<String, Any> = emptyMap(),
+    params: Map<String, String> = emptyMap(),
+    clazz: Class<JsonElement>,
+    responseListener: Response.Listener<JsonElement>,
+    errorListener: BaseErrorListener
+) : WPAPIGsonRequest<JsonElement>(method, url, params, body, clazz, responseListener, errorListener) {
+    override fun parseNetworkResponse(response: NetworkResponse?): Response<JsonElement> =
+        ReactNativeRequest.parseNetworkResponse(response, super.parseNetworkResponse(response))
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -54,12 +54,11 @@ class ReactNativeWPAPIRestClient @VisibleForTesting constructor(
         enableCaching: Boolean = true
     ): ReactNativeFetchResponse {
         val response =
-                wpApiGsonRequestBuilder.syncGetRequest(
+                wpApiGsonRequestBuilder.syncReactNativeGetRequest(
                         this,
                         url,
                         params,
                         emptyMap(),
-                        JsonElement::class.java,
                         enableCaching,
                         nonce = nonce)
         return when (response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -53,7 +53,7 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
         }
     }
 
-    private WPComGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
+    protected WPComGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
                              Class<T> clazz, Type type, Listener<T> listener, BaseErrorListener errorListener) {
         super(method, params, body, url, clazz, type, listener, errorListener);
         // Add the parameters to the URL regardless what the request method is
@@ -122,7 +122,7 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
                 wrapInBaseListener(errorListener));
     }
 
-    private static BaseErrorListener wrapInBaseListener(final WPComErrorListener wpComErrorListener) {
+    public static BaseErrorListener wrapInBaseListener(final WPComErrorListener wpComErrorListener) {
         return new BaseErrorListener() {
             @Override
             public void onErrorResponse(@NonNull BaseNetworkError error) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComGsonRequest.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.reactnative
+
+import com.android.volley.NetworkResponse
+import com.android.volley.Response
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.network.rest.ReactNativeRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+
+class ReactNativeWPComGsonRequest(
+    method: Int,
+    url: String,
+    params: Map<String, String>,
+    body: Map<String, Any>,
+    listener: (JsonElement) -> Unit,
+    errorListener: (WPComGsonNetworkError) -> Unit
+) : WPComGsonRequest<JsonElement>(
+        method,
+        url,
+        params,
+        body,
+        JsonElement::class.java,
+        null,
+        listener,
+        wrapInBaseListener(errorListener)
+) {
+    override fun parseNetworkResponse(response: NetworkResponse?): Response<JsonElement> =
+            ReactNativeRequest.parseNetworkResponse(response, super.parseNetworkResponse(response))
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
@@ -33,7 +33,7 @@ class ReactNativeWPComRestClient @Inject constructor(
         enableCaching: Boolean = true
     ): ReactNativeFetchResponse {
         val response =
-                wpComGsonRequestBuilder.syncGetRequest(this, url, params, JsonElement::class.java, enableCaching)
+                wpComGsonRequestBuilder.syncReactNativeGetRequest(this, url, params, enableCaching)
         return when (response) {
             is Success -> successHandler(response.data)
             is Error -> errorHandler(response.error)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.EditorTheme
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.ReactNativeRequest.ResponseKey
 import org.wordpress.android.fluxc.persistence.EditorThemeSqlUtils
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
@@ -80,12 +81,22 @@ class EditorThemeStore
         when (response) {
             is Success -> {
                 val noThemeError = OnEditorThemeChanged(EditorThemeError("Response does not contain a theme"), action)
-                if (response.result == null || !response.result.isJsonArray) {
+                if (response.result == null ||
+                        !response.result.isJsonObject ||
+                        !response.result.asJsonObject.has(ResponseKey.body) ||
+                        !response.result.asJsonObject.get(ResponseKey.body).isJsonArray
+                ) {
                     emitChange(noThemeError)
                     return
                 }
 
-                val responseTheme = response.result.asJsonArray.firstOrNull()
+                val responseTheme = response
+                        .result
+                        .asJsonObject
+                        .get(ResponseKey.body)
+                        .asJsonArray
+                        .firstOrNull()
+
                 if (responseTheme == null) {
                     emitChange(noThemeError)
                     return


### PR DESCRIPTION
Currently we only forward the body of api requests back to gutenberg but in order for the requests to work as expected we need to make sure that we send over the headers. 

The headers contain information such as next links as well as if particular actions are allowed. See `canUser()` 

To tests. 
Run the tests? Do they work as expected? 

