### PR TITLE
issue/1749-wc-empty-list-crash

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -117,7 +117,9 @@ object ProductSqlUtils {
         }
 
         excludedProductIds?.let {
-            queryBuilder.isNotIn(WCProductModelTable.REMOTE_PRODUCT_ID, excludedProductIds)
+            if (it.isNotEmpty()) {
+                queryBuilder.isNotIn(WCProductModelTable.REMOTE_PRODUCT_ID, it)
+            }
         }
 
         val sortOrder = when (sortType) {


### PR DESCRIPTION
Closes #1749 - Fixes a crash in `getProductsByFilterOptions` if an empty (rather than null) list of excluded product IDs is passed.
