### PR TITLE
Add support for rewind downloads endpoint

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -309,42 +309,6 @@ class ActivityLogRestClientTest {
         }
     }
 
-    private suspend fun initFetchActivity(
-        data: ActivitiesResponse = mock(),
-        error: WPComGsonNetworkError? = null
-    ): Response<ActivitiesResponse> {
-        val response = if (error != null) Response.Error<ActivitiesResponse>(error) else Success(data)
-        whenever(wpComGsonRequestBuilder.syncGetRequest(
-                eq(activityRestClient),
-                urlCaptor.capture(),
-                paramsCaptor.capture(),
-                eq(ActivitiesResponse::class.java),
-                eq(false),
-                any(),
-                eq(false))
-        ).thenReturn(response)
-        whenever(site.siteId).thenReturn(siteId)
-        return response
-    }
-
-    private suspend fun initFetchRewindStatus(
-        data: RewindStatusResponse = mock(),
-        error: WPComGsonNetworkError? = null
-    ):
-            Response<RewindStatusResponse> {
-        val response = if (error != null) Response.Error<RewindStatusResponse>(error) else Success(data)
-        whenever(wpComGsonRequestBuilder.syncGetRequest(
-                eq(activityRestClient),
-                urlCaptor.capture(),
-                paramsCaptor.capture(),
-                eq(RewindStatusResponse::class.java),
-                eq(false),
-                any(),
-                eq(false))).thenReturn(response)
-        whenever(site.siteId).thenReturn(siteId)
-        return response
-    }
-
     @Test
     fun postRewindOperationWithTypes() = test {
         val restoreId = 10L
@@ -429,6 +393,42 @@ class ActivityLogRestClientTest {
         val payload = activityRestClient.download(site, rewindId, types)
 
         assertTrue(payload.isError)
+    }
+
+    private suspend fun initFetchActivity(
+        data: ActivitiesResponse = mock(),
+        error: WPComGsonNetworkError? = null
+    ): Response<ActivitiesResponse> {
+        val response = if (error != null) Response.Error<ActivitiesResponse>(error) else Success(data)
+        whenever(wpComGsonRequestBuilder.syncGetRequest(
+                eq(activityRestClient),
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                eq(ActivitiesResponse::class.java),
+                eq(false),
+                any(),
+                eq(false))
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+
+    private suspend fun initFetchRewindStatus(
+        data: RewindStatusResponse = mock(),
+        error: WPComGsonNetworkError? = null
+    ):
+            Response<RewindStatusResponse> {
+        val response = if (error != null) Response.Error<RewindStatusResponse>(error) else Success(data)
+        whenever(wpComGsonRequestBuilder.syncGetRequest(
+                eq(activityRestClient),
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                eq(RewindStatusResponse::class.java),
+                eq(false),
+                any(),
+                eq(false))).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
     }
 
     private suspend fun initPostRewind(

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -345,41 +345,6 @@ class ActivityLogRestClientTest {
         return response
     }
 
-    private suspend fun initPostRewind(
-        data: RewindResponse = mock(),
-        error: WPComGsonNetworkError? = null
-    ): Response<RewindResponse> {
-        val response = if (error != null) Response.Error<RewindResponse>(error) else Success(data)
-
-        whenever(wpComGsonRequestBuilder.syncPostRequest(
-                eq(activityRestClient),
-                urlCaptor.capture(),
-                eq(null),
-                eq(mapOf()),
-                eq(RewindResponse::class.java)
-        )).thenReturn(response)
-        whenever(site.siteId).thenReturn(siteId)
-        return response
-    }
-
-    private suspend fun initPostRewindWithTypes(
-        data: RewindResponse = mock(),
-        error: WPComGsonNetworkError? = null,
-        requestTypes: RewindRequestTypes
-    ): Response<RewindResponse> {
-        val response = if (error != null) Response.Error<RewindResponse>(error) else Success(data)
-
-        whenever(wpComGsonRequestBuilder.syncPostRequest(
-                eq(activityRestClient),
-                urlCaptor.capture(),
-                eq(null),
-                eq(mapOf("types" to requestTypes)),
-                eq(RewindResponse::class.java)
-        )).thenReturn(response)
-        whenever(site.siteId).thenReturn(siteId)
-        return response
-    }
-
     @Test
     fun postRewindOperationWithTypes() = test {
         val restoreId = 10L
@@ -464,6 +429,41 @@ class ActivityLogRestClientTest {
         val payload = activityRestClient.download(site, rewindId, types)
 
         assertTrue(payload.isError)
+    }
+
+    private suspend fun initPostRewind(
+        data: RewindResponse = mock(),
+        error: WPComGsonNetworkError? = null
+    ): Response<RewindResponse> {
+        val response = if (error != null) Response.Error<RewindResponse>(error) else Success(data)
+
+        whenever(wpComGsonRequestBuilder.syncPostRequest(
+                eq(activityRestClient),
+                urlCaptor.capture(),
+                eq(null),
+                eq(mapOf()),
+                eq(RewindResponse::class.java)
+        )).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+
+    private suspend fun initPostRewindWithTypes(
+        data: RewindResponse = mock(),
+        error: WPComGsonNetworkError? = null,
+        requestTypes: RewindRequestTypes
+    ): Response<RewindResponse> {
+        val response = if (error != null) Response.Error<RewindResponse>(error) else Success(data)
+
+        whenever(wpComGsonRequestBuilder.syncPostRequest(
+                eq(activityRestClient),
+                urlCaptor.capture(),
+                eq(null),
+                eq(mapOf("types" to requestTypes)),
+                eq(RewindResponse::class.java)
+        )).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
     }
 
     private suspend fun initPostDownload(

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -310,11 +310,10 @@ class ActivityLogRestClientTest {
     }
 
     private suspend fun initFetchActivity(
-        data: ActivitiesResponse? = null,
+        data: ActivitiesResponse = mock(),
         error: WPComGsonNetworkError? = null
     ): Response<ActivitiesResponse> {
-        val nonNullData = data ?: mock()
-        val response = if (error != null) Response.Error<ActivitiesResponse>(error) else Success(nonNullData)
+        val response = if (error != null) Response.Error<ActivitiesResponse>(error) else Success(data)
         whenever(wpComGsonRequestBuilder.syncGetRequest(
                 eq(activityRestClient),
                 urlCaptor.capture(),
@@ -329,12 +328,11 @@ class ActivityLogRestClientTest {
     }
 
     private suspend fun initFetchRewindStatus(
-        data: RewindStatusResponse? = null,
+        data: RewindStatusResponse = mock(),
         error: WPComGsonNetworkError? = null
     ):
             Response<RewindStatusResponse> {
-        val nonNullData = data ?: mock()
-        val response = if (error != null) Response.Error<RewindStatusResponse>(error) else Success(nonNullData)
+        val response = if (error != null) Response.Error<RewindStatusResponse>(error) else Success(data)
         whenever(wpComGsonRequestBuilder.syncGetRequest(
                 eq(activityRestClient),
                 urlCaptor.capture(),
@@ -348,11 +346,10 @@ class ActivityLogRestClientTest {
     }
 
     private suspend fun initPostRewind(
-        data: RewindResponse? = null,
+        data: RewindResponse = mock(),
         error: WPComGsonNetworkError? = null
     ): Response<RewindResponse> {
-        val nonNullData = data ?: mock()
-        val response = if (error != null) Response.Error<RewindResponse>(error) else Success(nonNullData)
+        val response = if (error != null) Response.Error<RewindResponse>(error) else Success(data)
 
         whenever(wpComGsonRequestBuilder.syncPostRequest(
                 eq(activityRestClient),
@@ -366,12 +363,11 @@ class ActivityLogRestClientTest {
     }
 
     private suspend fun initPostRewindWithTypes(
-        data: RewindResponse? = null,
+        data: RewindResponse = mock(),
         error: WPComGsonNetworkError? = null,
         requestTypes: RewindRequestTypes
     ): Response<RewindResponse> {
-        val nonNullData = data ?: mock()
-        val response = if (error != null) Response.Error<RewindResponse>(error) else Success(nonNullData)
+        val response = if (error != null) Response.Error<RewindResponse>(error) else Success(data)
 
         whenever(wpComGsonRequestBuilder.syncPostRequest(
                 eq(activityRestClient),
@@ -432,27 +428,6 @@ class ActivityLogRestClientTest {
         assertTrue(payload.isError)
     }
 
-    private suspend fun initPostDownload(
-        data: DownloadResponse? = null,
-        error: WPComGsonNetworkError? = null,
-        requestTypes: DownloadRequestTypes,
-        rewindId: String
-    ): Response<DownloadResponse> {
-        val nonNullData = data ?: mock()
-        val response = if (error != null) Response.Error<DownloadResponse>(error) else Success(nonNullData)
-
-        whenever(wpComGsonRequestBuilder.syncPostRequest(
-                eq(activityRestClient),
-                urlCaptor.capture(),
-                eq(null),
-                eq(mapOf("rewindId" to rewindId,
-                        "types" to requestTypes)),
-                eq(DownloadResponse::class.java)
-        )).thenReturn(response)
-        whenever(site.siteId).thenReturn(siteId)
-        return response
-    }
-
     @Test
     fun postDownloadOperation() = test {
         val downloadId = 10L
@@ -489,5 +464,25 @@ class ActivityLogRestClientTest {
         val payload = activityRestClient.download(site, rewindId, types)
 
         assertTrue(payload.isError)
+    }
+
+    private suspend fun initPostDownload(
+        data: DownloadResponse = mock(),
+        error: WPComGsonNetworkError? = null,
+        requestTypes: DownloadRequestTypes,
+        rewindId: String
+    ): Response<DownloadResponse> {
+        val response = if (error != null) Response.Error<DownloadResponse>(error) else Success(data)
+
+        whenever(wpComGsonRequestBuilder.syncPostRequest(
+                eq(activityRestClient),
+                urlCaptor.capture(),
+                eq(null),
+                eq(mapOf("rewindId" to rewindId,
+                        "types" to requestTypes)),
+                eq(DownloadResponse::class.java)
+        )).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
     }
 }

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -4,6 +4,7 @@
 
 /sites/$site/activity
 /sites/$site/rewind
+/sites/$site/rewind/downloads
 
 /sites/$site/gutenberg
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
@@ -13,5 +13,7 @@ public enum ActivityLogAction implements IAction {
     @Action(payloadType = ActivityLogStore.FetchRewindStatePayload.class)
     FETCH_REWIND_STATE,
     @Action(payloadType = ActivityLogStore.RewindPayload.class)
-    REWIND
+    REWIND,
+    @Action(payloadType = ActivityLogStore.DownloadPayload.class)
+    DOWNLOAD
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -122,8 +122,7 @@ constructor(
 
     suspend fun download(site: SiteModel, rewindId: String, types: DownloadRequestTypes): DownloadResultPayload {
         val url = WPCOMV2.sites.site(site.siteId).rewind.downloads.url
-        val request = mapOf("rewindId" to rewindId,
-                "types" to types)
+        val request = mapOf("rewindId" to rewindId, "types" to types)
         val response = wpComGsonRequestBuilder.syncPostRequest(this, url, null, request, DownloadResponse::class.java)
         return when (response) {
             is Success -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -128,7 +128,7 @@ constructor(
         return when (response) {
             is Success -> {
                 DownloadResultPayload(
-                        rewindId,
+                        response.data.rewindId,
                         response.data.downloadId,
                         response.data.backupPoint,
                         response.data.startedAt,


### PR DESCRIPTION
Fixes #1764 

This PR adds support for `https://public-api.wordpress.com/wpcom/v2/sites/182675569/rewind/downloads` endpoint.
The logic was added to `ActivityLogStore`, as it's an extension of Activity Log functionality.

I was on the fence about creating `DownloadRequestTypes` instead of just reusing `RewindRequestTypes` and am open to a reuse if we can find a proper name. `RewindAndDownloadRequestTypes` just feels like a mouth full. Same goes for Error types - they don't appear to be reused among the separate functions in ActivityLog, so I maintained consistency and created a new set for Download. 

To test
The feature is not being used yet, so there is nothing to test.