### PR TITLE
Jetpack Section: Backup Screen - Introduce Rewindable Only Flag

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -150,9 +150,9 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
 
         this.mCountDownLatch = CountDownLatch(1)
 
-        val firstActivity = activityLogModel(1, true)
-        val secondActivity = activityLogModel(2, true)
-        val thirdActivity = activityLogModel(3, true)
+        val firstActivity = activityLogModel(index = 1, rewindable = true)
+        val secondActivity = activityLogModel(index = 2, rewindable = true)
+        val thirdActivity = activityLogModel(index = 3, rewindable = true)
         val activityModels = listOf(firstActivity, secondActivity, thirdActivity)
 
         activityLogSqlUtils.insertOrUpdateActivities(site, activityModels)
@@ -171,9 +171,9 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
 
         this.mCountDownLatch = CountDownLatch(1)
 
-        val firstActivity = activityLogModel(1, true)
-        val secondActivity = activityLogModel(2, false)
-        val thirdActivity = activityLogModel(3, true)
+        val firstActivity = activityLogModel(index = 1, rewindable = true)
+        val secondActivity = activityLogModel(index = 2, rewindable = false)
+        val thirdActivity = activityLogModel(index = 3, rewindable = true)
         val activityModels = listOf(firstActivity, secondActivity, thirdActivity)
 
         activityLogSqlUtils.insertOrUpdateActivities(site, activityModels)
@@ -191,7 +191,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
 
         this.mCountDownLatch = CountDownLatch(1)
 
-        val activity = activityLogModel(1, true)
+        val activity = activityLogModel(index = 1, rewindable = true)
 
         activityLogSqlUtils.insertOrUpdateActivities(site, listOf(activity))
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -81,7 +81,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         val payload = ActivityLogStore.FetchActivityLogPayload(site)
         val fetchActivities = runBlocking { activityLogStore.fetchActivities(payload) }
 
-        val activityLogForSite = activityLogStore.getActivityLogForSite(site)
+        val activityLogForSite = activityLogStore.getActivityLogForSite(site, false)
 
         assertNotNull(fetchActivities)
         assertEquals(fetchActivities.rowsAffected, activityLogForSite.size)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -88,6 +88,20 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
     }
 
     @Test
+    fun testFetchRewindableActivities() {
+        val site = authenticate(FreeJetpackSite)
+
+        val payload = ActivityLogStore.FetchActivityLogPayload(site)
+        val fetchActivities = runBlocking { activityLogStore.fetchActivities(payload) }
+
+        val activityLogForSite = activityLogStore.getActivityLogForSite(site, true)
+
+        assertNotNull(fetchActivities)
+        assertEquals(fetchActivities.rowsAffected, PAGE_SIZE) // All activities are persisted.
+        assertEquals(activityLogForSite.size, 0) // Non retrieved, all activities are non-rewindable.
+    }
+
+    @Test
     fun testFetchActivitiesActivityTypeFilter() {
         val site = authenticate(CompleteJetpackSite)
 
@@ -340,5 +354,9 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
                 wpPassword = BuildConfig.TEST_WPCOM_PASSWORD_JETPACK,
                 siteUrl = BuildConfig.TEST_WPORG_URL_JETPACK_COMPLETE
         )
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 20
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -144,6 +144,26 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
     }
 
     @Test
