### PR TITLE
Update out-dated checkstyle ide configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can install the CheckStyle-IDEA plugin in Android Studio here:
 
 Once installed, you can configure the plugin here:
 
-`Android Studio > Preferences... > Other Settings > Checkstyle`
+`Android Studio > Preferences... > Tools > Checkstyle`
 
 From there, add and enable the configuration file for FluxC, located at [config/checkstyle.xml](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/config/checkstyle.xml).
 


### PR DESCRIPTION
This PR updates the out-dated checkstyle IDE configuration instructions.

⚠️ This repository doesn't have a `Documentation` label, just like the [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android) repository does, maybe we should add it?

ℹ️ Note that this PR is closely related to its corresponding [WordPress-Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13308) and discussions within. Please check that PR as well before coming to any conclusions.