### PR TITLE
Update JetpackCapability - toString and fromString methods

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/JetpackCapability.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/JetpackCapability.kt
@@ -1,27 +1,27 @@
 package org.wordpress.android.fluxc.model
 
-enum class JetpackCapability {
-    BACKUP,
-    BACKUP_DAILY,
-    BACKUP_REALTIME,
-    SCAN,
-    ANTISPAM,
-    RESTORE,
-    ALTERNATE_RESTORE,
-    UNKNOWN;
+enum class JetpackCapability(private val stringValue: String) {
+    BACKUP("backup"),
+    BACKUP_DAILY("backup-daily"),
+    BACKUP_REALTIME("backup-realtime"),
+    SCAN("scan"),
+    ANTISPAM("antispam"),
+    RESTORE("restore"),
+    ALTERNATE_RESTORE("alternate-restore"),
+    UNKNOWN("unknown");
+
+    override fun toString(): String {
+        return stringValue
+    }
 
     companion object {
-        fun fromString(item: String): JetpackCapability {
-            return when (item) {
-                "backup" -> BACKUP
-                "backup-daily" -> BACKUP_DAILY
-                "backup-realtime" -> BACKUP_REALTIME
-                "scan" -> SCAN
-                "antispam" -> ANTISPAM
-                "restore" -> RESTORE
-                "alternate-restore" -> ALTERNATE_RESTORE
-                else -> UNKNOWN
+        fun fromString(string: String): JetpackCapability {
+            for (item in values()) {
+                if (item.stringValue == string) {
+                    return item
+                }
             }
+            return UNKNOWN
         }
     }
 }


### PR DESCRIPTION
This PR refactors JetpackCapability model and adds "toString" method. Related WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/13744

To test:
See WPAndroid PR test instructions