+    fun storeAndRetrieveRewindableActivityLogInOrderByDateFromDb() {
+        val site = authenticate(FreeJetpackSite)
+
+        this.mCountDownLatch = CountDownLatch(1)
+
+        val firstActivity = activityLogModel(1, true)
+        val secondActivity = activityLogModel(2, false)
+        val thirdActivity = activityLogModel(3, true)
+        val activityModels = listOf(firstActivity, secondActivity, thirdActivity)
+
+        activityLogSqlUtils.insertOrUpdateActivities(site, activityModels)
+
+        val activityLogForSite = activityLogSqlUtils.getRewindableActivitiesForSite(site, SelectQuery.ORDER_DESCENDING)
+
+        assertEquals(activityLogForSite.size, 2)
+        assertEquals(activityLogForSite[0], thirdActivity)
+        assertEquals(activityLogForSite[1], firstActivity)
+    }
+
+    @Test
     fun updatesActivityWithTheSameActivityId() {
         val site = authenticate(FreeJetpackSite)
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -81,7 +81,11 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         val payload = ActivityLogStore.FetchActivityLogPayload(site)
         val fetchActivities = runBlocking { activityLogStore.fetchActivities(payload) }
 
-        val activityLogForSite = activityLogStore.getActivityLogForSite(site, false)
+        val activityLogForSite = activityLogStore.getActivityLogForSite(
+                site = site,
+                ascending = true,
+                rewindableOnly = false
+        )
 
         assertNotNull(fetchActivities)
         assertEquals(fetchActivities.rowsAffected, activityLogForSite.size)
@@ -94,7 +98,11 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         val payload = ActivityLogStore.FetchActivityLogPayload(site)
         val fetchActivities = runBlocking { activityLogStore.fetchActivities(payload) }
 
-        val activityLogForSite = activityLogStore.getActivityLogForSite(site, true)
+        val activityLogForSite = activityLogStore.getActivityLogForSite(
+                site = site,
+                ascending = true,
+                rewindableOnly = true
+        )
 
         assertNotNull(fetchActivities)
         assertEquals(fetchActivities.rowsAffected, PAGE_SIZE) // All activities are persisted.

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -128,9 +128,9 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
 
         this.mCountDownLatch = CountDownLatch(1)
 
-        val firstActivity = activityLogModel(1)
-        val secondActivity = activityLogModel(2)
-        val thirdActivity = activityLogModel(3)
+        val firstActivity = activityLogModel(1, true)
+        val secondActivity = activityLogModel(2, true)
+        val thirdActivity = activityLogModel(3, true)
         val activityModels = listOf(firstActivity, secondActivity, thirdActivity)
 
         activityLogSqlUtils.insertOrUpdateActivities(site, activityModels)
@@ -149,7 +149,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
 
         this.mCountDownLatch = CountDownLatch(1)
 
-        val activity = activityLogModel(1)
+        val activity = activityLogModel(1, true)
 
         activityLogSqlUtils.insertOrUpdateActivities(site, listOf(activity))
 
@@ -227,8 +227,9 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         return siteStore.sites.find { it.unmappedUrl == site.siteUrl }!!
     }
 
