### PR TITLE
Issue/1776 wc cached order count

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -98,6 +98,21 @@ class OrderSqlUtilsTest {
     }
 
     @Test
+    fun testGetOrderCountForSite() {
+        val order1 = OrderTestUtils.generateSampleOrder(1)
+        val site = SiteModel().apply { id = order1.localSiteId }
+        OrderSqlUtils.insertOrUpdateOrder(order1)
+        assertEquals(1, OrderSqlUtils.getOrderCountForSite(site))
+
+        val order2 = OrderTestUtils.generateSampleOrder(2)
+        OrderSqlUtils.insertOrUpdateOrder(order2)
+        assertEquals(2, OrderSqlUtils.getOrderCountForSite(site))
+
+        OrderSqlUtils.deleteOrdersForSite(site)
+        assertEquals(0, OrderSqlUtils.getOrderCountForSite(site))
+    }
+
+    @Test
     fun testDeleteOrdersForSite() {
         val order1 = OrderTestUtils.generateSampleOrder(1)
         val order2 = OrderTestUtils.generateSampleOrder(2)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -133,7 +133,7 @@ object OrderSqlUtils {
     }
 
     fun getOrderCountForSite(site: SiteModel): Long {
-        return WellSql.select(SiteModel::class.java)
+        return WellSql.select(WCOrderModel::class.java)
                 .where()
                 .equals(WCOrderModelTable.LOCAL_SITE_ID, site.id)
                 .endWhere()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -132,12 +132,12 @@ object OrderSqlUtils {
                 .execute()
     }
 
-    fun getOrderCountForSite(site: SiteModel): Long {
+    fun getOrderCountForSite(site: SiteModel): Int {
         return WellSql.select(WCOrderModel::class.java)
                 .where()
                 .equals(WCOrderModelTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
-                .count()
+                .count().toInt()
     }
 
     fun insertOrIgnoreOrderNotes(notes: List<WCOrderNoteModel>): Int {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -6,6 +6,7 @@ import com.wellsql.generated.WCOrderShipmentProviderModelTable
 import com.wellsql.generated.WCOrderShipmentTrackingModelTable
 import com.wellsql.generated.WCOrderStatusModelTable
 import com.wellsql.generated.WCOrderSummaryModelTable
+import com.wellsql.generated.WCProductModelTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
@@ -130,6 +131,14 @@ object OrderSqlUtils {
                 .endGroup()
                 .endWhere()
                 .execute()
+    }
+
+    fun getOrderCountForSite(site: SiteModel): Long {
+        return WellSql.select(SiteModel::class.java)
+                .where()
+                .equals(WCOrderModelTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .count()
     }
 
     fun insertOrIgnoreOrderNotes(notes: List<WCOrderNoteModel>): Int {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -6,7 +6,6 @@ import com.wellsql.generated.WCOrderShipmentProviderModelTable
 import com.wellsql.generated.WCOrderShipmentTrackingModelTable
 import com.wellsql.generated.WCOrderStatusModelTable
 import com.wellsql.generated.WCOrderSummaryModelTable
-import com.wellsql.generated.WCProductModelTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -389,7 +389,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
     /**
      * @return Returns true if orders for the provided site exist in the DB, else false.
      */
-    fun hasCachedOrdersForSite(site: SiteModel) = OrderSqlUtils.getOrdersForSite(site).isNotEmpty()
+    fun hasCachedOrdersForSite(site: SiteModel) = OrderSqlUtils.getOrderCountForSite(site) > 0
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -449,7 +449,7 @@ class WCOrderStore @Inject constructor(dispatcher: Dispatcher, private val wcOrd
 
     private fun fetchOrders(payload: FetchOrdersPayload) {
         val offset = if (payload.loadMore) {
-            OrderSqlUtils.getOrdersForSite(payload.site).size
+            OrderSqlUtils.getOrderCountForSite(payload.site)
         } else {
             0
         }


### PR DESCRIPTION
Fixes #1776 - this PR changes `hasCachedOrdersForSite()` to use a simple count query, which is much more efficient than loading all the orders for a site. I also updated `fetchOrders` to use the same count to determine the offset when loading more orders.

This is being submitted because Sentry shows a large number of `SQLiteBlobTooBigExceptions` coming from `hasCachedOrdersForSite()`, and I expect that's due to us loading all the orders just to check if a site has orders. I don't expect this to fix every one of those exceptions but this should resolve quite a few of them.