### PR TITLE
Support attribute terms

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -57,7 +57,6 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
         update_product_attributes.setOnClickListener(::onUpdateAttributeButtonClicked)
         fetch_product_single_attribute.setOnClickListener(::onFetchAttributeButtonClicked)
         create_term_for_attribute.setOnClickListener(::onCreateAttributeTermButtonClicked)
-        delete_term_for_attribute.setOnClickListener(::onDeleteAttributeTermButtonClicked)
     }
 
     private fun onProductAttributesSelectSiteButtonClicked(view: View) {
@@ -206,38 +205,6 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
         }
     }
 
-    private fun onDeleteAttributeTermButtonClicked(view: View) {
-        try {
-            showSingleLineDialog(
-                    activity,
-                    "Enter the attribute ID you want to remove terms:"
-            ) { attributeIdEditText ->
-                showSingleLineDialog(
-                        activity,
-                        "Enter the term ID you want to delete:"
-                ) { termIdEditText ->
-                    coroutineScope.launch {
-                        takeAsyncRequestWithValidSite {
-                            wcAttributesStore.deleteOptionValueFromAttribute(
-                                    it,
-                                    attributeIdEditText.text.toString().toLongOrNull() ?: 0,
-                                    termIdEditText.text.toString().toLongOrNull() ?: 0
-                            )
-                        }?.apply {
-                            model?.let { logSingleAttributeResponse(it) }
-                                    ?.let { prependToLog("========== Attribute Term Created =========") }
-                                    ?: takeIf { isError }?.let {
-                                        prependToLog("Failed to delete Attribute. Error: ${error.message}")
-                                    }
-                        } ?: prependToLog("Failed to create Attribute Term. Error: Unknown")
-                    }
-                }
-            }
-        } catch (ex: Exception) {
-            prependToLog("Couldn't create Attribute Term. Error: ${ex.message}")
-        }
-    }
-
     private fun onFetchAttributesListClicked(view: View) = coroutineScope.launch {
         try {
             takeAsyncRequestWithValidSite { wcAttributesStore.fetchStoreAttributes(it) }
@@ -265,9 +232,9 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
 
     private fun logSingleAttributeTermResponse(termIndex: Int, response: WCAttributeTermModel) {
         response.let {
-            prependToLog("Term name: ${it.name}")
-            prependToLog("Term id: ${it.remoteId}")
-            prependToLog("  --------- Attribute Term #$termIndex ---------")
+            prependToLog("    Term name: ${it.name}")
+            prependToLog("    Term id: ${it.remoteId}")
+            prependToLog("    --------- Attribute Term #$termIndex ---------")
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -258,7 +258,7 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
             prependToLog("  Attribute slug: ${it.slug.ifEmpty { "Slug not available" }}")
             prependToLog("  Attribute type: ${it.type.ifEmpty { "Type not available" }}")
             prependToLog("  Attribute name: ${it.name.ifEmpty { "Attribute name not available" }}")
-            prependToLog("  Attribute id: ${it.id}")
+            prependToLog("  Attribute remote id: ${it.remoteId}")
             prependToLog("  --------- Attribute ---------")
         }
     }
@@ -266,7 +266,7 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
     private fun logSingleAttributeTermResponse(termIndex: Int, response: WCAttributeTermModel) {
         response.let {
             prependToLog("Term name: ${it.name}")
-            prependToLog("Term id: ${it.id}")
+            prependToLog("Term id: ${it.remoteId}")
             prependToLog("  --------- Attribute Term #${termIndex} ---------")
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -267,7 +267,7 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
         response.let {
             prependToLog("Term name: ${it.name}")
             prependToLog("Term id: ${it.remoteId}")
-            prependToLog("  --------- Attribute Term #${termIndex} ---------")
+            prependToLog("  --------- Attribute Term #$termIndex ---------")
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -54,6 +54,9 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
         create_product_attributes.setOnClickListener(::onCreateAttributeButtonClicked)
         delete_product_attributes.setOnClickListener(::onDeleteAttributeButtonClicked)
         update_product_attributes.setOnClickListener(::onUpdateAttributeButtonClicked)
+        fetch_product_single_attribute.setOnClickListener(::onFetchAttributeButtonClicked)
+        create_term_for_attribute.setOnClickListener(::onCreateAttributeTermButtonClicked)
+        delete_term_for_attribute.setOnClickListener(::onDeleteAttributeTermButtonClicked)
     }
 
     private fun onProductAttributesSelectSiteButtonClicked(view: View) {
@@ -141,6 +144,96 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
             }
         } catch (ex: Exception) {
             prependToLog("Couldn't create Attributes. Error: ${ex.message}")
+        }
+    }
+
+    private fun onFetchAttributeButtonClicked(view: View) {
+        try {
+            showSingleLineDialog(
+                    activity,
+                    "Enter the attribute ID you want to remove:"
+            ) { editText ->
+                coroutineScope.launch {
+                    takeAsyncRequestWithValidSite {
+                        wcAttributesStore.fetchAttribute(
+                                it,
+                                editText.text.toString().toLongOrNull() ?: 0
+                        )
+                    }?.apply {
+                        model?.let { logSingleAttributeResponse(it) }
+                                ?.let { prependToLog("========== Attribute Fetched =========") }
+                                ?: takeIf { isError }?.let {
+                                    prependToLog("Failed to delete Attribute. Error: ${error.message}")
+                                }
+                    } ?: prependToLog("Failed to delete Attribute. Error: Unknown")
+                }
+            }
+        } catch (ex: Exception) {
+            prependToLog("Couldn't create Attributes. Error: ${ex.message}")
+        }
+    }
+
+    private fun onCreateAttributeTermButtonClicked(view: View) {
+        try {
+            showSingleLineDialog(
+                    activity,
+                    "Enter the attribute ID you want to add terms:"
+            ) { attributeIdEditText ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter the term name you want to create:"
+                ) { termEditText ->
+                    coroutineScope.launch {
+                        takeAsyncRequestWithValidSite {
+                            wcAttributesStore.createOptionValueForAttribute(
+                                    it,
+                                    attributeIdEditText.text.toString().toLongOrNull() ?: 0,
+                                    termEditText.text.toString()
+                            )
+                        }?.apply {
+                            model?.let { logSingleAttributeResponse(it) }
+                                    ?.let { prependToLog("========== Attribute Term Created =========") }
+                                    ?: takeIf { isError }?.let {
+                                        prependToLog("Failed to delete Attribute. Error: ${error.message}")
+                                    }
+                        } ?: prependToLog("Failed to create Attribute Term. Error: Unknown")
+                    }
+                }
+            }
+        } catch (ex: Exception) {
+            prependToLog("Couldn't create Attribute Term. Error: ${ex.message}")
+        }
+    }
+
+    private fun onDeleteAttributeTermButtonClicked(view: View) {
+        try {
+            showSingleLineDialog(
+                    activity,
+                    "Enter the attribute ID you want to remove terms:"
+            ) { attributeIdEditText ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter the term ID you want to delete:"
+                ) { termIdEditText ->
+                    coroutineScope.launch {
+                        takeAsyncRequestWithValidSite {
+                            wcAttributesStore.deleteOptionValueFromAttribute(
+                                    it,
+                                    attributeIdEditText.text.toString().toLongOrNull() ?: 0,
+                                    termIdEditText.text.toString().toLongOrNull() ?: 0
+                            )
+                        }?.apply {
+                            model?.let { logSingleAttributeResponse(it) }
+                                    ?.let { prependToLog("========== Attribute Term Created =========") }
+                                    ?: takeIf { isError }?.let {
+                                        prependToLog("Failed to delete Attribute. Error: ${error.message}")
+                                    }
+                        } ?: prependToLog("Failed to create Attribute Term. Error: Unknown")
+                    }
+                }
+            }
+        } catch (ex: Exception) {
+            prependToLog("Couldn't create Attribute Term. Error: ${ex.message}")
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeModel
+import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.store.WCProductAttributesStore
 import javax.inject.Inject
 
@@ -249,11 +250,24 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
 
     private fun logSingleAttributeResponse(response: WCProductAttributeModel) {
         response.let {
+            response.terms
+                    ?.filterNotNull()
+                    ?.forEachIndexed { index, wcAttributeTermModel ->
+                logSingleAttributeTermResponse(index, wcAttributeTermModel)
+            }
             prependToLog("  Attribute slug: ${it.slug.ifEmpty { "Slug not available" }}")
             prependToLog("  Attribute type: ${it.type.ifEmpty { "Type not available" }}")
             prependToLog("  Attribute name: ${it.name.ifEmpty { "Attribute name not available" }}")
             prependToLog("  Attribute id: ${it.id}")
             prependToLog("  --------- Attribute ---------")
+        }
+    }
+
+    private fun logSingleAttributeTermResponse(termIndex: Int, response: WCAttributeTermModel) {
+        response.let {
+            prependToLog("Term name: ${it.name}")
+            prependToLog("Term id: ${it.id}")
+            prependToLog("  --------- Attribute Term #${termIndex} ---------")
         }
     }
 

--- a/example/src/main/res/layout/fragment_woo_product_attribute.xml
+++ b/example/src/main/res/layout/fragment_woo_product_attribute.xml
@@ -79,13 +79,6 @@
             android:enabled="false"
             android:text="Create Attribute Term"/>
 
-        <Button
-            android:id="@+id/delete_term_for_attribute"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:enabled="false"
-            android:text="Delete Attribute Term"/>
-
     </LinearLayout>
 
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woo_product_attribute.xml
+++ b/example/src/main/res/layout/fragment_woo_product_attribute.xml
@@ -65,6 +65,27 @@
             android:enabled="false"
             android:text="Update Attribute"/>
 
+        <Button
+            android:id="@+id/fetch_product_single_attribute"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Single Attribute"/>
+
+        <Button
+            android:id="@+id/create_term_for_attribute"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Create Attribute Term"/>
+
+        <Button
+            android:id="@+id/delete_term_for_attribute"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Delete Attribute Term"/>
+
     </LinearLayout>
 
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributeMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributeMapperTest.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.wc.attributes
 
+import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -8,6 +10,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
+import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeCreateResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributesFullListResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.stubSite
@@ -19,15 +22,15 @@ class WCProductAttributeMapperTest {
 
     @Before
     fun setUp() {
-        mapperUnderTest = WCProductAttributeMapper()
+        mapperUnderTest = WCProductAttributeMapper(mock())
     }
 
     @Test
-    fun `mapToAttributeModel should never allow null values`() {
+    fun `mapToAttributeModel should never allow null values`() = test {
         AttributeApiResponse()
                 .let {
-                    mapperUnderTest.mapToAttributeModel(it, stubSite)
-                }.let { result ->
+                    mapperUnderTest.responseToAttributeModel(it, stubSite)
+                }?.let { result ->
                     assertThat(result).isNotNull
                     assertThat(result.id).isNotNull
                     assertThat(result.name).isNotNull
@@ -35,12 +38,12 @@ class WCProductAttributeMapperTest {
                     assertThat(result.type).isNotNull
                     assertThat(result.orderBy).isNotNull
                     assertThat(result.hasArchives).isNotNull
-                }
+                } ?: fail("Result shouldn't be null")
     }
 
     @Test
-    fun `mapToAttributeModelList should parse list correctly`() {
-        mapperUnderTest.mapToAttributeModelList(attributesFullListResponse!!, stubSite)
+    fun `mapToAttributeModelList should parse list correctly`() = test {
+        mapperUnderTest.responseToAttributeModelList(attributesFullListResponse!!, stubSite)
                 .let { result ->
                     assertThat(result).isNotNull
                     assertThat(result.size).isEqualTo(2)
@@ -48,9 +51,9 @@ class WCProductAttributeMapperTest {
     }
 
     @Test
-    fun `mapToAttributeModel should parse correctly`() {
-        mapperUnderTest.mapToAttributeModel(attributeCreateResponse!!, stubSite)
-                .let { result ->
+    fun `mapToAttributeModel should parse correctly`() = test {
+        mapperUnderTest.responseToAttributeModel(attributeCreateResponse!!, stubSite)
+                ?.let { result ->
                     assertThat(result).isNotNull
                     assertThat(result.id).isEqualTo(1)
                     assertThat(result.name).isEqualTo("Color")
@@ -58,6 +61,6 @@ class WCProductAttributeMapperTest {
                     assertThat(result.type).isEqualTo("select")
                     assertThat(result.orderBy).isEqualTo("menu_order")
                     assertThat(result.hasArchives).isEqualTo(true)
-                }
+                } ?: fail("Result shouldn't be null")
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributeMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributeMapperTest.kt
@@ -1,17 +1,28 @@
 package org.wordpress.android.fluxc.wc.attributes
 
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.yarolegovich.wellsql.WellSql
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeMapper
+import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeCreateResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeTermsFullListResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributesFullListResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.stubSite
 
@@ -19,20 +30,32 @@ import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures
 @RunWith(RobolectricTestRunner::class)
 class WCProductAttributeMapperTest {
     private lateinit var mapperUnderTest: WCProductAttributeMapper
+    private lateinit var attributesRestClient: ProductAttributeRestClient
 
     @Before
     fun setUp() {
-        mapperUnderTest = WCProductAttributeMapper(mock())
+        SingleStoreWellSqlConfigForTests(
+                RuntimeEnvironment.application.applicationContext,
+                listOf(SiteModel::class.java, WCAttributeTermModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE
+        ).let {
+            WellSql.init(it)
+            it.reset()
+        }
+
+        attributesRestClient = mock()
+        mapperUnderTest = WCProductAttributeMapper(attributesRestClient)
     }
 
     @Test
     fun `mapToAttributeModel should never allow null values`() = test {
-        AttributeApiResponse()
-                .let {
+        attributeCreateResponse
+                ?.let {
+                    configureAttributeRestClientMock(it.id?.toIntOrNull() ?: 0)
                     mapperUnderTest.responseToAttributeModel(it, stubSite)
                 }?.let { result ->
                     assertThat(result).isNotNull
-                    assertThat(result.id).isNotNull
+                    assertThat(result.remoteId).isNotNull
                     assertThat(result.name).isNotNull
                     assertThat(result.slug).isNotNull
                     assertThat(result.type).isNotNull
@@ -43,6 +66,8 @@ class WCProductAttributeMapperTest {
 
     @Test
     fun `mapToAttributeModelList should parse list correctly`() = test {
+        configureAttributeRestClientMock(1)
+        configureAttributeRestClientMock(2)
         mapperUnderTest.responseToAttributeModelList(attributesFullListResponse!!, stubSite)
                 .let { result ->
                     assertThat(result).isNotNull
@@ -52,15 +77,23 @@ class WCProductAttributeMapperTest {
 
     @Test
     fun `mapToAttributeModel should parse correctly`() = test {
+        configureAttributeRestClientMock(1)
         mapperUnderTest.responseToAttributeModel(attributeCreateResponse!!, stubSite)
                 ?.let { result ->
                     assertThat(result).isNotNull
-                    assertThat(result.id).isEqualTo(1)
+                    assertThat(result.remoteId).isEqualTo(1)
                     assertThat(result.name).isEqualTo("Color")
                     assertThat(result.slug).isEqualTo("pa_color")
                     assertThat(result.type).isEqualTo("select")
                     assertThat(result.orderBy).isEqualTo("menu_order")
                     assertThat(result.hasArchives).isEqualTo(true)
                 } ?: fail("Result shouldn't be null")
+    }
+
+    private suspend fun configureAttributeRestClientMock(attributeID: Int) {
+        mock<ProductAttributeRestClient>().apply {
+            whenever(attributesRestClient.fetchAllAttributeTerms(stubSite, attributeID.toLong()))
+                    .thenReturn(WooPayload(attributeTermsFullListResponse))
+        }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributeMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributeMapperTest.kt
@@ -13,11 +13,9 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeMapper
 import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributesStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributesStoreTest.kt
@@ -70,7 +70,7 @@ class WCProductAttributesStoreTest {
                 .thenReturn(WooPayload(attributesFullListResponse))
 
         storeUnderTest.fetchStoreAttributes(stubSite)
-        verify(mapper).mapToAttributeModelList(attributesFullListResponse!!, stubSite)
+        verify(mapper).responseToAttributeModelList(attributesFullListResponse!!, stubSite)
     }
 
     @Test
@@ -78,7 +78,7 @@ class WCProductAttributesStoreTest {
         whenever(restClient.fetchProductFullAttributesList(stubSite))
                 .thenReturn(WooPayload(attributesFullListResponse))
 
-        whenever(mapper.mapToAttributeModelList(attributesFullListResponse!!, stubSite))
+        whenever(mapper.responseToAttributeModelList(attributesFullListResponse!!, stubSite))
                 .thenReturn(parsedAttributesList)
 
         storeUnderTest.fetchStoreAttributes(stubSite).let { result ->
@@ -110,7 +110,7 @@ class WCProductAttributesStoreTest {
             )
         })).thenReturn(WooPayload(attributeCreateResponse))
 
-        whenever(mapper.mapToAttributeModel(attributeCreateResponse!!, stubSite))
+        whenever(mapper.responseToAttributeModel(attributeCreateResponse!!, stubSite))
                 .thenReturn(parsedCreateAttributeResponse)
 
         storeUnderTest.createAttribute(
@@ -142,7 +142,7 @@ class WCProductAttributesStoreTest {
         whenever(restClient.deleteExistingAttribute(stubSite, 17))
                 .thenReturn(WooPayload(attributeDeleteResponse))
 
-        whenever(mapper.mapToAttributeModel(attributeDeleteResponse!!, stubSite))
+        whenever(mapper.responseToAttributeModel(attributeDeleteResponse!!, stubSite))
                 .thenReturn(parsedDeleteAttributeResponse)
 
         storeUnderTest.deleteAttribute(
@@ -181,7 +181,7 @@ class WCProductAttributesStoreTest {
                         })
         ).thenReturn(WooPayload(attributeUpdateResponse))
 
-        whenever(mapper.mapToAttributeModel(attributeUpdateResponse!!, stubSite))
+        whenever(mapper.responseToAttributeModel(attributeUpdateResponse!!, stubSite))
                 .thenReturn(parsedUpdateAttributeResponse)
 
         storeUnderTest.updateAttribute(

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributesTestFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributesTestFixtures.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
 
 object WCProductAttributesTestFixtures {
     val stubSite = SiteModel().apply { id = 321 }
@@ -27,6 +28,11 @@ object WCProductAttributesTestFixtures {
     val attributesFullListResponse by lazy {
         "wc/product-attributes-all.json"
                 .jsonFileAs(Array<AttributeApiResponse>::class.java)
+    }
+
+    val attributeTermsFullListResponse by lazy {
+        "wc/attribute-terms-full-list.json"
+                .jsonFileAs(Array<AttributeTermApiResponse>::class.java)
     }
 
     val parsedAttributesList by lazy {

--- a/example/src/test/resources/wc/attribute-term-operation-response.json
+++ b/example/src/test/resources/wc/attribute-term-operation-response.json
@@ -1,0 +1,20 @@
+{
+  "id": 23,
+  "name": "XXS",
+  "slug": "xxs",
+  "description": "",
+  "menu_order": 1,
+  "count": 1,
+  "_links": {
+    "self": [
+      {
+        "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/23"
+      }
+    ],
+    "collection": [
+      {
+        "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+      }
+    ]
+  }
+}

--- a/example/src/test/resources/wc/attribute-terms-full-list.json
+++ b/example/src/test/resources/wc/attribute-terms-full-list.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": 23,
+    "name": "XXS",
+    "slug": "xxs",
+    "description": "",
+    "menu_order": 1,
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/23"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+        }
+      ]
+    }
+  },
+  {
+    "id": 22,
+    "name": "XS",
+    "slug": "xs",
+    "description": "",
+    "menu_order": 2,
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/22"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+        }
+      ]
+    }
+  },
+  {
+    "id": 17,
+    "name": "S",
+    "slug": "s",
+    "description": "",
+    "menu_order": 3,
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/17"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+        }
+      ]
+    }
+  },
+  {
+    "id": 18,
+    "name": "M",
+    "slug": "m",
+    "description": "",
+    "menu_order": 4,
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/18"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+        }
+      ]
+    }
+  },
+  {
+    "id": 19,
+    "name": "L",
+    "slug": "l",
+    "description": "",
+    "menu_order": 5,
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/19"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+        }
+      ]
+    }
+  },
+  {
+    "id": 20,
+    "name": "XL",
+    "slug": "xl",
+    "description": "",
+    "menu_order": 6,
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/20"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+        }
+      ]
+    }
+  },
+  {
+    "id": 21,
+    "name": "XXL",
+    "slug": "xxl",
+    "description": "",
+    "menu_order": 7,
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/21"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+        }
+      ]
+    }
+  }
+]

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -13,6 +13,7 @@
 /products/shipping_classes/<id>/
 /products/attributes/
 /products/attributes/<attribute_id>
+/products/attributes/<attribute_id>/terms
 
 /products/reviews/
 /products/reviews/<id>/

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -14,6 +14,7 @@
 /products/attributes/
 /products/attributes/<attribute_id>
 /products/attributes/<attribute_id>/terms
+/products/attributes/<attribute_id>/terms/<term_id>
 
 /products/reviews/
 /products/reviews/<id>/

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1484,8 +1484,8 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "NAME TEXT NOT NULL," +
                                     "SLUG TEXT, " +
                                     "DESCRIPTION TEXT, " +
-                                    "COUNT TEXT, " +
-                                    "MENU_ORDER TEXT)"
+                                    "COUNT INTEGER, " +
+                                    "MENU_ORDER INTEGER)"
                     )
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 133
+        return 134
     }
 
     override fun getDbName(): String {
@@ -1466,10 +1466,12 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 133 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("DROP TABLE IF EXISTS WCAttributeTermModel")
+                    db.execSQL("ALTER TABLE WCProductAttributeModel ADD TERMS TEXT")
                     db.execSQL(
                             "CREATE TABLE WCAttributeTermModel (" +
                                     "_id INTEGER PRIMARY KEY, " +
                                     "LOCAL_SITE_ID INTEGER," +
+                                    "ATTRIBUTE_ID INTEGER," +
                                     "NAME TEXT NOT NULL," +
                                     "SLUG TEXT, " +
                                     "DESCRIPTION TEXT, " +

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1467,9 +1467,11 @@ open class WellSqlConfig : DefaultWellConfig {
                 133 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("DROP TABLE IF EXISTS WCAttributeTermModel")
                     db.execSQL("ALTER TABLE WCProductAttributeModel ADD TERMS TEXT")
+                    db.execSQL("ALTER TABLE WCProductAttributeModel ADD REMOTE_ID INTEGER")
                     db.execSQL(
                             "CREATE TABLE WCAttributeTermModel (" +
                                     "_id INTEGER PRIMARY KEY, " +
+                                    "REMOTE_ID INTEGER," +
                                     "LOCAL_SITE_ID INTEGER," +
                                     "ATTRIBUTE_ID INTEGER," +
                                     "NAME TEXT NOT NULL," +

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1464,6 +1464,19 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "HAS_ARCHIVES BOOLEAN NOT NULL)"
                     )
                 }
+                133 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCAttributeTermModel")
+                    db.execSQL(
+                            "CREATE TABLE WCAttributeTermModel (" +
+                                    "_id INTEGER PRIMARY KEY, " +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "NAME TEXT NOT NULL," +
+                                    "SLUG TEXT, " +
+                                    "DESCRIPTION TEXT, " +
+                                    "COUNT TEXT, " +
+                                    "MENU_ORDER TEXT)"
+                    )
+                }
             }
         }
         db.setTransactionSuccessful()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeMapper.kt
@@ -16,7 +16,7 @@ class WCProductAttributeMapper @Inject constructor(
         site: SiteModel
     ) = response.id?.toIntOrNull()?.let { attributeID ->
         restClient.fetchAllAttributeTerms(site, attributeID.toLong())
-                .result?.map { responseToAttributeTermModel(it, site) }
+                .result?.map { responseToAttributeTermModel(it, attributeID, site) }
                 ?.apply { insertAttributeTermsFromScratch(attributeID, site.id, this) }
                 ?.map { it.id.toString() }
                 ?.reduce { total, new -> "${total};${new}" }
@@ -44,11 +44,13 @@ class WCProductAttributeMapper @Inject constructor(
 
     private fun responseToAttributeTermModel(
         response: AttributeTermApiResponse,
+        attributeID: Int,
         site: SiteModel
     ) = with(response) {
         WCAttributeTermModel(
                 id = id?.toIntOrNull() ?: 0,
                 localSiteId = site.id,
+                attributeId = attributeID,
                 name = name.orEmpty(),
                 slug = slug.orEmpty(),
                 description = description.orEmpty(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeMapper.kt
@@ -1,28 +1,59 @@
 package org.wordpress.android.fluxc.model.product.attributes
 
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
+import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.insertAttributeTermsFromScratch
 import javax.inject.Inject
 
-class WCProductAttributeMapper @Inject constructor() {
-    fun mapToAttributeModel(
+class WCProductAttributeMapper @Inject constructor(
+    private val restClient: ProductAttributeRestClient
+) {
+    suspend fun responseToAttributeModel(
         response: AttributeApiResponse,
         site: SiteModel
+    ) = response.id?.toIntOrNull()?.let { attributeID ->
+        restClient.fetchAllAttributeTerms(site, attributeID.toLong())
+                .result?.map { responseToAttributeTermModel(it, site) }
+                ?.apply { insertAttributeTermsFromScratch(attributeID, site.id, this) }
+                ?.map { it.id.toString() }
+                ?.reduce { total, new -> "${total};${new}" }
+                ?.let { terms ->
+                    with(response) {
+                        WCProductAttributeModel(
+                                id = id?.toIntOrNull() ?: 0,
+                                localSiteId = site.id,
+                                name = name.orEmpty(),
+                                slug = slug.orEmpty(),
+                                type = type.orEmpty(),
+                                orderBy = orderBy.orEmpty(),
+                                hasArchives = hasArchives ?: false,
+                                termsId = terms
+                        )
+                    }
+                }
+    }
+
+    suspend fun responseToAttributeModelList(
+        response: Array<AttributeApiResponse>,
+        site: SiteModel
+    ) = response.mapNotNull { responseToAttributeModel(it, site) }
+            .toList()
+
+    private fun responseToAttributeTermModel(
+        response: AttributeTermApiResponse,
+        site: SiteModel
     ) = with(response) {
-        WCProductAttributeModel(
+        WCAttributeTermModel(
                 id = id?.toIntOrNull() ?: 0,
                 localSiteId = site.id,
                 name = name.orEmpty(),
                 slug = slug.orEmpty(),
-                type = type.orEmpty(),
-                orderBy = orderBy.orEmpty(),
-                hasArchives = hasArchives ?: false
+                description = description.orEmpty(),
+                count = count?.toIntOrNull() ?: 0,
+                menuOrder = menuOrder?.toIntOrNull() ?: 0
         )
     }
-
-    fun mapToAttributeModelList(
-        response: Array<AttributeApiResponse>,
-        site: SiteModel
-    ) = response.map { mapToAttributeModel(it, site) }
-            .toList()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeMapper.kt
@@ -25,7 +25,6 @@ class WCProductAttributeMapper @Inject constructor(
     ) = response.mapNotNull { responseToAttributeModel(it, site) }
             .toList()
 
-
     private fun AttributeApiResponse.asProductAttributeModel(
         id: String,
         site: SiteModel,
@@ -48,7 +47,7 @@ class WCProductAttributeMapper @Inject constructor(
             .result?.map { responseToAttributeTermModel(it, attributeID, site) }
             ?.apply { insertAttributeTermsFromScratch(attributeID, site.id, this) }
             ?.map { it.remoteId.toString() }
-            ?.reduce { total, new -> "${total};${new}" }
+            ?.reduce { total, new -> "$total;$new" }
 
     private fun responseToAttributeTermModel(
         response: AttributeTermApiResponse,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeMapper.kt
@@ -31,7 +31,7 @@ class WCProductAttributeMapper @Inject constructor(
         site: SiteModel,
         terms: String
     ) = WCProductAttributeModel(
-            id = id.toIntOrNull() ?: 0,
+            remoteId = id.toIntOrNull() ?: 0,
             localSiteId = site.id,
             name = name.orEmpty(),
             slug = slug.orEmpty(),
@@ -47,7 +47,7 @@ class WCProductAttributeMapper @Inject constructor(
     ) = restClient.fetchAllAttributeTerms(site, attributeID.toLong())
             .result?.map { responseToAttributeTermModel(it, attributeID, site) }
             ?.apply { insertAttributeTermsFromScratch(attributeID, site.id, this) }
-            ?.map { it.id.toString() }
+            ?.map { it.remoteId.toString() }
             ?.reduce { total, new -> "${total};${new}" }
 
     private fun responseToAttributeTermModel(
@@ -56,7 +56,7 @@ class WCProductAttributeMapper @Inject constructor(
         site: SiteModel
     ) = with(response) {
         WCAttributeTermModel(
-                id = id?.toIntOrNull() ?: 0,
+                remoteId = id?.toIntOrNull() ?: 0,
                 localSiteId = site.id,
                 attributeId = attributeID,
                 name = name.orEmpty(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeModel.kt
@@ -4,6 +4,7 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.getTerm
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
@@ -14,11 +15,19 @@ data class WCProductAttributeModel(
     @Column var slug: String = "",
     @Column var type: String = "",
     @Column var orderBy: String = "",
-    @Column var hasArchives: Boolean = false
+    @Column var hasArchives: Boolean = false,
+    @Column var termsId: String = ""
 ) : Identifiable {
     override fun setId(id: Int) {
         this.id = id
     }
 
     override fun getId() = id
+
+    val terms
+        get() = termsId
+                .split(";")
+                .mapNotNull { it.toIntOrNull() }
+                .takeIf { it.isNotEmpty() }
+                ?.map { getTerm(localSiteId, it) }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeModel.kt
@@ -24,10 +24,10 @@ data class WCProductAttributeModel(
 
     override fun getId() = id
 
-    val terms
-        get() = termsId
-                .split(";")
+    val terms by lazy {
+        termsId.split(";")
                 .mapNotNull { it.toIntOrNull() }
                 .takeIf { it.isNotEmpty() }
                 ?.map { getTerm(localSiteId, it) }
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCProductAttributeModel.kt
@@ -16,7 +16,8 @@ data class WCProductAttributeModel(
     @Column var type: String = "",
     @Column var orderBy: String = "",
     @Column var hasArchives: Boolean = false,
-    @Column var termsId: String = ""
+    @Column var termsId: String = "",
+    @Column var remoteId: Int = 0
 ) : Identifiable {
     override fun setId(id: Int) {
         this.id = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/terms/WCAttributeTermModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/terms/WCAttributeTermModel.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.model.product.attributes.terms
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+
+data class WCAttributeTermModel(
+    @PrimaryKey @Column private var id: Int = 0,
+    @Column var localSiteId: Int = 0,
+    @Column var name: String = "",
+    @Column var slug: String = "",
+    @Column var description: String = "",
+    @Column var count: Int = 0,
+    @Column var menuOrder: Int = 0
+) : Identifiable {
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    override fun getId() = id
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/terms/WCAttributeTermModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/terms/WCAttributeTermModel.kt
@@ -3,10 +3,14 @@ package org.wordpress.android.fluxc.model.product.attributes.terms
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCAttributeTermModel(
     @PrimaryKey @Column private var id: Int = 0,
     @Column var localSiteId: Int = 0,
+    @Column var attributeId: Int = 0,
     @Column var name: String = "",
     @Column var slug: String = "",
     @Column var description: String = "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/terms/WCAttributeTermModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/terms/WCAttributeTermModel.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCAttributeTermModel(
     @PrimaryKey @Column private var id: Int = 0,
+    @Column var remoteId: Int = 0,
     @Column var localSiteId: Int = 0,
     @Column var attributeId: Int = 0,
     @Column var name: String = "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -28,6 +28,12 @@ constructor(
     ) = WOOCOMMERCE.products.attributes.pathV3
             .request<Array<AttributeApiResponse>>(site)
 
+    suspend fun fetchSingleAttribute(
+        site: SiteModel,
+        attributeID: Long
+    ) = WOOCOMMERCE.products.attributes.attribute(attributeID).pathV3
+            .request<AttributeApiResponse>(site)
+
     suspend fun postNewAttribute(
         site: SiteModel,
         args: Map<String, String>
@@ -55,8 +61,8 @@ constructor(
 
     suspend fun postNewTerm(
         site: SiteModel,
-        args: Map<String, String>,
-        attributeID: Long
+        attributeID: Long,
+        args: Map<String, String>
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.pathV3
             .post<AttributeTermApiResponse>(site, args)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
 import org.wordpress.android.fluxc.utils.handleResult
 import javax.inject.Singleton
 
@@ -25,42 +26,67 @@ constructor(
     suspend fun fetchProductFullAttributesList(
         site: SiteModel
     ) = WOOCOMMERCE.products.attributes.pathV3
-            .requestTo(site)
-            .handleResult()
+            .request<Array<AttributeApiResponse>>(site)
 
     suspend fun postNewAttribute(
         site: SiteModel,
         args: Map<String, String>
     ) = WOOCOMMERCE.products.attributes.pathV3
-            .postTo(site, args)
-            .handleResult()
+            .post<AttributeApiResponse>(site, args)
 
     suspend fun updateExistingAttribute(
         site: SiteModel,
         attributeID: Long,
         args: Map<String, String>
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).pathV3
-            .putTo(site, args)
-            .handleResult()
+            .put<AttributeApiResponse>(site, args)
 
     suspend fun deleteExistingAttribute(
         site: SiteModel,
         attributeID: Long
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).pathV3
-            .deleteFrom(site)
-            .handleResult()
+            .delete<AttributeApiResponse>(site)
 
-    private suspend fun String.requestTo(
+    suspend fun fetchAllAttributeTermsList(
+        site: SiteModel,
+        attributeID: Long
+    ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.pathV3
+            .request<Array<AttributeTermApiResponse>>(site)
+
+    suspend fun postNewTerm(
+        site: SiteModel,
+        args: Map<String, String>,
+        attributeID: Long
+    ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.pathV3
+            .post<AttributeTermApiResponse>(site, args)
+
+    suspend fun updateExistingTerm(
+        site: SiteModel,
+        args: Map<String, String>,
+        attributeID: Long,
+        termID: Long
+    ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.term(termID).pathV3
+            .put<AttributeTermApiResponse>(site, args)
+
+    suspend fun deleteExistingTerm(
+        site: SiteModel,
+        args: Map<String, String>,
+        attributeID: Long,
+        termID: Long
+    ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.term(termID).pathV3
+            .delete<AttributeTermApiResponse>(site)
+
+    private suspend inline fun <reified T : Any> String.request(
         site: SiteModel
     ) = jetpackTunnelGsonRequestBuilder.syncGetRequest(
             this@ProductAttributeRestClient,
             site,
             this,
             emptyMap(),
-            Array<AttributeApiResponse>::class.java
-    )
+            T::class.java
+    ).handleResult()
 
-    private suspend fun String.postTo(
+    private suspend inline fun <reified T : Any> String.post(
         site: SiteModel,
         args: Map<String, String>
     ) = jetpackTunnelGsonRequestBuilder.syncPostRequest(
@@ -68,10 +94,10 @@ constructor(
             site,
             this,
             args,
-            AttributeApiResponse::class.java
-    )
+            T::class.java
+    ).handleResult()
 
-    private suspend fun String.putTo(
+    private suspend inline fun <reified T : Any> String.put(
         site: SiteModel,
         args: Map<String, String>
     ) = jetpackTunnelGsonRequestBuilder.syncPutRequest(
@@ -79,15 +105,15 @@ constructor(
             site,
             this,
             args,
-            AttributeApiResponse::class.java
-    )
+            T::class.java
+    ).handleResult()
 
-    private suspend fun String.deleteFrom(
+    private suspend inline fun <reified T : Any> String.delete(
         site: SiteModel
     ) = jetpackTunnelGsonRequestBuilder.syncDeleteRequest(
             this@ProductAttributeRestClient,
             site,
             this,
-            AttributeApiResponse::class.java
-    )
+            T::class.java
+    ).handleResult()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -47,7 +47,7 @@ constructor(
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).pathV3
             .delete<AttributeApiResponse>(site)
 
-    suspend fun fetchAllAttributeTermsList(
+    suspend fun fetchAllAttributeTerms(
         site: SiteModel,
         attributeID: Long
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.pathV3

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -76,7 +76,6 @@ constructor(
 
     suspend fun deleteExistingTerm(
         site: SiteModel,
-        args: Map<String, String>,
         attributeID: Long,
         termID: Long
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.term(termID).pathV3

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/terms/AttributeTermApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/terms/AttributeTermApiResponse.kt
@@ -8,7 +8,7 @@ class AttributeTermApiResponse : Response {
     val name: String? = null
     val slug: String? = null
     val description: String? = null
-    val count: Int? = null
+    val count: String? = null
     @SerializedName("menu_order")
-    val menuOrder: Int? = null
+    val menuOrder: String? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/terms/AttributeTermApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/terms/AttributeTermApiResponse.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+
+class AttributeTermApiResponse : Response {
+    val id: String? = null
+    val name: String? = null
+    val slug: String? = null
+    val description: String? = null
+    val count: Int? = null
+    @SerializedName("menu_order")
+    val menuOrder: Int? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCProductAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCProductAttributeSqlUtils.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.persistence
 
+import com.wellsql.generated.WCAttributeTermModelTable
 import com.wellsql.generated.WCProductAttributeModelTable
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeModel
+import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
 
 object WCProductAttributeSqlUtils {
     fun getCurrentAttributes(siteID: Int) =
@@ -13,13 +15,6 @@ object WCProductAttributeSqlUtils {
                     .asModel
                     ?.toList()
                     .orEmpty()
-
-    fun deleteCompleteAttributesList(siteID: Int) =
-            WellSql.delete(WCProductAttributeModel::class.java)
-                    .where()
-                    .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
-                    .endWhere()
-                    .execute()
 
     fun insertFromScratchCompleteAttributesList(attributes: List<WCProductAttributeModel>, siteID: Int) {
         deleteCompleteAttributesList(siteID)
@@ -51,4 +46,40 @@ object WCProductAttributeSqlUtils {
                 .put(attribute)
                 .execute()
     }
+
+    fun getTerm(siteID: Int, termID: Int) =
+            WellSql.select(WCAttributeTermModel::class.java)
+                    .where()
+                    .equals(WCAttributeTermModelTable.ID, termID)
+                    .equals(WCAttributeTermModelTable.LOCAL_SITE_ID, siteID)
+                    .endWhere()
+                    .asModel
+                    ?.toList()
+                    ?.firstOrNull()
+
+    fun insertAttributeTermsFromScratch(
+        attributeID: Int,
+        siteID: Int,
+        terms: List<WCAttributeTermModel>
+    ) {
+        deleteAllTermsFromSingleAttribute(attributeID, siteID)
+        WellSql.insert(terms)
+                .asSingleTransaction(true)
+                .execute()
+    }
+
+    private fun deleteCompleteAttributesList(siteID: Int) =
+            WellSql.delete(WCProductAttributeModel::class.java)
+                    .where()
+                    .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
+                    .endWhere()
+                    .execute()
+
+    private fun deleteAllTermsFromSingleAttribute(attributeID: Int, siteID: Int) =
+            WellSql.delete(WCAttributeTermModel::class.java)
+                    .where()
+                    .equals(WCAttributeTermModelTable.LOCAL_SITE_ID, siteID)
+                    .equals(WCAttributeTermModelTable.ATTRIBUTE_ID, attributeID)
+                    .endWhere()
+                    .execute()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCProductAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCProductAttributeSqlUtils.kt
@@ -28,6 +28,16 @@ object WCProductAttributeSqlUtils {
                 .execute()
     }
 
+    fun fetchSingleStoredAttribute(attributeId: Int, siteID: Int) =
+        WellSql.select(WCProductAttributeModel::class.java)
+                .where()
+                .equals(WCProductAttributeModelTable.ID, attributeId)
+                .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
+                .endWhere()
+                .asModel
+                .takeIf { it.isNotEmpty() }
+                ?.first()
+
     fun deleteSingleStoredAttribute(attribute: WCProductAttributeModel, siteID: Int) = attribute.apply {
         WellSql.delete(WCProductAttributeModel::class.java)
                 .where()
@@ -46,6 +56,11 @@ object WCProductAttributeSqlUtils {
                 .put(attribute)
                 .execute()
     }
+
+    fun insertOrUpdateSingleAttribute(attribute: WCProductAttributeModel, siteID: Int) =
+            fetchSingleStoredAttribute(attribute.id, siteID)
+                    ?.let { updateSingleStoredAttribute(attribute, siteID) }
+                    ?: insertSingleAttribute(attribute)
 
     fun getTerm(siteID: Int, termID: Int) =
             WellSql.select(WCAttributeTermModel::class.java)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCProductAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCProductAttributeSqlUtils.kt
@@ -31,7 +31,7 @@ object WCProductAttributeSqlUtils {
     fun fetchSingleStoredAttribute(attributeId: Int, siteID: Int) =
         WellSql.select(WCProductAttributeModel::class.java)
                 .where()
-                .equals(WCProductAttributeModelTable.ID, attributeId)
+                .equals(WCProductAttributeModelTable.REMOTE_ID, attributeId)
                 .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
                 .endWhere()
                 .asModel
@@ -41,7 +41,7 @@ object WCProductAttributeSqlUtils {
     fun deleteSingleStoredAttribute(attribute: WCProductAttributeModel, siteID: Int) = attribute.apply {
         WellSql.delete(WCProductAttributeModel::class.java)
                 .where()
-                .equals(WCProductAttributeModelTable.ID, attribute.id)
+                .equals(WCProductAttributeModelTable.REMOTE_ID, attribute.id)
                 .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
                 .endWhere()
                 .execute()
@@ -50,7 +50,7 @@ object WCProductAttributeSqlUtils {
     fun updateSingleStoredAttribute(attribute: WCProductAttributeModel, siteID: Int) = attribute.apply {
         WellSql.update(WCProductAttributeModel::class.java)
                 .where()
-                .equals(WCProductAttributeModelTable.ID, attribute.id)
+                .equals(WCProductAttributeModelTable.REMOTE_ID, attribute.id)
                 .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
                 .endWhere()
                 .put(attribute)
@@ -65,7 +65,7 @@ object WCProductAttributeSqlUtils {
     fun getTerm(siteID: Int, termID: Int) =
             WellSql.select(WCAttributeTermModel::class.java)
                     .where()
-                    .equals(WCAttributeTermModelTable.ID, termID)
+                    .equals(WCAttributeTermModelTable.REMOTE_ID, termID)
                     .equals(WCAttributeTermModelTable.LOCAL_SITE_ID, siteID)
                     .endWhere()
                     .asModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductAttributesStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductAttributesStore.kt
@@ -33,7 +33,7 @@ class WCProductAttributesStore @Inject constructor(
                         .asWooResult()
                         .model
                         ?.takeIf { it.isNotEmpty() }
-                        ?.let { mapper.mapToAttributeModelList(it, site) }
+                        ?.let { mapper.responseToAttributeModelList(it, site) }
                         ?.let {
                             insertFromScratchCompleteAttributesList(it, site.id)
                             getCurrentAttributes(site.id)
@@ -64,7 +64,7 @@ class WCProductAttributesStore @Inject constructor(
                 )
                         .asWooResult()
                         .model
-                        ?.let { mapper.mapToAttributeModel(it, site) }
+                        ?.let { mapper.responseToAttributeModel(it, site) }
                         ?.let { insertSingleAttribute(it) }
                         ?.let { WooResult(it) }
                         ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
@@ -91,7 +91,7 @@ class WCProductAttributesStore @Inject constructor(
                 )
                         .asWooResult()
                         .model
-                        ?.let { mapper.mapToAttributeModel(it, site) }
+                        ?.let { mapper.responseToAttributeModel(it, site) }
                         ?.let { updateSingleStoredAttribute(it, site.id) }
                         ?.let { WooResult(it) }
                         ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
@@ -105,7 +105,7 @@ class WCProductAttributesStore @Inject constructor(
                 restClient.deleteExistingAttribute(site, attributeID)
                         .asWooResult()
                         .model
-                        ?.let { mapper.mapToAttributeModel(it, site) }
+                        ?.let { mapper.responseToAttributeModel(it, site) }
                         ?.let { deleteSingleStoredAttribute(it, site.id) }
                         ?.let { WooResult(it) }
                         ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductAttributesStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductAttributesStore.kt
@@ -45,6 +45,20 @@ class WCProductAttributesStore @Inject constructor(
                         ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
 
+    suspend fun fetchAttribute(
+        site: SiteModel,
+        attributeID: Long
+    ): WooResult<WCProductAttributeModel> =
+            coroutineEngine.withDefaultContext(AppLog.T.API, this, "createStoreAttributes") {
+                restClient.fetchSingleAttribute(site, attributeID)
+                        .asWooResult()
+                        .model
+                        ?.let { mapper.responseToAttributeModel(it, site) }
+                        ?.let { insertSingleAttribute(it) }
+                        ?.let { WooResult(it) }
+                        ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+
     suspend fun createAttribute(
         site: SiteModel,
         name: String,
@@ -60,7 +74,8 @@ class WCProductAttributesStore @Inject constructor(
                         "slug" to slug,
                         "type" to type,
                         "order_by" to orderBy,
-                        "has_archives" to hasArchives.toString())
+                        "has_archives" to hasArchives.toString()
+                )
                 )
                         .asWooResult()
                         .model
@@ -87,7 +102,8 @@ class WCProductAttributesStore @Inject constructor(
                         "slug" to slug,
                         "type" to type,
                         "order_by" to orderBy,
-                        "has_archives" to hasArchives.toString())
+                        "has_archives" to hasArchives.toString()
+                )
                 )
                         .asWooResult()
                         .model
@@ -108,6 +124,23 @@ class WCProductAttributesStore @Inject constructor(
                         ?.let { mapper.responseToAttributeModel(it, site) }
                         ?.let { deleteSingleStoredAttribute(it, site.id) }
                         ?.let { WooResult(it) }
+                        ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+
+
+    suspend fun createOptionValueForAttribute(
+        site: SiteModel,
+        attributeID: Long,
+        term: String
+    ): WooResult<WCProductAttributeModel> =
+            coroutineEngine.withDefaultContext(AppLog.T.API, this, "createAttributeTerm") {
+                restClient.postNewTerm(
+                        site, attributeID,
+                        mapOf("name" to term)
+                )
+                        .asWooResult()
+                        .model
+                        ?.let { fetchAttribute(site, attributeID) }
                         ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductAttributesStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductAttributesStore.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.Prod
 import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.deleteSingleStoredAttribute
 import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.getCurrentAttributes
 import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.insertFromScratchCompleteAttributesList
+import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.insertOrUpdateSingleAttribute
 import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.insertSingleAttribute
 import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.updateSingleStoredAttribute
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -54,7 +55,7 @@ class WCProductAttributesStore @Inject constructor(
                         .asWooResult()
                         .model
                         ?.let { mapper.responseToAttributeModel(it, site) }
-                        ?.let { insertSingleAttribute(it) }
+                        ?.let { insertOrUpdateSingleAttribute(it, site.id) }
                         ?.let { WooResult(it) }
                         ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductAttributesStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductAttributesStore.kt
@@ -128,7 +128,6 @@ class WCProductAttributesStore @Inject constructor(
                         ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
 
-
     suspend fun createOptionValueForAttribute(
         site: SiteModel,
         attributeID: Long,
@@ -139,6 +138,19 @@ class WCProductAttributesStore @Inject constructor(
                         site, attributeID,
                         mapOf("name" to term)
                 )
+                        .asWooResult()
+                        .model
+                        ?.let { fetchAttribute(site, attributeID) }
+                        ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+
+    suspend fun deleteOptionValueFromAttribute(
+        site: SiteModel,
+        attributeID: Long,
+        termID: Long
+    ): WooResult<WCProductAttributeModel> =
+            coroutineEngine.withDefaultContext(AppLog.T.API, this, "deleteAttributeTerm") {
+                restClient.deleteExistingTerm(site, attributeID, termID)
                         .asWooResult()
                         .model
                         ?.let { fetchAttribute(site, attributeID) }


### PR DESCRIPTION
Summary
==========
Finish implementation for the [Woo Issue 3482](https://github.com/woocommerce/woocommerce-android/issues/3482). This PR adds support to synchronize all Attributes Terms with persistence and data parsing operations coming from the site.

⚠️ Attribute terms deletion isn't available since right now we shouldn't allow the device to modify global store values that can affect a large number of product variations all over the site.

Screenshots & How to Test
==========
| Select the Woo section | Scroll down until the Attribute option becomes visible and click on it | Fetch attributes and create terms
| ------------- | ------------- | ------------- |
| ![screenshot-1608543978049](https://user-images.githubusercontent.com/5920403/102763338-47758800-4358-11eb-8a05-1b29d0f69af9.jpg) | ![screenshot-1608543983921](https://user-images.githubusercontent.com/5920403/102763341-48a6b500-4358-11eb-9744-2765f3256b94.jpg) | ![screenshot-1612149602681](https://user-images.githubusercontent.com/5920403/106411153-450c5080-6423-11eb-904d-f961abb5a2f2.jpg) |

To verify if the changes are working under the Woo site, go to Products > Attributes on your Woo site and make sure everything is as expected.

<img width="1137" alt="Screen Shot 2020-12-21 at 4 25 56 AM" src="https://user-images.githubusercontent.com/5920403/102763945-25303a00-4359-11eb-8204-9297bf7f7e7f.png">
 
