### PR TITLE
Issue/13268 add clear cache method

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -146,7 +146,7 @@ class ActivityLogStoreTest {
                 false,
                 ActivityLogAction.FETCH_ACTIVITIES)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
-        verify(activityLogSqlUtils).deleteActivityLog()
+        verify(activityLogSqlUtils).deleteActivityLog(siteModel)
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -76,8 +76,13 @@ class ActivityLogSqlUtils
                 ?.build(formattableContentMapper)
     }
 
-    fun deleteActivityLog(): Int {
-        return WellSql.delete(ActivityLogBuilder::class.java).execute()
+    fun deleteActivityLog(site: SiteModel): Int {
+        return WellSql
+                .delete(ActivityLogBuilder::class.java)
+                .where()
+                .equals(ActivityLogTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .execute()
     }
 
     fun replaceRewindStatus(site: SiteModel, rewindStatusModel: RewindStatusModel) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -156,12 +156,13 @@ class ActivityLogStore
         return if (payload.error != null) {
             OnActivityLogFetched(payload.error, action)
         } else {
+            var rowsAffected = 0
             if (payload.offset == 0) {
-                activityLogSqlUtils.deleteActivityLog(payload.site)
+                rowsAffected += activityLogSqlUtils.deleteActivityLog(payload.site)
             }
-            val rowsAffected = if (payload.activityLogModels.isNotEmpty())
-                activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
-            else 0
+            if (payload.activityLogModels.isNotEmpty()) {
+                rowsAffected += activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)
+            }
             val canLoadMore = payload.activityLogModels.isNotEmpty() &&
                     (payload.offset + payload.number) < payload.totalItems
             OnActivityLogFetched(rowsAffected, canLoadMore, action)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -153,7 +153,7 @@ class ActivityLogStore
             OnActivityLogFetched(payload.error, action)
         } else {
             if (payload.offset == 0) {
-                activityLogSqlUtils.deleteActivityLog()
+                activityLogSqlUtils.deleteActivityLog(payload.site)
             }
             val rowsAffected = if (payload.activityLogModels.isNotEmpty())
                 activityLogSqlUtils.insertOrUpdateActivities(payload.site, payload.activityLogModels)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -97,6 +97,10 @@ class ActivityLogStore
         return activityLogSqlUtils.getBackupDownloadStatusForSite(site)
     }
 
+    fun clearActivityLogCache(site: SiteModel) {
+        activityLogSqlUtils.deleteActivityLog(site)
+    }
+
     override fun onRegister() {
         AppLog.d(AppLog.T.API, this.javaClass.name + ": onRegister")
     }


### PR DESCRIPTION
Parent issue https://github.com/wordpress-mobile/WordPress-Android/issues/13268

This PR does three things
1. Fixes a bug where the app cleared ActivityLog cache for all sites instead of clearing the cache just for the current site (https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/df00610cd9e8515cff2dc0d21ba60d3809ca625e).
2. Introduces "ClearActivityLogCache" method in the ActivityLogStore, which will be used in WPAndroid (https://github.com/wordpress-mobile/WordPress-Android/pull/13647).
3. Fixes a bug where the "rowsAffected" number was ignoring deleted rows in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1815/commits/27dca61ba6575f828d2d161196c3ab92b535f545


To test
Issue `1`
1. Open WPAndroid
2. Select SiteA
3. Open Activity Log - wait for the data
4. Click on back
5. Switch to SiteB
6. Open Activity Log - wait for the data (data for SiteA doesn't get deleted here)
7. Click on back
8. Turn on AirPlane mode
9. Switch to SiteA
10. Open Activity Log -> notice the cached data are shown. 

Issue `2`
- Test instructions are on the PR in WPAndroid (https://github.com/wordpress-mobile/WordPress-Android/pull/13647)