### PR TITLE
Fixed migration script to use woocommerce

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1352,7 +1352,7 @@ open class WellSqlConfig : DefaultWellConfig {
                             "REASON TEXT)"
                     )
                 }
-                125 -> migrate(version) {
+                125 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCOrderModel ADD FEE_LINES TEXT")
                 }
             }


### PR DESCRIPTION
PR #1787 introduced a migration script to `WellSqlConfig`.This would potentially cause a crash in the WordPress app (if that commit hash is used) since the `WCOrderModel` does not exist on WordPress.  I accidentally merged that PR before realising this. This PR just modifies the migration script to fix this. 