-    private fun activityLogModel(index: Long): ActivityLogModel {
-        return ActivityLogModel(activityID = "$index",
+    private fun activityLogModel(index: Long, rewindable: Boolean): ActivityLogModel {
+        return ActivityLogModel(
+                activityID = "$index",
                 summary = "summary$index",
                 content = FormattableContent(text = "text$index"),
                 name = "name$index",
@@ -236,8 +237,9 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
                 published = Date(index * 100),
                 rewindID = null,
                 gridicon = null,
-                rewindable = true,
-                status = "status")
+                rewindable = rewindable,
+                status = "status"
+        )
     }
 
     @Subscribe

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -54,7 +54,6 @@ class ActivityLogStoreTest {
 
     @Test
     fun onFetchActivityLogFirstPageActionCleanupDbAndCallRestClient() = test {
-        val number = 20
         val offset = 0
 
         val payload = FetchActivityLogPayload(siteModel)
@@ -71,13 +70,11 @@ class ActivityLogStoreTest {
         val action = ActivityLogActionBuilder.newFetchActivitiesAction(payload)
         activityLogStore.onAction(action)
 
-        verify(activityLogRestClient).fetchActivity(payload, number, offset)
+        verify(activityLogRestClient).fetchActivity(payload, PAGE_SIZE, offset)
     }
 
     @Test
     fun onFetchActivityLogNextActionReadCurrentDataAndCallRestClient() = test {
-        val number = 20
-
         val payload = FetchActivityLogPayload(siteModel, loadMore = true)
         whenever(activityLogRestClient.fetchActivity(eq(payload), any(), any())).thenReturn(
                 FetchedActivityLogPayload(
@@ -96,7 +93,7 @@ class ActivityLogStoreTest {
         val action = ActivityLogActionBuilder.newFetchActivitiesAction(payload)
         activityLogStore.onAction(action)
 
-        verify(activityLogRestClient).fetchActivity(payload, number, existingActivities.size)
+        verify(activityLogRestClient).fetchActivity(payload, PAGE_SIZE, existingActivities.size)
     }
 
     @Test
@@ -415,8 +412,8 @@ class ActivityLogStoreTest {
         activityModels: List<ActivityLogModel>,
         rowsAffected: Int,
         offset: Int = 0,
-        number: Int = 20,
-        totalItems: Int = 20
+        number: Int = PAGE_SIZE,
+        totalItems: Int = PAGE_SIZE
     ): Action<*> {
         val requestPayload = FetchActivityLogPayload(siteModel)
         val action = ActivityLogActionBuilder.newFetchActivitiesAction(requestPayload)
@@ -425,5 +422,9 @@ class ActivityLogStoreTest {
         whenever(activityLogRestClient.fetchActivity(requestPayload, number, offset)).thenReturn(payload)
         whenever(activityLogSqlUtils.insertOrUpdateActivities(any(), any())).thenReturn(rowsAffected)
         return action
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 20
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -183,8 +183,8 @@ class ActivityLogStoreTest {
 
         val activityModelsFromDb = activityLogStore.getActivityLogForSite(
                 site = siteModel,
-                rewindableOnly = false,
-                ascending = false
+                ascending = false,
+                rewindableOnly = false
         )
 
         verify(activityLogSqlUtils).getActivitiesForSite(siteModel, SelectQuery.ORDER_DESCENDING)
@@ -199,8 +199,8 @@ class ActivityLogStoreTest {
 
         val activityModelsFromDb = activityLogStore.getActivityLogForSite(
                 site = siteModel,
-                rewindableOnly = true,
-                ascending = false
+                ascending = false,
+                rewindableOnly = true
         )
 
         verify(activityLogSqlUtils).getRewindableActivitiesForSite(siteModel, SelectQuery.ORDER_DESCENDING)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -54,7 +54,7 @@ class ActivityLogStoreTest {
 
     @Test
     fun onFetchActivityLogFirstPageActionCleanupDbAndCallRestClient() = test {
-        val number = 10
+        val number = 20
         val offset = 0
 
         val payload = FetchActivityLogPayload(siteModel)
@@ -76,7 +76,7 @@ class ActivityLogStoreTest {
 
     @Test
     fun onFetchActivityLogNextActionReadCurrentDataAndCallRestClient() = test {
-        val number = 10
+        val number = 20
 
         val payload = FetchActivityLogPayload(siteModel, loadMore = true)
         whenever(activityLogRestClient.fetchActivity(eq(payload), any(), any())).thenReturn(
@@ -415,8 +415,8 @@ class ActivityLogStoreTest {
         activityModels: List<ActivityLogModel>,
         rowsAffected: Int,
         offset: Int = 0,
-        number: Int = 10,
-        totalItems: Int = 10
+        number: Int = 20,
+        totalItems: Int = 20
     ): Action<*> {
         val requestPayload = FetchActivityLogPayload(siteModel)
         val action = ActivityLogActionBuilder.newFetchActivitiesAction(requestPayload)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -192,6 +192,22 @@ class ActivityLogStoreTest {
     }
 
     @Test
+    fun returnRewindableOnlyActivitiesFromDb() {
+        val rewindableActivityModels = listOf<ActivityLogModel>(mock())
+        whenever(activityLogSqlUtils.getRewindableActivitiesForSite(siteModel, SelectQuery.ORDER_DESCENDING))
+                .thenReturn(rewindableActivityModels)
+
+        val activityModelsFromDb = activityLogStore.getActivityLogForSite(
+                site = siteModel,
+                rewindableOnly = true,
+                ascending = false
+        )
+
+        verify(activityLogSqlUtils).getRewindableActivitiesForSite(siteModel, SelectQuery.ORDER_DESCENDING)
+        assertEquals(rewindableActivityModels, activityModelsFromDb)
+    }
+
+    @Test
     fun storeFetchedRewindStatusToDb() = test {
         val rewindStatusModel = mock<RewindStatusModel>()
         val payload = FetchedRewindStatePayload(rewindStatusModel, siteModel)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -54,8 +54,6 @@ class ActivityLogStoreTest {
 
     @Test
     fun onFetchActivityLogFirstPageActionCleanupDbAndCallRestClient() = test {
-        val offset = 0
-
         val payload = FetchActivityLogPayload(siteModel)
         whenever(activityLogRestClient.fetchActivity(eq(payload), any(), any())).thenReturn(
                 FetchedActivityLogPayload(
@@ -70,7 +68,7 @@ class ActivityLogStoreTest {
         val action = ActivityLogActionBuilder.newFetchActivitiesAction(payload)
         activityLogStore.onAction(action)
 
-        verify(activityLogRestClient).fetchActivity(payload, PAGE_SIZE, offset)
+        verify(activityLogRestClient).fetchActivity(payload, PAGE_SIZE, OFFSET)
     }
 
     @Test
@@ -411,7 +409,7 @@ class ActivityLogStoreTest {
     private suspend fun initRestClient(
         activityModels: List<ActivityLogModel>,
         rowsAffected: Int,
-        offset: Int = 0,
+        offset: Int = OFFSET,
         number: Int = PAGE_SIZE,
         totalItems: Int = PAGE_SIZE
     ): Action<*> {
@@ -425,6 +423,7 @@ class ActivityLogStoreTest {
     }
 
     companion object {
+        private const val OFFSET = 0
         private const val PAGE_SIZE = 20
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -181,7 +181,11 @@ class ActivityLogStoreTest {
         whenever(activityLogSqlUtils.getActivitiesForSite(siteModel, SelectQuery.ORDER_DESCENDING))
                 .thenReturn(activityModels)
 
-        val activityModelsFromDb = activityLogStore.getActivityLogForSite(siteModel, ascending = false)
+        val activityModelsFromDb = activityLogStore.getActivityLogForSite(
+                site = siteModel,
+                rewindableOnly = false,
+                ascending = false
+        )
 
         verify(activityLogSqlUtils).getActivitiesForSite(siteModel, SelectQuery.ORDER_DESCENDING)
         assertEquals(activityModels, activityModelsFromDb)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -56,6 +56,10 @@ class ActivityLogSqlUtils
                 .map { it.build(formattableContentMapper) }
     }
 
+    fun getRewindableActivitiesForSite(site: SiteModel, @SelectQuery.Order order: Int): List<ActivityLogModel> {
+        return listOf()
+    }
+
     fun getActivityByRewindId(rewindId: String): ActivityLogModel? {
         return WellSql.select(ActivityLogBuilder::class.java)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -57,7 +57,14 @@ class ActivityLogSqlUtils
     }
 
     fun getRewindableActivitiesForSite(site: SiteModel, @SelectQuery.Order order: Int): List<ActivityLogModel> {
-        return listOf()
+        return WellSql.select(ActivityLogBuilder::class.java)
+                .where()
+                .equals(ActivityLogTable.LOCAL_SITE_ID, site.id)
+                .equals(ActivityLogTable.REWINDABLE, true)
+                .endWhere()
+                .orderBy(ActivityLogTable.PUBLISHED, order)
+                .asModel
+                .map { it.build(formattableContentMapper) }
     }
 
     fun getActivityByRewindId(rewindId: String): ActivityLogModel? {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -76,7 +76,10 @@ class ActivityLogStore
     }
 
     @SuppressLint("WrongConstant")
-    fun getActivityLogForSite(site: SiteModel, ascending: Boolean = true): List<ActivityLogModel> {
+    fun getActivityLogForSite(
+        site: SiteModel,
+        ascending: Boolean = true
+    ): List<ActivityLogModel> {
         val order = if (ascending) SelectQuery.ORDER_ASCENDING else SelectQuery.ORDER_DESCENDING
         return activityLogSqlUtils.getActivitiesForSite(site, order)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -78,6 +78,7 @@ class ActivityLogStore
     @SuppressLint("WrongConstant")
     fun getActivityLogForSite(
         site: SiteModel,
+        rewindableOnly: Boolean = false,
         ascending: Boolean = true
     ): List<ActivityLogModel> {
         val order = if (ascending) SelectQuery.ORDER_ASCENDING else SelectQuery.ORDER_DESCENDING

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -78,8 +78,8 @@ class ActivityLogStore
     @SuppressLint("WrongConstant")
     fun getActivityLogForSite(
         site: SiteModel,
-        rewindableOnly: Boolean = false,
-        ascending: Boolean = true
+        ascending: Boolean = true,
+        rewindableOnly: Boolean = false
     ): List<ActivityLogModel> {
         val order = if (ascending) SelectQuery.ORDER_ASCENDING else SelectQuery.ORDER_DESCENDING
         return if (rewindableOnly) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -28,7 +28,7 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val ACTIVITY_LOG_PAGE_SIZE = 10
+private const val ACTIVITY_LOG_PAGE_SIZE = 20
 
 @Singleton
 class ActivityLogStore

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -82,7 +82,11 @@ class ActivityLogStore
         ascending: Boolean = true
     ): List<ActivityLogModel> {
         val order = if (ascending) SelectQuery.ORDER_ASCENDING else SelectQuery.ORDER_DESCENDING
-        return activityLogSqlUtils.getActivitiesForSite(site, order)
+        return if (rewindableOnly) {
+            activityLogSqlUtils.getRewindableActivitiesForSite(site, order)
+        } else {
+            activityLogSqlUtils.getActivitiesForSite(site, order)
+        }
     }
 
     fun getActivityLogItemByRewindId(rewindId: String): ActivityLogModel? {


### PR DESCRIPTION
Parent [WordPress-Android#13629](https://github.com/wordpress-mobile/WordPress-Android/issues/13629)

This PR introduces the `rewindableOnly` flag to the `getActivityLogForSite` function. When this flag is passed as `true`, then the only activities that are being retrieved from the database are the rewindable ones. Else, if this flag is passed as `false`, then all the activities are being retrieved (as previously).

This solution is required to build the `Backups` screen. 

To test:
- Trigger the `ReleaseStack_ActivityLogTestJetpack` connected test suite and verify that all tests pass.