### PR TITLE
Refactor ScanStateErrors

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
@@ -242,7 +242,7 @@ class ScanRestClientTest {
 
         val payload = scanRestClient.fetchScanState(site)
 
-        assertEmittedScanStateError(payload, ScanStateErrorType.MISSING_THREAT_ID)
+        assertEmittedScanStateError(payload, ScanStateErrorType.INVALID_RESPONSE)
     }
 
     @Test
@@ -255,7 +255,7 @@ class ScanRestClientTest {
 
         val payload = scanRestClient.fetchScanState(site)
 
-        assertEmittedScanStateError(payload, ScanStateErrorType.MISSING_THREAT_SIGNATURE)
+        assertEmittedScanStateError(payload, ScanStateErrorType.INVALID_RESPONSE)
     }
 
     @Test
@@ -268,7 +268,7 @@ class ScanRestClientTest {
 
         val payload = scanRestClient.fetchScanState(site)
 
-        assertEmittedScanStateError(payload, ScanStateErrorType.MISSING_THREAT_FIRST_DETECTED)
+        assertEmittedScanStateError(payload, ScanStateErrorType.INVALID_RESPONSE)
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -177,19 +177,19 @@ class ScanRestClient(
             site,
             ScanStateErrorType.INVALID_RESPONSE
         )
-        var error: ScanStateErrorType? = null
+        var isError = false
         val threatModels = response.threats?.mapNotNull { threat ->
             val threatModel = when {
                 threat.id == null -> {
-                    error = ScanStateErrorType.MISSING_THREAT_ID
+                    isError = true
                     null
                 }
                 threat.signature == null -> {
-                    error = ScanStateErrorType.MISSING_THREAT_SIGNATURE
+                    isError = true
                     null
                 }
                 threat.firstDetected == null -> {
-                    error = ScanStateErrorType.MISSING_THREAT_FIRST_DETECTED
+                    isError = true
                     null
                 }
                 else -> {
@@ -197,15 +197,15 @@ class ScanRestClient(
                     if (threatStatus != ThreatStatus.UNKNOWN) {
                         threatMapper.map(threat)
                     } else {
-                        error = ScanStateErrorType.INVALID_RESPONSE
+                        isError = true
                         null
                     }
                 }
             }
             threatModel
         }
-        error?.let {
-            return buildScanStateErrorPayload(site, it)
+        if (isError) {
+            return buildScanStateErrorPayload(site, ScanStateErrorType.INVALID_RESPONSE)
         }
         val scanStateModel = ScanStateModel(
             state = state,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.scan.threat.FixThreatsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.scan.threat.FixThreatsStatusResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.scan.threat.Threat
 import org.wordpress.android.fluxc.store.ScanStore.FetchFixThreatsStatusResultPayload
 import org.wordpress.android.fluxc.store.ScanStore.FetchedScanStatePayload
 import org.wordpress.android.fluxc.store.ScanStore.FixThreatsError
@@ -179,7 +180,7 @@ class ScanRestClient(
             site,
             ScanStateError(ScanStateErrorType.INVALID_RESPONSE, "Unknown scan state")
         )
-        val (threatModels, isError, errorMsg) = mapThreatsToThreatModels(response)
+        val (threatModels, isError, errorMsg) = mapThreatsToThreatModels(response.threats)
         if (isError) {
             return buildScanStateErrorPayload(site, ScanStateError(ScanStateErrorType.INVALID_RESPONSE, errorMsg))
         }
@@ -211,10 +212,10 @@ class ScanRestClient(
         return FetchedScanStatePayload(scanStateModel, site)
     }
 
-    private fun mapThreatsToThreatModels(response: ScanStateResponse): Triple<Boolean, String?, List<ThreatModel>?> {
+    private fun mapThreatsToThreatModels(threats: List<Threat>?): Triple<List<ThreatModel>?, Boolean, String?> {
         var isError = false
         var errorMsg: String? = null
-        val threatModels = response.threats?.mapNotNull { threat ->
+        val threatModels = threats?.mapNotNull { threat ->
             val threatModel = when {
                 threat.id == null -> {
                     isError = true
@@ -243,7 +244,7 @@ class ScanRestClient(
             }
             threatModel
         }
-        return Triple(isError, errorMsg, threatModels)
+        return Triple(threatModels, isError, errorMsg)
     }
 
     private fun buildFixThreatsStatusPayload(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
@@ -247,10 +247,7 @@ class ScanStore @Inject constructor(
     enum class ScanStateErrorType {
         GENERIC_ERROR,
         AUTHORIZATION_REQUIRED,
-        INVALID_RESPONSE,
-        MISSING_THREAT_ID,
-        MISSING_THREAT_SIGNATURE,
-        MISSING_THREAT_FIRST_DETECTED
+        INVALID_RESPONSE
     }
 
     class ScanStateError(var type: ScanStateErrorType, var message: String? = null) : OnChangedError


### PR DESCRIPTION
This PR
1. Replace MISSING_THREAT_ID, MISSING_THREAT_SIGNATURE and MISSING_THREAT_FIRST_DETECTED with INVALID_RESPONSE. `Error message` is used to help us differentiate between these error cases.
2. Extracts "map Threat to Threat Model" into its own method so it can be easily re-used for "Scan History" endpoint which is coming in the next PR.

Note: Review by commits might be easier to follow.
Note2: I just realized the branch name is misleading, sorry. 

To Test:
CI will run unit tests and that should be enough