### PR TITLE
Update dagger library to v2.29.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ subprojects {
 }
 
 ext {
-    daggerVersion = '2.22.1'
+    daggerVersion = '2.29.1'
     wellSqlVersion = '1.6.0'
     supportLibraryVersion = '27.1.1'
     arch_paging_version = '1.0.1'

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.example
 
-import android.app.Activity
 import android.app.Application
 import com.yarolegovich.wellsql.WellSql
 import dagger.android.AndroidInjector

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
@@ -5,14 +5,14 @@ import android.app.Application
 import com.yarolegovich.wellsql.WellSql
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
-import dagger.android.HasActivityInjector
+import dagger.android.HasAndroidInjector
 import org.wordpress.android.fluxc.example.di.AppComponent
 import org.wordpress.android.fluxc.example.di.DaggerAppComponent
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import javax.inject.Inject
 
-open class ExampleApp : Application(), HasActivityInjector {
-    @Inject lateinit var activityInjector: DispatchingAndroidInjector<Activity>
+open class ExampleApp : Application(), HasAndroidInjector {
+    @Inject lateinit var androidInjector: DispatchingAndroidInjector<Any>
 
     protected open val component: AppComponent by lazy {
         DaggerAppComponent.builder()
@@ -27,5 +27,5 @@ open class ExampleApp : Application(), HasActivityInjector {
         WellSql.init(wellSqlConfig)
     }
 
-    override fun activityInjector(): AndroidInjector<Activity> = activityInjector
+    override fun androidInjector(): AndroidInjector<Any> = androidInjector
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
@@ -7,12 +7,13 @@ import androidx.fragment.app.FragmentActivity
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
-import dagger.android.support.HasSupportFragmentInjector
+import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_example.*
 import javax.inject.Inject
 
-class MainExampleActivity : FragmentActivity(), HasSupportFragmentInjector {
-    @Inject lateinit var fragmentInjector: DispatchingAndroidInjector<Fragment>
+class MainExampleActivity : FragmentActivity(), HasAndroidInjector {
+    @Inject lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
@@ -33,5 +34,5 @@ class MainExampleActivity : FragmentActivity(), HasSupportFragmentInjector {
         log.text = output
     }
 
-    override fun supportFragmentInjector(): AndroidInjector<Fragment> = fragmentInjector
+    override fun androidInjector(): AndroidInjector<Any> = dispatchingAndroidInjector
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.example
 
 import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
@@ -13,7 +12,6 @@ import javax.inject.Inject
 
 class MainExampleActivity : FragmentActivity(), HasAndroidInjector {
     @Inject lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)


### PR DESCRIPTION
This PR updates dagger version 2.22.1 -> 2.29.1.

The only breaking change (I found) that is is affecting our codebase is deprecation/removal of "HasServiceInjector and HasSupportFragmentInjector". They were replaced by a more generic "HasAndroidInjector".

Merge instructions:
1. Review this PR
2. Make sure the new dagger version works in [WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/13289) and [WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/3132)
3. Merge this PR and create a new fluxc version tag (or ping me)

To test:
Smoke test the example app.