### PR TITLE
Woo store address

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 133
+        return 134
     }
 
     override fun getDbName(): String {
@@ -1463,6 +1463,13 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "ORDER_BY TEXT, " +
                                     "HAS_ARCHIVES BOOLEAN NOT NULL)"
                     )
+                }
+                133 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCSettingsModel ADD ADDRESS TEXT")
+                    db.execSQL("ALTER TABLE WCSettingsModel ADD ADDRESS2 TEXT")
+                    db.execSQL("ALTER TABLE WCSettingsModel ADD CITY TEXT")
+                    db.execSQL("ALTER TABLE WCSettingsModel ADD POSTAL_CODE TEXT")
+                    db.execSQL("ALTER TABLE WCSettingsModel ADD STATE_CODE TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSettingsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSettingsModel.kt
@@ -9,14 +9,19 @@ data class WCSettingsModel(
     val currencyThousandSeparator: String, // The thousands separator character (e.g. the comma in 3,000)
     val currencyDecimalSeparator: String, // The decimal separator character (e.g. the dot in 41.12)
     val currencyDecimalNumber: Int, // How many decimal points to display
-    val countryCode: String = "" // The country code for the site in 2-letter format i.e. US
+    val countryCode: String = "", // The country code for the site in 2-letter format i.e. US
+    val address: String = "",
+    val address2: String = "",
+    val city: String = "",
+    val postalCode: String = "",
+    val stateCode: String = "" // The state code for the site in 2-letter format i.e. NY
 ) {
     enum class CurrencyPosition {
         LEFT, RIGHT, LEFT_SPACE, RIGHT_SPACE;
 
         companion object {
-            private val reverseMap = CurrencyPosition.values().associateBy(CurrencyPosition::name)
-            fun fromString(type: String?) = CurrencyPosition.reverseMap[type?.toUpperCase(Locale.US)] ?: LEFT
+            private val reverseMap = values().associateBy(CurrencyPosition::name)
+            fun fromString(type: String?) = reverseMap[type?.toUpperCase(Locale.US)] ?: LEFT
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -94,7 +94,15 @@ class WooCommerceRestClient(
                         val currencyThousandSep = getValueForSettingsField(it, "woocommerce_price_thousand_sep")
                         val currencyDecimalSep = getValueForSettingsField(it, "woocommerce_price_decimal_sep")
                         val currencyNumDecimals = getValueForSettingsField(it, "woocommerce_price_num_decimals")
-                        val countryCode = getValueForSettingsField(it, "woocommerce_default_country")
+                        val address = getValueForSettingsField(it, "woocommerce_store_address")
+                        val address2 = getValueForSettingsField(it, "woocommerce_store_address_2")
+                        val city = getValueForSettingsField(it, "woocommerce_store_city")
+                        val postalCode = getValueForSettingsField(it, "woocommerce_store_postcode")
+                        val countryAndState = getValueForSettingsField(it, "woocommerce_default_country")
+                                ?.split(":")
+                        val country = countryAndState?.firstOrNull()
+                        val state = countryAndState?.getOrNull(1)
+
                         val settings = WCSettingsModel(
                                 localSiteId = site.id,
                                 currencyCode = currencyCode ?: "",
@@ -102,11 +110,12 @@ class WooCommerceRestClient(
                                 currencyThousandSeparator = currencyThousandSep ?: "",
                                 currencyDecimalSeparator = currencyDecimalSep ?: "",
                                 currencyDecimalNumber = currencyNumDecimals?.toIntOrNull() ?: 2,
-                                /**
-                                 * The default store country is provided in a format like `US:NY`
-                                 * If no country code is available, storing empty value
-                                 * */
-                                countryCode = countryCode ?: ""
+                                countryCode = country ?: "",
+                                stateCode = state ?: "",
+                                address = address ?: "",
+                                address2 = address2 ?: "",
+                                city = city ?: "",
+                                postalCode = postalCode ?: ""
                         )
 
                         val payload = FetchWCSiteSettingsResponsePayload(site, settings)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCSettingsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCSettingsSqlUtils.kt
@@ -47,7 +47,12 @@ object WCSettingsSqlUtils {
         @Column var currencyThousandSeparator: String = "",
         @Column var currencyDecimalSeparator: String = "",
         @Column var currencyDecimalNumber: Int = 2,
-        @Column var countryCode: String = ""
+        @Column var countryCode: String = "",
+        @Column var stateCode: String = "",
+        @Column var address: String = "",
+        @Column var address2: String = "",
+        @Column var city: String = "",
+        @Column var postalCode: String = ""
     ) : Identifiable {
         override fun getId() = id
 
@@ -63,7 +68,12 @@ object WCSettingsSqlUtils {
                     currencyThousandSeparator = currencyThousandSeparator,
                     currencyDecimalSeparator = currencyDecimalSeparator,
                     currencyDecimalNumber = currencyDecimalNumber,
-                    countryCode = countryCode
+                    countryCode = countryCode,
+                    stateCode = stateCode,
+                    address = address,
+                    address2 = address2,
+                    city = city,
+                    postalCode = postalCode
             )
         }
     }
@@ -76,7 +86,12 @@ object WCSettingsSqlUtils {
                 currencyThousandSeparator = this.currencyThousandSeparator,
                 currencyDecimalSeparator = this.currencyDecimalSeparator,
                 currencyDecimalNumber = this.currencyDecimalNumber,
-                countryCode = countryCode
+                countryCode = countryCode,
+                stateCode = stateCode,
+                address = address,
+                address2 = address2,
+                city = city,
+                postalCode = postalCode
         )
     }
 }


### PR DESCRIPTION
This PR adds additional columns to the Woo settings table for the store address, which is required for shipping labels.

**To test:**
1. Run the example app & login
2. Go to Woo
3. Tap on the Log Woo Settings button
4. Notice the address, city, postal code, state and country are printed in the log