### PR TITLE
Adds `mobile_screenshot` and `tablet_screenshot` in FETCH_STARTER_DESIGNS return model

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/StarterDesignModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/StarterDesignModel.kt
@@ -13,5 +13,7 @@ data class StarterDesignModel(
     @SerializedName("demo_url") val demoUrl: String?,
     val theme: String?,
     @SerializedName("segment_id") val segmentId: Long?,
-    val screenshot: String?
+    val screenshot: String?,
+    @SerializedName("mobile_screenshot") val mobileScreenshot: String?,
+    @SerializedName("tablet_screenshot") val tabletScreenshot: String?
 ) : Parcelable


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2978

**Description**
This PR adds `mobile_screenshot` and `tablet_screenshot` return fields in FETCH_STARTER_DESIGNS action

**To test**
This can be tested with https://github.com/wordpress-mobile/WordPress-Android/pull/13674