### PR TITLE
Issue/1767 download status

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
@@ -47,4 +47,3 @@ val DOWNLOAD_STATUS_RESPONSE = ActivityLogRestClient.DownloadStatusResponse(
         downloadCount = null,
         validUntil = null,
         url = null)
-

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityFixtures.kt
@@ -38,3 +38,13 @@ val REWIND_STATUS_RESPONSE = ActivityLogRestClient.RewindStatusResponse(
         can_autoconfigure = true,
         credentials = listOf(),
         rewind = REWIND_RESPONSE)
+val DOWNLOAD_STATUS_RESPONSE = ActivityLogRestClient.DownloadStatusResponse(
+        downloadId = 0,
+        rewindId = "rewindId",
+        backupPoint = Date(),
+        startedAt = Date(),
+        progress = 35,
+        downloadCount = null,
+        validUntil = null,
+        url = null)
+

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
@@ -198,7 +197,7 @@ class ActivityLogRestClientTest {
 
     @Test
     fun fetchActivity_dispatchesErrorOnFailure() = test {
-        initFetchActivity(error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR)))
+        initFetchActivity(error = WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
 
         val payload = activityRestClient.fetchActivity(requestPayload, number, offset)
 
@@ -407,7 +406,10 @@ class ActivityLogRestClientTest {
         assertEmittedDownloadStatusError(payload, DownloadStatusErrorType.GENERIC_ERROR)
     }
 
-    private fun assertEmittedDownloadStatusError(payload: FetchedDownloadStatePayload, errorType: DownloadStatusErrorType) {
+    private fun assertEmittedDownloadStatusError(
+        payload: FetchedDownloadStatePayload,
+        errorType: DownloadStatusErrorType
+    ) {
         with(payload) {
             assertEquals(this.site, site)
             assertTrue(this.isError)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -411,9 +411,9 @@ class ActivityLogRestClientTest {
         errorType: DownloadStatusErrorType
     ) {
         with(payload) {
-            assertEquals(this.site, site)
-            assertTrue(this.isError)
-            assertEquals(errorType, this.error.type)
+            assertEquals(site, site)
+            assertTrue(isError)
+            assertEquals(errorType, error.type)
         }
     }
 
@@ -426,8 +426,8 @@ class ActivityLogRestClientTest {
         val payload = activityRestClient.fetchActivityDownload(site)
 
         with(payload) {
-            assertEquals(this.site, site)
-            assertNull(this.error)
+            assertEquals(site, site)
+            assertNull(error)
             assertNotNull(this.downloadStatusModelResponse)
             this.downloadStatusModelResponse?.apply {
                 assertEquals(this.downloadId, DOWNLOAD_STATUS_RESPONSE.downloadId)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.ActivityLogActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
+import org.wordpress.android.fluxc.model.activity.DownloadStatusModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.activity.ActivityLogRestClient
 import org.wordpress.android.fluxc.persistence.ActivityLogSqlUtils
@@ -26,8 +27,10 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.DownloadPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.DownloadRequestTypes
 import org.wordpress.android.fluxc.store.ActivityLogStore.DownloadResultPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchActivityLogPayload
+import org.wordpress.android.fluxc.store.ActivityLogStore.FetchDownloadStatePayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchRewindStatePayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
+import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedDownloadStatePayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedRewindStatePayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindRequestTypes
@@ -362,6 +365,35 @@ class ActivityLogStoreTest {
                 startedAt,
                 progress,
                 ActivityLogAction.DOWNLOAD)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
+    @Test
+    fun onFetchDownloadStatusActionCallRestClient() = test {
+        val payload = FetchDownloadStatePayload(siteModel)
+        whenever(activityLogRestClient.fetchActivityDownload(siteModel)).thenReturn(
+                FetchedDownloadStatePayload(
+                        null,
+                        siteModel
+                )
+        )
+        val action = ActivityLogActionBuilder.newFetchDownloadStateAction(payload)
+        activityLogStore.onAction(action)
+
+        verify(activityLogRestClient).fetchActivityDownload(siteModel)
+    }
+
+    @Test
+    fun storeFetchedDownloadStatusToDb() = test {
+        val downloadStatusModel = mock<DownloadStatusModel>()
+        val payload = FetchedDownloadStatePayload(downloadStatusModel, siteModel)
+        whenever(activityLogRestClient.fetchActivityDownload(siteModel)).thenReturn(payload)
+
+        val fetchAction = ActivityLogActionBuilder.newFetchDownloadStateAction(FetchDownloadStatePayload(siteModel))
+        activityLogStore.onAction(fetchAction)
+
+        verify(activityLogSqlUtils).replaceDownloadStatus(siteModel, downloadStatusModel)
+        val expectedChangeEvent = ActivityLogStore.OnDownloadStatusFetched(ActivityLogAction.FETCH_DOWNLOAD_STATE)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -406,7 +406,6 @@ class ActivityLogStoreTest {
         val downloadStatusFromDb = activityLogStore.getDownloadStatusForSite(siteModel)
 
         verify(activityLogSqlUtils).getDownloadStatusForSite(siteModel)
-        assertEquals(downloadStatusModel, downloadStatusFromDb)
     }
 
     private suspend fun initRestClient(

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -223,7 +223,7 @@ class ActivityLogStoreTest {
         val rewindId = "rewindId"
         val restoreId = 10L
 
-        val payload = ActivityLogStore.RewindResultPayload(rewindId, restoreId, siteModel)
+        val payload = RewindResultPayload(rewindId, restoreId, siteModel)
         whenever(activityLogRestClient.rewind(siteModel, rewindId)).thenReturn(payload)
 
         activityLogStore.onAction(ActivityLogActionBuilder.newRewindAction(RewindPayload(
@@ -294,7 +294,7 @@ class ActivityLogStoreTest {
                     roots = true,
                     contents = true)
 
-        val payload = ActivityLogStore.RewindResultPayload(rewindId, restoreId, siteModel)
+        val payload = RewindResultPayload(rewindId, restoreId, siteModel)
         whenever(activityLogRestClient.rewind(siteModel, rewindId, types)).thenReturn(payload)
 
         activityLogStore.onAction(ActivityLogActionBuilder.newRewindAction(RewindPayload(siteModel, rewindId, types)))
@@ -344,7 +344,7 @@ class ActivityLogStoreTest {
                 roots = true,
                 contents = true)
 
-        val payload = ActivityLogStore.DownloadResultPayload(
+        val payload = DownloadResultPayload(
                 rewindId,
                 downloadId,
                 backupPoint,
@@ -395,6 +395,18 @@ class ActivityLogStoreTest {
         verify(activityLogSqlUtils).replaceDownloadStatus(siteModel, downloadStatusModel)
         val expectedChangeEvent = ActivityLogStore.OnDownloadStatusFetched(ActivityLogAction.FETCH_DOWNLOAD_STATE)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
+    @Test
+    fun returnDownloadStatusFromDb() {
+        val downloadStatusModel = mock<DownloadStatusModel>()
+        whenever(activityLogSqlUtils.getDownloadStatusForSite(siteModel))
+                .thenReturn(downloadStatusModel)
+
+        val downloadStatusFromDb = activityLogStore.getDownloadStatusForSite(siteModel)
+
+        verify(activityLogSqlUtils).getDownloadStatusForSite(siteModel)
+        assertEquals(downloadStatusModel, downloadStatusFromDb)
     }
 
     private suspend fun initRestClient(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
@@ -15,5 +15,7 @@ public enum ActivityLogAction implements IAction {
     @Action(payloadType = ActivityLogStore.RewindPayload.class)
     REWIND,
     @Action(payloadType = ActivityLogStore.DownloadPayload.class)
-    DOWNLOAD
+    DOWNLOAD,
+    @Action(payloadType = ActivityLogStore.FetchDownloadStatePayload.class)
+    FETCH_DOWNLOAD_STATE
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/DownloadStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/DownloadStatusModel.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.model.activity
+
+import java.util.Date
+
+data class DownloadStatusModel(
+    val downloadId: Long,
+    val rewindId: String,
+    val backupPoint: Date,
+    val startedAt: Date,
+    val progress: Int?,
+    val downloadCount: Int?,
+    val validUntil: Date?,
+    val url: String?
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.ActivityError
 import org.wordpress.android.fluxc.store.ActivityLogStore.ActivityLogErrorType
 import org.wordpress.android.fluxc.store.ActivityLogStore.DownloadError

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.persistence
 
 import com.wellsql.generated.ActivityLogTable
+import com.wellsql.generated.DownloadStatusTable
 import com.wellsql.generated.RewindStatusCredentialsTable
 import com.wellsql.generated.RewindStatusTable
 import com.yarolegovich.wellsql.SelectQuery
@@ -11,6 +12,7 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
+import org.wordpress.android.fluxc.model.activity.DownloadStatusModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Credentials
 import org.wordpress.android.fluxc.tools.FormattableContentMapper
@@ -101,6 +103,16 @@ class ActivityLogSqlUtils
         return rewindStatusBuilder?.build(credentials?.map { it.build() })
     }
 
+    fun replaceDownloadStatus(site: SiteModel, downloadStatusModel: DownloadStatusModel) {
+        val downloadStatusBuilder = downloadStatusModel.toBuilder(site)
+        WellSql.delete(DownloadStatusBuilder::class.java)
+                .where()
+                .equals(DownloadStatusTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .execute()
+        WellSql.insert(downloadStatusBuilder).execute()
+    }
+
     private fun getRewindStatusBuilder(site: SiteModel): RewindStatusBuilder? {
         return WellSql.select(RewindStatusBuilder::class.java)
                 .where()
@@ -167,6 +179,21 @@ class ActivityLogSqlUtils
                 host = this.host,
                 port = this.port,
                 stillValid = this.stillValid
+        )
+    }
+
+    private fun DownloadStatusModel.toBuilder(site: SiteModel): DownloadStatusBuilder {
+        return DownloadStatusBuilder(
+                localSiteId = site.id,
+                remoteSiteId = site.siteId,
+                downloadId = this.downloadId,
+                rewindId = this.rewindId,
+                backupPoint = this.backupPoint.time,
+                startedAt = this.startedAt.time,
+                progress = this.progress,
+                downloadCount = this.downloadCount,
+                validUntil = this.validUntil?.time,
+                url = this.url
         )
     }
 
@@ -287,6 +314,45 @@ class ActivityLogSqlUtils
 
         fun build(): Credentials {
             return Credentials(type, role, host, port, stillValid)
+        }
+    }
+
+    @Table(name = "DownloadStatus")
+    data class DownloadStatusBuilder(
+        @PrimaryKey
+        @Column private var mId: Int = -1,
+        @Column var localSiteId: Int,
+        @Column var remoteSiteId: Long,
+        @Column var downloadId: Long,
+        @Column var rewindId: String,
+        @Column var backupPoint: Long,
+        @Column var startedAt: Long,
+        @Column var progress: Int? = null,
+        @Column var downloadCount: Int? = null,
+        @Column var validUntil: Long? = null,
+        @Column var url: String? = null
+    ) : Identifiable {
+        constructor() : this(-1, 0, 0, 0, "", 0, 0)
+
+        override fun setId(id: Int) {
+            this.mId = id
+        }
+
+        override fun getId() = mId
+
+        fun build(): DownloadStatusModel {
+            return DownloadStatusModel(
+                    downloadId,
+                    rewindId,
+                    Date(backupPoint),
+                    Date(startedAt),
+                    progress,
+                    downloadCount,
+                    validUntil?.let {
+                        Date(it)
+                    },
+                    url
+            )
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -103,6 +103,11 @@ class ActivityLogSqlUtils
         return rewindStatusBuilder?.build(credentials?.map { it.build() })
     }
 
+    fun getDownloadStatusForSite(site: SiteModel): DownloadStatusModel? {
+        val downloadStatusBuilder = getDownloadStatusBuilder(site)
+        return downloadStatusBuilder?.build()
+    }
+
     fun replaceDownloadStatus(site: SiteModel, downloadStatusModel: DownloadStatusModel) {
         val downloadStatusBuilder = downloadStatusModel.toBuilder(site)
         WellSql.delete(DownloadStatusBuilder::class.java)
@@ -128,6 +133,15 @@ class ActivityLogSqlUtils
                 .equals(RewindStatusCredentialsTable.REWIND_STATE_ID, rewindId)
                 .endWhere()
                 .asModel
+    }
+
+    private fun getDownloadStatusBuilder(site: SiteModel): DownloadStatusBuilder? {
+        return WellSql.select(DownloadStatusBuilder::class.java)
+                .where()
+                .equals(RewindStatusTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .asModel
+                .firstOrNull()
     }
 
     private fun ActivityLogModel.toBuilder(site: SiteModel): ActivityLogBuilder {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -86,6 +86,10 @@ class ActivityLogStore
         return activityLogSqlUtils.getRewindStatusForSite(site)
     }
 
+    fun getDownloadStatusForSite(site: SiteModel): DownloadStatusModel? {
+        return activityLogSqlUtils.getDownloadStatusForSite(site)
+    }
+
     override fun onRegister() {
         AppLog.d(AppLog.T.API, this.javaClass.name + ": onRegister")
     }


### PR DESCRIPTION
Fixes #1767 

This PR adds support for checking download preparation status.
GET https://public-api.wordpress.com/wpcom/v2/sites/182675569/rewind/downloads

Note: I named everything "download", but after submitting this PR I decided to rename methods/objects to BackupDownload so it has more context. That will be in a separate PR following approval of this one.

This PR follows along with the same patterns used for checking rewind status.

P.S. I also adjusted minor Kotlin inspection finds such as redundant qualifiers.

**To Test**
The feature has not been implemented yet. CI tests passing are okay for this PR.