### PR TITLE
ScanStore: Fix/ Ignore Threat

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
@@ -318,7 +318,7 @@ class ScanRestClientTest {
         val payload = scanRestClient.fixThreats(siteId, listOf(threatId))
 
         with(payload) {
-            assertEquals(remoteSiteId, this@ScanRestClientTest.siteId)
+            assertEquals(remoteSiteId, siteId)
             assertNull(error)
         }
     }
@@ -344,7 +344,7 @@ class ScanRestClientTest {
         val payload = scanRestClient.ignoreThreat(siteId, threatId)
 
         with(payload) {
-            assertEquals(remoteSiteId, this@ScanRestClientTest.siteId)
+            assertEquals(remoteSiteId, siteId)
             assertNull(error)
         }
     }
@@ -356,7 +356,7 @@ class ScanRestClientTest {
         val payload = scanRestClient.ignoreThreat(siteId, threatId)
 
         with(payload) {
-            assertEquals(remoteSiteId, this@ScanRestClientTest.siteId)
+            assertEquals(remoteSiteId, siteId)
             assertTrue(isError)
             assertEquals(IgnoreThreatErrorType.GENERIC_ERROR, error.type)
         }
@@ -369,7 +369,7 @@ class ScanRestClientTest {
         val payload = scanRestClient.fetchFixThreatsStatus(siteId, listOf(threatId))
 
         with(payload) {
-            assertEquals(remoteSiteId, this@ScanRestClientTest.siteId)
+            assertEquals(remoteSiteId, siteId)
             assertNull(error)
         }
     }
@@ -381,7 +381,7 @@ class ScanRestClientTest {
         val payload = scanRestClient.fetchFixThreatsStatus(siteId, listOf(threatId))
 
         with(payload) {
-            assertEquals(remoteSiteId, this@ScanRestClientTest.siteId)
+            assertEquals(remoteSiteId, siteId)
             assertTrue(isError)
             assertEquals(FixThreatsStatusErrorType.API_ERROR, error.type)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
@@ -68,17 +68,6 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `fetch scan state triggers rest client`() = test {
-        val payload = FetchScanStatePayload(siteModel)
-        whenever(scanRestClient.fetchScanState(siteModel)).thenReturn(FetchedScanStatePayload(null, siteModel))
-
-        val action = ScanActionBuilder.newFetchScanStateAction(payload)
-        scanStore.onAction(action)
-
-        verify(scanRestClient).fetchScanState(siteModel)
-    }
-
-    @Test
     fun `error on fetch scan state returns the error`() = test {
         val error = ScanStateError(ScanStateErrorType.INVALID_RESPONSE, "error")
         val payload = FetchedScanStatePayload(error, siteModel)
@@ -121,17 +110,6 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `start scan triggers rest client`() = test {
-        val payload = ScanStartPayload(siteModel)
-        whenever(scanRestClient.startScan(siteModel)).thenReturn(ScanStartResultPayload(siteModel))
-
-        val action = ScanActionBuilder.newStartScanAction(payload)
-        scanStore.onAction(action)
-
-        verify(scanRestClient).startScan(siteModel)
-    }
-
-    @Test
     fun `error on start scan returns the error`() = test {
         val error = ScanStartError(ScanStartErrorType.GENERIC_ERROR, "error")
         val payload = ScanStartResultPayload(error, siteModel)
@@ -142,19 +120,6 @@ class ScanStoreTest {
 
         val expectedEventWithError = ScanStore.OnScanStarted(payload.error, ScanAction.START_SCAN)
         verify(dispatcher).emitChange(expectedEventWithError)
-    }
-
-    @Test
-    fun `fix threats triggers rest client`() = test {
-        val payload = FixThreatsPayload(siteId, threatIds)
-        whenever(scanRestClient.fixThreats(siteId, threatIds)).thenReturn(
-            FixThreatsResultPayload(siteId)
-        )
-
-        val action = ScanActionBuilder.newFixThreatsAction(payload)
-        scanStore.onAction(action)
-
-        verify(scanRestClient).fixThreats(siteId, threatIds)
     }
 
     @Test
@@ -171,19 +136,6 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `ignore threat triggers rest client`() = test {
-        val payload = IgnoreThreatPayload(siteId, threatId)
-        whenever(scanRestClient.ignoreThreat(siteId, threatId)).thenReturn(
-            IgnoreThreatResultPayload(siteId)
-        )
-
-        val action = ScanActionBuilder.newIgnoreThreatAction(payload)
-        scanStore.onAction(action)
-
-        verify(scanRestClient).ignoreThreat(siteId, threatId)
-    }
-
-    @Test
     fun `error on ignore threat returns the error`() = test {
         val error = IgnoreThreatError(IgnoreThreatErrorType.GENERIC_ERROR, "error")
         val payload = IgnoreThreatResultPayload(error, siteId)
@@ -194,19 +146,6 @@ class ScanStoreTest {
 
         val expectedEventWithError = ScanStore.OnIgnoreThreatStarted(payload.error, ScanAction.IGNORE_THREAT)
         verify(dispatcher).emitChange(expectedEventWithError)
-    }
-
-    @Test
-    fun `fetch fix threats status triggers rest client`() = test {
-        val payload = FetchFixThreatsStatusPayload(siteId, listOf(threatId))
-        whenever(scanRestClient.fetchFixThreatsStatus(siteId, listOf(threatId))).thenReturn(
-            FetchFixThreatsStatusResultPayload(siteId, mock())
-        )
-
-        val action = ScanActionBuilder.newFetchFixThreatsStatusAction(payload)
-        scanStore.onAction(action)
-
-        verify(scanRestClient).fetchFixThreatsStatus(siteId, listOf(threatId))
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
@@ -68,6 +68,17 @@ class ScanStoreTest {
     }
 
     @Test
+    fun `fetch scan state triggers rest client`() = test {
+        val payload = FetchScanStatePayload(siteModel)
+        whenever(scanRestClient.fetchScanState(siteModel)).thenReturn(FetchedScanStatePayload(null, siteModel))
+
+        val action = ScanActionBuilder.newFetchScanStateAction(payload)
+        scanStore.onAction(action)
+
+        verify(scanRestClient).fetchScanState(siteModel)
+    }
+
+    @Test
     fun `error on fetch scan state returns the error`() = test {
         val error = ScanStateError(ScanStateErrorType.INVALID_RESPONSE, "error")
         val payload = FetchedScanStatePayload(error, siteModel)
@@ -110,6 +121,17 @@ class ScanStoreTest {
     }
 
     @Test
+    fun `start scan triggers rest client`() = test {
+        val payload = ScanStartPayload(siteModel)
+        whenever(scanRestClient.startScan(siteModel)).thenReturn(ScanStartResultPayload(siteModel))
+
+        val action = ScanActionBuilder.newStartScanAction(payload)
+        scanStore.onAction(action)
+
+        verify(scanRestClient).startScan(siteModel)
+    }
+
+    @Test
     fun `error on start scan returns the error`() = test {
         val error = ScanStartError(ScanStartErrorType.GENERIC_ERROR, "error")
         val payload = ScanStartResultPayload(error, siteModel)
@@ -120,6 +142,19 @@ class ScanStoreTest {
 
         val expectedEventWithError = ScanStore.OnScanStarted(payload.error, ScanAction.START_SCAN)
         verify(dispatcher).emitChange(expectedEventWithError)
+    }
+
+    @Test
+    fun `fix threats triggers rest client`() = test {
+        val payload = FixThreatsPayload(siteId, threatIds)
+        whenever(scanRestClient.fixThreats(siteId, threatIds)).thenReturn(
+            FixThreatsResultPayload(siteId)
+        )
+
+        val action = ScanActionBuilder.newFixThreatsAction(payload)
+        scanStore.onAction(action)
+
+        verify(scanRestClient).fixThreats(siteId, threatIds)
     }
 
     @Test
@@ -136,6 +171,19 @@ class ScanStoreTest {
     }
 
     @Test
+    fun `ignore threat triggers rest client`() = test {
+        val payload = IgnoreThreatPayload(siteId, threatId)
+        whenever(scanRestClient.ignoreThreat(siteId, threatId)).thenReturn(
+            IgnoreThreatResultPayload(siteId)
+        )
+
+        val action = ScanActionBuilder.newIgnoreThreatAction(payload)
+        scanStore.onAction(action)
+
+        verify(scanRestClient).ignoreThreat(siteId, threatId)
+    }
+
+    @Test
     fun `error on ignore threat returns the error`() = test {
         val error = IgnoreThreatError(IgnoreThreatErrorType.GENERIC_ERROR, "error")
         val payload = IgnoreThreatResultPayload(error, siteId)
@@ -146,6 +194,19 @@ class ScanStoreTest {
 
         val expectedEventWithError = ScanStore.OnIgnoreThreatStarted(payload.error, ScanAction.IGNORE_THREAT)
         verify(dispatcher).emitChange(expectedEventWithError)
+    }
+
+    @Test
+    fun `fetch fix threats status triggers rest client`() = test {
+        val payload = FetchFixThreatsStatusPayload(siteId, listOf(threatId))
+        whenever(scanRestClient.fetchFixThreatsStatus(siteId, listOf(threatId))).thenReturn(
+            FetchFixThreatsStatusResultPayload(siteId, mock())
+        )
+
+        val action = ScanActionBuilder.newFetchFixThreatsStatusAction(payload)
+        scanStore.onAction(action)
+
+        verify(scanRestClient).fetchFixThreatsStatus(siteId, listOf(threatId))
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
@@ -68,14 +68,15 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `fetch scan state triggers rest client`() = test {
+    fun `success on fetch scan state returns the success`() = test {
         val payload = FetchScanStatePayload(siteModel)
         whenever(scanRestClient.fetchScanState(siteModel)).thenReturn(FetchedScanStatePayload(null, siteModel))
 
         val action = ScanActionBuilder.newFetchScanStateAction(payload)
         scanStore.onAction(action)
 
-        verify(scanRestClient).fetchScanState(siteModel)
+        val expected = ScanStore.OnScanStateFetched(ScanAction.FETCH_SCAN_STATE)
+        verify(dispatcher).emitChange(expected)
     }
 
     @Test
@@ -121,14 +122,15 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `start scan triggers rest client`() = test {
+    fun `success on start scan returns the success`() = test {
         val payload = ScanStartPayload(siteModel)
         whenever(scanRestClient.startScan(siteModel)).thenReturn(ScanStartResultPayload(siteModel))
 
         val action = ScanActionBuilder.newStartScanAction(payload)
         scanStore.onAction(action)
 
-        verify(scanRestClient).startScan(siteModel)
+        val expected = ScanStore.OnScanStarted(ScanAction.START_SCAN)
+        verify(dispatcher).emitChange(expected)
     }
 
     @Test
@@ -145,7 +147,7 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `fix threats triggers rest client`() = test {
+    fun `success on fix threats return the success`() = test {
         val payload = FixThreatsPayload(siteId, threatIds)
         whenever(scanRestClient.fixThreats(siteId, threatIds)).thenReturn(
             FixThreatsResultPayload(siteId)
@@ -154,7 +156,8 @@ class ScanStoreTest {
         val action = ScanActionBuilder.newFixThreatsAction(payload)
         scanStore.onAction(action)
 
-        verify(scanRestClient).fixThreats(siteId, threatIds)
+        val expected = ScanStore.OnFixThreatsStarted(ScanAction.FIX_THREATS)
+        verify(dispatcher).emitChange(expected)
     }
 
     @Test
@@ -171,7 +174,7 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `ignore threat triggers rest client`() = test {
+    fun `success on ignore threat returns the success`() = test {
         val payload = IgnoreThreatPayload(siteId, threatId)
         whenever(scanRestClient.ignoreThreat(siteId, threatId)).thenReturn(
             IgnoreThreatResultPayload(siteId)
@@ -180,7 +183,8 @@ class ScanStoreTest {
         val action = ScanActionBuilder.newIgnoreThreatAction(payload)
         scanStore.onAction(action)
 
-        verify(scanRestClient).ignoreThreat(siteId, threatId)
+        val expected = ScanStore.OnIgnoreThreatStarted(ScanAction.IGNORE_THREAT)
+        verify(dispatcher).emitChange(expected)
     }
 
     @Test
@@ -197,16 +201,20 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `fetch fix threats status triggers rest client`() = test {
+    fun `success on fetch fix threats status returns the success`() = test {
         val payload = FetchFixThreatsStatusPayload(siteId, listOf(threatId))
-        whenever(scanRestClient.fetchFixThreatsStatus(siteId, listOf(threatId))).thenReturn(
-            FetchFixThreatsStatusResultPayload(siteId, mock())
-        )
+        val resultPayload = FetchFixThreatsStatusResultPayload(siteId, mock())
+        whenever(scanRestClient.fetchFixThreatsStatus(siteId, listOf(threatId))).thenReturn(resultPayload)
 
         val action = ScanActionBuilder.newFetchFixThreatsStatusAction(payload)
         scanStore.onAction(action)
 
-        verify(scanRestClient).fetchFixThreatsStatus(siteId, listOf(threatId))
+        val expected = ScanStore.OnFixThreatsStatusFetched(
+            siteId,
+            resultPayload.fixThreatStatusModels,
+            ScanAction.FETCH_FIX_THREATS_STATUS
+        )
+        verify(dispatcher).emitChange(expected)
     }
 
     @Test
@@ -216,10 +224,7 @@ class ScanStoreTest {
         whenever(scanRestClient.fetchFixThreatsStatus(siteId, listOf(threatId))).thenReturn(payload)
 
         val fetchAction = ScanActionBuilder.newFetchFixThreatsStatusAction(
-            FetchFixThreatsStatusPayload(
-                siteId,
-                listOf(threatId)
-            )
+            FetchFixThreatsStatusPayload(siteId, listOf(threatId))
         )
         scanStore.onAction(fetchAction)
 

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -10,6 +10,8 @@
 /sites/$site/scan
 /sites/$site/scan/enqueue
 /sites/$site/scan/threat/$threat_id
+/sites/$site/alerts/fix
+/sites/$site/alerts/$threat_id
 
 /sites/$site/gutenberg
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
@@ -10,5 +10,7 @@ enum class ScanAction : IAction {
     @Action(payloadType = ScanStore.FetchScanStatePayload::class)
     FETCH_SCAN_STATE,
     @Action(payloadType = ScanStore.ScanStartPayload::class)
-    START_SCAN
+    START_SCAN,
+    @Action(payloadType = ScanStore.FixThreatsPayload::class)
+    FIX_THREATS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
@@ -14,5 +14,7 @@ enum class ScanAction : IAction {
     @Action(payloadType = ScanStore.FixThreatsPayload::class)
     FIX_THREATS,
     @Action(payloadType = ScanStore.IgnoreThreatPayload::class)
-    IGNORE_THREAT
+    IGNORE_THREAT,
+    @Action(payloadType = ScanStore.FetchFixThreatsStatusPayload::class)
+    FETCH_FIX_THREATS_STATUS,
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ScanAction.kt
@@ -12,5 +12,7 @@ enum class ScanAction : IAction {
     @Action(payloadType = ScanStore.ScanStartPayload::class)
     START_SCAN,
     @Action(payloadType = ScanStore.FixThreatsPayload::class)
-    FIX_THREATS
+    FIX_THREATS,
+    @Action(payloadType = ScanStore.IgnoreThreatPayload::class)
+    IGNORE_THREAT
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/threat/FixThreatStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/threat/FixThreatStatusModel.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.model.scan.threat
+
+data class FixThreatStatusModel(
+    val id: Long,
+    val status: FixStatus,
+    val error: String? = null
+) {
+    enum class FixStatus(val value: String) {
+        NOT_STARTED("not_started"),
+        IN_PROGRESS("in_progress"),
+        NOT_FIXED("not_fixed"),
+        FIXED("fixed"),
+        UNKNOWN("unknown");
+
+        companion object {
+            fun fromValue(value: String?): FixStatus {
+                return values().firstOrNull { it.value == value } ?: UNKNOWN
+            }
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -82,8 +82,9 @@ class ScanRestClient(
         }
     }
 
+    // Build Payloads
     private fun buildScanStatePayload(response: ScanStateResponse, site: SiteModel): FetchedScanStatePayload {
-        val state = State.fromValue(response.state) ?: return buildErrorPayload(
+        val state = State.fromValue(response.state) ?: return buildScanStateErrorPayload(
             site,
             ScanStateErrorType.INVALID_RESPONSE
         )
@@ -115,7 +116,7 @@ class ScanRestClient(
             threatModel
         }
         error?.let {
-            return buildErrorPayload(site, it)
+            return buildScanStateErrorPayload(site, it)
         }
         val scanStateModel = ScanStateModel(
             state = state,
@@ -145,6 +146,6 @@ class ScanRestClient(
         return FetchedScanStatePayload(scanStateModel, site)
     }
 
-    private fun buildErrorPayload(site: SiteModel, errorType: ScanStateErrorType) =
+    private fun buildScanStateErrorPayload(site: SiteModel, errorType: ScanStateErrorType) =
         FetchedScanStatePayload(ScanStateError(errorType), site)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -172,7 +172,6 @@ class ScanRestClient(
         }
     }
 
-    // Build Payloads
     private fun buildScanStatePayload(response: ScanStateResponse, site: SiteModel): FetchedScanStatePayload {
         val state = State.fromValue(response.state) ?: return buildScanStateErrorPayload(
             site,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsResponse.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.scan.threat
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+
+data class FixThreatsResponse(@SerializedName("ok") val ok: Boolean?) : Response

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsStatusDeserializer.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsStatusDeserializer.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.scan.threat
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import org.wordpress.android.fluxc.network.rest.wpcom.scan.threat.FixThreatsStatusResponse.FixThreatStatus
+import java.lang.reflect.Type
+
+class FixThreatsStatusDeserializer : JsonDeserializer<List<FixThreatStatus>?> {
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ) = if (context != null && json != null && json.isJsonObject) {
+        /**
+         * Input: { "39154018": {"status": "fixed" }} / { "39154018": {"error": "not_found" }}
+         * Output: [{ "id": 39154018, "status": "fixed" }] /  [{ "id": 39154018, "error": "not_found" }]
+         */
+        mutableListOf<FixThreatStatus>().apply {
+            val inputJsonObject = json.asJsonObject
+            inputJsonObject.keySet().iterator().forEach { key ->
+                getFixThreatStatus(key, inputJsonObject)?.let { add(it) }
+            }
+        }.toList()
+    } else {
+        null
+    }
+
+    private fun getFixThreatStatus(key: String, inputJsonObject: JsonObject) =
+        inputJsonObject.get(key)?.takeIf { it.isJsonObject }?.asJsonObject?.let { threat ->
+            try {
+                FixThreatStatus(
+                    id = key.toLong(),
+                    status = threat.get(STATUS)?.asString,
+                    error = threat.get(ERROR)?.asString
+                )
+            } catch (ex: ClassCastException) {
+                null
+            } catch (ex: IllegalStateException) {
+                null
+            } catch (ex: NumberFormatException) {
+                null
+            }
+        }
+
+    companion object {
+        private const val STATUS = "status"
+        private const val ERROR = "error"
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsStatusResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsStatusResponse.kt
@@ -6,8 +6,8 @@ import org.wordpress.android.fluxc.network.Response
 
 data class FixThreatsStatusResponse(
     @SerializedName("ok") val ok: Boolean?,
-    @SerializedName("threats") @JsonAdapter(FixThreatsStatusDeserializer::class)
-    val fixThreatsStatus: List<FixThreatStatus>?
+    @JsonAdapter(FixThreatsStatusDeserializer::class)
+    @SerializedName("threats") val fixThreatsStatus: List<FixThreatStatus>?
 ) : Response {
     data class FixThreatStatus(
         @SerializedName("id") val id: Long?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsStatusResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsStatusResponse.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.scan.threat
+
+import com.google.gson.annotations.JsonAdapter
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+
+data class FixThreatsStatusResponse(
+    @SerializedName("ok") val ok: Boolean?,
+    @SerializedName("threats") @JsonAdapter(FixThreatsStatusDeserializer::class)
+    val fixThreatsStatus: List<FixThreatStatus>?
+) : Response {
+    data class FixThreatStatus(
+        @SerializedName("id") val id: Long?,
+        @SerializedName("status") val status: String?,
+        @SerializedName("error") val error: String?
+    )
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
@@ -132,10 +132,7 @@ class ScanStore @Inject constructor(
     }
 
     suspend fun fetchFixThreatsStatus(payload: FetchFixThreatsStatusPayload): OnFixThreatsStatusFetched {
-        val resultPayload = scanRestClient.fetchFixThreatsStatus(
-            payload.remoteSiteId,
-            payload.threatIds
-        )
+        val resultPayload = scanRestClient.fetchFixThreatsStatus(payload.remoteSiteId, payload.threatIds)
         return emitFixThreatsStatus(resultPayload)
     }
 


### PR DESCRIPTION
Parent wordpress-mobile/WordPress-Android#13326

This PR adds following endpoints [Internal Ref: pcdRpT-3J (Jetpack Scan API Audit)]

1. **Fix Threats** POST `/sites/$site/alerts/fix?threat_ids[1]=<id1>&threat_ids[2]=<id2>`
2. **Ignore Threat** POST `/sites/$site/alerts/$threat_id?ignore=true`
3. **Fetch Fix Threats Status** GET `/sites/$site/alerts/fix?threat_ids[1]=<id1>&threat_ids[2]=<id2>`

and adds corresponding `ScanAction`, models and methods in the `ScanRestClient` and `ScanThreatStore`.

To test

That newly added tests in `ScanRestClientTest`, `ScanStoreTests` run fine.

Notes

1. "Fix Threats" POST request is asynchronous. To check on the status of the fix, GET request is provided separately. 
2. To fix a single threat, we can pass corresponding threat id in the list to the "Fix Threats" API.
3. "Fix Threat Status" response is returned directly and not stored into the db. We'll consider adding to db if a need arises during implementation in the client app.
4. Connected tests not included yet (added to back log) as real threat ids from the test site might become invalid during internal testing. Will figure out a way those threats are not updated and then include tests.
5. For **Ignore Threat**, currently just checking if the request has succeeded and not worrying about the data in the response as it contains site's rewind site state data which doesn't seem to be useful, documented in calypso code [here](https://opengrok.a8c.com/source/xref/calypso/client/state/data-layer/wpcom/sites/alerts/ignore.js?r=bbad57e4#41) and commented in the Scan API Audit p2 post here (pcdRpT-3J#comment-201).
