### PR TITLE
Added logic to parse products response as json object as well as json array

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -210,6 +210,13 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals("10,11,12", products[1].getUpsellProductIdList().joinToString(","))
             assertEquals("10,11,12", products[1].getCrossSellProductIdList().joinToString(","))
             assertEquals(3, products[1].getNumVariations())
+
+            // verify that response as null in product response is handled correctly
+            assertEquals(0, products[2].getGroupedProductIdList().size)
+            assertEquals(0, products[2].getUpsellProductIdList().size)
+            assertEquals(0, products[2].getCrossSellProductIdList().size)
+            assertEquals(0, products[2].getNumVariations())
+            assertEquals(0, products[2].getCategoryList().size)
         }
 
         // delete all products then insert these into the store

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -44,7 +44,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPay
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 import kotlin.properties.Delegates.notNull
 
@@ -199,6 +198,18 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertNotNull(products)
             assertEquals(products.size, 3)
             assertNull(products[0].getFirstImageUrl())
+
+            // verify that response as json array in product response is handled correctly
+            assertEquals("10,11,12", products[0].getGroupedProductIdList().joinToString(","))
+            assertEquals("10,11,12", products[0].getUpsellProductIdList().joinToString(","))
+            assertEquals("10,11,12", products[0].getCrossSellProductIdList().joinToString(","))
+            assertEquals(3, products[0].getNumVariations())
+
+            // verify that response as json object in product response is handled correctly
+            assertEquals("10,11,12", products[1].getGroupedProductIdList().joinToString(","))
+            assertEquals("10,11,12", products[1].getUpsellProductIdList().joinToString(","))
+            assertEquals("10,11,12", products[1].getCrossSellProductIdList().joinToString(","))
+            assertEquals(3, products[1].getNumVariations())
         }
 
         // delete all products then insert these into the store
@@ -658,7 +669,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         productRestClient.updateVariation(siteModel, testVariation, updateVariation)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         assertEquals(WCProductAction.UPDATED_VARIATION, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteUpdateVariationPayload
@@ -680,7 +691,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         productRestClient.updateVariation(siteModel, testVariation, updateVariation)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         assertEquals(WCProductAction.UPDATED_VARIATION, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteUpdateVariationPayload

--- a/example/src/androidTest/resources/wc-fetch-products-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-products-response-success.json
@@ -337,10 +337,8 @@
       "backorders_allowed": true,
       "button_text": "",
       "catalog_visibility": "visible",
-      "categories": [
-      ],
-      "cross_sell_ids": [
-      ],
+      "categories": null,
+      "cross_sell_ids": null,
       "date_created": "2019-02-21T06:40:58",
       "date_created_gmt": "2019-02-21T11:40:58",
       "date_modified": "2019-04-26T21:50:47",
@@ -364,8 +362,7 @@
       ],
       "external_url": "",
       "featured": true,
-      "grouped_products": [
-      ],
+      "grouped_products": null,
       "id": 37,
       "images": [
         {
@@ -420,8 +417,7 @@
       "purchase_note": "",
       "rating_count": 0,
       "regular_price": "19.99",
-      "related_ids": [
-      ],
+      "related_ids": null,
       "reviews_allowed": true,
       "sale_price": "",
       "shipping_class": "booklet",
@@ -441,10 +437,8 @@
       "tax_status": "taxable",
       "total_sales": 7,
       "type": "simple",
-      "upsell_ids": [
-      ],
-      "variations": [
-      ],
+      "upsell_ids": null,
+      "variations": null,
       "virtual": false,
       "weight": "12.30"
     }

--- a/example/src/androidTest/resources/wc-fetch-products-response-success.json
+++ b/example/src/androidTest/resources/wc-fetch-products-response-success.json
@@ -24,6 +24,7 @@
       "categories": [
       ],
       "cross_sell_ids": [
+        10, 11, 12
       ],
       "date_created": "2019-04-09T15:36:08",
       "date_created_gmt": "2019-04-09T20:36:08",
@@ -54,6 +55,7 @@
       "external_url": "",
       "featured": false,
       "grouped_products": [
+        10, 11, 12
       ],
       "id": 202,
       "images": [],
@@ -79,6 +81,7 @@
       "rating_count": 1,
       "regular_price": "0.00",
       "related_ids": [
+        10, 11, 12
       ],
       "reviews_allowed": true,
       "sale_price": "",
@@ -100,8 +103,10 @@
       "total_sales": 2,
       "type": "simple",
       "upsell_ids": [
+        10, 11, 12
       ],
       "variations": [
+        10, 11, 12
       ],
       "virtual": true,
       "weight": ""
@@ -167,8 +172,11 @@
           "slug": "test3"
         }
       ],
-      "cross_sell_ids": [
-      ],
+      "cross_sell_ids": {
+        "1": 10,
+        "2": 11,
+        "3": 12
+      },
       "date_created": "2019-02-26T11:34:43",
       "date_created_gmt": "2019-02-26T16:34:43",
       "date_modified": "2019-08-12T13:19:10",
@@ -192,8 +200,11 @@
       ],
       "external_url": "",
       "featured": false,
