### PR TITLE
Add BackupDownloadStatus table to wellsqlutils

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 130
+        return 131
     }
 
     override fun getDbName(): String {
@@ -1422,6 +1422,23 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "FOREIGN KEY(SOURCE_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE," +
                                     "FOREIGN KEY(TARGET_SITE_ID) REFERENCES XPostSites(BLOG_ID)," +
                                     "UNIQUE (SOURCE_SITE_ID, TARGET_SITE_ID) ON CONFLICT IGNORE)"
+                    )
+                }
+                130 -> migrate(version) {
+                    db.execSQL("DROP TABLE IF EXISTS BackupDownloadStatus")
+                    db.execSQL(
+                            "CREATE TABLE BackupDownloadStatus (" +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "REMOTE_SITE_ID INTEGER," +
+                                    "DOWNLOAD_ID INTEGER," +
+                                    "REWIND_ID TEXT NOT NULL," +
+                                    "BACKUP_POINT INTEGER," +
+                                    "STARTED_AT INTEGER," +
+                                    "PROGRESS INTEGER," +
+                                    "DOWNLOAD_COUNT INTEGER," +
+                                    "VALID_UNTIL INTEGER," +
+                                    "URL TEXT)"
                     )
                 }
             }


### PR DESCRIPTION
Parent [WordPress-Android 13329](https://github.com/wordpress-mobile/WordPress-Android/issues/13329)

This PR update WellSqlUtils to drop and recreate `BackupDownloadStatus` table on upgrades

To Test
- Install WP Android using this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13657) over the current version
- Make sure the app doesn't crash

Merge Instructions
- Only after [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13657) has been tested