### PR TITLE
ScanStore: Add method to store scan state model into DB from the client

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/ScanStateModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/ScanStateModel.kt
@@ -8,7 +8,7 @@ data class ScanStateModel(
     val reason: String? = null,
     val threats: List<ThreatModel>? = null,
     val credentials: List<Credentials>? = null,
-    val hasCloud: Boolean,
+    val hasCloud: Boolean = false,
     val mostRecentStatus: ScanProgressStatus? = null,
     val currentStatus: ScanProgressStatus? = null
 ) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
@@ -80,7 +80,7 @@ class ScanStore @Inject constructor(
         return storeScanState(payload)
     }
 
-    private fun storeScanState(payload: FetchedScanStatePayload): OnScanStateFetched {
+    fun storeScanState(payload: FetchedScanStatePayload): OnScanStateFetched {
         return if (payload.error != null) {
             OnScanStateFetched(payload.error, FETCH_SCAN_STATE)
         } else {


### PR DESCRIPTION
This PR adds a method `addOrUpdateScanStateModelForSite` to add or update scan state model into db and makes `ScanStateModel.hasCloud` an optional field.

Referenced in 
https://github.com/wordpress-mobile/WordPress-Android/pull/13740
https://github.com/wordpress-mobile/WordPress-Android/pull/13741

 
