### PR TITLE
Merge hotfix/1.6.27.1 into trunk

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
@@ -8,7 +8,6 @@ import junit.framework.Assert.assertTrue
 import junit.framework.Assert.fail
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.TransactionAction
@@ -93,7 +92,6 @@ class ReleaseStack_TransactionsTest : ReleaseStack_WPComBase() {
         Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
     }
 
-    @Ignore("Temporarily disabled due to an API issue")
     @Test
     fun testRedeemingCardWithWrongCountryCode() {
         nextEvent = ERROR_REDEEMING_SHOPPING_CART_WRONG_COUNTRY_CODE

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TransactionsTest.kt
@@ -8,6 +8,7 @@ import junit.framework.Assert.assertTrue
 import junit.framework.Assert.fail
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert
+import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.TransactionAction
@@ -92,6 +93,7 @@ class ReleaseStack_TransactionsTest : ReleaseStack_WPComBase() {
         Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
     }
 
+    @Ignore("Temporarily disabled due to an API issue")
     @Test
     fun testRedeemingCardWithWrongCountryCode() {
         nextEvent = ERROR_REDEEMING_SHOPPING_CART_WRONG_COUNTRY_CODE


### PR DESCRIPTION
Somehow we accidentally closed https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1782 instead of merging it, which means that the fix that we landed in 1.6.26.1 never made it into `develop` and never got included in the later versions of FluxC.

This required a hotfix for 1.6.27.1 – as WC 5.6's production build depends on 1.6.27 – so that we can then do a WC 5.6.1 hotfix immediately after with this FluxC hotfix