### PR TITLE
Add Stock photo caption and include it when uploading a photo

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/StockMediaStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/StockMediaStoreTest.kt
@@ -33,6 +33,7 @@ class StockMediaStoreTest {
     private val date = "date"
     private val url = "url"
     private val thumbnail = "thumbnail"
+    private val caption = "caption"
 
     @Before
     fun setUp() {
@@ -49,7 +50,8 @@ class StockMediaStoreTest {
         stockMediaModel.date = date
         stockMediaModel.url = url
         stockMediaModel.thumbnail = thumbnail
-        stockMediaItem = StockMediaItem(id, name, title, url, date, thumbnail)
+        stockMediaModel.caption = caption
+        stockMediaItem = StockMediaItem(id, name, title, url, date, thumbnail, caption)
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/StockMediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/StockMediaModel.java
@@ -14,6 +14,7 @@ public class StockMediaModel extends Payload<BaseNetworkError> {
     private String mType;
     private String mUrl;
     private String mDate;
+    private String mCaption;
 
     private String mLargeThumbnail;
     private String mMediumThumbnail;
@@ -93,6 +94,14 @@ public class StockMediaModel extends Payload<BaseNetworkError> {
 
     public void setDate(String date) {
         this.mDate = date;
+    }
+
+    public String getCaption() {
+        return mCaption;
+    }
+
+    public void setCaption(String caption) {
+        this.mCaption = caption;
     }
 
     public String getLargeThumbnail() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/SearchStockMediaResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/SearchStockMediaResponse.kt
@@ -6,10 +6,14 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParseException
 import com.google.gson.annotations.JsonAdapter
+import org.json.JSONException
+import org.json.JSONObject
 import org.wordpress.android.fluxc.model.StockMediaModel
 import org.wordpress.android.fluxc.network.utils.getInt
 import org.wordpress.android.fluxc.network.utils.getJsonObject
 import org.wordpress.android.fluxc.network.utils.getString
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.MEDIA
 import java.lang.reflect.Type
 
 /**
@@ -64,6 +68,17 @@ private class SearchStockMediaDeserializer : JsonDeserializer<SearchStockMediaRe
             media.mediumThumbnail = jsonThumbnails.getString("medium")
             media.postThumbnail = jsonThumbnails.getString("post_thumbnail")
         }
+
+        /**
+         * Guid property needs to be manually parsed to object because comes in String format
+         */
+        try {
+            val jsonGuid = JSONObject(media.guid)
+            media.caption = jsonGuid.getString("caption")
+        } catch (e: JSONException) {
+            AppLog.e(MEDIA, e)
+        }
+
         return media
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/SearchStockMediaResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/SearchStockMediaResponse.kt
@@ -70,7 +70,7 @@ private class SearchStockMediaDeserializer : JsonDeserializer<SearchStockMediaRe
         }
 
         /**
-         * Guid property needs to be manually parsed to object because comes in String format
+         * The GUID property needs to be manually parsed to a JSON object because it was originally deserialized as a string property.
          */
         try {
             val jsonGuid = JSONObject(media.guid)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.kt
@@ -94,6 +94,7 @@ class StockMediaRestClient
             json.addProperty("url", StringUtils.notNullStr(stockMedia.url))
             json.addProperty("name", StringUtils.notNullStr(stockMedia.name))
             json.addProperty("title", StringUtils.notNullStr(stockMedia.title))
+            json.addProperty("caption", StringUtils.notNullStr(stockMedia.caption))
             jsonBody.add(json.toString())
         }
         val body: MutableMap<String, Any> = HashMap()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StockMediaSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StockMediaSqlUtils.kt
@@ -31,7 +31,8 @@ class StockMediaSqlUtils
                                 title = it.title,
                                 url = it.url,
                                 date = it.date,
-                                thumbnail = it.thumbnail
+                                thumbnail = it.thumbnail,
+                                caption = it.caption
                         )
                     }
             ).execute()
@@ -49,7 +50,8 @@ class StockMediaSqlUtils
                     it.title,
                     it.url,
                     it.date,
-                    it.thumbnail
+                    it.thumbnail,
+                    it.caption
             )
         }
     }
@@ -94,9 +96,10 @@ class StockMediaSqlUtils
         @Column var title: String?,
         @Column var url: String?,
         @Column var date: String?,
