### PR TITLE
Update okhttp version

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -141,12 +141,7 @@ dependencies {
     // Debug dependencies
     debugImplementation 'com.facebook.flipper:flipper:0.51.0'
     debugImplementation 'com.facebook.soloader:soloader:0.9.0'
-    debugImplementation ('com.facebook.flipper:flipper-network-plugin:0.51.0') {
-        // Force Flipper to use the okhttp version defined in the fluxc module
-        // okhttp versions higher than 3.9.0 break handling for self-signed SSL sites
-        // See https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
-        exclude group: 'com.squareup.okhttp3'
-    }
+    debugImplementation ('com.facebook.flipper:flipper-network-plugin:0.51.0')
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -87,8 +87,8 @@ dependencies {
 
     // External libs
     api 'org.greenrobot:eventbus:3.1.1'
-    api 'com.squareup.okhttp3:okhttp:3.9.0'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.9.0'
+    api 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.12.1'
     api 'com.android.volley:volley:1.1.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-text:1.1'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     // External libs
     api 'org.greenrobot:eventbus:3.1.1'
     api 'com.squareup.okhttp3:okhttp:4.9.0'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.12.1'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.0'
     api 'com.android.volley:volley:1.1.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-text:1.1'

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
@@ -62,7 +62,7 @@ public abstract class DebugOkHttpClientModule {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new SecureRandom());
             final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
-            builder.sslSocketFactory(sslSocketFactory);
+            builder.sslSocketFactory(sslSocketFactory, memorizingTrustManager);
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             AppLog.e(T.API, e);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DebugOkHttpClientModule.java
@@ -25,6 +25,7 @@ import okhttp3.CookieJar;
 import okhttp3.Interceptor;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
+import okhttp3.internal.tls.OkHostnameVerifier;
 
 @Module
 public abstract class DebugOkHttpClientModule {
@@ -61,6 +62,7 @@ public abstract class DebugOkHttpClientModule {
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new SecureRandom());
+            builder.hostnameVerifier(memorizingTrustManager.wrapHostnameVerifier(OkHostnameVerifier.INSTANCE));
             final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
             builder.sslSocketFactory(sslSocketFactory, memorizingTrustManager);
         } catch (NoSuchAlgorithmException | KeyManagementException e) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -385,7 +385,7 @@ public class ReleaseNetworkModule {
     @Singleton
     @Provides
     public MemorizingTrustManager provideMemorizingTrustManager(Context appContext) {
-        return new MemorizingTrustManager(appContext);
+        return new MemorizingTrustManager();
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -44,7 +44,7 @@ public class ReleaseOkHttpClientModule {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new SecureRandom());
             final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
-            builder.sslSocketFactory(sslSocketFactory);
+            builder.sslSocketFactory(sslSocketFactory, memorizingTrustManager);
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             AppLog.e(T.API, e);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseOkHttpClientModule.java
@@ -22,6 +22,7 @@ import dagger.Provides;
 import okhttp3.CookieJar;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
+import okhttp3.internal.tls.OkHostnameVerifier;
 
 @Module
 public class ReleaseOkHttpClientModule {
@@ -44,6 +45,7 @@ public class ReleaseOkHttpClientModule {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new TrustManager[]{memorizingTrustManager}, new SecureRandom());
             final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+            builder.hostnameVerifier(memorizingTrustManager.wrapHostnameVerifier(OkHostnameVerifier.INSTANCE));
             builder.sslSocketFactory(sslSocketFactory, memorizingTrustManager);
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             AppLog.e(T.API, e);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
@@ -167,28 +167,29 @@ public class MemorizingTrustManager implements X509TrustManager {
     }
 
     public HostnameVerifier wrapHostnameVerifier(final HostnameVerifier defaultVerifier) {
-        if (defaultVerifier == null)
+        if (defaultVerifier == null) {
             throw new IllegalArgumentException("The default verifier may not be null");
+        }
 
         return new MemorizingHostnameVerifier(defaultVerifier);
     }
 
-    class MemorizingHostnameVerifier implements HostnameVerifier {
-        private HostnameVerifier defaultVerifier;
+    private class MemorizingHostnameVerifier implements HostnameVerifier {
+        private HostnameVerifier mDefaultVerifier;
 
-        public MemorizingHostnameVerifier(HostnameVerifier wrapped) {
-            defaultVerifier = wrapped;
+        MemorizingHostnameVerifier(HostnameVerifier hostnameVerifier) {
+            mDefaultVerifier = hostnameVerifier;
         }
 
         @Override
         public boolean verify(String hostname, SSLSession session) {
             // if the default verifier accepts the hostname, we are done
-            if (defaultVerifier.verify(hostname, session)) {
+            if (mDefaultVerifier.verify(hostname, session)) {
                 return true;
             }
             // otherwise, we check if the hostname is an alias for this cert in our keystore
             try {
-                X509Certificate cert = (X509Certificate)session.getPeerCertificates()[0];
+                X509Certificate cert = (X509Certificate) session.getPeerCertificates()[0];
                 return cert.equals(getLocalKeyStore().getCertificate(cert.getSubjectDN().toString()));
             } catch (Exception e) {
                 e.printStackTrace();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java
@@ -119,7 +119,7 @@ public class MemorizingTrustManager implements X509TrustManager {
 
     public void storeCert(String hostname, X509Certificate cert) {
         try {
-            getLocalKeyStore().setCertificateEntry(hostname.toLowerCase(Locale.US), cert);
+            getLocalKeyStore().setCertificateEntry(hostname, cert);
         } catch (KeyStoreException e) {
             AppLog.e(T.API, "Unable to store the certificate: " + cert);
         }
@@ -195,8 +195,10 @@ public class MemorizingTrustManager implements X509TrustManager {
                 //Log.d(TAG, "cert: " + cert);
                 if (cert.equals(getLocalKeyStore().getCertificate(hostname.toLowerCase(Locale.US)))) {
                     return true;
+                } if (cert.equals(getLocalKeyStore().getCertificate(cert.getSubjectDN().toString()))) {
+                    return true;
                 } else {
-                    mLastFailedHost = hostname;
+                    mLastFailedHost = hostname.toLowerCase(Locale.US);
                     mLastFailure = cert;
                     return false;
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
@@ -82,7 +82,8 @@ public class OkHttpStack extends BaseHttpStack {
     }
 
     @Override
-    public HttpResponse executeRequest(Request<?> request, Map<String, String> additionalHeaders) throws IOException, AuthFailureError {
+    public HttpResponse executeRequest(Request<?> request, Map<String, String> additionalHeaders)
+            throws IOException, AuthFailureError {
         int timeoutMs = request.getTimeoutMs();
 
         mClientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
@@ -1,116 +1,54 @@
 package org.wordpress.android.fluxc.network;
 
 import com.android.volley.AuthFailureError;
+import com.android.volley.Header;
 import com.android.volley.Request;
-import com.android.volley.toolbox.HttpStack;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.StatusLine;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.message.BasicHttpResponse;
-import org.apache.http.message.BasicStatusLine;
+import com.android.volley.toolbox.BaseHttpStack;
+import com.android.volley.toolbox.HttpResponse;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
 import okhttp3.Headers;
+import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
-import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 
 /**
- * Modified version of https://gist.github.com/alashow/c96c09320899e4caa06b
- *
- * OkHttp backed {@link HttpStack HttpStack} that does not
+ * Modified version of https://gist.github.com/LOG-TAG/3ad1c191b3ca7eab3ea6834386e30eb9
+ * <p>
+ * OkHttp backed {@link BaseHttpStack BaseHttpStack} that does not
  * use okhttp-urlconnection
  */
-public class OkHttpStack implements HttpStack {
+public class OkHttpStack extends BaseHttpStack {
     private final OkHttpClient.Builder mClientBuilder;
 
     public OkHttpStack(OkHttpClient.Builder clientBuilder) {
         this.mClientBuilder = clientBuilder;
     }
 
-    @Override
-    public HttpResponse performRequest(Request<?> request, Map<String, String> additionalHeaders)
-            throws IOException, AuthFailureError {
-        int timeoutMs = request.getTimeoutMs();
-        mClientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);
-        mClientBuilder.readTimeout(timeoutMs, TimeUnit.MILLISECONDS);
-        mClientBuilder.writeTimeout(timeoutMs, TimeUnit.MILLISECONDS);
-
-        Builder okHttpRequestBuilder = new okhttp3.Request.Builder();
-        okHttpRequestBuilder.url(request.getUrl());
-
-        Map<String, String> headers = request.getHeaders();
-        for (final String name : headers.keySet()) {
-            okHttpRequestBuilder.addHeader(name, headers.get(name));
-        }
-        for (final String name : additionalHeaders.keySet()) {
-            okHttpRequestBuilder.addHeader(name, additionalHeaders.get(name));
-        }
-
-        setConnectionParametersForRequest(okHttpRequestBuilder, request);
-
-        OkHttpClient client = mClientBuilder.build();
-        okhttp3.Request okHttpRequest = okHttpRequestBuilder.build();
-        Call okHttpCall = client.newCall(okHttpRequest);
-        okhttp3.Response okHttpResponse = okHttpCall.execute();
-
-        StatusLine responseStatus = new BasicStatusLine(parseProtocol(okHttpResponse.protocol()),
-                okHttpResponse.code(), okHttpResponse.message());
-        BasicHttpResponse response = new BasicHttpResponse(responseStatus);
-        response.setEntity(entityFromOkHttpResponse(okHttpResponse));
-
-        Headers responseHeaders = okHttpResponse.headers();
-        for (int i = 0, len = responseHeaders.size(); i < len; i++) {
-            final String name = responseHeaders.name(i), value = responseHeaders.value(i);
-            if (name != null) {
-                response.addHeader(new BasicHeader(name, value));
-            }
-        }
-
-        return response;
-    }
-
-    private static HttpEntity entityFromOkHttpResponse(okhttp3.Response r) throws IOException {
-        BasicHttpEntity entity = new BasicHttpEntity();
-        ResponseBody body = r.body();
-
-        entity.setContent(body.byteStream());
-        entity.setContentLength(body.contentLength());
-        entity.setContentEncoding(r.header("Content-Encoding"));
-
-        if (body.contentType() != null) {
-            entity.setContentType(body.contentType().type());
-        }
-        return entity;
-    }
-
-    @SuppressWarnings("deprecation")
-    private static void setConnectionParametersForRequest(Builder builder, Request<?> request)
-            throws IOException, AuthFailureError {
+    private static void setConnectionParametersForRequest(okhttp3.Request.Builder builder, Request<?> request)
+            throws AuthFailureError {
         switch (request.getMethod()) {
             case Request.Method.DEPRECATED_GET_OR_POST:
                 // Ensure backwards compatibility.  Volley assumes a request with a null body is a GET.
-                byte[] postBody = request.getPostBody();
+                byte[] postBody = request.getBody();
                 if (postBody != null) {
-                    builder.post(RequestBody.create(MediaType.parse(request.getPostBodyContentType()), postBody));
+                    builder.post(RequestBody.create(MediaType.parse(request.getBodyContentType()), postBody));
                 }
                 break;
             case Request.Method.GET:
                 builder.get();
                 break;
             case Request.Method.DELETE:
-                builder.delete();
+                builder.delete(createRequestBody(request));
                 break;
             case Request.Method.POST:
                 builder.post(createRequestBody(request));
@@ -135,27 +73,62 @@ public class OkHttpStack implements HttpStack {
         }
     }
 
-    private static ProtocolVersion parseProtocol(final Protocol p) {
-        switch (p) {
-            case HTTP_1_0:
-                return new ProtocolVersion("HTTP", 1, 0);
-            case HTTP_1_1:
-                return new ProtocolVersion("HTTP", 1, 1);
-            case SPDY_3:
-                return new ProtocolVersion("SPDY", 3, 1);
-            case HTTP_2:
-                return new ProtocolVersion("HTTP", 2, 0);
-        }
-
-        throw new IllegalAccessError("Unkwown protocol");
-    }
-
     private static RequestBody createRequestBody(Request r) throws AuthFailureError {
-        byte[] body = r.getBody();
+        final byte[] body = r.getBody();
         if (body == null) {
-            // Use the empty body when we get the null body
-            body = "".getBytes();
+            return null;
         }
         return RequestBody.create(MediaType.parse(r.getBodyContentType()), body);
+    }
+
+    @Override
+    public HttpResponse executeRequest(Request<?> request, Map<String, String> additionalHeaders) throws IOException, AuthFailureError {
+        int timeoutMs = request.getTimeoutMs();
+
+        mClientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+        mClientBuilder.readTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+        mClientBuilder.writeTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+
+        okhttp3.Request.Builder okHttpRequestBuilder = new okhttp3.Request.Builder();
+        okHttpRequestBuilder.url(request.getUrl());
+
+        Map<String, String> headers = request.getHeaders();
+        for (final String name : headers.keySet()) {
+            okHttpRequestBuilder.addHeader(name, headers.get(name));
+        }
+        for (final String name : additionalHeaders.keySet()) {
+            okHttpRequestBuilder.addHeader(name, additionalHeaders.get(name));
+        }
+
+        setConnectionParametersForRequest(okHttpRequestBuilder, request);
+
+
+        for (Interceptor interceptor : mClientBuilder.interceptors()) {
+            mClientBuilder.addNetworkInterceptor(interceptor);
+        }
+
+        OkHttpClient client = mClientBuilder.build();
+        okhttp3.Request okHttpRequest = okHttpRequestBuilder.build();
+        Call okHttpCall = client.newCall(okHttpRequest);
+        okhttp3.Response okHttpResponse = okHttpCall.execute();
+
+
+        int code = okHttpResponse.code();
+        ResponseBody body = okHttpResponse.body();
+        InputStream content = body == null ? null : body.byteStream();
+        int contentLength = body == null ? 0 : (int) body.contentLength();
+        List<Header> responseHeaders = mapHeaders(okHttpResponse.headers());
+        return new HttpResponse(code, responseHeaders, contentLength, content);
+    }
+
+    private List<Header> mapHeaders(Headers responseHeaders) {
+        List<Header> headers = new ArrayList<>();
+        for (int i = 0, len = responseHeaders.size(); i < len; i++) {
+            final String name = responseHeaders.name(i), value = responseHeaders.value(i);
+            if (name != null) {
+                headers.add(new Header(name, value));
+            }
+        }
+        return headers;
     }
 }


### PR DESCRIPTION
Fixes #919 

In this PR I'm updating OkHTTP version and implementing a fix that enables logging in with a self-signed certificate once it's been approved by the user. This should fix the issue linked in this PR. Let me know if this approach makes sense to you. I was inspired by the newer implementation of the `MemorizingTrustManager`. It seems that adding the `MemorizingHostnameVerifier` does the trick. 

This could be tested using the self-signed site from tests.properties using [this WP Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13291).