### PR TITLE
Add types request to rewind endpoint

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.store
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -26,6 +27,7 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.FetchRewindStatePayloa
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedRewindStatePayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindPayload
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindRequestTypes
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindResultPayload
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
@@ -108,7 +110,7 @@ class ActivityLogStoreTest {
 
     @Test
     fun onRewindActionCallRestClient() = test {
-        whenever(activityLogRestClient.rewind(eq(siteModel), any(), any())).thenReturn(
+        whenever(activityLogRestClient.rewind(eq(siteModel), any(), anyOrNull())).thenReturn(
                 RewindResultPayload(
                         "rewindId",
                         null,
@@ -117,7 +119,7 @@ class ActivityLogStoreTest {
         )
 
         val rewindId = "rewindId"
-        val payload = RewindPayload(siteModel, rewindId, mutableMapOf())
+        val payload = RewindPayload(siteModel, rewindId, null)
         val action = ActivityLogActionBuilder.newRewindAction(payload)
         activityLogStore.onAction(action)
 
@@ -221,7 +223,7 @@ class ActivityLogStoreTest {
         activityLogStore.onAction(ActivityLogActionBuilder.newRewindAction(RewindPayload(
                 siteModel,
                 rewindId,
-                mutableMapOf())))
+                null)))
 
         val expectedChangeEvent = ActivityLogStore.OnRewind(rewindId, restoreId, ActivityLogAction.REWIND)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
@@ -262,25 +264,29 @@ class ActivityLogStoreTest {
         )
 
         val rewindId = "rewindId"
-        val payload = RewindPayload(siteModel, rewindId, mutableMapOf())
+        val types = RewindRequestTypes(themes = true,
+                plugins = true,
+                uploads = true,
+                sqls = true,
+                roots = true,
+                contents = true)
+        val payload = RewindPayload(siteModel, rewindId, types)
         val action = ActivityLogActionBuilder.newRewindAction(payload)
         activityLogStore.onAction(action)
 
-        verify(activityLogRestClient).rewind(siteModel, rewindId)
+        verify(activityLogRestClient).rewind(siteModel, rewindId, types)
     }
 
     @Test
     fun emitsRewindResultWhenSendingTypes() = test {
         val rewindId = "rewindId"
         val restoreId = 10L
-        val types = mapOf(
-            "themes" to true,
-            "plugins" to true,
-            "uploads" to true,
-            "sqls" to true,
-            "roots" to true,
-            "contents" to true
-        )
+        val types = RewindRequestTypes(themes = true,
+                    plugins = true,
+                    uploads = true,
+                    sqls = true,
+                    roots = true,
+                    contents = true)
 
         val payload = ActivityLogStore.RewindResultPayload(rewindId, restoreId, siteModel)
         whenever(activityLogRestClient.rewind(siteModel, rewindId, types)).thenReturn(payload)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -218,7 +218,10 @@ class ActivityLogStoreTest {
         val payload = ActivityLogStore.RewindResultPayload(rewindId, restoreId, siteModel)
         whenever(activityLogRestClient.rewind(siteModel, rewindId)).thenReturn(payload)
 
-        activityLogStore.onAction(ActivityLogActionBuilder.newRewindAction(RewindPayload(siteModel, rewindId, mutableMapOf())))
+        activityLogStore.onAction(ActivityLogActionBuilder.newRewindAction(RewindPayload(
+                siteModel,
+                rewindId,
+                mutableMapOf())))
 
         val expectedChangeEvent = ActivityLogStore.OnRewind(rewindId, restoreId, ActivityLogAction.REWIND)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -87,9 +87,14 @@ constructor(
         }
     }
 
-    suspend fun rewind(site: SiteModel, rewindId: String): RewindResultPayload {
+    suspend fun rewind(site: SiteModel, rewindId: String, types: Map<String, Boolean> = mapOf()): RewindResultPayload {
         val url = WPCOMREST.activity_log.site(site.siteId).rewind.to.rewind(rewindId).urlV1
-        val response = wpComGsonRequestBuilder.syncPostRequest(this, url, null, mapOf(), RewindResponse::class.java)
+        val typesBody = if (types.isNotEmpty()) {
+            mapOf("types" to types)
+        } else {
+            types
+        }
+        val response = wpComGsonRequestBuilder.syncPostRequest(this, url, null, typesBody, RewindResponse::class.java)
         return when (response) {
             is Success -> {
                 if (response.data.ok != true && (response.data.error != null && response.data.error.isNotEmpty())) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedRewindStatePayl
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindError
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindErrorType
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindErrorType.API_ERROR
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindRequestTypes
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindResultPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusError
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusErrorType
@@ -87,13 +88,14 @@ constructor(
         }
     }
 
-    suspend fun rewind(site: SiteModel, rewindId: String, types: Map<String, Boolean> = mapOf()): RewindResultPayload {
+    suspend fun rewind(site: SiteModel, rewindId: String, types: RewindRequestTypes? = null): RewindResultPayload {
         val url = WPCOMREST.activity_log.site(site.siteId).rewind.to.rewind(rewindId).urlV1
-        val typesBody = if (types.isNotEmpty()) {
+        val typesBody = if (types != null) {
             mapOf("types" to types)
         } else {
-            types
+            mapOf()
         }
+
         val response = wpComGsonRequestBuilder.syncPostRequest(this, url, null, typesBody, RewindResponse::class.java)
         return when (response) {
             is Success -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -172,8 +172,10 @@ class ActivityLogStore
 
     class FetchRewindStatePayload(val site: SiteModel) : Payload<BaseRequest.BaseNetworkError>()
 
-    class RewindPayload(val site: SiteModel, val rewindId: String, val types: Map<String, Boolean> = mapOf())
-        : Payload<BaseRequest.BaseNetworkError>()
+    class RewindPayload(
+        val site: SiteModel,
+        val rewindId: String,
+        val types: Map<String, Boolean> = mapOf()) : Payload<BaseRequest.BaseNetworkError>()
 
     class FetchedActivityLogPayload(
         val activityLogModels: List<ActivityLogModel> = listOf(),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -175,7 +175,8 @@ class ActivityLogStore
     class RewindPayload(
         val site: SiteModel,
         val rewindId: String,
-        val types: Map<String, Boolean> = mapOf()) : Payload<BaseRequest.BaseNetworkError>()
+        val types: RewindRequestTypes? = null
+    ) : Payload<BaseRequest.BaseNetworkError>()
 
     class FetchedActivityLogPayload(
         val activityLogModels: List<ActivityLogModel> = listOf(),
@@ -247,4 +248,13 @@ class ActivityLogStore
     }
 
     class RewindError(var type: RewindErrorType, var message: String? = null) : Store.OnChangedError
+
+    data class RewindRequestTypes(
+        val themes: Boolean,
+        val plugins: Boolean,
+        val uploads: Boolean,
+        val sqls: Boolean,
+        val roots: Boolean,
+        val contents: Boolean
+    )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -95,7 +95,7 @@ class ActivityLogStore
     }
 
     suspend fun rewind(rewindPayload: RewindPayload): OnRewind {
-        val payload = activityLogRestClient.rewind(rewindPayload.site, rewindPayload.rewindId)
+        val payload = activityLogRestClient.rewind(rewindPayload.site, rewindPayload.rewindId, rewindPayload.types)
         return emitRewindResult(payload, REWIND)
     }
 
@@ -172,7 +172,8 @@ class ActivityLogStore
 
     class FetchRewindStatePayload(val site: SiteModel) : Payload<BaseRequest.BaseNetworkError>()
 
-    class RewindPayload(val site: SiteModel, val rewindId: String) : Payload<BaseRequest.BaseNetworkError>()
+    class RewindPayload(val site: SiteModel, val rewindId: String, val types: Map<String, Boolean> = mapOf())
+        : Payload<BaseRequest.BaseNetworkError>()
 
     class FetchedActivityLogPayload(
         val activityLogModels: List<ActivityLogModel> = listOf(),


### PR DESCRIPTION
Fixes #1759 

This PR adds `types: Map<String, Boolean` parameter to `RewindPayload` which supports individual features when requesting a rewind (restore) action. The default is a mapOf(). This value is passed along to`ActivityLogRestClient`, which will add it to the request body when it is not empty.

**To test**
The types parameter is not in use yet; however you can test WPAndroid still works as expected using commit c52dc11 locally.