### PR TITLE
Update example test properties documentation

### DIFF
--- a/example/tests.properties-example
+++ b/example/tests.properties-example
@@ -15,6 +15,7 @@ TEST_WPCOM_PASSWORD_2FA = FIXME
 TEST_WPCOM_EMAIL_PASSWORDLESS = FIXME
 
 ## Self-hosted
+# Almost all self-hosted endpoint URL paths need the extra '/xmlrpc.php' suffix to work properly.
 
 # Simple Self hosted (no Jetpack)
 TEST_WPORG_USERNAME_SH_SIMPLE = FIXME


### PR DESCRIPTION
This PR adds an extra comment on the `test.properties-example` file for the self-hosted section.

This comment will inform developers that they need to include the extra `/xmlrpc.php` suffix on almost all the self-hosted endpoint URL paths in order for them to work properly while testing. This is especially important for external contributors, trialmatticians or newcomers.