### PR TITLE
ScanStore: Start new scan

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
@@ -75,7 +75,7 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
         assertNotNull(scanStateForSite)
         scanStateForSite?.apply {
             assertNotNull(state)
-            assertEquals(state, IDLE)
+            Assert.assertTrue(listOf(IDLE, SCANNING).contains(state))
         }
 
         assertNotNull(fetchedScanStatePayload)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
@@ -5,6 +5,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.annotations.action.Action
@@ -112,6 +113,18 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
             assertEquals(mostRecentStatus.error, error)
             assertEquals(mostRecentStatus.isInitial, isInitial)
         }
+    }
+
+    @Test
+    fun testStartScan() {
+        val site = authenticate(CompleteJetpackSite)
+        val payload = ScanStore.ScanStartPayload(site)
+
+        mCountDownLatch = CountDownLatch(1)
+        val scanStartResultPayload = runBlocking { scanStore.startScan(payload) }
+
+        assertNotNull(scanStartResultPayload)
+        assertNull(scanStartResultPayload.error)
     }
 
     @Subscribe

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
@@ -290,14 +290,14 @@ class ScanRestClientTest {
         }
     }
 
-    private fun getScanStateResponseFromJsonString(json: String): ScanStateResponse? {
+    private fun getScanStateResponseFromJsonString(json: String): ScanStateResponse {
         val responseType = object : TypeToken<ScanStateResponse>() {}.type
-        return Gson().fromJson(json, responseType) as? ScanStateResponse
+        return Gson().fromJson(json, responseType) as ScanStateResponse
     }
 
-    private fun getStartScanResponseFromJsonString(json: String): ScanStartResponse? {
+    private fun getStartScanResponseFromJsonString(json: String): ScanStartResponse {
         val responseType = object : TypeToken<ScanStartResponse>() {}.type
-        return Gson().fromJson(json, responseType) as? ScanStartResponse
+        return Gson().fromJson(json, responseType) as ScanStartResponse
     }
 
     private suspend fun initFetchScanState(

--- a/example/src/test/resources/wp/jetpack/scan/jp-backup-daily-start-scan-error.json
+++ b/example/src/test/resources/wp/jetpack/scan/jp-backup-daily-start-scan-error.json
@@ -1,0 +1,11 @@
+{
+	"success": false,
+	"error": {
+		"errors": {
+			"vp_api_error": [
+				"Site does not have scan capability."
+			]
+		},
+		"error_data": []
+	}
+}

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -6,6 +6,7 @@
 /sites/$site/rewind
 /sites/$site/rewind/downloads
 /sites/$site/scan
+/sites/$site/scan/enqueue
 
 /sites/$site/gutenberg
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
@@ -8,5 +8,7 @@ import org.wordpress.android.fluxc.store.ScanStore
 @ActionEnum
 enum class ScanAction : IAction {
     @Action(payloadType = ScanStore.FetchScanStatePayload::class)
-    FETCH_SCAN_STATE
+    FETCH_SCAN_STATE,
+    @Action(payloadType = ScanStore.ScanStartPayload::class)
+    START_SCAN
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -62,7 +62,7 @@ class ScanRestClient(
         val response = wpComGsonRequestBuilder.syncPostRequest(this, url, mapOf(), null, ScanStartResponse::class.java)
         return when (response) {
             is Success -> {
-                if (!response.data.success && response.data.error != null) {
+                if (response.data.success == false && response.data.error != null) {
                     val error = ScanStartError(ScanStartErrorType.API_ERROR)
                     ScanStartResultPayload(error, site)
                 } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -19,6 +19,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.ScanStore.FetchedScanStatePayload
+import org.wordpress.android.fluxc.store.ScanStore.ScanStartError
+import org.wordpress.android.fluxc.store.ScanStore.ScanStartErrorType
+import org.wordpress.android.fluxc.store.ScanStore.ScanStartResultPayload
 import org.wordpress.android.fluxc.store.ScanStore.ScanStateError
 import org.wordpress.android.fluxc.store.ScanStore.ScanStateErrorType
 import org.wordpress.android.fluxc.utils.NetworkErrorMapper
@@ -49,6 +52,32 @@ class ScanRestClient(
                 )
                 val error = ScanStateError(errorType, response.error.message)
                 FetchedScanStatePayload(error, site)
+            }
+        }
+    }
+
+    suspend fun startScan(site: SiteModel): ScanStartResultPayload {
+        val url = WPCOMV2.sites.site(site.siteId).scan.enqueue.url
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(this, url, mapOf(), null, ScanStartResponse::class.java)
+        return when (response) {
+            is Success -> {
+                if (!response.data.success && response.data.error != null) {
+                    val error = ScanStartError(ScanStartErrorType.API_ERROR)
+                    ScanStartResultPayload(error, site)
+                } else {
+                    ScanStartResultPayload(site)
+                }
+            }
+            is Error -> {
+                val errorType = NetworkErrorMapper.map(
+                    response.error,
+                    ScanStartErrorType.GENERIC_ERROR,
+                    ScanStartErrorType.INVALID_RESPONSE,
+                    ScanStartErrorType.AUTHORIZATION_REQUIRED
+                )
+                val error = ScanStartError(errorType, response.error.message)
+                ScanStartResultPayload(error, site)
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanStartResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanStartResponse.kt
@@ -1,15 +1,17 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.scan
 
+import com.google.gson.annotations.SerializedName
+
 data class ScanStartResponse(
-    val error: Error? = null,
-    val success: Boolean
+    @SerializedName("error") val error: Error? = null,
+    @SerializedName("success") val success: Boolean?
 ) {
     data class Error(
-        val error_data: List<Any>,
-        val errors: Errors
+        @SerializedName("error_data") val errorData: List<Any>?,
+        @SerializedName("errors") val errors: Errors?
     )
 
     data class Errors(
-        val vp_api_error: List<String>
+        @SerializedName("vp_api_error") val vpApiError: List<String>?
     )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanStartResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanStartResponse.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.scan
+
+data class ScanStartResponse(
+    val error: Error? = null,
+    val success: Boolean
+) {
+    data class Error(
+        val error_data: List<Any>,
+        val errors: Errors
+    )
+
+    data class Errors(
+        val vp_api_error: List<String>
+    )
+}


### PR DESCRIPTION
Issue: wordpress-mobile/WordPress-Android#13326

This PR introduces `/sites/$site/scan/enqueue` API and adds corresponding `ScanAction`, `ScanRestClient` and `ScanStore` methods and tests.

**To test**
That tests run fine and cover important flows/ results for success, error states.
