### PR TITLE
Hotfix: 1.6.26.1 - Add check for empty order product attribute key

### DIFF
--- a/example/src/test/resources/wc/lineitems.json
+++ b/example/src/test/resources/wc/lineitems.json
@@ -108,6 +108,10 @@
       },
       {
         "display_value": []
+      },
+      {
+        "display_key": "",
+        "display_value": "empty key"
       }
     ],
     "sku":"woo-vneck-tee",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -112,8 +112,8 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
                     .filter {
                         // Don't include null, empty, or the "_reduced_stock" key
                         // skipping "_reduced_stock" is a temporary workaround until "type" is added to the response.
-                        it.value != null && it.value.isNotEmpty()
-                                && it.key != null && it.key.isNotEmpty() && it.key.first().toString() != "_"
+                        it.value != null && it.value.isNotEmpty() && it.key != null &&
+                                it.key.isNotEmpty() && it.key.first().toString() != "_"
                     }.joinToString { it.value?.capitalize(Locale.getDefault()) ?: "" }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -109,10 +109,11 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
          */
         fun getAttributesAsString(): String {
             return getAttributeList()
-                    .takeWhile {
+                    .filter {
                         // Don't include null, empty, or the "_reduced_stock" key
                         // skipping "_reduced_stock" is a temporary workaround until "type" is added to the response.
-                        it.value != null && it.value.isNotEmpty() && it.key != null && it.key.first().toString() != "_"
+                        it.value != null && it.value.isNotEmpty()
+                                && it.key != null && it.key.isNotEmpty() && it.key.first().toString() != "_"
                     }.joinToString { it.value?.capitalize(Locale.getDefault()) ?: "" }
         }
     }


### PR DESCRIPTION
This PR merges the hotfix from #1778 that prevents a crash when an order product attribute `display_key` is missing a value even though `display_value` has a value. cc: @wordpress-mobile/release-managers for review. 