-        @Column var thumbnail: String?
+        @Column var thumbnail: String?,
+        @Column var caption: String?
     ) : Identifiable {
-        constructor() : this(-1, null, null, null, null, null, null)
+        constructor() : this(-1, null, null, null, null, null, null, null)
 
         override fun setId(id: Int) {
             this.mId = id

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 132
+        return 133
     }
 
     override fun getDbName(): String {
@@ -1450,6 +1450,9 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "RESTORE_ID INTEGER,REWIND_STATUS TEXT,REWIND_PROGRESS INTEGER," +
                                     "REWIND_REASON TEXT,MESSAGE TEXT,CURRENT_ENTRY TEXT)"
                     )
+                }
+                132 -> migrate(version) {
+                    db.execSQL("ALTER TABLE StockMedia ADD CAPTION TEXT")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaItem.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaItem.kt
@@ -6,5 +6,6 @@ data class StockMediaItem(
     val title: String? = null,
     val url: String? = null,
     val date: String? = null,
-    val thumbnail: String? = null
+    val thumbnail: String? = null,
+    val caption: String? = null
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.kt
@@ -115,14 +115,7 @@ class StockMediaStore
                         loadedPage,
                         if (payload.canLoadMore) payload.nextPage else null,
                         payload.mediaList.map {
-                            var caption: String? = null
-                            try {
-                                val jsonObject = JSONObject(it.guid)
-                                caption = jsonObject.getString("caption")
-                            } catch (e: JSONException) {
-                                AppLog.e(MEDIA, e)
-                            }
-                            StockMediaItem(it.id, it.name, it.title, it.url, it.date, it.thumbnail, caption)
+                            StockMediaItem(it.id, it.name, it.title, it.url, it.date, it.thumbnail, it.caption)
                         })
                 OnStockMediaListFetched(payload.mediaList, filter, payload.nextPage, payload.canLoadMore)
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.store
 
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.ASYNC
+import org.json.JSONException
+import org.json.JSONObject
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.StockMediaAction
@@ -113,7 +115,15 @@ class StockMediaStore
                         loadedPage,
                         if (payload.canLoadMore) payload.nextPage else null,
                         payload.mediaList.map {
-                            StockMediaItem(it.id, it.name, it.title, it.url, it.date, it.thumbnail)
+                            var caption: String? = null;
+                            try {
+                                val jsonObject = JSONObject(it.guid);
+                                caption = jsonObject.getString("caption");
+                                
+                            } catch (e: JSONException) {
+                                AppLog.e(MEDIA, e);
+                            }
+                            StockMediaItem(it.id, it.name, it.title, it.url, it.date, it.thumbnail, caption)
                         })
                 OnStockMediaListFetched(payload.mediaList, filter, payload.nextPage, payload.canLoadMore)
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.kt
@@ -115,13 +115,12 @@ class StockMediaStore
                         loadedPage,
                         if (payload.canLoadMore) payload.nextPage else null,
                         payload.mediaList.map {
-                            var caption: String? = null;
+                            var caption: String? = null
                             try {
-                                val jsonObject = JSONObject(it.guid);
-                                caption = jsonObject.getString("caption");
-                                
+                                val jsonObject = JSONObject(it.guid)
+                                caption = jsonObject.getString("caption")
                             } catch (e: JSONException) {
-                                AppLog.e(MEDIA, e);
+                                AppLog.e(MEDIA, e)
                             }
                             StockMediaItem(it.id, it.name, it.title, it.url, it.date, it.thumbnail, caption)
                         })

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaStore.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.fluxc.store
 
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.ASYNC
-import org.json.JSONException
-import org.json.JSONObject
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.StockMediaAction

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaUploadItem.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StockMediaUploadItem.kt
@@ -3,5 +3,6 @@ package org.wordpress.android.fluxc.store
 data class StockMediaUploadItem(
     val name: String? = null,
     val title: String? = null,
-    val url: String? = null
+    val url: String? = null,
+    val caption: String? = null
 )


### PR DESCRIPTION
**Issue**: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1609

### Related PRs
- [`gutenberg-mobile`](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3046)
- [`gutenberg`](https://github.com/WordPress/gutenberg/pull/28469)
- [`WordPress-iOS`](https://github.com/wordpress-mobile/WordPress-iOS/pull/15674)
- [`WordPress-Android`](https://github.com/wordpress-mobile/WordPress-Android/pull/13829)

## Description

Parse `caption` field from the response of Stock media search requests and add it to the Stock media model and item. This field is now also included in the payload when a photo is uploaded.

## Test
The changes can be tested in two different flows:

<details><summary><strong>Media screen</strong></summary>

### Steps

1. Go to a site.
2. Tap on `Media` button.
3. Tap on `+` button.
4. Tap on `Choose from Free Photo Library`
5. Search any term.
6. Tap one or multiple photos.
7. Tap on ✔️ button.
8. Wait for the items to be uploaded.
9. [Back in the Media screen] Tap on any of the recently uploaded photos.
10. Check that `Caption` field has value.

_Note: It's possible that in some cases the item doesn't have a caption value with the credit/attribution of the photo. In this case try another one._

</details>

<details><summary><strong>Image block</strong></summary>

### Steps

1. Go to a site.
2. Open a post/page.
3. Tap on `+` button.
4. Tap on `Image` block.
5. Tap on `ADD IMAGE`.
6. Tap on `Choose from Free Photo Library`
7. Search any term.
8. Tap one photo.
9. Tap on ✔️ button.
10. Wait for the item to be uploaded.
11. Check that below the photo the caption field has a value.

_Note: It's possible that in some cases the item doesn't have a caption value with the credit/attribution of the photo. In this case try another one._

</details>

<hr>

**Merge Instructions:**
Only merger after [WordPress Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13829) has been tested and approved.