### PR TITLE
ScanStore: Get threat details by id

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/model/scan/threat/ThreatsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/scan/threat/ThreatsMapperTest.kt
@@ -162,7 +162,6 @@ class ThreatsMapperTest {
 
         val model = mapper.map(threat.copy(fixable = Fixable(fixer = "rollback", file = null, target = null)))
 
-        assertNotNull(model.baseThreatModel.fixable)
         assertEquals(model.baseThreatModel.fixable?.fixer, FixType.UNKNOWN)
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/model/scan/threat/ThreatsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/scan/threat/ThreatsMapperTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType
 import org.wordpress.android.fluxc.network.rest.wpcom.scan.threat.Threat
+import org.wordpress.android.fluxc.network.rest.wpcom.scan.threat.Threat.Fixable
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -152,6 +153,17 @@ class ThreatsMapperTest {
 
         assertNotNull(model.baseThreatModel.fixable)
         assertEquals(model.baseThreatModel.fixable?.fixer, FixType.fromValue(threat.fixable?.fixer))
+    }
+
+    @Test
+    fun `maps fixable threat correctly for unknown fix type`() {
+        val threatJsonString = UnitTestUtils.getStringFromResourceFile(javaClass, THREAT_FIXABLE_JSON)
+        val threat = getThreatFromJsonString(threatJsonString)
+
+        val model = mapper.map(threat.copy(fixable = Fixable(fixer = "rollback", file = null, target = null)))
+
+        assertNotNull(model.baseThreatModel.fixable)
+        assertEquals(model.baseThreatModel.fixable?.fixer, FixType.UNKNOWN)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtilsTest.kt
@@ -161,8 +161,7 @@ class ThreatSqlUtilsTest {
 
         val threat = threatSqlUtils.getThreatByThreatId(threatId)
 
-        assertThat(threat).isNotNull
         assertThat(threat).isInstanceOf(GenericThreatModel::class.java)
-        assertEquals(threatId, requireNotNull(threat).baseThreatModel.id)
+        assertEquals(threatId, threat?.baseThreatModel?.id)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtilsTest.kt
@@ -152,4 +152,17 @@ class ThreatSqlUtilsTest {
             assertEquals(dummyThreat.context.lines.first().contents, context.lines.first().contents)
         }
     }
+
+    @Test
+    fun `threat model gets retrieved for the given threat id`() {
+        val threatId = dummyBaseThreatModel.id
+        val dummyThreat = GenericThreatModel(baseThreatModel = dummyBaseThreatModel)
+        threatSqlUtils.replaceThreatsForSite(site, listOf(dummyThreat))
+
+        val threat = threatSqlUtils.getThreatByThreatId(threatId)
+
+        assertThat(threat).isNotNull
+        assertThat(threat).isInstanceOf(GenericThreatModel::class.java)
+        assertEquals(threatId, requireNotNull(threat).baseThreatModel.id)
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/threat/ThreatMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/threat/ThreatMapper.kt
@@ -5,7 +5,6 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.DatabaseThreatM
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.Fixable
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.Fixable.FixType
-import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.Fixable.FixType.UNKNOWN
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel
@@ -70,11 +69,7 @@ class ThreatMapper @Inject constructor() {
 
         val fixable = response.fixable?.let {
             val fixType = FixType.fromValue(it.fixer)
-            if (fixType != UNKNOWN) {
-                Fixable(file = it.file, fixer = fixType, target = it.target)
-            } else {
-                null
-            }
+            Fixable(file = it.file, fixer = fixType, target = it.target)
         }
 
         return BaseThreatModel(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtils.kt
@@ -40,6 +40,16 @@ class ThreatSqlUtils @Inject constructor(private val gson: Gson, private val thr
             .map { it.build(gson, threatMapper) }
     }
 
+    fun getThreatByThreatId(threatId: Long): ThreatModel? {
+        return WellSql.select(ThreatBuilder::class.java)
+            .where()
+            .equals(ThreatModelTable.THREAT_ID, threatId)
+            .endWhere()
+            .asModel
+            .firstOrNull()
+            ?.build(gson, threatMapper)
+    }
+
     private fun ThreatModel.toBuilder(site: SiteModel): ThreatBuilder {
         var fileName: String? = null
         var diff: String? = null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtils.kt
@@ -124,7 +124,7 @@ class ThreatSqlUtils @Inject constructor(private val gson: Gson, private val thr
         @Column var rows: String? = null,
         @Column var context: String? = null
     ) : Identifiable {
-        constructor() : this(-1, 0, 0, 0, "", "", "", 0, 0, "", "", "")
+        constructor() : this(-1, 0, 0, 0, "", "", "", 0, 0)
 
         override fun setId(id: Int) {
             this.id = id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
@@ -50,6 +50,8 @@ class ScanStore @Inject constructor(
         return scanStateModel?.copy(threats = threats)
     }
 
+    fun getThreatModelByThreatId(threatId: Long) = threatSqlUtils.getThreatByThreatId(threatId)
+
     override fun onRegister() {
         AppLog.d(AppLog.T.API, this.javaClass.name + ": onRegister")
     }


### PR DESCRIPTION
This PR gets threat model from the Db for the given threat id.

EDIT: It also fixes threat mapping when a fixable threat with unknown `FixType` (like "rollback") was returned as a non fixable threat (`fixable = null)`. It is now returned with a non-null fixable property with `FixType` set to `UNKNOWN`.

**To test** 
That newly introduced tests in `ThreatSqlUtilsTest`, `ThreatMapperTest` run fine.