### PR TITLE
Adds "template" in CREATE_NEW_SITE and "language in FETCH_STARTER_DESIGNS

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -218,7 +218,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void newSite(@NonNull String siteName, @NonNull String language,
-                        @NonNull SiteVisibility visibility, @Nullable Long segmentId,
+                        @NonNull SiteVisibility visibility, @Nullable Long segmentId, @Nullable String siteDesign,
                         final boolean dryRun) {
         String url = WPCOMREST.sites.new_.getUrlV1_1();
         Map<String, Object> body = new HashMap<>();
@@ -233,6 +233,9 @@ public class SiteRestClient extends BaseWPComRestClient {
         Map<String, Object> options = new HashMap<>();
         if (segmentId != null) {
             options.put("site_segment", segmentId);
+        }
+        if (siteDesign != null) {
+            options.put("template", siteDesign);
         }
         if (options.size() > 0) {
             body.put("options", options);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
@@ -159,6 +160,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
     public void fetchStarterDesigns(Float previewWidth, Float scale) {
         Map<String, String> params = new HashMap<>();
         params.put("type", "mobile");
+        params.put("language", LanguageUtils.getPatchedCurrentDeviceLanguage(mAppContext));
         if (previewWidth != null) {
             params.put("preview_width", String.format(Locale.US, "%.1f", previewWidth));
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -84,19 +84,21 @@ public class SiteStore extends Store {
         @NonNull public String language;
         @NonNull public SiteVisibility visibility;
         @Nullable public Long segmentId;
+        @Nullable public String siteDesign;
         @NonNull public boolean dryRun;
 
         public NewSitePayload(@NonNull String siteName, @NonNull String language,
                               @NonNull SiteVisibility visibility, boolean dryRun) {
-            this(siteName, language, visibility, null, dryRun);
+            this(siteName, language, visibility, null, null, dryRun);
         }
 
-        public NewSitePayload(@NonNull String siteName, @NonNull String language,
-                              @NonNull SiteVisibility visibility, @Nullable Long segmentId, boolean dryRun) {
+        public NewSitePayload(@NonNull String siteName, @NonNull String language, @NonNull SiteVisibility visibility,
+                              @Nullable Long segmentId, @Nullable String siteDesign, boolean dryRun) {
             this.siteName = siteName;
             this.language = language;
             this.visibility = visibility;
             this.segmentId = segmentId;
+            this.siteDesign = siteDesign;
             this.dryRun = dryRun;
         }
     }
@@ -1799,7 +1801,7 @@ public class SiteStore extends Store {
 
     private void createNewSite(NewSitePayload payload) {
         mSiteRestClient.newSite(payload.siteName, payload.language, payload.visibility,
-                payload.segmentId, payload.dryRun);
+                payload.segmentId, payload.siteDesign, payload.dryRun);
     }
 
     private void handleCreateNewSiteCompleted(NewSiteResponsePayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -258,7 +258,7 @@ public class SiteStore extends Store {
             this.includeVendorDot = includeVendorDot;
         }
 
-        public SuggestDomainsPayload(@NonNull String query, long segmentId, int quantity, boolean includeVendorDot) {
+        public SuggestDomainsPayload(@NonNull String query, @Nullable Long segmentId, int quantity, boolean includeVendorDot) {
             this.query = query;
             this.segmentId = segmentId;
             this.quantity = quantity;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -258,7 +258,8 @@ public class SiteStore extends Store {
             this.includeVendorDot = includeVendorDot;
         }
 
-        public SuggestDomainsPayload(@NonNull String query, @Nullable Long segmentId, int quantity, boolean includeVendorDot) {
+        public SuggestDomainsPayload(@NonNull String query, @Nullable Long segmentId,
+                                     int quantity, boolean includeVendorDot) {
             this.query = query;
             this.segmentId = segmentId;
             this.quantity = quantity;


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2721

**Description**
This PR adds
* `template` parameter in CREATE_NEW_SITE action
* `language` parameter in FETCH_STARTER_DESIGNS action

**To test**
This can be tested with https://github.com/wordpress-mobile/WordPress-Android/pull/13316