### PR TITLE
ExPlat: Improve handling of null Variations and not found Experiments

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.experiments.Assignments
 import org.wordpress.android.fluxc.model.experiments.Variation
 import org.wordpress.android.fluxc.model.experiments.Variation.Control
-import org.wordpress.android.fluxc.model.experiments.Variation.Other
 import org.wordpress.android.fluxc.model.experiments.Variation.Treatment
 import org.wordpress.android.fluxc.store.ExperimentStore
 import org.wordpress.android.fluxc.store.ExperimentStore.FetchAssignmentsPayload
@@ -101,8 +100,7 @@ class ExperimentsFragment : Fragment() {
 
     private fun getVariationString(variation: Variation) = when (variation) {
         is Control -> "control"
-        is Treatment -> "treatment"
-        is Other -> variation.name
+        is Treatment -> variation.name
     }
 
     private fun prependToLog(s: String) = (activity as MainExampleActivity).prependToLog(s)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.model.experiments.Variation
 import org.wordpress.android.fluxc.model.experiments.Variation.Control
 import org.wordpress.android.fluxc.model.experiments.Variation.Other
 import org.wordpress.android.fluxc.model.experiments.Variation.Treatment
-import org.wordpress.android.fluxc.model.experiments.Variation.Unknown
 import org.wordpress.android.fluxc.store.ExperimentStore
 import org.wordpress.android.fluxc.store.ExperimentStore.FetchAssignmentsPayload
 import org.wordpress.android.fluxc.store.ExperimentStore.OnAssignmentsFetched
@@ -103,7 +102,6 @@ class ExperimentsFragment : Fragment() {
     private fun getVariationString(variation: Variation) = when (variation) {
         is Control -> "control"
         is Treatment -> "treatment"
-        is Unknown -> "unknown"
         is Other -> variation.name
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/experiments/AssignmentsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/experiments/AssignmentsTest.kt
@@ -5,6 +5,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.experiments.Assignments
+import org.wordpress.android.fluxc.model.experiments.AssignmentsModel
+import org.wordpress.android.fluxc.model.experiments.Variation.Control
+import org.wordpress.android.fluxc.model.experiments.Variation.Treatment
 import java.lang.System.currentTimeMillis
 import java.util.Date
 
@@ -15,7 +18,7 @@ class AssignmentsTest {
         val now = currentTimeMillis()
         val oneHourAgo = now - ONE_HOUR_IN_SECONDS * 1000
         val assignments = Assignments(emptyMap(), ONE_HOUR_IN_SECONDS, Date(oneHourAgo))
-        assertThat(assignments.isStale(Date(now))).isTrue()
+        assertThat(assignments.isStale(Date(now))).isTrue
     }
 
     @Test
@@ -23,7 +26,31 @@ class AssignmentsTest {
         val now = currentTimeMillis()
         val oneHourFromNow = now + ONE_HOUR_IN_SECONDS * 1000
         val assignments = Assignments(emptyMap(), ONE_HOUR_IN_SECONDS, Date(oneHourFromNow))
-        assertThat(assignments.isStale(Date(now))).isFalse()
+        assertThat(assignments.isStale(Date(now))).isFalse
+    }
+
+    @Test
+    fun `variation is control if experiment is not found`() {
+        val model = AssignmentsModel(mapOf("test_experiment" to "treatment"))
+        val assignments = Assignments.fromModel(model)
+        val variation = assignments.getVariationForExperiment("other_experiment")
+        assertThat(variation).isInstanceOf(Control::class.java)
+    }
+
+    @Test
+    fun `null variation is mapped to control type`() {
+        val model = AssignmentsModel(mapOf("test_experiment" to null))
+        val assignments = Assignments.fromModel(model)
+        val variation = assignments.getVariationForExperiment("test_experiment")
+        assertThat(variation).isInstanceOf(Control::class.java)
+    }
+
+    @Test
+    fun `treatment variation is mapped to treatment type with correct name`() {
+        val model = AssignmentsModel(mapOf("test_experiment" to "treatment_name"))
+        val assignments = Assignments.fromModel(model)
+        val variation = assignments.getVariationForExperiment("test_experiment")
+        assertThat(variation).isEqualTo(Treatment("treatment_name"))
     }
 
     companion object {

--- a/example/src/test/java/org/wordpress/android/fluxc/experiments/ExperimentStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/experiments/ExperimentStoreTest.kt
@@ -87,19 +87,17 @@ class ExperimentStoreTest {
         val defaultPlatform = CALYPSO
 
         private val successfulVariations = mapOf(
-                "experiment_one" to "control",
+                "experiment_one" to null,
                 "experiment_two" to "treatment",
-                "experiment_three" to null,
-                "experiment_four" to "other"
+                "experiment_three" to "other"
         )
 
         private val successfulModel = AssignmentsModel(successfulVariations, 3600, 1604964458273)
 
         const val successfulModelJson = "{\"variations\":{" +
-                "\"experiment_one\":\"control\"," +
+                "\"experiment_one\":null," +
                 "\"experiment_two\":\"treatment\"," +
-                "\"experiment_three\":null," +
-                "\"experiment_four\":\"other\"}," +
+                "\"experiment_three\":\"other\"}," +
                 "\"ttl\":3600," +
                 "\"fetchedAt\":1604964458273}"
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClientTest.kt
@@ -90,7 +90,7 @@ class ExperimentRestClientTest {
         val payload = experimentRestClient.fetchAssignments(defaultPlatform)
 
         assertThat(payload).isNotNull
-        assertThat(payload.isError).isTrue()
+        assertThat(payload.isError).isTrue
     }
 
     private suspend fun initRequest(response: Response<FetchAssignmentsResponse>) {
@@ -113,10 +113,9 @@ class ExperimentRestClientTest {
         val defaultPlatform = CALYPSO
 
         private val successfulVariations = mapOf(
-                "experiment_one" to "control",
+                "experiment_one" to null,
                 "experiment_two" to "treatment",
-                "experiment_three" to null,
-                "experiment_four" to "other"
+                "experiment_three" to "other"
         )
 
         val successfulResponse = FetchAssignmentsResponse(successfulVariations, 3600)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
@@ -33,7 +33,6 @@ data class Assignments(
 sealed class Variation {
     object Control : Variation()
     object Treatment : Variation()
-    object Unknown : Variation()
     data class Other(val name: String) : Variation()
 
     companion object {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
@@ -32,14 +32,12 @@ data class Assignments(
 
 sealed class Variation {
     object Control : Variation()
-    object Treatment : Variation()
-    data class Other(val name: String) : Variation()
+    data class Treatment(val name: String) : Variation()
 
     companion object {
         fun fromName(name: String?) = when (name) {
             null -> Control
-            "treatment" -> Treatment
-            else -> Other(name)
+            else -> Treatment(name)
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.model.experiments
 
-import org.wordpress.android.fluxc.model.experiments.Variation.Unknown
+import org.wordpress.android.fluxc.model.experiments.Variation.Control
 import java.lang.System.currentTimeMillis
 import java.util.Date
 
@@ -19,7 +19,7 @@ data class Assignments(
 
     fun isStale(now: Date = Date()) = !now.before(expiresAt)
 
-    fun getVariationForExperiment(experiment: String) = variations[experiment] ?: Unknown
+    fun getVariationForExperiment(experiment: String) = variations[experiment] ?: Control
 
     companion object {
         fun fromModel(model: AssignmentsModel) = Assignments(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
@@ -38,9 +38,8 @@ sealed class Variation {
 
     companion object {
         fun fromName(name: String?) = when (name) {
-            "control" -> Control
+            null -> Control
             "treatment" -> Treatment
-            null -> Unknown
             else -> Other(name)
         }
     }


### PR DESCRIPTION
This PR adds the following changes to the ExPlat implementation, based on feedback from @withinboredom [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1756#pullrequestreview-571316712) and [here](https://github.com/Automattic/Automattic-Tracks-iOS/pull/155#pullrequestreview-571332826):

1. If a variation is `null` in the API response, we now map it to the `Control` variation type.
1. If an experiment is not found when calling `Assignments::getVariationForExperiment`, we now fallback to the `Control` variation type.
1. The `Unknown` variation type has been removed.
1. The `Other` variation type has been removed and its `name` attribute has been incorporated to the `Treatment` variation type, since we can now infer that if a variation has a name in the API response, then that variation is effectively a treatment.

These changes result in a simpler use of this feature:

```kotlin
// Use case for an experiment with a single treatment
when (assignments.getVariationForExperiment("ab_experiment")) {
    Control -> handleControl()
    else -> handleTreatment()
}

// Use case for experiments with multiple treatments
when (assignments.getVariationForExperiment("multivariate_experiment")) {
    Treatment("treatment_one") -> handleTreatmentOne()
    Treatment("treatment_two") -> handleTreatmentTwo()
    else -> handleControl()
}
```


## To test

Make sure unit tests passes and/or use the following steps on the example app:

1. On the initial screen, tap **Experiments**.
1. On the next screen, select a platform to query (keep in mind the only platforms officially supported at the moment are `calypso` and `wpcom`).
1. Optionally, you can add or generate an Anonymous ID to be included in the request as well.
1. Tap **Fetch Assignments**.
1. Check the results printed by the in-app console.
1. Tap **Get Cached Assignments**.
1. Verify that the returned results match the ones fetched before.

Feel free to try out different combinations, both signed in and signed out.