### PR TITLE
Woo: Woo Services plugin availability check

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
@@ -6,11 +6,16 @@ import dagger.Module
 import dagger.Provides
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -54,4 +59,15 @@ class MockedWCNetworkModule {
         token: AccessToken,
         userAgent: UserAgent
     ) = OrderStatsRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideWooPluginRestClient(
+        appContext: Context,
+        wpComBuilder: WPComGsonRequestBuilder,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = WooPluginRestClient(dispatcher, wpComBuilder, appContext, requestQueue, token, userAgent)
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
@@ -8,13 +8,11 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
 import javax.inject.Named
 import javax.inject.Singleton
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -201,6 +201,22 @@ class WooShippingLabelFragment : Fragment() {
                 }
             }
         }
+
+        get_shipping_plugin_info.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    val result = withContext(Dispatchers.Default) {
+                        wooCommerceStore.fetchWooCommerceServicesPluginInfo(site)
+                    }
+                    result.error?.let {
+                        prependToLog("${it.type}: ${it.message}")
+                    }
+                    result.model?.let {
+                        prependToLog("Installed: ${it.isPluginInstalled}, Active: ${it.isPluginActive}")
+                    }
+                }
+            }
+        }
     }
 
     private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -212,7 +212,7 @@ class WooShippingLabelFragment : Fragment() {
                         prependToLog("${it.type}: ${it.message}")
                     }
                     result.model?.let {
-                        prependToLog("Installed: ${it.isPluginInstalled}, Active: ${it.isPluginActive}")
+                        prependToLog("$it")
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -211,8 +211,11 @@ class WooShippingLabelFragment : Fragment() {
                     result.error?.let {
                         prependToLog("${it.type}: ${it.message}")
                     }
-                    result.model?.let {
-                        prependToLog("$it")
+                    if (result.model != null) {
+                        prependToLog("${result.model}")
+                    }
+                    else {
+                        prependToLog("The WooCommerce services plugin is not installed")
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -213,8 +213,7 @@ class WooShippingLabelFragment : Fragment() {
                     }
                     if (result.model != null) {
                         prependToLog("${result.model}")
-                    }
-                    else {
+                    } else {
                         prependToLog("The WooCommerce services plugin is not installed")
                     }
                 }

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -73,5 +73,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Get packages"/>
+
+        <Button
+            android:id="@+id/get_shipping_plugin_info"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Get shipping plugin info"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WCPluginSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WCPluginSqlUtilsTest.kt
@@ -88,4 +88,17 @@ class WCPluginSqlUtilsTest {
         val plugin = WCPluginSqlUtils.selectSingle(site, testPlugins.first().slug)
         assertNull(plugin)
     }
+
+    @Test
+    fun `test select after item deleted`() {
+        WCPluginSqlUtils.insertOrUpdate(testPlugins)
+        val plugins = WCPluginSqlUtils.selectAll(site)
+        assertEquals(testPlugins.size, plugins.count())
+
+        WCPluginSqlUtils.insertOrUpdate(listOf(testPlugins.first()))
+        val listOfOne = WCPluginSqlUtils.selectAll(site)
+        assertEquals(1, listOfOne.count())
+        val missing = WCPluginSqlUtils.selectSingle(site, testPlugins[1].slug)
+        assertNull(missing)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WCPluginSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WCPluginSqlUtilsTest.kt
@@ -63,7 +63,7 @@ class WCPluginSqlUtilsTest {
         val testPlugin = testPlugins.first()
         WCPluginSqlUtils.insertOrUpdate(listOf(testPlugin))
         val plugin = WCPluginSqlUtils.selectSingle(site, testPlugin.slug)!!
-        assertEquals(plugin, testPlugin)
+        assertEquals(testPlugin, plugin)
 
         val newTitle = "New title"
         WCPluginSqlUtils.insertOrUpdate(listOf(plugin.copy(displayName = newTitle)))
@@ -75,8 +75,8 @@ class WCPluginSqlUtilsTest {
     fun `test select`() {
         WCPluginSqlUtils.insertOrUpdate(testPlugins)
 
-        val gateway = WCPluginSqlUtils.selectSingle(site, "plugin2")
-        assertEquals(testPlugins[1], gateway)
+        val plugin = WCPluginSqlUtils.selectSingle(site, testPlugins[1].slug)
+        assertEquals(testPlugins[1], plugin)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WCPluginSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WCPluginSqlUtilsTest.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.fluxc.wc
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils
+import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils.WCPluginModel
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCPluginSqlUtilsTest {
+    private val site = SiteModel().apply { id = 2 }
+    private val testPlugins = listOf(
+            WCPluginModel(
+                    1,
+                    site.id,
+                    true,
+                    "Plugin 1",
+                    "plugin1",
+                    "1.0"
+            ),
+            WCPluginModel(
+                    2,
+                    site.id,
+                    false,
+                    "Plugin 2",
+                    "plugin2",
+                    "2.0"
+            )
+    )
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(WCPluginModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE)
+        WellSql.init(config)
+        config.reset()
+    }
+
+    @Test
+    fun `test plugin insert`() {
+        WCPluginSqlUtils.insertOrUpdate(testPlugins)
+        val plugins = WCPluginSqlUtils.selectAll(site)
+        assertEquals(2, plugins.size)
+        assertEquals(testPlugins, plugins)
+    }
+
+    @Test
+    fun `test gateway update`() {
+        val testPlugin = testPlugins.first()
+        WCPluginSqlUtils.insertOrUpdate(listOf(testPlugin))
+        val plugin = WCPluginSqlUtils.selectSingle(site, testPlugin.slug)!!
+        assertEquals(plugin, testPlugin)
+
+        val newTitle = "New title"
+        WCPluginSqlUtils.insertOrUpdate(listOf(plugin.copy(displayName = newTitle)))
+        val updatedPlugin = WCPluginSqlUtils.selectSingle(site, plugin.slug)!!
+        assertEquals(newTitle, updatedPlugin.displayName)
+    }
+
+    @Test
+    fun `test select`() {
+        WCPluginSqlUtils.insertOrUpdate(testPlugins)
+
+        val gateway = WCPluginSqlUtils.selectSingle(site, "plugin2")
+        assertEquals(testPlugins[1], gateway)
+    }
+
+    @Test
+    fun `test select empty result`() {
+        WCPluginSqlUtils.insertOrUpdate(testPlugins.map { it.copy(localSiteId = 3) })
+        val plugins = WCPluginSqlUtils.selectAll(site)
+        assertTrue(plugins.isEmpty())
+
+        val plugin = WCPluginSqlUtils.selectSingle(site, testPlugins.first().slug)
+        assertNull(plugin)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -14,10 +14,6 @@ import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Valid
-import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult
-import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.DESTINATION
-import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.ORIGIN
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
@@ -26,7 +22,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse.PluginModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
 import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils.WCPluginModel
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WooCommerceStore

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.fluxc.wc
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import com.yarolegovich.wellsql.WellSql
+import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -11,20 +14,49 @@ import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Valid
+import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.DESTINATION
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.ORIGIN
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse.PluginModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
+import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils.WCPluginModel
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import kotlin.test.assertEquals
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
 class WooCommerceStoreTest {
     private val appContext = RuntimeEnvironment.application.applicationContext
-    private val wooCommerceStore = WooCommerceStore(appContext, Dispatcher(), mock(), mock(), mock())
+    private val restClient = mock<WooPluginRestClient>()
+    private val wooCommerceStore = WooCommerceStore(appContext, Dispatcher(), initCoroutineEngine(), restClient, mock())
+    private val error = WooError(INVALID_RESPONSE, NETWORK_ERROR, "Invalid site ID")
+    private val site = SiteModel().apply { id = 1 }
+
+    private val response = FetchPluginsResponse(
+            listOf(
+                    PluginModel("woocommerce-services", "1.0", true, "Woo Services"),
+                    PluginModel("other", "2.0", false, "Other Plugin")
+            )
+    )
 
     @Before
     fun setUp() {
-        val config = SingleStoreWellSqlConfigForTests(appContext, SiteModel::class.java,
-                WellSqlConfig.ADDON_WOOCOMMERCE)
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(WCPluginModel::class.java, SiteModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE
+        )
         WellSql.init(config)
         config.reset()
     }
@@ -53,5 +85,26 @@ class WooCommerceStoreTest {
         WellSql.insert(wooAtomicSite).execute()
 
         assertEquals(2, wooCommerceStore.getWooCommerceSites().size)
+    }
+
+    @Test
+    fun `test fetching woo services plugin info`() = test {
+        val result = getPlugin()
+        val expectedModel = response.plugins.map { WCPluginModel(site, it).apply { id = 1 } }.first()
+        Assertions.assertThat(result.model).isEqualTo(expectedModel)
+
+        val invalidRequestResult = getPlugin(true)
+        Assertions.assertThat(invalidRequestResult.model).isNull()
+        Assertions.assertThat(invalidRequestResult.error).isEqualTo(error)
+    }
+
+    private suspend fun getPlugin(isError: Boolean = false): WooResult<WCPluginModel> {
+        val payload = WooPayload(response)
+        if (isError) {
+            whenever(restClient.fetchInstalledPlugins(any())).thenReturn(WooPayload(error))
+        } else {
+            whenever(restClient.fetchInstalledPlugins(any())).thenReturn(payload)
+        }
+        return wooCommerceStore.fetchWooCommerceServicesPluginInfo(site)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertEquals
 @RunWith(RobolectricTestRunner::class)
 class WooCommerceStoreTest {
     private val appContext = RuntimeEnvironment.application.applicationContext
-    private val wooCommerceStore = WooCommerceStore(appContext, Dispatcher(), mock())
+    private val wooCommerceStore = WooCommerceStore(appContext, Dispatcher(), mock(), mock(), mock())
 
     @Before
     fun setUp() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 121
+        return 122
     }
 
     override fun getDbName(): String {
@@ -1324,6 +1324,17 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("CREATE TABLE StatsBlock (_id INTEGER PRIMARY KEY AUTOINCREMENT," +
                             "LOCAL_SITE_ID INTEGER,BLOCK_TYPE TEXT NOT NULL,STATS_TYPE TEXT NOT NULL,DATE TEXT," +
                             "POST_ID INTEGER,JSON TEXT NOT NULL)")
+                }
+                121 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCPlugins")
+                    db.execSQL("CREATE TABLE WCPlugins (" +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "LOCAL_SITE_ID INTEGER," +
+                            "ACTIVE BOOLEAN NOT NULL," +
+                            "DISPLAY_NAME TEXT NOT NULL," +
+                            "SLUG TEXT NOT NULL," +
+                            "VERSION TEXT NOT NULL)"
+                    )
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCPluginResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCPluginResult.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+data class WCPluginResult(
+    val isPluginInstalled: Boolean,
+    val isPluginActive: Boolean,
+    val name: String?,
+    val slug: String?,
+    val version: String?
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCPluginResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCPluginResult.kt
@@ -1,9 +1,0 @@
-package org.wordpress.android.fluxc.model.shippinglabels
-
-data class WCPluginResult(
-    val isPluginInstalled: Boolean,
-    val isPluginActive: Boolean,
-    val name: String?,
-    val slug: String?,
-    val version: String?
-)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.refunds.RefundMapper
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
@@ -14,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestCli
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
@@ -107,6 +109,17 @@ class ReleaseWCNetworkModule {
         token: AccessToken,
         userAgent: UserAgent
     ) = ShippingLabelRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideWooPluginRestClient(
+        appContext: Context,
+        wpComBuilder: WPComGsonRequestBuilder,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = WooPluginRestClient(dispatcher, wpComBuilder, appContext, requestQueue, token, userAgent)
 
     @Singleton
     @Provides

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/plugins/WooPluginRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/plugins/WooPluginRestClient.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+
+class WooPluginRestClient
+constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchInstalledPlugins(
+        site: SiteModel
+    ): WooPayload<FetchPluginsResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).plugins.urlV1_2;
+
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                emptyMap(),
+                FetchPluginsResponse::class.java
+        )
+        return when (response) {
+            is Success -> {
+                WooPayload(response.data)
+            }
+            is Error -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
+    data class FetchPluginsResponse(val plugins: List<PluginModel>) {
+        data class PluginModel(
+            val slug: String,
+            val version: String,
+            @SerializedName("active") val isActive: Boolean,
+            @SerializedName("display_name") val displayName: String
+        )
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/plugins/WooPluginRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/plugins/WooPluginRestClient.kt
@@ -14,7 +14,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Singleton
 
+@Singleton
 class WooPluginRestClient
 constructor(
     dispatcher: Dispatcher,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/plugins/WooPluginRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/plugins/WooPluginRestClient.kt
@@ -27,7 +27,7 @@ constructor(
     suspend fun fetchInstalledPlugins(
         site: SiteModel
     ): WooPayload<FetchPluginsResponse> {
-        val url = WPCOMREST.sites.site(site.siteId).plugins.urlV1_2;
+        val url = WPCOMREST.sites.site(site.siteId).plugins.urlV1_2
 
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
@@ -9,12 +9,15 @@ import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
 
 object WCPluginSqlUtils {
-    fun insertOrUpdate(site: SiteModel, data: List<WCPluginModel>) {
-        WellSql.delete(WCPluginModel::class.java)
-            .where()
-            .equals(WCPluginsTable.LOCAL_SITE_ID, site.id)
-            .endWhere()
-            .execute()
+    fun insertOrUpdate(data: List<WCPluginModel>) {
+        data.forEach {
+            WellSql.delete(WCPluginModel::class.java)
+                    .where()
+                    .equals(WCPluginsTable.LOCAL_SITE_ID, it.localSiteId)
+                    .equals(WCPluginsTable.SLUG, it.slug)
+                    .endWhere()
+                    .execute()
+        }
 
         WellSql.insert(data).execute()
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
@@ -11,11 +11,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestCl
 
 object WCPluginSqlUtils {
     fun insertOrUpdate(data: List<WCPluginModel>) {
-        data.forEach {
+        data.map { it.localSiteId }.distinct().forEach {
             WellSql.delete(WCPluginModel::class.java)
                     .where()
-                    .equals(WCPluginsTable.LOCAL_SITE_ID, it.localSiteId)
-                    .equals(WCPluginsTable.SLUG, it.slug)
+                    .equals(WCPluginsTable.LOCAL_SITE_ID, it)
                     .endWhere()
                     .execute()
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
@@ -7,6 +7,7 @@ import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse.PluginModel
 
 object WCPluginSqlUtils {
     fun insertOrUpdate(data: List<WCPluginModel>) {
@@ -49,6 +50,14 @@ object WCPluginSqlUtils {
         @Column var slug: String = "",
         @Column var version: String = ""
     ) : Identifiable {
+        constructor(site: SiteModel, networkModel: PluginModel) : this(
+                localSiteId = site.id,
+                active = networkModel.isActive,
+                displayName = networkModel.displayName,
+                slug = networkModel.slug,
+                version = networkModel.version
+        )
+
         override fun getId() = id
 
         override fun setId(id: Int) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.WCPluginsTable
+import com.yarolegovich.wellsql.WellSql
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.SiteModel
+
+object WCPluginSqlUtils {
+    fun insertOrUpdate(site: SiteModel, data: List<WCPluginModel>) {
+        WellSql.delete(WCPluginModel::class.java)
+            .where()
+            .equals(WCPluginsTable.LOCAL_SITE_ID, site.id)
+            .endWhere()
+            .execute()
+
+        WellSql.insert(data).execute()
+    }
+
+    fun selectAll(site: SiteModel): List<WCPluginModel> {
+        return WellSql.select(WCPluginModel::class.java)
+                .where()
+                .equals(WCPluginsTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .asModel
+    }
+
+    fun selectSingle(site: SiteModel, slug: String): WCPluginModel? {
+        return WellSql.select(WCPluginModel::class.java)
+                .where()
+                .equals(WCPluginsTable.LOCAL_SITE_ID, site.id)
+                .equals(WCPluginsTable.SLUG, slug)
+                .endWhere()
+                .asModel
+                .firstOrNull()
+    }
+
+    @Table(name = "WCPlugins", addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+    data class WCPluginModel(
+        @PrimaryKey @Column private var id: Int = -1,
+        @Column var localSiteId: Int = -1,
+        @Column var active: Boolean = false,
+        @Column var displayName: String = "",
+        @Column var slug: String = "",
+        @Column var version: String = ""
+    ) : Identifiable {
+        override fun getId() = id
+
+        override fun setId(id: Int) {
+            this.id = id
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -165,15 +165,7 @@ open class WooCommerceStore @Inject constructor(
                     WooResult(response.error)
                 }
                 response.result != null -> {
-                    val plugins = response.result.plugins.map {
-                        WCPluginModel(
-                                localSiteId = site.id,
-                                active = it.isActive,
-                                displayName = it.displayName,
-                                slug = it.slug,
-                                version = it.version
-                        )
-                    }
+                    val plugins = response.result.plugins.map { WCPluginModel(site, it) }
                     WCPluginSqlUtils.insertOrUpdate(plugins)
                     
                     val plugin = WCPluginSqlUtils.selectSingle(site, WOO_SERVICES_PLUGIN_NAME)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -155,6 +155,10 @@ open class WooCommerceStore @Inject constructor(
         return siteSettings?.countryCode
     }
 
+    fun getWooCommerceServicesPluginInfo(site: SiteModel): WCPluginModel? {
+        return WCPluginSqlUtils.selectSingle(site, WOO_SERVICES_PLUGIN_NAME)
+    }
+
     suspend fun fetchWooCommerceServicesPluginInfo(
         site: SiteModel
     ): WooResult<WCPluginModel> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -174,7 +174,7 @@ open class WooCommerceStore @Inject constructor(
                                 version = it.version
                         )
                     }
-                    WCPluginSqlUtils.insertOrUpdate(site, plugins)
+                    WCPluginSqlUtils.insertOrUpdate(plugins)
                     
                     val plugin = WCPluginSqlUtils.selectSingle(site, WOO_SERVICES_PLUGIN_NAME)
                     WooResult(plugin)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -167,7 +167,6 @@ open class WooCommerceStore @Inject constructor(
                 response.result != null -> {
                     val plugins = response.result.plugins.map { WCPluginModel(site, it) }
                     WCPluginSqlUtils.insertOrUpdate(plugins)
-                    
                     val plugin = WCPluginSqlUtils.selectSingle(site, WOO_SERVICES_PLUGIN_NAME)
                     WooResult(plugin)
                 }


### PR DESCRIPTION
This PR adds the ability to request information about the WooCommerce Services plugin, which is necessary for implementing the shipping label creation functionality.

**Unit tests:**
- Run `WooCommerceStoreTest`
- Run `WCPluginSqlUtilsTest`

**Example app:**
1. Run the example app
2. Go to Woo -> Shipping labels
3. Select a site with the WooCommerce Services plugin installed and activated
4. Tap on the Get shipping plugin info button
5. Notice the plugin information is logged
6. Disable the plugin (or choose a different site)
7. Request the shipping plugin info
8. Notice the plugin is reported as disabled
9. Delete the plugin (or choose a different site)
10. Request the shipping plugin info
11. Notice the plugin is reported as missing