### PR TITLE
Temporarily disable a failing test - testRedeemingCardWithWrongCountryCode

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
@@ -8,6 +8,7 @@ import junit.framework.Assert.assertTrue
 import junit.framework.Assert.fail
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert
+import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.TransactionAction
@@ -92,6 +93,7 @@ class ReleaseStack_TransactionsTest : ReleaseStack_WPComBase() {
         Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
     }
 
+    @Ignore("Temporarily disabled due to an API issue")
     @Test
     fun testRedeemingCardWithWrongCountryCode() {
         nextEvent = ERROR_REDEEMING_SHOPPING_CART_WRONG_COUNTRY_CODE


### PR DESCRIPTION
This PR temporarily disables a test which is failing due to a bug on the API.

We plan to revert this change when the bug on the API is fixed - https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1801