### PR TITLE
Woo/product image nullpointer fix

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -188,6 +188,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertNull(error)
             assertNotNull(products)
             assertEquals(products.size, 3)
+            assertNull(products[0].getFirstImageUrl())
         }
 
         // delete all products then insert these into the store

--- a/example/src/androidTest/resources/wc-fetch-products-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-products-response-success.json
@@ -56,18 +56,7 @@
       "grouped_products": [
       ],
       "id": 202,
-      "images": [
-        {
-          "alt": "",
-          "date_created": "2019-04-09T11:35:26",
-          "date_created_gmt": "2019-04-09T20:35:26",
-          "date_modified": "2019-04-09T11:35:26",
-          "date_modified_gmt": "2019-04-09T20:35:26",
-          "id": 203,
-          "name": "1350747580204",
-          "src": "https://i2.wp.com/example.com/wp-content/uploads/2019/04/1350747580204.jpg?fit=385%2C266&ssl=1"
-        }
-      ],
+      "images": [],
       "jetpack_likes_enabled": true,
       "jetpack_sharing_enabled": true,
       "manage_stock": false,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -161,8 +161,10 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      */
     fun getFirstImageUrl(): String? {
         try {
-            Gson().fromJson(images, JsonElement::class.java).asJsonArray.firstOrNull { jsonElement ->
-                return (jsonElement.asJsonObject).getString("src")
+            if (images.isNotEmpty()) {
+                Gson().fromJson(images, JsonElement::class.java).asJsonArray.firstOrNull { jsonElement ->
+                    return (jsonElement.asJsonObject).getString("src")
+                }
             }
         } catch (e: JsonParseException) {
             AppLog.e(T.API, e)


### PR DESCRIPTION
Fixes part of woocommerce/woocommerce-android#3083 by adding a null check when fetching the first image url of a product. I was able to reproduce this crash by SSP into the user's site from the app. I tested the changes in this PR in the Woo app after SSP to ensure the app was not crashing.

### To test
- Run `MockedStack_WCProductsTest.kt`. 