### PR TITLE
Added methods to fetch product count + virtual product count for an order

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -155,7 +155,7 @@ class ProductSqlUtilsTest {
         assertEquals(remoteProductIds.size, storedProductCountForSite1)
 
         // verify that only 2 of the products are virtual
-        assertEquals(2, ProductSqlUtils.getVirtualProductCountForOrder(site1, remoteProductIds))
+        assertEquals(2, ProductSqlUtils.getVirtualProductCountByRemoteIds(site1, remoteProductIds))
 
         // insert products for another site
         val site2 = SiteModel().apply { id = 10 }
@@ -172,7 +172,7 @@ class ProductSqlUtilsTest {
         assertEquals(remoteProductIds2.size, storedProductCountForSite2)
 
         // verify that all of the products are virtual
-        assertEquals(3, ProductSqlUtils.getVirtualProductCountForOrder(site2, remoteProductIds2))
+        assertEquals(3, ProductSqlUtils.getVirtualProductCountByRemoteIds(site2, remoteProductIds2))
 
         // insert products for another site
         val site3 = SiteModel().apply { id = 11 }
@@ -189,7 +189,7 @@ class ProductSqlUtilsTest {
         assertEquals(remoteProductIds3.size, storedProductCountForSite3)
 
         // verify that none of the products are virtual
-        assertEquals(0, ProductSqlUtils.getVirtualProductCountForOrder(site3, remoteProductIds3))
+        assertEquals(0, ProductSqlUtils.getVirtualProductCountByRemoteIds(site3, remoteProductIds3))
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -138,6 +138,61 @@ class ProductSqlUtilsTest {
     }
 
     @Test
+    fun testGetVirtualProductsForSite() {
+        // insert products for one site
+        val site1 = SiteModel().apply { id = 2 }
+        val products = ArrayList<WCProductModel>().apply {
+            this.add(ProductTestUtils.generateSampleProduct(40, siteId = site1.id, virtual = true))
+            this.add(ProductTestUtils.generateSampleProduct(41, siteId = site1.id, virtual = false))
+            this.add(ProductTestUtils.generateSampleProduct(42, siteId = site1.id, virtual = true))
+        }
+
+        ProductSqlUtils.insertOrUpdateProducts(products)
+
+        // verify that the product list exists locally
+        val remoteProductIds = products.map { it.remoteProductId }.toList()
+        val storedProductCountForSite1 = ProductSqlUtils.getProductCountByRemoteIds(site1, remoteProductIds)
+        assertEquals(remoteProductIds.size, storedProductCountForSite1)
+
+        // verify that only 2 of the products are virtual
+        assertEquals(2, ProductSqlUtils.getVirtualProductCountForOrder(site1, remoteProductIds))
+
+        // insert products for another site
+        val site2 = SiteModel().apply { id = 10 }
+        val products2 = ArrayList<WCProductModel>().apply {
+            this.add(ProductTestUtils.generateSampleProduct(40, siteId = site2.id, virtual = true))
+            this.add(ProductTestUtils.generateSampleProduct(41, siteId = site2.id, virtual = true))
+            this.add(ProductTestUtils.generateSampleProduct(42, siteId = site2.id, virtual = true))
+        }
+        ProductSqlUtils.insertOrUpdateProducts(products2)
+
+        // verify that it is stored
+        val remoteProductIds2 = products2.map { it.remoteProductId }.toList()
+        val storedProductCountForSite2 = ProductSqlUtils.getProductCountByRemoteIds(site2, remoteProductIds2)
+        assertEquals(remoteProductIds2.size, storedProductCountForSite2)
+
+        // verify that all of the products are virtual
+        assertEquals(3, ProductSqlUtils.getVirtualProductCountForOrder(site2, remoteProductIds2))
+
+        // insert products for another site
+        val site3 = SiteModel().apply { id = 11 }
+        val products3 = ArrayList<WCProductModel>().apply {
+            this.add(ProductTestUtils.generateSampleProduct(40, siteId = site3.id))
+            this.add(ProductTestUtils.generateSampleProduct(41, siteId = site3.id))
+            this.add(ProductTestUtils.generateSampleProduct(42, siteId = site3.id))
+        }
+        ProductSqlUtils.insertOrUpdateProducts(products3)
+
+        // verify that it is stored
+        val remoteProductIds3 = products3.map { it.remoteProductId }.toList()
+        val storedProductCountForSite3 = ProductSqlUtils.getProductCountByRemoteIds(site3, remoteProductIds3)
+        assertEquals(remoteProductIds3.size, storedProductCountForSite3)
+
+        // verify that none of the products are virtual
+        assertEquals(0, ProductSqlUtils.getVirtualProductCountForOrder(site3, remoteProductIds3))
+    }
+
+    @Test
     fun testDeleteProduct() {
         val remoteProductId = 40L
         val productModel = ProductTestUtils.generateSampleProduct(remoteProductId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -105,7 +105,7 @@ object ProductSqlUtils {
                 .count().toInt()
     }
 
-    fun getVirtualProductCountForOrder(site: SiteModel, remoteProductIds: List<Long>): Int {
+    fun getVirtualProductCountByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): Int {
         return WellSql.select(WCProductModel::class.java)
                 .where().beginGroup()
                 .isIn(WCProductModelTable.REMOTE_PRODUCT_ID, remoteProductIds)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -96,6 +96,25 @@ object ProductSqlUtils {
                 .asModel
     }
 
+    fun getProductCountByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): Int {
+        return WellSql.select(WCProductModel::class.java)
+                .where().beginGroup()
+                .isIn(WCProductModelTable.REMOTE_PRODUCT_ID, remoteProductIds)
+                .equals(WCProductModelTable.LOCAL_SITE_ID, site.id)
+                .endGroup().endWhere()
+                .count().toInt()
+    }
+
+    fun getVirtualProductCountForOrder(site: SiteModel, remoteProductIds: List<Long>): Int {
+        return WellSql.select(WCProductModel::class.java)
+                .where().beginGroup()
+                .isIn(WCProductModelTable.REMOTE_PRODUCT_ID, remoteProductIds)
+                .equals(WCProductModelTable.LOCAL_SITE_ID, site.id)
+                .equals(WCProductModelTable.VIRTUAL, true)
+                .endGroup().endWhere()
+                .count().toInt()
+    }
+
     fun getProductsByFilterOptions(
         site: SiteModel,
         filterOptions: Map<ProductFilterOption, String>,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -682,6 +682,20 @@ class WCProductStore @Inject constructor(
             ProductSqlUtils.getProductReviewsForProductAndSiteId(localSiteId, remoteProductId)
 
     /**
+     * returns the count of products for the given [SiteModel] and [remoteProductIds]
+     * if it exists in the database
+     */
+    fun getProductCountByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): Int =
+            ProductSqlUtils.getProductCountByRemoteIds(site, remoteProductIds)
+
+    /**
+     * returns the count of virtual products for the given [SiteModel] and [remoteProductIds]
+     * if it exists in the database
+     */
+    fun hasVirtualProductsOnly(site: SiteModel, remoteProductIds: List<Long>): Int =
+            ProductSqlUtils.getVirtualProductCountForOrder(site, remoteProductIds)
+
+    /**
      * returns a list of tags for a specific site in the database
      */
     fun getTagsForSite(site: SiteModel): List<WCProductTagModel> =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -692,8 +692,8 @@ class WCProductStore @Inject constructor(
      * returns the count of virtual products for the given [SiteModel] and [remoteProductIds]
      * if it exists in the database
      */
-    fun hasVirtualProductsOnly(site: SiteModel, remoteProductIds: List<Long>): Int =
-            ProductSqlUtils.getVirtualProductCountForOrder(site, remoteProductIds)
+    fun getVirtualProductCountByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): Int =
+            ProductSqlUtils.getVirtualProductCountByRemoteIds(site, remoteProductIds)
 
     /**
      * returns a list of tags for a specific site in the database


### PR DESCRIPTION
This PR adds new methods to `ProductSqlUtils` to fetch the products count and the virtual products count for an order. We seem to be getting a few `SqliteBlobTooBigException` crashes when fetching `getProductsByRemoteIds` method in `WCProductStore`.

There are 2 places in the Woo app where this method is called:
- When trying to find if there are any virtual products for the order.
- When trying to find the total product count available locally for the order. 

Both of these scenarios require only the product count and not the entire product model list. So this PR adds methods to fetch just the product count for an order.

### To test
Run `ProductSqlUtilsTest.kt`.