### PR TITLE
Persist the fetched products

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -833,10 +833,13 @@ class WCProductStore @Inject constructor(
         }
     }
 
-    suspend fun fetchProductListSynced(site: SiteModel, productIds: List<Long>) =
-            coroutineEngine?.withDefaultContext(T.API, this, "fetchProductList") {
-                wcProductRestClient.fetchProductsWithSyncRequest(site = site, remoteProductIds = productIds)?.result
-            }
+    suspend fun fetchProductListSynced(site: SiteModel, productIds: List<Long>): List<WCProductModel>? {
+        return coroutineEngine?.withDefaultContext(T.API, this, "fetchProductList") {
+            wcProductRestClient.fetchProductsWithSyncRequest(site = site, remoteProductIds = productIds)?.result
+        }?.also {
+            ProductSqlUtils.insertOrUpdateProducts(it)
+        }
+    }
 
     private fun searchProducts(payload: SearchProductsPayload) {
         with(payload) { wcProductRestClient.searchProducts(


### PR DESCRIPTION
This PR adds product persistence to the `fetchProductListSynced` call to make it consistent with the rest of fetch requests, since there is currently no other way to save products in the DB from the store as a separate action.