### PR TITLE
Woo: Order Product Attribute fixes

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
@@ -95,7 +95,7 @@ class WCOrderModelTest {
             assertEquals(1, attributes.size)
 
             assertEquals("size", attributes[0].key)
-            assertEquals("Medium", attributes[0].value)
+            assertEquals("medium", attributes[0].value)
         }
 
         with(renderedLineItems[2]) {

--- a/example/src/test/resources/wc/lineitems.json
+++ b/example/src/test/resources/wc/lineitems.json
@@ -101,6 +101,13 @@
         "value": "2",
         "display_key": "_other_attribute",
         "display_value": "2"
+      },
+      {
+        "display_key": "emptyArray",
+        "display_value": []
+      },
+      {
+        "display_value": []
       }
     ],
     "sku":"woo-vneck-tee",

--- a/example/src/test/resources/wc/lineitems.json
+++ b/example/src/test/resources/wc/lineitems.json
@@ -94,6 +94,13 @@
         "value": "1",
         "display_key": "_reduced_stock",
         "display_value": "1"
+      },
+      {
+        "id": 6413,
+        "key": "_other_attribute",
+        "value": "2",
+        "display_key": "_other_attribute",
+        "display_value": "2"
       }
     ],
     "sku":"woo-vneck-tee",

--- a/example/src/test/resources/wc/lineitems.json
+++ b/example/src/test/resources/wc/lineitems.json
@@ -48,7 +48,7 @@
         "key":"pa_size",
         "value":"medium",
         "display_key":"size",
-        "display_value":"Medium"
+        "display_value":"medium"
       }
     ],
     "sku":"blabla",
@@ -79,7 +79,7 @@
         "key":"pa_size",
         "value":"medium",
         "display_key":"size",
-        "display_value":"Medium"
+        "display_value":"medium"
       },
       {
         "id":45560,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -113,7 +113,7 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
                     .takeWhile {
                         // Don't include null, empty, or the "_reduced_stock" key
                         // skipping "_reduced_stock" is a temporary workaround until "type" is added to the response.
-                        it.value != null && it.value.isNotEmpty() && it.key != "_reduced_stock"
+                        it.value != null && it.value.isNotEmpty() && it.key != null && it.key.first().toString() != "_"
                     }.joinToString { it.value ?: "" }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.OrderAddress.AddressType
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import java.util.Locale
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
@@ -114,7 +115,7 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
                         // Don't include null, empty, or the "_reduced_stock" key
                         // skipping "_reduced_stock" is a temporary workaround until "type" is added to the response.
                         it.value != null && it.value.isNotEmpty() && it.key != null && it.key.first().toString() != "_"
-                    }.joinToString { it.value ?: "" }
+                    }.joinToString { it.value?.capitalize(Locale.getDefault()) ?: "" }
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -11,6 +11,7 @@ import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.OrderAddress.AddressType
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.model.order.OrderProductAttributeListDeserializer
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import java.util.Locale
 
@@ -94,16 +95,13 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         @SerializedName("meta_data")
         private val attributes: JsonArray? = null
 
-        class Attribute {
-            @SerializedName("display_key")
-            val key: String? = null
-            @SerializedName("display_value")
-            val value: String? = null
-        }
+        class Attribute(val key: String?, val value: String?)
 
         fun getAttributeList(): List<Attribute> {
             val responseType = object : TypeToken<List<Attribute>>() {}.type
-            return gson.fromJson(attributes, responseType) as? List<Attribute> ?: emptyList()
+            val newGson = gson.newBuilder()
+                    .registerTypeAdapter(responseType, OrderProductAttributeListDeserializer()).create()
+            return newGson.fromJson(attributes, responseType)
         }
 
         /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderProductAttributeListDeserializer.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderProductAttributeListDeserializer.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.fluxc.model.order
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderModel.LineItem.Attribute
+import java.lang.reflect.Type
+
+/**
+ * Custom deserializer to parse the attributes from [WCOrderModel.LineItem.attributes] to return a list
+ * of [Attribute]. This was necessary to prevent issues with plugins adding unexpected content such as json
+ * arrays as the value when a String is expected.
+ */
+class OrderProductAttributeListDeserializer : JsonDeserializer<List<Attribute>> {
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): List<Attribute> {
+        val result = mutableListOf<Attribute>()
+
+        json as JsonArray
+        for (item: JsonElement in json) {
+            if (item.isJsonObject) {
+                item as JsonObject
+
+                if (item.has("display_key") && item.get("display_key").isJsonPrimitive &&
+                        item.has("display_value") && item.get("display_value").isJsonPrimitive) {
+                    val key = item.get("display_key").asString.trim()
+                    val value = item.get("display_value").asString.trim()
+                    result.add(Attribute(key, value))
+                }
+            }
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
This PR adds the following fixes to the `WCOrderModel.LineItem.Attribute` logic:
- Added a new custom deserializer to prevent crashes due to unexpected values being returned by the API. For example, `display_value` containing a json array instead of a string. (see https://github.com/woocommerce/woocommerce-android/issues/3153)
- Capitalize the first letter of each attribute returned from `getAttributesAsString`
- Filter out line items where the `display_key` begins with `_`.
- Added test scenarios for each of the above items.

### To Test
- Run the unit test `WCOrderModelTest`
- Run the tests in `MockedStack_WCOrdersTest`