### PR TITLE
Return correct current date from CurrentTimeProvider

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStoreTest.kt
@@ -59,7 +59,7 @@ class VisitsAndViewsStoreTest {
                 appLogWrapper
         )
         val currentDate = Date(0)
-        whenever(currentTimeProvider.currentDate).thenReturn(currentDate)
+        whenever(currentTimeProvider.currentDate()).thenReturn(currentDate)
         val timeZone = "GMT"
         whenever(site.timezone).thenReturn(timeZone)
         whenever(

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/CurrentTimeProviderTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/CurrentTimeProviderTest.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.utils
+
+import kotlinx.coroutines.delay
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.test
+
+class CurrentTimeProviderTest {
+    private val currentTimeProvider = CurrentTimeProvider()
+
+    @Test
+    fun `always returns current date`() = test {
+        val firstDate = currentTimeProvider.currentDate()
+        delay(1)
+        val secondDate = currentTimeProvider.currentDate()
+
+        assertThat(firstDate).isNotEqualTo(secondDate)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -37,12 +37,12 @@ class VisitsAndViewsStore
         forced: Boolean = false
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
         val dateWithTimeZone = statsUtils.getFormattedDate(
-                currentTimeProvider.currentDate,
+                currentTimeProvider.currentDate(),
                 SiteUtils.getNormalizedTimezone(site.timezone)
         )
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {
-            logProgress(granularity, "Current date: ${currentTimeProvider.currentDate}")
+            logProgress(granularity, "Current date: ${currentTimeProvider.currentDate()}")
         } catch (e: AssertionError) {
             // Workaround for a bug in Android that can cause crashes on Android 8.0 and 8.1
             logProgress(granularity, "Cannot print current date because of AssertionError: $e")
@@ -88,7 +88,7 @@ class VisitsAndViewsStore
         limitMode: LimitMode
     ): VisitsAndViewsModel? {
         val dateWithTimeZone = statsUtils.getFormattedDate(
-                currentTimeProvider.currentDate,
+                currentTimeProvider.currentDate(),
                 SiteUtils.getNormalizedTimezone(site.timezone)
         )
         return getVisits(site, granularity, limitMode, dateWithTimeZone)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CurrentTimeProvider.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CurrentTimeProvider.kt
@@ -5,5 +5,5 @@ import javax.inject.Inject
 
 class CurrentTimeProvider
 @Inject constructor() {
-    val currentDate = Date()
+    fun currentDate() = Date()
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/11412

The current date provider was keeping the returned date instead of always returning the current date. This could lead to the app showing obsolete data (unless the singleton store was killed). This PR replaces the `val` with `fun` and adds some tests. 

This PR could be tested with the WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/13748