### PR TITLE
ScanStore: Introduce skeleton classes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -29,6 +29,7 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_AccountTest test);
     void inject(ReleaseStack_AccountAvailabilityTest test);
     void inject(ReleaseStack_ActivityLogTestJetpack test);
+    void inject(ReleaseStack_ScanTestJetpack test);
     void inject(ReleaseStack_InsightsTestJetpack test);
     void inject(ReleaseStack_TimeStatsTestJetpack test);
     void inject(ReleaseStack_TimeStatsTestWPCom test);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.release
+
+import kotlin.jvm.Throws
+
+class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        // Register
+        init()
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.fluxc.action
+
+import org.wordpress.android.fluxc.annotations.ActionEnum
+import org.wordpress.android.fluxc.annotations.action.IAction
+
+@ActionEnum
+enum class ScanAction : IAction

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.planoffers.PlanOffersRestC
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.reader.ReaderRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.scan.ScanRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.AllTimeInsightsRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.CommentsRestClient;
@@ -192,6 +193,16 @@ public class ReleaseNetworkModule {
                                                               AccessToken token, UserAgent userAgent,
                                                               WPComGsonRequestBuilder wpComGsonRequestBuilder) {
         return new ActivityLogRestClient(dispatcher, wpComGsonRequestBuilder, appContext, requestQueue, token,
+                userAgent);
+    }
+
+    @Singleton
+    @Provides
+    public ScanRestClient provideScanRestClient(Context appContext, Dispatcher dispatcher,
+                                                       @Named("regular") RequestQueue requestQueue,
+                                                       AccessToken token, UserAgent userAgent,
+                                                       WPComGsonRequestBuilder wpComGsonRequestBuilder) {
+        return new ScanRestClient(dispatcher, wpComGsonRequestBuilder, appContext, requestQueue, token,
                 userAgent);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -202,7 +202,7 @@ public class ReleaseNetworkModule {
                                                        @Named("regular") RequestQueue requestQueue,
                                                        AccessToken token, UserAgent userAgent,
                                                        WPComGsonRequestBuilder wpComGsonRequestBuilder) {
-        return new ScanRestClient(dispatcher, wpComGsonRequestBuilder, appContext, requestQueue, token,
+        return new ScanRestClient(wpComGsonRequestBuilder, dispatcher, appContext, requestQueue, token,
                 userAgent);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.scan
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import javax.inject.Singleton
+
+@Singleton
+class ScanRestClient
+constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -10,10 +10,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import javax.inject.Singleton
 
 @Singleton
-class ScanRestClient
-constructor(
-    dispatcher: Dispatcher,
+class ScanRestClient(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    dispatcher: Dispatcher,
     appContext: Context?,
     requestQueue: RequestQueue,
     accessToken: AccessToken,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.fluxc.persistence
+
+import javax.inject.Singleton
+
+@Singleton
+class ScanSqlUtils

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
@@ -12,8 +12,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ScanStore
-@Inject constructor(
+class ScanStore @Inject constructor(
     private val scanRestClient: ScanRestClient,
     private val scanSqlUtils: ScanSqlUtils,
     private val coroutineEngine: CoroutineEngine,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.fluxc.store
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.network.rest.wpcom.scan.ScanRestClient
+import org.wordpress.android.fluxc.persistence.ScanSqlUtils
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ScanStore
+@Inject constructor(
+    private val scanRestClient: ScanRestClient,
+    private val scanSqlUtils: ScanSqlUtils,
+    private val coroutineEngine: CoroutineEngine,
+    dispatcher: Dispatcher
+) : Store(dispatcher) {
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>) {
+    }
+
+    override fun onRegister() {
+        AppLog.d(AppLog.T.API, this.javaClass.name + ": onRegister")
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/13326

This PR adds skeleton classes for the `ScanStore`, `ScanAction`,`ScanRestClient`, `ScanSqlUtils` that will be used  
for the network and persistence part of the Scan feature.

To test: 
Nothing to test, just see that basic skeleton classes are added similar to other stores (e.g. `ActivityLogStore`).