### PR TITLE
Modify Quick Start Steps to support quick start steps

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/quickstart/QuickStartStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/quickstart/QuickStartStoreTest.kt
@@ -13,12 +13,13 @@ import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.fluxc.persistence.QuickStartSqlUtils
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHOOSE_THEME
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CREATE_SITE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.FOLLOW_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.PUBLISH_POST
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.REVIEW_PAGES
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
@@ -47,7 +48,6 @@ class QuickStartStoreTest {
     @Test
     fun orderOfDoneTasks() = test {
         // marking tasks as done in random order
-        quickStartStore.setDoneTask(testLocalSiteId, CHOOSE_THEME, true)
         quickStartStore.setDoneTask(testLocalSiteId, EXPLORE_PLANS, true)
         quickStartStore.setDoneTask(testLocalSiteId, VIEW_SITE, true)
         quickStartStore.setDoneTask(testLocalSiteId, FOLLOW_SITE, true)
@@ -55,10 +55,9 @@ class QuickStartStoreTest {
 
         // making sure done tasks are retrieved in a correct order
         val completedCustomizeTasks = quickStartStore.getCompletedTasksByType(testLocalSiteId, CUSTOMIZE)
-        assertEquals(3, completedCustomizeTasks.size)
+        assertEquals(2, completedCustomizeTasks.size)
         assertEquals(CREATE_SITE, completedCustomizeTasks[0])
-        assertEquals(CHOOSE_THEME, completedCustomizeTasks[1])
-        assertEquals(VIEW_SITE, completedCustomizeTasks[2])
+        assertEquals(VIEW_SITE, completedCustomizeTasks[1])
 
         val completedGrowTasks = quickStartStore.getCompletedTasksByType(testLocalSiteId, GROW)
         assertEquals(2, completedGrowTasks.size)
@@ -67,9 +66,11 @@ class QuickStartStoreTest {
 
         // making sure undone tasks are retrieved in a correct order
         val uncompletedCustomizeTasks = quickStartStore.getUncompletedTasksByType(testLocalSiteId, CUSTOMIZE)
-        assertEquals(2, uncompletedCustomizeTasks.size)
+        assertEquals(4, uncompletedCustomizeTasks.size)
         assertEquals(UPDATE_SITE_TITLE, uncompletedCustomizeTasks[0])
         assertEquals(UPLOAD_SITE_ICON, uncompletedCustomizeTasks[1])
+        assertEquals(EDIT_HOMEPAGE, uncompletedCustomizeTasks[2])
+        assertEquals(REVIEW_PAGES, uncompletedCustomizeTasks[3])
 
         val uncompletedGrowTasks = quickStartStore.getUncompletedTasksByType(testLocalSiteId, GROW)
         assertEquals(3, uncompletedGrowTasks.size)
@@ -81,6 +82,7 @@ class QuickStartStoreTest {
     @Test
     fun orderOfShownTasks() = test {
         // marking tasks as shown in random order
+        quickStartStore.setShownTask(testLocalSiteId, REVIEW_PAGES, true)
         quickStartStore.setShownTask(testLocalSiteId, UPLOAD_SITE_ICON, true)
         quickStartStore.setShownTask(testLocalSiteId, CHECK_STATS, true)
         quickStartStore.setShownTask(testLocalSiteId, ENABLE_POST_SHARING, true)
@@ -88,8 +90,9 @@ class QuickStartStoreTest {
 
         // making sure shown tasks are retrieved in a correct order
         val shownCustomizeTasks = quickStartStore.getShownTasksByType(testLocalSiteId, CUSTOMIZE)
-        assertEquals(1, shownCustomizeTasks.size)
+        assertEquals(2, shownCustomizeTasks.size)
         assertEquals(UPLOAD_SITE_ICON, shownCustomizeTasks[0])
+        assertEquals(REVIEW_PAGES, shownCustomizeTasks[1])
 
         val shownGrowTasks = quickStartStore.getShownTasksByType(testLocalSiteId, GROW)
         assertEquals(3, shownGrowTasks.size)
@@ -102,7 +105,7 @@ class QuickStartStoreTest {
         assertEquals(4, unshownCustomizeTasks.size)
         assertEquals(CREATE_SITE, unshownCustomizeTasks[0])
         assertEquals(UPDATE_SITE_TITLE, unshownCustomizeTasks[1])
-        assertEquals(CHOOSE_THEME, unshownCustomizeTasks[2])
+        assertEquals(EDIT_HOMEPAGE, unshownCustomizeTasks[2])
         assertEquals(VIEW_SITE, unshownCustomizeTasks[3])
 
         val unshownGrowTasks = quickStartStore.getUnshownTasksByType(testLocalSiteId, GROW)

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/QuickStartSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/QuickStartSqlUtilsTest.kt
@@ -72,10 +72,10 @@ class QuickStartSqlUtilsTest {
     fun testShownCount() {
         assertEquals(0, quickStartSqlUtils.getShownCount(testLocalSiteId))
 
-        quickStartSqlUtils.setShownTask(testLocalSiteId, QuickStartTask.CHOOSE_THEME, true)
+        quickStartSqlUtils.setShownTask(testLocalSiteId, QuickStartTask.UNKNOWN, true)
         assertEquals(1, quickStartSqlUtils.getShownCount(testLocalSiteId))
 
-        quickStartSqlUtils.setShownTask(testLocalSiteId, QuickStartTask.CHOOSE_THEME, false)
+        quickStartSqlUtils.setShownTask(testLocalSiteId, QuickStartTask.UNKNOWN, false)
         assertEquals(0, quickStartSqlUtils.getShownCount(testLocalSiteId))
     }
 
@@ -103,13 +103,13 @@ class QuickStartSqlUtilsTest {
 
     @Test
     fun testTaskDoneStatus() {
-        assertFalse(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.CUSTOMIZE_SITE))
+        assertFalse(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.UNKNOWN))
 
-        quickStartSqlUtils.setDoneTask(testLocalSiteId, QuickStartTask.CUSTOMIZE_SITE, true)
-        assertTrue(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.CUSTOMIZE_SITE))
+        quickStartSqlUtils.setDoneTask(testLocalSiteId, QuickStartTask.UNKNOWN, true)
+        assertTrue(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.UNKNOWN))
 
-        quickStartSqlUtils.setDoneTask(testLocalSiteId, QuickStartTask.CUSTOMIZE_SITE, false)
-        assertFalse(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.CUSTOMIZE_SITE))
+        quickStartSqlUtils.setDoneTask(testLocalSiteId, QuickStartTask.UNKNOWN, false)
+        assertFalse(quickStartSqlUtils.hasDoneTask(testLocalSiteId, QuickStartTask.UNKNOWN))
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.persistence.QuickStartSqlUtils
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.UNKNOWN
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,15 +19,13 @@ constructor(private val quickStartSqlUtils: QuickStartSqlUtils, dispatcher: Disp
         val taskType: QuickStartTaskType,
         val order: Int
     ) {
+        UNKNOWN("unknown", QuickStartTaskType.UNKNOWN, 0),
         CREATE_SITE("create_site", CUSTOMIZE, 0),
         UPDATE_SITE_TITLE("update_site_title", CUSTOMIZE, 1),
         UPLOAD_SITE_ICON("upload_site_icon", CUSTOMIZE, 2),
-        CHOOSE_THEME("choose_theme", CUSTOMIZE, 3),
-        // Disabeling until a long term plan is made https://github.com/wordpress-mobile/WordPress-Android/issues/13713
-        CUSTOMIZE_SITE("customize_site", UNKNOWN, 0),
-        // Disabeling until a long term plan is made https://github.com/wordpress-mobile/WordPress-Android/issues/13713
-        CREATE_NEW_PAGE("create_new_page", UNKNOWN, 1),
-        VIEW_SITE("view_site", CUSTOMIZE, 4),
+        EDIT_HOMEPAGE("edit_homepage", CUSTOMIZE, 3),
+        REVIEW_PAGES("review_pages", CUSTOMIZE, 4),
+        VIEW_SITE("view_site", CUSTOMIZE, 5),
         ENABLE_POST_SHARING("enable_post_sharing", GROW, 7),
         PUBLISH_POST("publish_post", GROW, 8),
         FOLLOW_SITE("follow_site", GROW, 9),
@@ -47,7 +44,7 @@ constructor(private val quickStartSqlUtils: QuickStartSqlUtils, dispatcher: Disp
                     }
                 }
 
-                return CHOOSE_THEME
+                return UNKNOWN
             }
 
             fun getTasksByType(taskType: QuickStartTaskType): List<QuickStartTask> {


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-Android/issues/13832
**Can be tested with:** https://github.com/wordpress-mobile/WordPress-Android/pull/13855

<details>
<summary>Test script from parent PR:</summary>

## To test:

### Setup steps
1. Create a site. 
2. Select "Yes, Help Me"

### Removed steps
3. (After the setup if needed) Open the Customize Quick Start Tour
4. **Expect:** to **NOT** see "Browse themes", "Customize your site", or "Create a new page" in the list or in "Complete"

### Edit your homepage
3. (After the setup if needed) Open the Customize Quick Start Tour
4. Select "Edit your homepage"
5. **Expect:** 
    - Quick Start to dismiss.
    - The table to scroll to "Site Pages" and present a notice. 
    - Show a tap indicator on "Site Pages" row
6. Tap the highlighted row.
7. **Expect:** 
    - Page List to be displayed
    - A Notice for selecting the homepage should be displayed 
       - backing out should dismiss the notice
    - Show a tap indicator on the Homepage cell
        - 📓 I didn't add logic to scroll to the Homepage as it's highly likely to be on the screen
8. Tap the highlighted row.
9. **Expect:** To see the Gutenberg Editor
10. Backout to the Site Detail screen
11. **Expect:** 
    - To be prompted to start the next step. 
    - To have the "Edit your homepage" marked as complete

### Restart Edit your homepage
3. (After the setup if needed) Open the Customize Quick Start Tour
4. Complete the Homepage Tour
5. Open the Customize Quick Start Tour
4. Select "Edit your homepage" in the "Completed" section
5. Expect to be able to rerun through the Edit your homepage tour

### Complete Edit your homepage "naturally"
3. (After the setup if needed) Open the Customize Quick Start Tour and made sure Edit your homepage isn't done
     - If it is completed, setup a new site. 
4. Return to site details
5. Navigate to Pages
    - This will also complete Review Pages
6. Select your homepage
7. Return to the Customize Quick Start Tour
    - You should not see a prompt to start the next step of quick start
8. **Expect** "Edit your homepage" to be in the "Completed" section

📓 This is different than the way iOS handles quick start currently. There will be a PR to align these flows

### Review site pages
3. (After the setup if needed) Open the Customize Quick Start Tour
4. Select "Review site pages"
5. **Expect:** 
    - Quick Start to dismiss.
    - The table to scroll to "Site Pages" and present a notice. 
    - Show a tap indicator on "Site Pages" row
6. Tap the highlighted row.
7. **Expect:** 
8. Backout to the Site Detail screen
9. **Expect:** 
    - To be prompted to start the next step. 
    - To have the "Review site pages" marked as complete

### Restart Review site pages
3. (After the setup if needed) Open the Customize Quick Start Tour
4. Complete the Homepage Tour
5. Open the Customize Quick Start Tour
4. Select "Review site pages" in the "Completed" section
5. Expect to be able to rerun through the Review site pages tour

### Complete Review site pages "naturally"
3. (After the setup if needed) Open the Customize Quick Start Tour and made sure Review site pages isn't done
     - If it is completed, setup a new site. 
4. Return to site details
5. Navigate to Pages
6. Return to the Customize Quick Start Tour
    - You should not see a prompt to start the next step of quick start
7. **Expect** "Edit your homepage" to be in the "Completed" section

📓 This is different than the way iOS handles quick start currently. There will be a PR to align these flows
 
### Full Tour
1. Select Create Your Site 
2. Expect to be able to walk through the full tour

</details>

<details>
<summary>Sample run</summary>
<kbd><a href="https://user-images.githubusercontent.com/3384451/105506073-a69c2480-5c97-11eb-8a3f-1ecfcd06cbd2.gif"><img width="300" src="https://user-images.githubusercontent.com/3384451/105506073-a69c2480-5c97-11eb-8a3f-1ecfcd06cbd2.gif"/></a></kbd>
</details>
