### PR TITLE
Add more logs to media errors

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -275,7 +275,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
 
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                AppLog.w(T.MEDIA, "media upload failed: " + e);
+                String message = "media upload failed: " + e;
+                AppLog.w(T.MEDIA, message);
                 if (!mCurrentUploadCalls.containsKey(media.getId())) {
                     // This call has already been removed from the in-progress list - probably because it was cancelled
                     // In that case this has already been handled and there's nothing to do
@@ -283,6 +284,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                 }
 
                 MediaError error = MediaError.fromIOException(e);
+                error.logMessage = message;
                 notifyMediaUploaded(media, error);
             }
         });

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -97,7 +97,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     @Override
     public void onProgress(MediaModel media, float progress) {
         if (mCurrentUploadCalls.containsKey(media.getId())) {
-            notifyMediaProgress(media, Math.min(progress, 0.99f), null);
+            notifyMediaProgress(media, Math.min(progress, 0.99f));
         }
     }
 
@@ -557,8 +557,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newPushedMediaAction(payload));
     }
 
-    private void notifyMediaProgress(MediaModel media, float progress, MediaError error) {
-        ProgressPayload payload = new ProgressPayload(media, progress, false, error);
+    private void notifyMediaProgress(MediaModel media, float progress) {
+        ProgressPayload payload = new ProgressPayload(media, progress, false, null);
         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -243,6 +243,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                     MediaError error = new MediaError(MediaErrorType.fromHttpStatusCode(response.code()));
                     error.message = response.message();
                     error.logMessage = "XMLRPC: error uploading media";
+                    error.statusCode = response.code();
                     notifyMediaUploaded(media, error);
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -87,7 +87,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     @Override
     public void onProgress(MediaModel media, float progress) {
         if (mCurrentUploadCalls.containsKey(media.getId())) {
-            notifyMediaProgress(media, Math.min(progress, 0.99f), null);
+            notifyMediaProgress(media, Math.min(progress, 0.99f));
         }
     }
 
@@ -460,8 +460,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newPushedMediaAction(payload));
     }
 