-      "grouped_products": [
-      ],
+      "grouped_products": {
+        "1": 10,
+        "2": 11,
+        "3": 12
+      },
       "id": 152,
       "images": [
         {
@@ -253,8 +264,11 @@
       "purchase_note": "<p>This is the purchase note. It is not the slightest bit interesting. You are wasting your life by bothering to read this.</p>",
       "rating_count": 46,
       "regular_price": "",
-      "related_ids": [
-      ],
+      "related_ids": {
+        "1": 10,
+        "2": 11,
+        "3": 12
+      },
       "reviews_allowed": true,
       "sale_price": "",
       "shipping_class": "booklet",
@@ -289,12 +303,16 @@
       "tax_status": "taxable",
       "total_sales": 12,
       "type": "variable",
-      "upsell_ids": [
-      ],
-      "variations": [
-        192,
-        193
-      ],
+      "upsell_ids": {
+        "1": 10,
+        "2": 11,
+        "3": 12
+      },
+      "variations": {
+        "1": 10,
+        "2": 11,
+        "3": 12
+      },
       "virtual": false,
       "weight": "4"
     },

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -257,13 +257,19 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         try {
             if (jsonString.isNotEmpty()) {
                 val jsonElement = Gson().fromJson(jsonString, JsonElement::class.java)
-                if (jsonElement.isJsonArray) {
-                    jsonElement.asJsonArray.forEach { jsonArray ->
-                        jsonArray.asLong.let { productIds.add(it) }
+                when {
+                    jsonElement.isJsonNull -> {
+                        return emptyList()
                     }
-                } else if (jsonElement.isJsonObject) {
-                    jsonElement.asJsonObject.entrySet().forEach {
-                        productIds.add(it.value.asLong)
+                    jsonElement.isJsonArray -> {
+                        jsonElement.asJsonArray.forEach { jsonArray ->
+                            jsonArray.asLong.let { productIds.add(it) }
+                        }
+                    }
+                    jsonElement.isJsonObject -> {
+                        jsonElement.asJsonObject.entrySet().forEach {
+                            productIds.add(it.value.asLong)
+                        }
                     }
                 }
             }
@@ -306,15 +312,18 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         val triplets = ArrayList<ProductTriplet>()
         try {
             if (jsonStr.isNotEmpty()) {
-                Gson().fromJson<JsonElement>(jsonStr, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
-                    with(jsonElement.asJsonObject) {
-                        triplets.add(
-                                ProductTriplet(
-                                        id = this.getLong("id"),
-                                        name = this.getString("name") ?: "",
-                                        slug = this.getString("slug") ?: ""
-                                )
-                        )
+                val jsonElement = Gson().fromJson<JsonElement>(jsonStr, JsonElement::class.java)
+                if (jsonElement.isJsonArray) {
+                    jsonElement.asJsonArray.forEach { jsonArray ->
+                        with(jsonArray.asJsonObject) {
+                            triplets.add(
+                                    ProductTriplet(
+                                            id = this.getLong("id"),
+                                            name = this.getString("name") ?: "",
+                                            slug = this.getString("slug") ?: ""
+                                    )
+                            )
+                        }
                     }
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -239,24 +239,32 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return fileList
     }
 
-    fun getNumVariations(): Int {
-        return try {
-            Gson().fromJson(variations, JsonElement::class.java).asJsonArray.size()
-        } catch (e: JsonParseException) {
-            AppLog.e(T.API, e)
-            0
-        }
-    }
-
     /**
      * Returns a list of product IDs from the passed string, assumed to be a JSON array of IDs
      */
-    private fun parseProductIds(jsonString: String): List<Long> {
+    /**
+     * Deserializes the [jsonString] passed to the method. This can include:
+     * variations, groupedProductIds, upsellIds, crossSellIds
+     *
+     * There are some instances where the [jsonString] param can be a JsonArray or a JsonElement.
+     * https://github.com/woocommerce/woocommerce-android/issues/2374
+     *
+     * To address this issue, we check if the [jsonString] param is a JsonArray or a JsonElement
+     * and return a appropriate response, if that's the case.
+     */
+    private fun parseJson(jsonString: String): List<Long> {
         val productIds = ArrayList<Long>()
         try {
             if (jsonString.isNotEmpty()) {
-                Gson().fromJson(jsonString, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
-                    jsonElement.asLong.let { productIds.add(it) }
+                val jsonElement = Gson().fromJson(jsonString, JsonElement::class.java)
+                if (jsonElement.isJsonArray) {
+                    jsonElement.asJsonArray.forEach { jsonArray ->
+                        jsonArray.asLong.let { productIds.add(it) }
+                    }
+                } else if (jsonElement.isJsonObject) {
+                    jsonElement.asJsonObject.entrySet().forEach {
+                        productIds.add(it.value.asLong)
+                    }
                 }
             }
         } catch (e: JsonParseException) {
@@ -265,11 +273,13 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return productIds
     }
 
-    fun getGroupedProductIdList() = parseProductIds(groupedProductIds)
+    fun getNumVariations() = parseJson(variations).size
 
-    fun getUpsellProductIdList() = parseProductIds(upsellIds)
+    fun getGroupedProductIdList() = parseJson(groupedProductIds)
 
-    fun getCrossSellProductIdList() = parseProductIds(crossSellIds)
+    fun getUpsellProductIdList() = parseJson(upsellIds)
+
+    fun getCrossSellProductIdList() = parseJson(crossSellIds)
 
     fun getCategoryList() = getTriplets(categories)
 


### PR DESCRIPTION
There are a bunch of crashes in the Woo app when parsing the products response. This is related to woocommerce/woocommerce-android#2374. There are a couple of different crashes happening when parsing:
- product categories: the app is expecting a json array but the response returned is null.
- cross sell ids: the app is expecting a json array but the response is either null or a json object.
- upsell ids: the app is expecting a json array but the response is either null or a json object.
- grouped products: the app is expecting a json array but the response is either null or a json object.
- variations: he app is expecting a json array but the response is either null or a json object.

This could be because there could be some plugins on the merchant's store that might be messing with the API response. This PR handles the above scenarios by ensuring that we can parse the response as a `jsonObject`, `jsonArray` or `jsonNull`.

### To test
- Run `MockedStack_WCProductsTest`.
- Smoke test the GET products feature in the example app to ensure that everything is working correctly. 