### PR TITLE
BackupDownload change class type and update test

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -436,17 +436,17 @@ class ActivityLogRestClientTest {
 
     @Test
     fun fetchActivityDownload_dispatchesGenericErrorOnFailure() = test {
-            initFetchBackupDownloadStatus(
-                    error = WPComGsonNetworkError(
-                            BaseNetworkError(
-                                    NETWORK_ERROR
-                            )
-                    )
-            )
+        initFetchBackupDownloadStatus(
+                error = WPComGsonNetworkError(
+                        BaseNetworkError(
+                                NETWORK_ERROR
+                        )
+                )
+        )
 
-            val payload = activityRestClient.fetchBackupDownloadState(site)
+        val payload = activityRestClient.fetchBackupDownloadState(site)
 
-            assertEmittedDownloadStatusError(payload, BackupDownloadStatusErrorType.GENERIC_ERROR)
+        assertEmittedDownloadStatusError(payload, BackupDownloadStatusErrorType.GENERIC_ERROR)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -447,9 +447,6 @@ class ActivityLogRestClientTest {
             val payload = activityRestClient.fetchBackupDownloadState(site)
 
             assertEmittedDownloadStatusError(payload, BackupDownloadStatusErrorType.GENERIC_ERROR)
-//        } catch (e: Exception) {
-//            print("***=> something weird happened with ${e.message}")
-//        }
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -170,11 +170,11 @@ class ActivityLogRestClient(
                 this,
                 url,
                 mapOf(),
-                BackupDownloadStatusResponse::class.java
+                Array<BackupDownloadStatusResponse>::class.java
         )
         return when (response) {
             is Success -> {
-                buildBackupDownloadStatusPayload(response.data, site)
+                buildBackupDownloadStatusPayload(response.data[0], site)
             }
             is Error -> {
                 val errorType = NetworkErrorMapper.map(


### PR DESCRIPTION
Parent: [Wordpress-Android - 13329](https://github.com/wordpress-mobile/WordPress-Android/issues/13329)

This PR fixes the response format when fetching the status of an ongoing backup download file preparation. The API response is wrapped in an array and it needed to be accounted for while unwrapping. This PR changes `fetchBackupDownloadState()` by passing an `Array<BackupDownloadStatusResponse>` as the class. 

**To Test**
- Run ActivityLogRestClientTest
- All tests should pass