-    private void notifyMediaProgress(MediaModel media, float progress, MediaError error) {
-        ProgressPayload payload = new ProgressPayload(media, progress, false, error);
+    private void notifyMediaProgress(MediaModel media, float progress) {
+        ProgressPayload payload = new ProgressPayload(media, progress, false, null);
         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -216,6 +216,8 @@ public class MediaStore extends Store {
     public static class MediaError implements OnChangedError {
         public MediaErrorType type;
         public String message;
+        public int statusCode;
+        public String logMessage;
         public MediaError(MediaErrorType type) {
             this.type = type;
         }
@@ -227,6 +229,7 @@ public class MediaStore extends Store {
         public static MediaError fromIOException(IOException e) {
             MediaError mediaError = new MediaError(MediaErrorType.GENERIC_ERROR);
             mediaError.message = e.getLocalizedMessage();
+            mediaError.logMessage = e.getMessage();
 
             if (e instanceof SocketTimeoutException) {
                 mediaError.type = MediaErrorType.TIMEOUT;
@@ -694,11 +697,15 @@ public class MediaStore extends Store {
         OnMediaChanged event = new OnMediaChanged(MediaAction.UPDATE_MEDIA);
 
         if (media == null) {
-            event.error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
+            MediaError mediaError = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
+            mediaError.logMessage = "Empty media on updateMedia";
+            event.error = mediaError;
         } else if (MediaSqlUtils.insertOrUpdateMedia(media) > 0) {
             event.mediaList.add(media);
         } else {
-            event.error = new MediaError(MediaErrorType.DB_QUERY_FAILURE);
+            MediaError mediaError = new MediaError(MediaErrorType.DB_QUERY_FAILURE);
+            mediaError.logMessage = "Insert in DB failed";
+            event.error = mediaError;
         }
 
         if (emit) {
@@ -710,11 +717,15 @@ public class MediaStore extends Store {
         OnMediaChanged event = new OnMediaChanged(MediaAction.REMOVE_MEDIA);
 
         if (media == null) {
-            event.error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
+            MediaError mediaError = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
+            mediaError.logMessage = "Empty media on removeMedia";
+            event.error = mediaError;
         } else if (MediaSqlUtils.deleteMedia(media) > 0) {
             event.mediaList.add(media);
         } else {
-            event.error = new MediaError(MediaErrorType.DB_QUERY_FAILURE);
+            MediaError mediaError = new MediaError(MediaErrorType.DB_QUERY_FAILURE);
+            mediaError.logMessage = "Delete from DB failed";
+            event.error = mediaError;
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -744,7 +744,8 @@ public class MediaStore extends Store {
         }
     }
 
-    private void notifyMediaUploadError(MediaErrorType errorType, String errorMessage, MediaModel media, String logMessage) {
+    private void notifyMediaUploadError(MediaErrorType errorType, String errorMessage, MediaModel media,
+                                        String logMessage) {
         OnMediaUploaded onMediaUploaded = new OnMediaUploaded(media, 1, false, false);
         MediaError mediaError = new MediaError(errorType, errorMessage);
         mediaError.logMessage = logMessage;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -697,15 +697,11 @@ public class MediaStore extends Store {
         OnMediaChanged event = new OnMediaChanged(MediaAction.UPDATE_MEDIA);
 
         if (media == null) {
-            MediaError mediaError = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
-            mediaError.logMessage = "Empty media on updateMedia";
-            event.error = mediaError;
+            event.error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
         } else if (MediaSqlUtils.insertOrUpdateMedia(media) > 0) {
             event.mediaList.add(media);
         } else {
-            MediaError mediaError = new MediaError(MediaErrorType.DB_QUERY_FAILURE);
-            mediaError.logMessage = "Insert in DB failed";
-            event.error = mediaError;
+            event.error = new MediaError(MediaErrorType.DB_QUERY_FAILURE);
         }
 
         if (emit) {
@@ -717,15 +713,11 @@ public class MediaStore extends Store {
         OnMediaChanged event = new OnMediaChanged(MediaAction.REMOVE_MEDIA);
 
         if (media == null) {
-            MediaError mediaError = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
-            mediaError.logMessage = "Empty media on removeMedia";
-            event.error = mediaError;
+            event.error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
         } else if (MediaSqlUtils.deleteMedia(media) > 0) {
             event.mediaList.add(media);
         } else {
-            MediaError mediaError = new MediaError(MediaErrorType.DB_QUERY_FAILURE);
-            mediaError.logMessage = "Delete from DB failed";
-            event.error = mediaError;
+            event.error = new MediaError(MediaErrorType.DB_QUERY_FAILURE);
         }
         emitChange(event);
     }
@@ -752,19 +744,22 @@ public class MediaStore extends Store {
         }
     }
 
-    private void notifyMediaUploadError(MediaErrorType errorType, String errorMessage, MediaModel media) {
+    private void notifyMediaUploadError(MediaErrorType errorType, String errorMessage, MediaModel media, String logMessage) {
         OnMediaUploaded onMediaUploaded = new OnMediaUploaded(media, 1, false, false);
-        onMediaUploaded.error = new MediaError(errorType, errorMessage);
+        MediaError mediaError = new MediaError(errorType, errorMessage);
+        mediaError.logMessage = logMessage;
+        onMediaUploaded.error = mediaError;
         emitChange(onMediaUploaded);
     }
 
     private void performUploadMedia(UploadMediaPayload payload) {
         String errorMessage = MediaUtils.getMediaValidationError(payload.media);
         if (errorMessage != null) {
-            AppLog.e(AppLog.T.MEDIA, "Media doesn't have required data: " + errorMessage);
+            String message = "Media doesn't have required data: " + errorMessage;
+            AppLog.e(AppLog.T.MEDIA, message);
             payload.media.setUploadState(MediaUploadState.FAILED);
             MediaSqlUtils.insertOrUpdateMedia(payload.media);
-            notifyMediaUploadError(MediaErrorType.MALFORMED_MEDIA_ARG, errorMessage, payload.media);
+            notifyMediaUploadError(MediaErrorType.MALFORMED_MEDIA_ARG, errorMessage, payload.media, message);
             return;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -352,7 +352,9 @@ public class UploadStore extends Store {
             case MediaUploadModel.UPLOADING:
                 if (newUploadState == MediaUploadState.FAILED) {
                     mediaUploadModel.setUploadState(MediaUploadModel.FAILED);
-                    mediaUploadModel.setMediaError(new MediaError(MediaErrorType.GENERIC_ERROR));
+                    MediaError mediaError = new MediaError(MediaErrorType.GENERIC_ERROR);
+                    mediaError.logMessage = "Change state from UPLOADING to FAILED";
+                    mediaUploadModel.setMediaError(mediaError);
                     mediaUploadModel.setProgress(0);
                     UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel);
                     // Also cancel the associated post

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -352,9 +352,7 @@ public class UploadStore extends Store {
             case MediaUploadModel.UPLOADING:
                 if (newUploadState == MediaUploadState.FAILED) {
                     mediaUploadModel.setUploadState(MediaUploadModel.FAILED);
-                    MediaError mediaError = new MediaError(MediaErrorType.GENERIC_ERROR);
-                    mediaError.logMessage = "Change state from UPLOADING to FAILED";
-                    mediaUploadModel.setMediaError(mediaError);
+                    mediaUploadModel.setMediaError(new MediaError(MediaErrorType.GENERIC_ERROR));
                     mediaUploadModel.setProgress(0);
                     UploadSqlUtils.insertOrUpdateMedia(mediaUploadModel);
                     // Also cancel the associated post


### PR DESCRIPTION
This PR adds 2 more fields to the MediaError which we'll be tracking in the WPAndroid app to analyze media upload errors. These fields only need to be filled in in the `OnMediaUploaded` events which are the only ones relevant for the media upload.  I was trying to add a meaningful message and differentiate between XMLRPC and WP.com The first field is a log message and the second field is the response status code. This will tell us whether we're handling all the possible response codes from the backend. 

You can test this PR with this WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/13325