### PR TITLE
Restores the old NewSitePayload constructor as a secondary constructor

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -92,6 +92,11 @@ public class SiteStore extends Store {
             this(siteName, language, visibility, null, null, dryRun);
         }
 
+        public NewSitePayload(@NonNull String siteName, @NonNull String language,
+                              @NonNull SiteVisibility visibility, @Nullable Long segmentId, boolean dryRun) {
+            this(siteName, language, visibility, segmentId, null, dryRun);
+        }
+
         public NewSitePayload(@NonNull String siteName, @NonNull String language, @NonNull SiteVisibility visibility,
                               @Nullable Long segmentId, @Nullable String siteDesign, boolean dryRun) {
             this.siteName = siteName;


### PR DESCRIPTION
**Relates with** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2721

**Description**
Restores the old NewSitePayload constructor as a secondary constructor and fixes incompatibility with DEV branch on WPAndroid after merging https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1752 without the accompanying Android PR https://github.com/wordpress-mobile/WordPress-Android/pull/13316

**To test**
This can be tested with the dev branch of https://github.com/wordpress-mobile/WordPress-Android/