### PR TITLE
Adds `type` and `is_beta` parameters in FETCH_BLOCK_LAYOUTS action

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -215,6 +215,15 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @Test
     public void testFetchBlockLayouts() throws InterruptedException {
+        testFetchBlockLayouts(false);
+    }
+
+    @Test
+    public void testFetchBlockLayoutsBeta() throws InterruptedException {
+        testFetchBlockLayouts(true);
+    }
+
+    private void testFetchBlockLayouts(boolean isBeta) throws InterruptedException {
         authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
                 BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         SiteModel firstSite = mSiteStore.getSites().get(0);
@@ -229,7 +238,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mNextEvent = TestEvents.BLOCK_LAYOUTS_FETCHED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchBlockLayoutsAction(
                 new SiteStore.FetchBlockLayoutsPayload(firstSite, supportedBlocks,
-                        828.0f, 2.0f)));
+                        828.0f, 2.0f, isBeta)));
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -236,6 +236,15 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
 
     @Test
     public void testFetchBlockLayouts() throws InterruptedException {
+        testFetchBlockLayouts(false);
+    }
+
+    @Test
+    public void testFetchBlockLayoutsBeta() throws InterruptedException {
+        testFetchBlockLayouts(true);
+    }
+
+    private void testFetchBlockLayouts(boolean isBeta) throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
@@ -251,7 +260,7 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TestEvents.BLOCK_LAYOUTS_FETCHED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchBlockLayoutsAction(
                 new SiteStore.FetchBlockLayoutsPayload(firstSite, supportedBlocks,
-                        828.0f, 2.0f)));
+                        828.0f, 2.0f, isBeta)));
         mCountDownLatch = new CountDownLatch(1);
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -572,23 +572,26 @@ public class SiteRestClient extends BaseWPComRestClient {
     public void fetchWpComBlockLayouts(final SiteModel site,
                                        List<String> supportedBlocks,
                                        Float previewWidth,
-                                       Float scale) {
+                                       Float scale,
+                                       Boolean isBeta) {
         String url = WPCOMV2.sites.site(site.getSiteId()).block_layouts.getUrl();
-        fetchBlockLayouts(site, url, supportedBlocks, previewWidth, scale);
+        fetchBlockLayouts(site, url, supportedBlocks, previewWidth, scale, isBeta);
     }
 
     public void fetchSelfHostedBlockLayouts(final SiteModel site,
                                             List<String> supportedBlocks,
                                             Float previewWidth,
-                                            Float scale) {
+                                            Float scale,
+                                            Boolean isBeta) {
         String url = WPCOMV2.common_block_layouts.getUrl();
-        fetchBlockLayouts(site, url, supportedBlocks, previewWidth, scale);
+        fetchBlockLayouts(site, url, supportedBlocks, previewWidth, scale, isBeta);
     }
 
     private void fetchBlockLayouts(final SiteModel site, String url,
                                    List<String> supportedBlocks,
                                    Float previewWidth,
-                                   Float scale) {
+                                   Float scale,
+                                   Boolean isBeta) {
         Map<String, String> params = new HashMap<>();
 
         if (supportedBlocks != null && !supportedBlocks.isEmpty()) {
@@ -601,6 +604,12 @@ public class SiteRestClient extends BaseWPComRestClient {
 
         if (scale != null) {
             params.put("scale", String.format(Locale.US, "%.1f", scale));
+        }
+
+        params.put("type", "mobile");
+
+        if (isBeta != null) {
+            params.put("is_beta", String.valueOf(isBeta));
         }
 
         final WPComGsonRequest<BlockLayoutsResponse> request = WPComGsonRequest.buildGetRequest(url, params,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -643,7 +643,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 }
                                                                                                );
-        add(request);
+        add(request, false);
     }
 
     //

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.java
@@ -643,7 +643,7 @@ public class SiteRestClient extends BaseWPComRestClient {
                     }
                 }
                                                                                                );
-        add(request, false);
+        add(request);
     }
 
     //

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -161,15 +161,18 @@ public class SiteStore extends Store {
         @Nullable public List<String> supportedBlocks;
         @Nullable public Float previewWidth;
         @Nullable public Float scale;
+        @Nullable public Boolean isBeta;
 
         public FetchBlockLayoutsPayload(@NonNull SiteModel site,
                                         @Nullable List<String> supportedBlocks,
                                         @Nullable Float previewWidth,
-                                        @Nullable Float scale) {
+                                        @Nullable Float scale,
+                                        @Nullable Boolean isBeta) {
             this.site = site;
             this.supportedBlocks = supportedBlocks;
             this.previewWidth = previewWidth;
             this.scale = scale;
+            this.isBeta = isBeta;
         }
     }
 
@@ -1901,10 +1904,11 @@ public class SiteStore extends Store {
     private void fetchBlockLayouts(FetchBlockLayoutsPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mSiteRestClient
-                    .fetchWpComBlockLayouts(payload.site, payload.supportedBlocks, payload.previewWidth, payload.scale);
+                    .fetchWpComBlockLayouts(payload.site, payload.supportedBlocks, payload.previewWidth, payload.scale,
+                            payload.isBeta);
         } else {
             mSiteRestClient.fetchSelfHostedBlockLayouts(payload.site, payload.supportedBlocks, payload.previewWidth,
-                    payload.scale);
+                    payload.scale, payload.isBeta);
         }
     }
 


### PR DESCRIPTION
**Description**
This PR adds `type` and `is_beta` parameters in fetch block layouts call both for WPCom and self hosted site.
This make it so that the api will be able to return type ( mobile or web ) specific page layouts as well as beta versions.

**To test**
This can be tested with https://github.com/wordpress-mobile/WordPress-Android/pull/13905
or by running the `testFetchBlockLayouts()` and `testFetchBlockLayoutsBeta()` tests.

**Context**
This PR clones the [iOS implementation](https://github.com/wordpress-mobile/WordPress-iOS/pull/15678)