### PR TITLE
Woo: Add support for deleting image from product variation

### DIFF
--- a/example/src/androidTest/resources/wc-delete-product-variation-image-failure.json
+++ b/example/src/androidTest/resources/wc-delete-product-variation-image-failure.json
@@ -1,0 +1,4 @@
+{
+  "error": "woocommerce_variation_invalid_image_id",
+  "message": "#0 is an invalid image ID."
+}

--- a/example/src/androidTest/resources/wc-delete-product-variation-image-success.json
+++ b/example/src/androidTest/resources/wc-delete-product-variation-image-success.json
@@ -1,0 +1,84 @@
+{
+  "data": {
+    "id": 181,
+    "date_created": "2019-12-18T23:15:16",
+    "date_created_gmt": "2019-12-19T06:15:16",
+    "date_modified": "2020-12-10T09:23:47",
+    "date_modified_gmt": "2020-12-10T16:23:47",
+    "description": "<p>This a great product</p>\n",
+    "permalink": "https://testwooshop.mystagingwebsite.com/product/v-neck-t-shirt/?attribute_pa_color=red&attribute_pa_size=large",
+    "sku": "ufuducuvkcifufp",
+    "price": "10.99",
+    "regular_price": "35.99",
+    "sale_price": "10.99",
+    "date_on_sale_from": null,
+    "date_on_sale_from_gmt": null,
+    "date_on_sale_to": null,
+    "date_on_sale_to_gmt": null,
+    "on_sale": true,
+    "status": "publish",
+    "purchasable": true,
+    "virtual": false,
+    "downloadable": false,
+    "downloads": [],
+    "download_limit": -1,
+    "download_expiry": -1,
+    "tax_status": "taxable",
+    "tax_class": "",
+    "manage_stock": true,
+    "stock_quantity": 400,
+    "stock_status": "instock",
+    "backorders": "no",
+    "backorders_allowed": false,
+    "backordered": false,
+    "weight": "0.5",
+    "dimensions": {
+      "length": "24",
+      "width": "1",
+      "height": "2"
+    },
+    "shipping_class": "",
+    "shipping_class_id": 0,
+    "image": {
+      "id": 2183,
+      "date_created": "2018-10-23T19:36:26",
+      "date_created_gmt": "2018-10-24T01:36:26",
+      "date_modified": "2020-12-09T11:54:31",
+      "date_modified_gmt": "2020-12-10T01:54:31",
+      "src": "https://testwooshop.mystagingwebsite.com/wp-content/uploads/2018/10/vnech-tee-blue-1.jpg",
+      "name": "vnech-tee-blue-1",
+      "alt": ""
+    },
+    "attributes": [
+      {
+        "id": 1,
+        "name": "color",
+        "option": "Red"
+      },
+      {
+        "id": 2,
+        "name": "size",
+        "option": "large"
+      }
+    ],
+    "menu_order": 6,
+    "meta_data": [],
+    "_links": {
+      "self": [
+        {
+          "href": "https://testwooshop.mystagingwebsite.com/wp-json/wc/v3/products/12/variations/7566"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://testwooshop.mystagingwebsite.com/wp-json/wc/v3/products/12/variations"
+        }
+      ],
+      "up": [
+        {
+          "href": "https://testwooshop.mystagingwebsite.com/wp-json/wc/v3/products/12"
+        }
+      ]
+    }
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductImageModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductImageModel.kt
@@ -24,10 +24,14 @@ class WCProductImageModel(val id: Long) {
     fun toJson(): JsonObject {
         return JsonObject().also { json ->
             json.addProperty("id", id)
-            json.addProperty("date_created", dateCreated)
-            json.addProperty("src", src)
-            json.addProperty("alt", alt)
-            json.addProperty("name", name)
+            // If id == 0 then the variation image has been deleted. Don't include the other
+            // fields or this delete request will fail.
+            if (id > 0) {
+                json.addProperty("date_created", dateCreated)
+                json.addProperty("src", src)
+                json.addProperty("alt", alt)
+                json.addProperty("name", name)
+            }
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1447,6 +1447,7 @@ class ProductRestClient(
             "woocommerce_product_invalid_image_id" -> ProductErrorType.INVALID_IMAGE_ID
             "product_invalid_sku" -> ProductErrorType.DUPLICATE_SKU
             "term_exists" -> ProductErrorType.TERM_EXISTS
+            "woocommerce_variation_invalid_image_id" -> ProductErrorType.INVALID_VARIATION_IMAGE_ID
             else -> ProductErrorType.fromString(wpComError.apiError)
         }
         return ProductError(productErrorType, wpComError.message)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -192,7 +192,15 @@ class WCProductStore @Inject constructor(
         INVALID_REVIEW_ID,
         INVALID_IMAGE_ID,
         DUPLICATE_SKU,
-        TERM_EXISTS, // indicates duplicate term name. Currently only used when adding product categories
+
+        // indicates duplicate term name. Currently only used when adding product categories
+        TERM_EXISTS,
+
+        // Happens if a store is running Woo 4.6 and below and tries to delete the product image
+        // from a variation. See this PR for more detail:
+        // https://github.com/woocommerce/woocommerce/pull/27299
+        INVALID_VARIATION_IMAGE_ID,
+
         GENERIC_ERROR;
 
         companion object {


### PR DESCRIPTION
This PR adds support for deleting the image from a product variation. This is done by sending only `{ id: 0 }` as the value for the variation image. It’s important that *only* the `id` is sent, because if `src` get’s set the API will expect a new image is being *added* and throw an error. [This functionality was recently added to the API in Woo 4.7](https://github.com/woocommerce/woocommerce/pull/27299) so if a store is running an older copy of Woo then the error `woocommerce_variation_invalid_image_id` will be returned from the API. 

This PR adds the following: 
- If the image `id=0`, then the `toJson()` method will only include the `id` property 
- New error type `woocommerce_variation_invalid_image_id` added
- Two new tests added to `MockedStack_WCProductsTest`

### To Test
- Run the tests in `MockedStack_WCProductsTest` and verify success.