### PR TITLE
NPE in okhttpstack

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
@@ -39,9 +39,9 @@ public class OkHttpStack extends BaseHttpStack {
         switch (request.getMethod()) {
             case Request.Method.DEPRECATED_GET_OR_POST:
                 // Ensure backwards compatibility.  Volley assumes a request with a null body is a GET.
-                byte[] postBody = request.getBody();
-                if (postBody != null) {
-                    builder.post(RequestBody.create(MediaType.parse(request.getBodyContentType()), postBody));
+                byte[] getOrPostBody = request.getBody();
+                if (getOrPostBody != null) {
+                    builder.post(RequestBody.create(MediaType.parse(request.getBodyContentType()), getOrPostBody));
                 }
                 break;
             case Request.Method.GET:
@@ -51,10 +51,16 @@ public class OkHttpStack extends BaseHttpStack {
                 builder.delete(createRequestBody(request));
                 break;
             case Request.Method.POST:
-                builder.post(createRequestBody(request));
+                RequestBody postBody = createRequestBody(request);
+                if (postBody != null) {
+                    builder.post(postBody);
+                }
                 break;
             case Request.Method.PUT:
-                builder.put(createRequestBody(request));
+                RequestBody putBody = createRequestBody(request);
+                if (putBody != null) {
+                    builder.put(putBody);
+                }
                 break;
             case Request.Method.HEAD:
                 builder.head();
@@ -66,7 +72,10 @@ public class OkHttpStack extends BaseHttpStack {
                 builder.method("TRACE", null);
                 break;
             case Request.Method.PATCH:
-                builder.patch(createRequestBody(request));
+                RequestBody patchBody = createRequestBody(request);
+                if (patchBody != null) {
+                    builder.patch(patchBody);
+                }
                 break;
             default:
                 throw new IllegalStateException("Unknown method type.");
@@ -95,10 +104,16 @@ public class OkHttpStack extends BaseHttpStack {
 
         Map<String, String> headers = request.getHeaders();
         for (final String name : headers.keySet()) {
-            okHttpRequestBuilder.addHeader(name, headers.get(name));
+            String value = headers.get(name);
+            if (value != null) {
+                okHttpRequestBuilder.addHeader(name, value);
+            }
         }
         for (final String name : additionalHeaders.keySet()) {
-            okHttpRequestBuilder.addHeader(name, additionalHeaders.get(name));
+            String value = additionalHeaders.get(name);
+            if (value != null) {
+                okHttpRequestBuilder.addHeader(name, value);
+            }
         }
 
         setConnectionParametersForRequest(okHttpRequestBuilder, request);
@@ -126,9 +141,7 @@ public class OkHttpStack extends BaseHttpStack {
         List<Header> headers = new ArrayList<>();
         for (int i = 0, len = responseHeaders.size(); i < len; i++) {
             final String name = responseHeaders.name(i), value = responseHeaders.value(i);
-            if (name != null) {
-                headers.add(new Header(name, value));
-            }
+            headers.add(new Header(name, value));
         }
         return headers;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OkHttpStack.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network;
 
+import androidx.annotation.NonNull;
+
 import com.android.volley.AuthFailureError;
 import com.android.volley.Header;
 import com.android.volley.Request;
@@ -39,9 +41,9 @@ public class OkHttpStack extends BaseHttpStack {
         switch (request.getMethod()) {
             case Request.Method.DEPRECATED_GET_OR_POST:
                 // Ensure backwards compatibility.  Volley assumes a request with a null body is a GET.
-                byte[] getOrPostBody = request.getBody();
-                if (getOrPostBody != null) {
-                    builder.post(RequestBody.create(MediaType.parse(request.getBodyContentType()), getOrPostBody));
+                byte[] postBody = request.getBody();
+                if (postBody != null) {
+                    builder.post(RequestBody.create(MediaType.parse(request.getBodyContentType()), postBody));
                 }
                 break;
             case Request.Method.GET:
@@ -51,16 +53,10 @@ public class OkHttpStack extends BaseHttpStack {
                 builder.delete(createRequestBody(request));
                 break;
             case Request.Method.POST:
-                RequestBody postBody = createRequestBody(request);
-                if (postBody != null) {
-                    builder.post(postBody);
-                }
+                builder.post(createRequestBody(request));
                 break;
             case Request.Method.PUT:
-                RequestBody putBody = createRequestBody(request);
-                if (putBody != null) {
-                    builder.put(putBody);
-                }
+                builder.put(createRequestBody(request));
                 break;
             case Request.Method.HEAD:
                 builder.head();
@@ -72,20 +68,18 @@ public class OkHttpStack extends BaseHttpStack {
                 builder.method("TRACE", null);
                 break;
             case Request.Method.PATCH:
-                RequestBody patchBody = createRequestBody(request);
-                if (patchBody != null) {
-                    builder.patch(patchBody);
-                }
+                builder.patch(createRequestBody(request));
                 break;
             default:
                 throw new IllegalStateException("Unknown method type.");
         }
     }
 
+    @NonNull
     private static RequestBody createRequestBody(Request r) throws AuthFailureError {
         final byte[] body = r.getBody();
         if (body == null) {
-            return null;
+            return RequestBody.create(null, new byte[]{});
         }
         return RequestBody.create(MediaType.parse(r.getBodyContentType()), body);
     }


### PR DESCRIPTION
With updated OkHttp it's no longer possible to send invalid POST requests with empty body. That's now causing a NullPointerException. This fix adds an empty body instead when it was null before.

The other changes are small improvements based on what Android Studio suggested

This could be tested with the Reader tags in the [linked WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13372).