### PR TITLE
Only add search parameters when a searchQuery exists

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -71,6 +71,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload
+import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import java.util.HashMap
 import javax.inject.Singleton
 
@@ -180,9 +181,8 @@ class ProductRestClient(
         val responseType = object : TypeToken<List<ProductTagApiResponse>>() {}.type
         val params = mutableMapOf(
                 "per_page" to pageSize.toString(),
-                "offset" to offset.toString(),
-                "search" to (searchQuery ?: "")
-        )
+                "offset" to offset.toString()
+        ).putIfNotEmpty("search" to searchQuery)
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<ProductTagApiResponse>? ->
@@ -347,8 +347,8 @@ class ProductRestClient(
                 "orderby" to orderBy,
                 "order" to sortOrder,
                 "offset" to offset.toString(),
-                "search" to (searchQuery ?: "")
-        )
+        ).putIfNotEmpty("search" to searchQuery)
+
         remoteProductIds?.let { ids ->
             params.put("include", ids.map { it }.joinToString())
         }
@@ -475,9 +475,8 @@ class ProductRestClient(
                 "orderby" to sortType.asOrderByParameter(),
                 "order" to sortType.asSortOrderParameter(),
                 "offset" to offset.toString(),
-                "search" to (searchQuery ?: ""),
                 "include" to productIds.map { it }.joinToString()
-        )
+        ).putIfNotEmpty("search" to searchQuery)
     }
 
     private fun ProductSorting.asOrderByParameter() = when (this) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -346,7 +346,7 @@ class ProductRestClient(
                 "per_page" to pageSize.toString(),
                 "orderby" to orderBy,
                 "order" to sortOrder,
-                "offset" to offset.toString(),
+                "offset" to offset.toString()
         ).putIfNotEmpty("search" to searchQuery)
 
         remoteProductIds?.let { ids ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/MapExt.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/MapExt.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.fluxc.utils
+
+fun <T> MutableMap<T, String>.putIfNotEmpty(pair: Pair<T, String?>) = apply {
+    pair.second?.takeIf { it.isNotEmpty() }
+            ?.let { put(pair.first, it) }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/MapExt.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/MapExt.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.utils
 
-fun <T> MutableMap<T, String>.putIfNotEmpty(pair: Pair<T, String?>) = apply {
-    pair.second?.takeIf { it.isNotEmpty() }
-            ?.let { put(pair.first, it) }
+fun <T> MutableMap<T, String>.putIfNotEmpty(vararg pairs: Pair<T, String?>) = apply {
+    pairs.forEach { pair ->
+        pair.second?.takeIf { it.isNotEmpty() }
+                ?.let { put(pair.first, it) }
+    }
 }


### PR DESCRIPTION
Summary
==========
Fixes https://github.com/woocommerce/woocommerce-android/issues/3470. Some merchants using our app are reporting of ocasional problems loading data from the site, this was caused by an issues between our app and the site where we request data passing the `search` parameter into the URL even when there's no search query to inform, causing some very specific sites to return 

How to Test
==========
Sites affected by this aren't able to load Orders and Products properly so it's pretty easy to reproduce the problem, the hard part is to be able to come up with a Woo Store site with the exact same configuration issue since it still not clear why only some sites behave like this. The main suspicion is plugin related problems.

So in order to be able to properly verify the changes done here, the ideal test scenario would be to make sure using Charles Proxy that the Woo app requests doesn't include the search parameter for each of these operations:

1. Fetch Product list
2. Fetch Top Performers Products stats
3. Fetch Product tags
4. Fetch Order list