### PR TITLE
Implements FETCH_STARTER_DESIGNS call

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.ThemeStore;
 import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched;
+import org.wordpress.android.fluxc.store.ThemeStore.OnStarterDesignsFetched;
 import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated;
 import org.wordpress.android.fluxc.store.ThemeStore.OnWpComThemesChanged;
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
@@ -32,7 +33,8 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         NONE,
         FETCHED_WPCOM_THEMES,
         FETCHED_CURRENT_THEME,
-        ACTIVATED_THEME
+        ACTIVATED_THEME,
+        FETCHED_STARTER_DESIGNS
     }
 
     @Inject ThemeStore mThemeStore;
@@ -94,6 +96,15 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
     }
 
+    @Test
+    public void testFetchStarterDesigns() throws InterruptedException {
+        mCountDownLatch = new CountDownLatch(1);
+        mNextEvent = TestEvents.FETCHED_STARTER_DESIGNS;
+        mDispatcher.dispatch(ThemeActionBuilder.newFetchStarterDesignsAction(
+                new ThemeStore.FetchStarterDesignsPayload(400f, 2f)));
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
     @SuppressWarnings("unused")
     @Subscribe
     public void onThemeActivated(OnThemeActivated event) {
@@ -149,6 +160,16 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
+        mCountDownLatch.countDown();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onStarterDesignsFetched(OnStarterDesignsFetched event) {
+        assertEquals(mNextEvent, TestEvents.FETCHED_STARTER_DESIGNS);
+        assertFalse(event.isError());
+        assertNotNull(event.designs);
+        assertFalse(event.designs.isEmpty());
         mCountDownLatch.countDown();
     }
 

--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -99,6 +99,8 @@
 /sites/$site/themes/$theme_ID#String/delete
 /sites/$site/themes/$theme_ID#String/install
 
+/nux/starter-designs
+
 /sites/$siteUrl#String
 
 /sites/$site/mobile-quick-start

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -4,8 +4,10 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.ThemeStore.FetchStarterDesignsPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
+import org.wordpress.android.fluxc.store.ThemeStore.FetchedStarterDesignsPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
@@ -14,6 +16,8 @@ public enum ThemeAction implements IAction {
     // Remote actions
     @Action
     FETCH_WP_COM_THEMES,
+    @Action(payloadType = FetchStarterDesignsPayload.class)
+    FETCH_STARTER_DESIGNS,
     @Action(payloadType = SiteModel.class)
     FETCH_INSTALLED_THEMES, // Jetpack only
     @Action(payloadType = SiteModel.class)
@@ -28,6 +32,8 @@ public enum ThemeAction implements IAction {
     // Remote responses
     @Action(payloadType = FetchedWpComThemesPayload.class)
     FETCHED_WP_COM_THEMES,
+    @Action(payloadType = FetchedStarterDesignsPayload.class)
+    FETCHED_STARTER_DESIGNS,
     @Action(payloadType = FetchedSiteThemesPayload.class)
     FETCHED_INSTALLED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/StarterDesignModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/StarterDesignModel.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.model
+
+import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class StarterDesignModel(
+    @SerializedName("blog_id") val blogId: Int?,
+    val slug: String?,
+    val title: String?,
+    @SerializedName("site_url") val siteUrl: String?,
+    @SerializedName("demo_url") val demoUrl: String?,
+    val theme: String?,
+    val screenshot: String?
+) : Parcelable

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -7,11 +7,13 @@ import androidx.annotation.NonNull;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
+import com.google.gson.reflect.TypeToken;
 
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.StarterDesignModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
@@ -24,6 +26,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.W
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeMobileFriendlyTaxonomy;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
+import org.wordpress.android.fluxc.store.ThemeStore.FetchedStarterDesignsPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
@@ -33,6 +36,7 @@ import org.wordpress.android.util.StringUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.inject.Singleton;
@@ -148,6 +152,34 @@ public class ThemeRestClient extends BaseWPComRestClient {
                                 error.apiError, error.message);
                         FetchedWpComThemesPayload payload = new FetchedWpComThemesPayload(themeError);
                         mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
+                    }
+                }));
+    }
+
+    public void fetchStarterDesigns(Float previewWidth, Float scale) {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "mobile");
+        if (previewWidth != null) {
+            params.put("preview_width", String.format(Locale.US, "%.1f", previewWidth));
+        }
+        if (scale != null) {
+            params.put("scale", String.format(Locale.US, "%.1f", scale));
+        }
+        String url = WPCOMREST.nux.starter_designs.getUrlV1_1();
+        add(WPComGsonRequest.buildGetRequest(url, params, new TypeToken<List<StarterDesignModel>>() {}.getType(),
+                new Response.Listener<List<StarterDesignModel>>() {
+                    @Override public void onResponse(List<StarterDesignModel> response) {
+                        AppLog.d(AppLog.T.API, "Received response to WP.com starter designs fetch request.");
+                        FetchedStarterDesignsPayload payload = new FetchedStarterDesignsPayload(response);
+                        mDispatcher.dispatch(ThemeActionBuilder.newFetchedStarterDesignsAction(payload));
+                    }
+                }, new WPComErrorListener() {
+                    @Override
+                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
+                        AppLog.e(AppLog.T.API, "Received error response to WP.com starter designs fetch request.");
+                        ThemesError themeError = new ThemesError(error.apiError, error.message);
+                        FetchedStarterDesignsPayload payload = new FetchedStarterDesignsPayload(themeError);
+                        mDispatcher.dispatch(ThemeActionBuilder.newFetchedStarterDesignsAction(payload));
                     }
                 }));
     }


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2718

**Description**
This PR fetches the starter designs for the Home Page Picker implementation

**To test**
This can be tested with https://github.com/wordpress-mobile/WordPress-Android/pull/13218
or by running the `testFetchStarterDesigns()` test.
