### PR TITLE
Changed download limit from Int to Long

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -100,7 +100,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(product.getNumVariations(), 2)
             assertEquals(product.getDownloadableFiles().size, 1)
             assertEquals(product.downloadExpiry, 10)
-            assertEquals(product.downloadLimit, 2)
+            assertEquals(product.downloadLimit, 123123124124)
         }
 
         // save the product to the db
@@ -121,7 +121,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(product.getNumVariations(), 2)
             assertEquals(product.getDownloadableFiles().size, 1)
             assertEquals(product.downloadExpiry, 10)
-            assertEquals(product.downloadLimit, 2)
+            assertEquals(product.downloadLimit, 123123124124)
         }
     }
 
@@ -654,7 +654,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             downloadable = true
             downloads = generateTestFileListAsJsonString()
             downloadExpiry = 10
-            downloadLimit = 2
+            downloadLimit = 123123124124
         }
         productRestClient.updateProduct(siteModel, testProduct, updatedProduct)
 
@@ -677,7 +677,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(updatedProduct.type, product.type)
             assertEquals(updatedProduct.getDownloadableFiles().size, 1)
             assertEquals(updatedProduct.downloadExpiry, 10)
-            assertEquals(updatedProduct.downloadLimit, 2)
+            assertEquals(updatedProduct.downloadLimit, 123123124124)
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -660,7 +660,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             add(downloadableFile.toJson())
         }.toString()
 
-        val updatedProductDownloadLimit = 10
+        val updatedProductDownloadLimit = 10L
         productModel.downloadLimit = updatedProductDownloadLimit
 
         val updatedProductDownloadExpiry = 365

--- a/example/src/androidTest/resources/wc-fetch-product-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-product-response-success.json
@@ -76,7 +76,7 @@
       "width": "3"
     },
     "download_expiry": 10,
-    "download_limit": 2,
+    "download_limit": 123123124124,
     "downloadable": true,
     "downloads": [
       {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -431,7 +431,7 @@ class WooUpdateProductFragment : Fragment() {
         }
 
         product_download_limit.onTextChanged { text ->
-            text.toIntOrNull()?.let { selectedProductModel?.downloadLimit = it }
+            text.toLongOrNull()?.let { selectedProductModel?.downloadLimit = it }
         }
 
         savedInstanceState?.let { bundle ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -52,7 +52,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
 
     @Column var virtual = false
     @Column var downloadable = false
-    @Column var downloadLimit = -1
+    @Column var downloadLimit = -1L
     @Column var downloadExpiry = -1
     @Column var soldIndividually = false
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -50,7 +50,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     @Column var virtual = false
     @Column var downloadable = false
 
-    @Column var downloadLimit = 0
+    @Column var downloadLimit = 0L
     @Column var downloadExpiry = 0
 
     @Column var downloads = "" // array of downloadable files

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -32,7 +32,7 @@ class ProductApiResponse : Response {
 
     var virtual = false
     var downloadable = false
-    var download_limit = 0
+    var download_limit = 0L
     var download_expiry = 0
 
     var external_url: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -38,7 +38,7 @@ class ProductVariationApiResponse : Response {
     var shipping_class: String? = null
     var shipping_class_id = 0
 
-    var download_limit = 0
+    var download_limit = 0L
     var download_expiry = 0
 
     var manage_stock = false


### PR DESCRIPTION
This PR partially addresses woocommerce/woocommerce-android#3057 by modifying the `download_limit` field from Int to Long to fix a crash when fetching/updating products.

#### To test
- From `wp-admin`, update the `download_limit` field of a product to `123123124124`.
- Open the example app, click on `Woo` -> `Products` -> `Fetch single product` and enter the `productId` from the previous step.
- Verify that the app does not crash and there is no error in the logs similar to `java.lang.NumberFormatException: Expected an int but was 123123124124 at line 1 column 1188 path $.data.download_limit`
