### PR TITLE
Increase mocked response delay to possibly fix MockedStack_UploadTest.testCancelImageUpload failures

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -117,7 +117,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
 
     @Test
     public void testCancelImageUpload() throws InterruptedException {
-        mInterceptor.respondWithSticky("media-upload-response-success.json", null);
+        mInterceptor.respondWithSticky("media-upload-response-success.json", 1000L, null);
 
         // First, try canceling an image with the default behavior (canceled image is deleted from the store)
         MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
@@ -26,7 +26,7 @@ import javax.inject.Singleton
 class ResponseMockingInterceptor : Interceptor {
     companion object {
         private val SUBSTITUTION_DEFAULT = { string: String -> string }
-        private const val NETWORK_DELAY_MS = 500L
+        const val NETWORK_DELAY_MS = 500L
     }
 
     /**
@@ -38,6 +38,7 @@ class ResponseMockingInterceptor : Interceptor {
 
     private var nextResponseJson: String? = null
     private var nextResponseCode: Int = 200
+    private var nextResponseDelay: Long = NETWORK_DELAY_MS
 
     private var mode: InterceptorMode = ONE_TIME
     private var transformStickyResponse = SUBSTITUTION_DEFAULT
@@ -62,13 +63,19 @@ class ResponseMockingInterceptor : Interceptor {
     fun respondWith(jsonResponseFileName: String) {
         nextResponseJson = getStringFromResourceFile(jsonResponseFileName)
         nextResponseCode = 200
+        nextResponseDelay = NETWORK_DELAY_MS
         mode = ONE_TIME
         transformStickyResponse = SUBSTITUTION_DEFAULT
     }
 
-    fun respondWithSticky(jsonResponseFileName: String, transformResponse: ((String) -> String)? = null) {
+    fun respondWithSticky(
+        jsonResponseFileName: String,
+        responseDelay: Long = NETWORK_DELAY_MS,
+        transformResponse: ((String) -> String)? = null
+    ) {
         nextResponseJson = getStringFromResourceFile(jsonResponseFileName)
         nextResponseCode = 200
+        nextResponseDelay = responseDelay
         transformResponse?.let {
             transformStickyResponse = it
         }
@@ -79,11 +86,13 @@ class ResponseMockingInterceptor : Interceptor {
     fun respondWithError(jsonResponseFileName: String, errorCode: Int = 404) {
         nextResponseJson = getStringFromResourceFile(jsonResponseFileName)
         nextResponseCode = errorCode
+        nextResponseDelay = NETWORK_DELAY_MS
     }
 
     fun respondWith(jsonResponse: JsonElement) {
         nextResponseJson = jsonResponse.toString()
         nextResponseCode = 200
+        nextResponseDelay = NETWORK_DELAY_MS
     }
 
     @JvmOverloads


### PR DESCRIPTION
[MockedStack_UploadTest.testCancelImageUpload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java#L118-L166) has been failing intermittently. I've looked into this a bit and found 2 possible issues with it:

1. Even though directly running the test in my local machine was always a success, debugging the test usually ended up with [an assertion failure where we are expecting a `CANCELED_MEDIA` event but instead receiving `UPLOADED_MEDIA`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java#L486). Unfortunately this exception is not properly propagated, so the test doesn't fail as it should. This can be tested by adding an `assertTrue(false)` around the beginning of `onMediaUploaded` and observing that it's completely ignored. As far as I can tell, we are doing everything necessary for the `EventBus` configuration [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/Dispatcher.java#L19). So, I tried `@Subscribe(threadMode = ThreadMode.MAIN)` and it seems to work as expected. We may need to do this for all mocked tests.
2. The debugging session ^ points to the media uploading instead of being canceled. This is most likely because there isn't enough time to process the cancel event before the success response is delivered. Increasing the network delay seems to address this issue as I was able to consistently pass the error described above. I don't have enough context about the workings of this test or its implementation, so I don't know whether this change is enough or if there is something else wrong with the test or implementation.

I am going to open this as a draft PR and try it a few times in CI. Even if it doesn't work, I thought writing down the initial issue would provide value. If it does work, I think it might be best to merge this as is and try to address the issue described in `1` separately. If we need the `ThreadMode.MAIN`, we'd want to do it everywhere and hope that it won't open a can of worms.