### PR TITLE
Remove "Create a new Page" and "Customize your site" from Quick Start

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/quickstart/QuickStartStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/quickstart/QuickStartStoreTest.kt
@@ -14,9 +14,7 @@ import org.wordpress.android.fluxc.persistence.QuickStartSqlUtils
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHOOSE_THEME
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CREATE_NEW_PAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CREATE_SITE
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CUSTOMIZE_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.FOLLOW_SITE
@@ -69,11 +67,9 @@ class QuickStartStoreTest {
 
         // making sure undone tasks are retrieved in a correct order
         val uncompletedCustomizeTasks = quickStartStore.getUncompletedTasksByType(testLocalSiteId, CUSTOMIZE)
-        assertEquals(4, uncompletedCustomizeTasks.size)
+        assertEquals(2, uncompletedCustomizeTasks.size)
         assertEquals(UPDATE_SITE_TITLE, uncompletedCustomizeTasks[0])
         assertEquals(UPLOAD_SITE_ICON, uncompletedCustomizeTasks[1])
-        assertEquals(CUSTOMIZE_SITE, uncompletedCustomizeTasks[2])
-        assertEquals(CREATE_NEW_PAGE, uncompletedCustomizeTasks[3])
 
         val uncompletedGrowTasks = quickStartStore.getUncompletedTasksByType(testLocalSiteId, GROW)
         assertEquals(3, uncompletedGrowTasks.size)
@@ -88,14 +84,12 @@ class QuickStartStoreTest {
         quickStartStore.setShownTask(testLocalSiteId, UPLOAD_SITE_ICON, true)
         quickStartStore.setShownTask(testLocalSiteId, CHECK_STATS, true)
         quickStartStore.setShownTask(testLocalSiteId, ENABLE_POST_SHARING, true)
-        quickStartStore.setShownTask(testLocalSiteId, CREATE_NEW_PAGE, true)
         quickStartStore.setShownTask(testLocalSiteId, PUBLISH_POST, true)
 
         // making sure shown tasks are retrieved in a correct order
         val shownCustomizeTasks = quickStartStore.getShownTasksByType(testLocalSiteId, CUSTOMIZE)
-        assertEquals(2, shownCustomizeTasks.size)
+        assertEquals(1, shownCustomizeTasks.size)
         assertEquals(UPLOAD_SITE_ICON, shownCustomizeTasks[0])
-        assertEquals(CREATE_NEW_PAGE, shownCustomizeTasks[1])
 
         val shownGrowTasks = quickStartStore.getShownTasksByType(testLocalSiteId, GROW)
         assertEquals(3, shownGrowTasks.size)
@@ -105,12 +99,11 @@ class QuickStartStoreTest {
 
         // making sure unshown tasks are retrieved in a correct order
         val unshownCustomizeTasks = quickStartStore.getUnshownTasksByType(testLocalSiteId, CUSTOMIZE)
-        assertEquals(5, unshownCustomizeTasks.size)
+        assertEquals(4, unshownCustomizeTasks.size)
         assertEquals(CREATE_SITE, unshownCustomizeTasks[0])
         assertEquals(UPDATE_SITE_TITLE, unshownCustomizeTasks[1])
         assertEquals(CHOOSE_THEME, unshownCustomizeTasks[2])
-        assertEquals(CUSTOMIZE_SITE, unshownCustomizeTasks[3])
-        assertEquals(VIEW_SITE, unshownCustomizeTasks[4])
+        assertEquals(VIEW_SITE, unshownCustomizeTasks[3])
 
         val unshownGrowTasks = quickStartStore.getUnshownTasksByType(testLocalSiteId, GROW)
         assertEquals(2, unshownGrowTasks.size)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.persistence.QuickStartSqlUtils
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.UNKNOWN
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,9 +24,11 @@ constructor(private val quickStartSqlUtils: QuickStartSqlUtils, dispatcher: Disp
         UPDATE_SITE_TITLE("update_site_title", CUSTOMIZE, 1),
         UPLOAD_SITE_ICON("upload_site_icon", CUSTOMIZE, 2),
         CHOOSE_THEME("choose_theme", CUSTOMIZE, 3),
-        CUSTOMIZE_SITE("customize_site", CUSTOMIZE, 4),
-        CREATE_NEW_PAGE("create_new_page", CUSTOMIZE, 5),
-        VIEW_SITE("view_site", CUSTOMIZE, 6),
+        // Disabeling until a long term plan is made https://github.com/wordpress-mobile/WordPress-Android/issues/13713
+        CUSTOMIZE_SITE("customize_site", UNKNOWN, 0),
+        // Disabeling until a long term plan is made https://github.com/wordpress-mobile/WordPress-Android/issues/13713
+        CREATE_NEW_PAGE("create_new_page", UNKNOWN, 1),
+        VIEW_SITE("view_site", CUSTOMIZE, 4),
         ENABLE_POST_SHARING("enable_post_sharing", GROW, 7),
         PUBLISH_POST("publish_post", GROW, 8),
         FOLLOW_SITE("follow_site", GROW, 9),


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-Android/issues/13713

Can be tested with: https://github.com/wordpress-mobile/WordPress-Android/pull/13756

📓 I left the references to the tour steps in place for now because I wasn't sure if we would want to incorporate them somewhere else or not. If we don't think they're worth keeping around, I can open a more extensive clean-out PR against develop.

### To test:
- Navigate to the Create WordPress.com site
    - Choose Site > ➕ > Create WordPress.com site
- Complete the site creation flow
- Choose "Yes, Help Me" on the "Want a little help..." dialog
- **Expect** To no longer see the options for "Create a new Page" or "Customize your site"

## Screenshots
Before | After
--- | ---
<kbd><a href="https://user-images.githubusercontent.com/3384451/103805173-39468d80-5021-11eb-98cf-5c13127b30b9.jpg"><img width="300" src="https://user-images.githubusercontent.com/3384451/103805173-39468d80-5021-11eb-98cf-5c13127b30b9.jpg"/></a></kbd> |  <kbd><a href="https://user-images.githubusercontent.com/3384451/104388919-4f17ef00-5508-11eb-9a78-da86a3f53ecd.jpg"><img width="300" src="https://user-images.githubusercontent.com/3384451/104388919-4f17ef00-5508-11eb-9a78-da86a3f53ecd.jpg"/></a></kbd>
