### PR TITLE
Woo: Parse fees in order details

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -93,6 +93,8 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertFalse(pricesIncludeTax)
             assertEquals(2, getLineItemList().size)
             assertEquals(40.0, getOrderSubtotal(), 0.01)
+            assertEquals(2, getFeeLineList().size)
+            assertEquals("10.00", getFeeLineList()[0].total)
         }
 
         // Customer note

--- a/example/src/androidTest/resources/wc-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-orders-response-success.json
@@ -74,6 +74,42 @@
           "price": 30
         }
       ],
+      "fee_lines": [
+        {
+          "id": 28,
+          "name": "$10.00 fee",
+          "tax_class": "",
+          "tax_status": "taxable",
+          "amount": "10",
+          "total": "10.00",
+          "total_tax": "2.00",
+          "taxes": [
+            {
+              "id": 1,
+              "total": "2",
+              "subtotal": ""
+            }
+          ],
+          "meta_data": []
+        },
+        {
+          "id": 30,
+          "name": "12.00 fee",
+          "tax_class": "",
+          "tax_status": "taxable",
+          "amount": "12",
+          "total": "12.00",
+          "total_tax": "2.40",
+          "taxes": [
+            {
+              "id": 1,
+              "total": "2.4",
+              "subtotal": ""
+            }
+          ],
+          "meta_data": []
+        }
+      ],
       "coupon_lines": [],
       "refunds": []
     },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 124
+        return 125
     }
 
     override fun getDbName(): String {
@@ -1351,6 +1351,9 @@ open class WellSqlConfig : DefaultWellConfig {
                             "INITIAL BOOLEAN," +
                             "REASON TEXT)"
                     )
+                }
+                125 -> migrate(version) {
+                    db.execSQL("ALTER TABLE WCOrderModel ADD FEE_LINES TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -66,6 +66,8 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
 
     @Column var shippingLines = ""
 
+    @Column var feeLines = ""
+
     companion object {
         private val gson by lazy { Gson() }
     }
@@ -73,6 +75,18 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     class ShippingLine {
         @SerializedName("method_title")
         val methodTitle: String? = null
+    }
+
+    /**
+     * Represents a fee line
+     * We are reading only the name and the total, as the tax is already included in the order totalTax
+     */
+    class FeeLine {
+        @SerializedName("name")
+        val name: String? = null
+
+        @SerializedName("total")
+        val total: String? = null
     }
 
     class LineItem {
@@ -168,6 +182,14 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     fun getShippingLineList(): List<ShippingLine> {
         val responseType = object : TypeToken<List<ShippingLine>>() {}.type
         return gson.fromJson(shippingLines, responseType) as? List<ShippingLine> ?: emptyList()
+    }
+
+    /**
+     * Deserializes the JSON contained in [feeLines] into a list of [FeeLine] objects.
+     */
+    fun getFeeLineList(): List<FeeLine> {
+        val responseType = object : TypeToken<List<FeeLine>>() {}.type
+        return gson.fromJson(feeLines, responseType) as? List<FeeLine> ?: emptyList()
     }
 
     fun isMultiShippingLinesAvailable() = getShippingLineList().size > 1

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -70,4 +70,7 @@ class OrderApiResponse : Response {
     // This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand.
     // See WCOrderModel.ShippingLines
     val shipping_lines: JsonElement? = null
+
+    //Same as shipping_lines, it's a list of objects
+    val fee_lines: JsonElement? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -71,6 +71,6 @@ class OrderApiResponse : Response {
     // See WCOrderModel.ShippingLines
     val shipping_lines: JsonElement? = null
 
-    //Same as shipping_lines, it's a list of objects
+    // Same as shipping_lines, it's a list of objects
     val fee_lines: JsonElement? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -58,7 +58,7 @@ class OrderRestClient(
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     private val ORDER_FIELDS = "id,number,status,currency,date_created_gmt,total,total_tax,shipping_total," +
             "payment_method,payment_method_title,prices_include_tax,customer_note,discount_total," +
-            "coupon_lines,refunds,billing,shipping,line_items,date_paid_gmt,shipping_lines"
+            "coupon_lines,refunds,billing,shipping,line_items,date_paid_gmt,shipping_lines,fee_lines"
     private val TRACKING_FIELDS = "tracking_id,tracking_number,tracking_link,tracking_provider,date_shipped"
 
     /**
@@ -727,6 +727,7 @@ class OrderRestClient(
 
             lineItems = response.line_items.toString()
             shippingLines = response.shipping_lines.toString()
+            feeLines = response.fee_lines.toString()
         }
     }
 


### PR DESCRIPTION
Requirement for https://github.com/woocommerce/woocommerce-android/issues/3141

Adds support for parsing and exposing the fees details of an order.