### PR TITLE
Sync operations between Attributes and Variable Products

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -19,8 +19,8 @@ import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
-import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
+import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
+import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
 import javax.inject.Inject
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -19,13 +19,13 @@ import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeModel
+import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
-import org.wordpress.android.fluxc.store.WCProductAttributesStore
+import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
 import javax.inject.Inject
 
 class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
-    @Inject internal lateinit var wcAttributesStore: WCProductAttributesStore
+    @Inject internal lateinit var wcAttributesStore: WCGlobalAttributeStore
 
     private var selectedPos: Int = -1
     private var selectedSite: SiteModel? = null
@@ -215,7 +215,7 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
         }
     }
 
-    private fun logSingleAttributeResponse(response: WCProductAttributeModel) {
+    private fun logSingleAttributeResponse(response: WCGlobalAttributeModel) {
         response.let {
             response.terms
                     ?.filterNotNull()
@@ -238,7 +238,7 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
         }
     }
 
-    private fun logAttributeListResponse(model: List<WCProductAttributeModel>) {
+    private fun logAttributeListResponse(model: List<WCGlobalAttributeModel>) {
         model.forEach(::logSingleAttributeResponse)
         prependToLog("========== Full Site Attribute list =========")
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -695,10 +695,12 @@ class WooProductsFragment : Fragment() {
                                         productIdEditText,
                                         attributeIdEditText,
                                         termEditText
-                                )?.apply {
-                                    model?.let { logProduct(it) }
-                                            ?: prependToLog("Couldn't fetch product data")
-                                } ?: prependToLog("Something went wrong with attach operation")
+                                )?.model.let { product ->
+                                    withContext(Dispatchers.Main) {
+                                        product?.let { logProduct(it) }
+                                                ?: prependToLog("Couldn't fetch product data")
+                                    }
+                                }
                             }
                         }
                     }
@@ -732,10 +734,12 @@ class WooProductsFragment : Fragment() {
                                                 attributeIdEditText.text.toString().toIntOrNull() ?: 0
                                         )
                                     }?.let { wcProductStore.submitProductAttributeChanges(site, it) }
-                                    ?.apply {
-                                        model?.let { logProduct(it) }
-                                                ?: prependToLog("Couldn't fetch product data")
-                                    } ?: prependToLog("Something went wrong with detach operation")
+                                    ?.model.let { product ->
+                                        withContext(Dispatchers.Main) {
+                                            product?.let { logProduct(it) }
+                                                    ?: prependToLog("Couldn't fetch product data")
+                                        }
+                                    }
                         }
                     }
                 }
@@ -806,7 +810,7 @@ class WooProductsFragment : Fragment() {
     }
 
     private fun logAttributeOptions(options: List<String>) {
-        options.forEach { prependToLog(it) }
+        options.forEach { prependToLog("  $it") }
         prependToLog("  --------- Attribute Options ---------")
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -706,10 +706,7 @@ class WooProductsFragment : Fragment() {
                                                     )?.let {
                                                         product.updateAttribute(it)
                                                     }?.let {
-                                                        wcProductStore.submitProductAttributeChanges(
-                                                                site,
-                                                                product
-                                                        )
+                                                        wcProductStore.submitProductAttributeChanges(site, it)
                                                     }
                                         }
                             }?.apply {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -695,11 +695,11 @@ class WooProductsFragment : Fragment() {
                                         productIdEditText,
                                         attributeIdEditText,
                                         termEditText
-                                )
-                            }?.apply {
-                                model?.let { logProduct(it) }
-                                        ?: prependToLog("Couldn't fetch product data")
-                            } ?: prependToLog("Something went wrong with attach operation")
+                                )?.apply {
+                                    model?.let { logProduct(it) }
+                                            ?: prependToLog("Couldn't fetch product data")
+                                } ?: prependToLog("Something went wrong with attach operation")
+                            }
                         }
                     }
                 }
@@ -770,16 +770,15 @@ class WooProductsFragment : Fragment() {
         attributeId: Long,
         termId: Int,
         product: WCProductModel
-    ) = wcAttributesStore.fetchAttribute(site, attributeId)
+    ) = wcAttributesStore.fetchAttribute(
+            site = site,
+            attributeID = attributeId,
+            withTerms = true
+    )
             .model
+            ?.asProductAttributeModel(termId)
+            ?.run { product.updateAttribute(this) }
             ?.let {
-                wcAttributesStore.fetchAttributeTerms(
-                        site,
-                        it.remoteId.toLong()
-                )
-                it.asProductAttributeModel(termId)
-                        .run { product.updateAttribute(this) }
-            }?.let {
                 wcProductStore.submitProductAttributeChanges(site, it)
             }
 
@@ -790,12 +789,12 @@ class WooProductsFragment : Fragment() {
         }
     }
 
-    private fun logProduct(product: WCProductModel) = product.let {
-        it.attributeList.forEach { logAttribute(it) }
-        prependToLog("  Product slug: ${it.slug.ifEmpty { "Slug not available" }}")
-        prependToLog("  Product type: ${it.type.ifEmpty { "Type not available" }}")
-        prependToLog("  Product name: ${it.name.ifEmpty { "Product name not available" }}")
-        prependToLog("  Product remote id: ${it.remoteProductId}")
+    private fun logProduct(product: WCProductModel) = product.apply {
+        attributeList.forEach { logAttribute(it) }
+        prependToLog("  Product slug: ${slug.ifEmpty { "Slug not available" }}")
+        prependToLog("  Product type: ${type.ifEmpty { "Type not available" }}")
+        prependToLog("  Product name: ${name.ifEmpty { "Product name not available" }}")
+        prependToLog("  Product remote id: $remoteProductId")
         prependToLog("  --------- Product ---------")
     }
 

--- a/example/src/main/res/layout/fragment_woo_product_attribute.xml
+++ b/example/src/main/res/layout/fragment_woo_product_attribute.xml
@@ -73,6 +73,13 @@
             android:text="Fetch Single Attribute"/>
 
         <Button
+            android:id="@+id/fetch_term_for_attribute"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Attribute Terms"/>
+
+        <Button
             android:id="@+id/create_term_for_attribute"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -213,5 +213,19 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Delete product"/>
+
+        <Button
+            android:id="@+id/attach_attribute"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Attach Attribute"/>
+
+        <Button
+            android:id="@+id/detach_attribute"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Detach Attribute"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeMapperTest.kt
@@ -1,25 +1,14 @@
 package org.wordpress.android.fluxc.wc.attributes
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
-import com.yarolegovich.wellsql.WellSql
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeMapper
-import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
-import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeCreateResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeTermsFullListResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributesFullListResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.stubSite
 import kotlin.test.fail
@@ -28,28 +17,16 @@ import kotlin.test.fail
 @RunWith(RobolectricTestRunner::class)
 class WCGlobalAttributeMapperTest {
     private lateinit var mapperUnderTest: WCGlobalAttributeMapper
-    private lateinit var attributesRestClient: ProductAttributeRestClient
 
     @Before
     fun setUp() {
-        SingleStoreWellSqlConfigForTests(
-                RuntimeEnvironment.application.applicationContext,
-                listOf(SiteModel::class.java, WCAttributeTermModel::class.java),
-                WellSqlConfig.ADDON_WOOCOMMERCE
-        ).let {
-            WellSql.init(it)
-            it.reset()
-        }
-
-        attributesRestClient = mock()
-        mapperUnderTest = WCGlobalAttributeMapper(attributesRestClient)
+        mapperUnderTest = WCGlobalAttributeMapper()
     }
 
     @Test
     fun `mapToAttributeModel should never allow null values`() = test {
         attributeCreateResponse
                 ?.let {
-                    configureAttributeRestClientMock(it.id?.toIntOrNull() ?: 0)
                     mapperUnderTest.responseToAttributeModel(it, stubSite)
                 }?.let { result ->
                     assertThat(result).isNotNull
@@ -64,8 +41,6 @@ class WCGlobalAttributeMapperTest {
 
     @Test
     fun `mapToAttributeModelList should parse list correctly`() = test {
-        configureAttributeRestClientMock(1)
-        configureAttributeRestClientMock(2)
         mapperUnderTest.responseToAttributeModelList(attributesFullListResponse!!, stubSite)
                 .let { result ->
                     assertThat(result).isNotNull
@@ -75,7 +50,6 @@ class WCGlobalAttributeMapperTest {
 
     @Test
     fun `mapToAttributeModel should parse correctly`() = test {
-        configureAttributeRestClientMock(1)
         mapperUnderTest.responseToAttributeModel(attributeCreateResponse!!, stubSite)
                 ?.let { result ->
                     assertThat(result).isNotNull
@@ -86,12 +60,5 @@ class WCGlobalAttributeMapperTest {
                     assertThat(result.orderBy).isEqualTo("menu_order")
                     assertThat(result.hasArchives).isEqualTo(true)
                 } ?: fail("Result shouldn't be null")
-    }
-
-    private suspend fun configureAttributeRestClientMock(attributeID: Int) {
-        mock<ProductAttributeRestClient>().apply {
-            whenever(attributesRestClient.fetchAllAttributeTerms(stubSite, attributeID.toLong()))
-                    .thenReturn(WooPayload(attributeTermsFullListResponse))
-        }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeMapperTest.kt
@@ -4,7 +4,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.yarolegovich.wellsql.WellSql
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,16 +12,17 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeMapper
-import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
+import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeMapper
+import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.test
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeCreateResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeTermsFullListResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributesFullListResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.stubSite
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeCreateResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeTermsFullListResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributesFullListResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.stubSite
+import kotlin.test.fail
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeMapperTest.kt
@@ -13,21 +13,21 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeMapper
+import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeMapper
 import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.test
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeCreateResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeTermsFullListResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributesFullListResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.stubSite
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeCreateResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeTermsFullListResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributesFullListResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.stubSite
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
-class WCProductAttributeMapperTest {
-    private lateinit var mapperUnderTest: WCProductAttributeMapper
+class WCGlobalAttributeMapperTest {
+    private lateinit var mapperUnderTest: WCGlobalAttributeMapper
     private lateinit var attributesRestClient: ProductAttributeRestClient
 
     @Before
@@ -42,7 +42,7 @@ class WCProductAttributeMapperTest {
         }
 
         attributesRestClient = mock()
-        mapperUnderTest = WCProductAttributeMapper(attributesRestClient)
+        mapperUnderTest = WCGlobalAttributeMapper(attributesRestClient)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeStoreTest.kt
@@ -14,32 +14,32 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeMapper
-import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeModel
+import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeMapper
+import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
-import org.wordpress.android.fluxc.store.WCProductAttributesStore
+import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeCreateResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeDeleteResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeTermsFullListResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeUpdateResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributesFullListResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedAttributesList
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedCreateAttributeResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedDeleteAttributeResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedUpdateAttributeResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.stubSite
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeCreateResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeDeleteResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeTermsFullListResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeUpdateResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributesFullListResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.parsedAttributesList
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.parsedCreateAttributeResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.parsedDeleteAttributeResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.parsedUpdateAttributeResponse
+import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.stubSite
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
-class WCProductAttributesStoreTest {
-    private lateinit var storeUnderTest: WCProductAttributesStore
+class WCGlobalAttributeStoreTest {
+    private lateinit var storeUnderTest: WCGlobalAttributeStore
     private lateinit var restClient: ProductAttributeRestClient
-    private lateinit var mapper: WCProductAttributeMapper
+    private lateinit var mapper: WCGlobalAttributeMapper
 
     @Before
     fun setUp() {
@@ -48,7 +48,7 @@ class WCProductAttributesStoreTest {
                 appContext,
                 listOf(
                         SiteModel::class.java,
-                        WCProductAttributeModel::class.java,
+                        WCGlobalAttributeModel::class.java,
                         WCAttributeTermModel::class.java
                 ),
                 WellSqlConfig.ADDON_WOOCOMMERCE
@@ -70,7 +70,7 @@ class WCProductAttributesStoreTest {
 
     @Test
     fun `fetch attributes should call mapper once`() = test {
-        mapper = spy(WCProductAttributeMapper(
+        mapper = spy(WCGlobalAttributeMapper(
                 mock<ProductAttributeRestClient>().apply {
                     val response = WooPayload(attributeTermsFullListResponse)
                     whenever(this.fetchAllAttributeTerms(stubSite, 1))
@@ -104,7 +104,7 @@ class WCProductAttributesStoreTest {
 
     @Test
     fun `create Attribute should return WooResult with parsed entity`() = test {
-        val expectedResult = WCProductAttributeModel(
+        val expectedResult = WCGlobalAttributeModel(
                 1,
                 321,
                 "Color",
@@ -143,7 +143,7 @@ class WCProductAttributesStoreTest {
 
     @Test
     fun `delete Attribute should return WooResult with parsed entity`() = test {
-        val expectedResult = WCProductAttributeModel(
+        val expectedResult = WCGlobalAttributeModel(
                 17,
                 321,
                 "Size",
@@ -171,7 +171,7 @@ class WCProductAttributesStoreTest {
 
     @Test
     fun `update Attribute should return WooResult with parsed entity`() = test {
-        val expectedResult = WCProductAttributeModel(
+        val expectedResult = WCGlobalAttributeModel(
                 99,
                 321,
                 "test_name",
@@ -219,7 +219,7 @@ class WCProductAttributesStoreTest {
     }
 
     private fun createStoreUnderTest() =
-            WCProductAttributesStore(
+            WCGlobalAttributeStore(
                     restClient,
                     mapper,
                     initCoroutineEngine()

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeStoreTest.kt
@@ -14,25 +14,25 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeMapper
-import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
-import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
+import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeMapper
+import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
+import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeCreateResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeDeleteResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeTermsFullListResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributeUpdateResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.attributesFullListResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.parsedAttributesList
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.parsedCreateAttributeResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.parsedDeleteAttributeResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.parsedUpdateAttributeResponse
-import org.wordpress.android.fluxc.wc.attributes.WCGlobalAttributesTestFixtures.stubSite
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeCreateResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeDeleteResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeTermsFullListResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeUpdateResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributesFullListResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedAttributesList
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedCreateAttributeResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedDeleteAttributeResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedUpdateAttributeResponse
+import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.stubSite
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeStoreTest.kt
@@ -70,15 +70,7 @@ class WCGlobalAttributeStoreTest {
 
     @Test
     fun `fetch attributes should call mapper once`() = test {
-        mapper = spy(WCGlobalAttributeMapper(
-                mock<ProductAttributeRestClient>().apply {
-                    val response = WooPayload(attributeTermsFullListResponse)
-                    whenever(this.fetchAllAttributeTerms(stubSite, 1))
-                            .thenReturn(response)
-                    whenever(this.fetchAllAttributeTerms(stubSite, 2))
-                            .thenReturn(response)
-                }
-        ))
+        mapper = spy()
         createStoreUnderTest()
         whenever(restClient.fetchProductFullAttributesList(stubSite))
                 .thenReturn(WooPayload(attributesFullListResponse))

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributeStoreTest.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeCreateResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeDeleteResponse
-import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeTermsFullListResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributeUpdateResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.attributesFullListResponse
 import org.wordpress.android.fluxc.wc.attributes.WCProductAttributesTestFixtures.parsedAttributesList

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributesTestFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCGlobalAttributesTestFixtures.kt
@@ -3,11 +3,11 @@ package org.wordpress.android.fluxc.wc.attributes
 import com.google.gson.Gson
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeModel
+import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
 
-object WCProductAttributesTestFixtures {
+object WCGlobalAttributesTestFixtures {
     val stubSite = SiteModel().apply { id = 321 }
 
     val attributeDeleteResponse by lazy {
@@ -37,7 +37,7 @@ object WCProductAttributesTestFixtures {
 
     val parsedAttributesList by lazy {
         listOf(
-                WCProductAttributeModel(
+                WCGlobalAttributeModel(
                         1,
                         321,
                         "Color",
@@ -46,7 +46,7 @@ object WCProductAttributesTestFixtures {
                         "menu_order",
                         true
                 ),
-                WCProductAttributeModel(
+                WCGlobalAttributeModel(
                         2,
                         321,
                         "Size",
@@ -59,7 +59,7 @@ object WCProductAttributesTestFixtures {
     }
 
     val parsedCreateAttributeResponse by lazy {
-        WCProductAttributeModel(
+        WCGlobalAttributeModel(
                 1,
                 321,
                 "Color",
@@ -71,7 +71,7 @@ object WCProductAttributesTestFixtures {
     }
 
     val parsedDeleteAttributeResponse by lazy {
-        WCProductAttributeModel(
+        WCGlobalAttributeModel(
                 17,
                 321,
                 "Size",
@@ -83,7 +83,7 @@ object WCProductAttributesTestFixtures {
     }
 
     val parsedUpdateAttributeResponse by lazy {
-        WCProductAttributeModel(
+        WCGlobalAttributeModel(
                 99,
                 321,
                 "test_name",
@@ -96,7 +96,7 @@ object WCProductAttributesTestFixtures {
 
     private fun <T> String.jsonFileAs(clazz: Class<T>) =
             UnitTestUtils.getStringFromResourceFile(
-                    this@WCProductAttributesTestFixtures.javaClass,
+                    this@WCGlobalAttributesTestFixtures.javaClass,
                     this
             )?.let { Gson().fromJson(it, clazz) }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributesTestFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/attributes/WCProductAttributesTestFixtures.kt
@@ -3,11 +3,11 @@ package org.wordpress.android.fluxc.wc.attributes
 import com.google.gson.Gson
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
+import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
 
-object WCGlobalAttributesTestFixtures {
+object WCProductAttributesTestFixtures {
     val stubSite = SiteModel().apply { id = 321 }
 
     val attributeDeleteResponse by lazy {
@@ -96,7 +96,7 @@ object WCGlobalAttributesTestFixtures {
 
     private fun <T> String.jsonFileAs(clazz: Class<T>) =
             UnitTestUtils.getStringFromResourceFile(
-                    this@WCGlobalAttributesTestFixtures.javaClass,
+                    this@WCProductAttributesTestFixtures.javaClass,
                     this
             )?.let { Gson().fromJson(it, clazz) }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 135
+        return 136
     }
 
     override fun getDbName(): String {
@@ -1488,7 +1488,7 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "MENU_ORDER INTEGER)"
                     )
                 }
-                134 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                135 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductAttributeModel RENAME TO WCGlobalAttributeModel")
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 134
+        return 135
     }
 
     override fun getDbName(): String {
@@ -1480,6 +1480,9 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "COUNT TEXT, " +
                                     "MENU_ORDER TEXT)"
                     )
+                }
+                134 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductAttributeModel RENAME TO WCGlobalAttributeModel")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -161,10 +161,11 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     fun getAttribute(attributeID: Int) =
         attributeList.find { it.globalAttributeId == attributeID }
 
-    fun updateAttribute(updatedAttribute: WCProductAttributeModel) =
-        getAttribute(updatedAttribute.globalAttributeId)?.let {
-            removeAttribute(it.globalAttributeId)
-        }.also { addAttribute(updatedAttribute) }
+    fun updateAttribute(updatedAttribute: WCProductAttributeModel) = apply {
+        getAttribute(updatedAttribute.globalAttributeId)
+                ?.let { removeAttribute(it.globalAttributeId) }
+        addAttribute(updatedAttribute)
+    }
 
     /**
      * Parses the images json array into a list of product images

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -100,11 +100,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var width = ""
     @Column var height = ""
 
-    private val gson by lazy { Gson() }
-
-    val attributeList by lazy {
-        gson.fromJson(attributes, Array<WCProductAttributeModel>::class.java)
-    }
+    val attributeList: Array<WCProductAttributeModel>
+        get() = Gson().fromJson(attributes, Array<WCProductAttributeModel>::class.java)
 
     class ProductTriplet(val id: Long, val name: String, val slug: String) {
         fun toJson(): JsonObject {
@@ -144,7 +141,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
                                 ?.takeIf { it.isNotEmpty() }
                                 ?.let { addAll(it) }
                         add(newAttribute)
-                    }.also { attributes = gson.toJson(it) }
+                    }.also { attributes = Gson().toJson(it) }
 
     fun removeAttribute(removableAttribute: WCProductAttributeModel) =
             mutableListOf<WCProductAttributeModel>().apply {
@@ -152,7 +149,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
                         ?.takeIf { it.isNotEmpty() }
                         ?.filter { removableAttribute.globalAttributeId != it.globalAttributeId }
                         ?.let { addAll(it) }
-            }.also { attributes = gson.toJson(it) }
+            }.also { attributes = Gson().toJson(it) }
 
     /**
      * Parses the images json array into a list of product images
@@ -161,7 +158,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         val imageList = ArrayList<WCProductImageModel>()
         if (images.isNotEmpty()) {
             try {
-                gson.fromJson(images, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+                Gson().fromJson(images, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
                     with(jsonElement.asJsonObject) {
                         WCProductImageModel(this.getLong("id")).also {
                             it.name = this.getString("name") ?: ""
@@ -186,7 +183,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     fun getFirstImageUrl(): String? {
         try {
             if (images.isNotEmpty()) {
-                gson.fromJson(images, JsonElement::class.java).asJsonArray.firstOrNull { jsonElement ->
+                Gson().fromJson(images, JsonElement::class.java).asJsonArray.firstOrNull { jsonElement ->
                     return (jsonElement.asJsonObject).getString("src")
                 }
             }
@@ -224,7 +221,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
 
         val attrList = ArrayList<ProductAttribute>()
         try {
-            gson.fromJson(attributes, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+            Gson().fromJson(attributes, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
                 with(jsonElement.asJsonObject) {
                     attrList.add(
                             ProductAttribute(
@@ -246,7 +243,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         if (downloads.isEmpty()) return emptyList()
         val fileList = ArrayList<WCProductFileModel>()
         try {
-            gson.fromJson(downloads, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
+            Gson().fromJson(downloads, JsonElement::class.java).asJsonArray.forEach { jsonElement ->
                 with(jsonElement.asJsonObject) {
                     fileList.add(
                             WCProductFileModel(
@@ -280,7 +277,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         val productIds = ArrayList<Long>()
         try {
             if (jsonString.isNotEmpty()) {
-                val jsonElement = gson.fromJson(jsonString, JsonElement::class.java)
+                val jsonElement = Gson().fromJson(jsonString, JsonElement::class.java)
                 when {
                     jsonElement.isJsonNull -> {
                         return emptyList()
@@ -336,7 +333,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         val triplets = ArrayList<ProductTriplet>()
         try {
             if (jsonStr.isNotEmpty()) {
-                val jsonElement = gson.fromJson<JsonElement>(jsonStr, JsonElement::class.java)
+                val jsonElement = Gson().fromJson<JsonElement>(jsonStr, JsonElement::class.java)
                 if (jsonElement.isJsonArray) {
                     jsonElement.asJsonArray.forEach { jsonArray ->
                         with(jsonArray.asJsonObject) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -134,22 +134,37 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         this.id = id
     }
 
-    fun addAttribute(newAttribute: WCProductAttributeModel) =
-            mutableListOf<WCProductAttributeModel>()
-                    .apply {
-                        attributeList
-                                ?.takeIf { it.isNotEmpty() }
-                                ?.let { addAll(it) }
-                        add(newAttribute)
-                    }.also { attributes = Gson().toJson(it) }
+    fun addAttribute(newAttribute: WCProductAttributeModel) {
+        mutableListOf<WCProductAttributeModel>()
+                .apply {
+                    attributeList
+                            .takeIf { it.isNotEmpty() }
+                            ?.takeIf {
+                                it.find { currentAttribute ->
+                                    currentAttribute.globalAttributeId == newAttribute.globalAttributeId
+                                } == null
+                            }?.let {
+                                add(newAttribute)
+                                addAll(it)
+                            }
+                }.also { attributes = Gson().toJson(it) }
+    }
 
-    fun removeAttribute(removableAttribute: WCProductAttributeModel) =
+    fun removeAttribute(attributeID: Int) =
             mutableListOf<WCProductAttributeModel>().apply {
                 attributeList
-                        ?.takeIf { it.isNotEmpty() }
-                        ?.filter { removableAttribute.globalAttributeId != it.globalAttributeId }
+                        .takeIf { it.isNotEmpty() }
+                        ?.filter { attributeID != it.globalAttributeId }
                         ?.let { addAll(it) }
             }.also { attributes = Gson().toJson(it) }
+
+    fun getAttribute(attributeID: Int) =
+        attributeList.find { it.globalAttributeId == attributeID }
+
+    fun updateAttribute(updatedAttribute: WCProductAttributeModel) =
+        getAttribute(updatedAttribute.globalAttributeId)?.let {
+            removeAttribute(it.globalAttributeId)
+        }.also { addAttribute(updatedAttribute) }
 
     /**
      * Parses the images json array into a list of product images

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -138,14 +138,15 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         mutableListOf<WCProductAttributeModel>()
                 .apply {
                     attributeList
-                            .takeIf { it.isNotEmpty() }
-                            ?.takeIf {
+                            .takeIf {
                                 it.find { currentAttribute ->
                                     currentAttribute.globalAttributeId == newAttribute.globalAttributeId
                                 } == null
-                            }?.let {
+                            }?.let { currentAttributes ->
                                 add(newAttribute)
-                                addAll(it)
+                                currentAttributes
+                                        .takeIf { it.isNotEmpty() }
+                                        ?.let { addAll(it) }
                             }
                 }.also { attributes = Gson().toJson(it) }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -83,7 +83,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
         this.id = id
     }
 
-    data class ProductVariantOption (
+    data class ProductVariantOption(
         val id: Long? = null,
         val name: String? = null,
         val option: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCGlobalAttributeMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCGlobalAttributeMapper.kt
@@ -3,9 +3,7 @@ package org.wordpress.android.fluxc.model.attribute
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
-import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.insertAttributeTermsFromScratch
 import javax.inject.Inject
 
 class WCGlobalAttributeMapper @Inject constructor() {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCGlobalAttributeMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCGlobalAttributeMapper.kt
@@ -1,7 +1,7 @@
-package org.wordpress.android.fluxc.model.product.attributes
+package org.wordpress.android.fluxc.model.attribute
 
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
+import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCGlobalAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCGlobalAttributeModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.model.product.attributes
+package org.wordpress.android.fluxc.model.attribute
 
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCGlobalAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCGlobalAttributeModel.kt
@@ -4,6 +4,7 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.getTerm
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
@@ -31,4 +32,22 @@ data class WCGlobalAttributeModel(
                 .takeIf { it.isNotEmpty() }
                 ?.map { getTerm(localSiteId, it) }
     }
+
+    fun asProductAttributeModel(vararg includedTermId: Int) =
+            WCProductAttributeModel(
+                    globalAttributeId = remoteId,
+                    name = name,
+                    visible = true,
+                    variation = true,
+                    options = includedTermId.takeIf { it.isNotEmpty() }
+                            ?.let { terms?.filterFromIdList(it) }
+                            ?.map { it.name }
+                            ?.toMutableList()
+                            ?: mutableListOf()
+            )
+
+    private fun List<WCAttributeTermModel?>.filterFromIdList(ids: IntArray) =
+                    filterNotNull().filter { term ->
+                        term.remoteId.let { ids.contains(it) }
+                    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCProductAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCProductAttributeModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model.attribute
 
 import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
 import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.fetchSingleStoredAttribute
 
 data class WCProductAttributeModel(
@@ -12,6 +13,23 @@ data class WCProductAttributeModel(
     val variation: Boolean = false,
     var options: MutableList<String> = mutableListOf()
 ) {
+    init {
+        options.add(anyOption)
+    }
+
     fun asGlobalAttribute(siteID: Int) =
             fetchSingleStoredAttribute(globalAttributeId, siteID)
+
+    fun generateProductVariantOption(selectedOption: String) =
+            takeIf { options.contains(selectedOption) }?.let {
+                ProductVariantOption(
+                        id = globalAttributeId.toLong(),
+                        name = name,
+                        option = selectedOption
+                )
+            }
+
+    companion object {
+        const val anyOption = "Any"
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCProductAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCProductAttributeModel.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.model.attribute
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.fetchSingleStoredAttribute
+
+data class WCProductAttributeModel(
+    @SerializedName("id")
+    val globalAttributeId: Int,
+    val name: String = "",
+    val position: Int = 0,
+    val visible: Boolean = false,
+    val options: List<String> = emptyList()
+) {
+    fun asGlobalAttribute(siteID: Int) =
+            fetchSingleStoredAttribute(globalAttributeId, siteID)
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCProductAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCProductAttributeModel.kt
@@ -9,7 +9,8 @@ data class WCProductAttributeModel(
     val name: String = "",
     val position: Int = 0,
     val visible: Boolean = false,
-    val options: List<String> = emptyList()
+    val variation: Boolean = false,
+    var options: MutableList<String> = mutableListOf()
 ) {
     fun asGlobalAttribute(siteID: Int) =
             fetchSingleStoredAttribute(globalAttributeId, siteID)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCProductAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/WCProductAttributeModel.kt
@@ -13,10 +13,6 @@ data class WCProductAttributeModel(
     val variation: Boolean = false,
     var options: MutableList<String> = mutableListOf()
 ) {
-    init {
-        options.add(anyOption)
-    }
-
     fun asGlobalAttribute(siteID: Int) =
             fetchSingleStoredAttribute(globalAttributeId, siteID)
 
@@ -28,8 +24,4 @@ data class WCProductAttributeModel(
                         option = selectedOption
                 )
             }
-
-    companion object {
-        const val anyOption = "Any"
-    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/terms/WCAttributeTermModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/attribute/terms/WCAttributeTermModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.model.product.attributes.terms
+package org.wordpress.android.fluxc.model.attribute.terms
 
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/leaderboards/WCTopPerformerProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/leaderboards/WCTopPerformerProductModel.kt
@@ -18,7 +18,8 @@ data class WCTopPerformerProductModel(
     @Column var unit: String = "",
     @PrimaryKey @Column private var id: Int = 0
 ) : Identifiable {
-    val product by lazy { Gson().fromJson(productInfo, WCProductModel::class.java) }
+    val product
+        get() = Gson().fromJson(productInfo, WCProductModel::class.java)
 
     override fun setId(id: Int) {
         this.id = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCGlobalAttributeMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCGlobalAttributeMapper.kt
@@ -5,10 +5,10 @@ import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTer
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.AttributeApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
-import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.insertAttributeTermsFromScratch
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.insertAttributeTermsFromScratch
 import javax.inject.Inject
 
-class WCProductAttributeMapper @Inject constructor(
+class WCGlobalAttributeMapper @Inject constructor(
     private val restClient: ProductAttributeRestClient
 ) {
     suspend fun responseToAttributeModel(
@@ -29,7 +29,7 @@ class WCProductAttributeMapper @Inject constructor(
         id: String,
         site: SiteModel,
         terms: String
-    ) = WCProductAttributeModel(
+    ) = WCGlobalAttributeModel(
             remoteId = id.toIntOrNull() ?: 0,
             localSiteId = site.id,
             name = name.orEmpty(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCGlobalAttributeModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/product/attributes/WCGlobalAttributeModel.kt
@@ -4,11 +4,11 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
-import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.getTerm
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.getTerm
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
-data class WCProductAttributeModel(
+data class WCGlobalAttributeModel(
     @PrimaryKey @Column private var id: Int = 0,
     @Column var localSiteId: Int = 0,
     @Column var name: String = "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooResult.kt
@@ -1,11 +1,19 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
 import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.Store
 
 data class WooPayload<T>(val result: T? = null) : Payload<WooError>() {
     constructor(error: WooError) : this() {
         this.error = error
+    }
+
+    fun asWooResult() = when {
+        isError -> WooResult(error)
+        result != null -> WooResult<T>(result)
+        else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
     }
 }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
 import android.content.Context
 import com.android.volley.RequestQueue
+import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
@@ -17,6 +18,7 @@ import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.model.attribute.WCProductAttributeModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -71,6 +73,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload
+import org.wordpress.android.fluxc.utils.handleResult
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import java.util.HashMap
 import javax.inject.Singleton
@@ -714,6 +717,21 @@ class ProductRestClient(
                 })
         add(request)
     }
+
+    suspend fun updateAttributes(
+        site: SiteModel,
+        product: WCProductModel,
+        attributes: List<WCProductAttributeModel>
+    ) = WOOCOMMERCE.products.id(product.remoteProductId).pathV3
+            .let { url ->
+                jetpackTunnelGsonRequestBuilder?.syncPutRequest(
+                        this,
+                        site,
+                        url,
+                        mapOf("attributes" to Gson().toJson(attributes)),
+                        ProductApiResponse::class.java
+                )?.handleResult()
+            }
 
     /**
      * Makes a PUT request to `/wp-json/wc/v3/products/[remoteProductId]` to replace a product's images

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -715,6 +715,17 @@ class ProductRestClient(
         add(request)
     }
 
+    /**
+     * Makes a PUT request to
+     * `/wp-json/wc/v3/products/[WCProductModel.remoteProductId]/variations/[WCProductVariationModel.remoteVariationId]`
+     * to replace a variation's attributes with [WCProductVariationModel.attributes]
+     *
+     * Returns a WooPayload with the Api response as result
+     *
+     * @param [site] The site to fetch product reviews for
+     * @param [variation] Locally updated product variation to be sent
+     */
+
     suspend fun updateVariationAttributes(
         site: SiteModel,
         variation: WCProductVariationModel
@@ -730,6 +741,16 @@ class ProductRestClient(
                     )?.handleResult()
                 }
     }
+
+    /**
+     * Makes a PUT request to `/wp-json/wc/v3/products/[WCProductModel.remoteProductId]`
+     * to replace a product's attributes with [WCProductModel.attributes]
+     *
+     * Returns a WooPayload with the Api response as result
+     *
+     * @param [site] The site to fetch product reviews for
+     * @param [product] Locally updated product to be sent
+     */
 
     suspend fun updateProductAttributes(
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
 import android.content.Context
 import com.android.volley.RequestQueue
-import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
@@ -18,7 +17,6 @@ import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
-import org.wordpress.android.fluxc.model.attribute.WCProductAttributeModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -720,15 +718,14 @@ class ProductRestClient(
 
     suspend fun updateAttributes(
         site: SiteModel,
-        product: WCProductModel,
-        attributes: List<WCProductAttributeModel>
+        product: WCProductModel
     ) = WOOCOMMERCE.products.id(product.remoteProductId).pathV3
             .let { url ->
                 jetpackTunnelGsonRequestBuilder?.syncPutRequest(
                         this,
                         site,
                         url,
-                        mapOf("attributes" to Gson().toJson(attributes)),
+                        mapOf("attributes" to product.attributes),
                         ProductApiResponse::class.java
                 )?.handleResult()
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -645,7 +645,7 @@ class ProductRestClient(
         val remoteProductId = updatedProductModel.remoteProductId
         val url = WOOCOMMERCE.products.id(remoteProductId).pathV3
         val responseType = object : TypeToken<ProductApiResponse>() {}.type
-        val body = productModelToProductJsonBody(updatedProductModel, storedWCProductModel)
+        val body = productModelToProductJsonBody(storedWCProductModel, updatedProductModel)
 
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, body, responseType,
                 { response: ProductApiResponse? ->
@@ -687,7 +687,7 @@ class ProductRestClient(
         val remoteVariationId = updatedProductVariationModel.remoteVariationId
         val url = WOOCOMMERCE.products.id(remoteProductId).variations.variation(remoteVariationId).pathV3
         val responseType = object : TypeToken<ProductVariationApiResponse>() {}.type
-        val body = variantModelToProductJsonBody(updatedProductVariationModel, storedWCProductVariationModel)
+        val body = variantModelToProductJsonBody(storedWCProductVariationModel, updatedProductVariationModel)
 
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, body, responseType,
                 { response: ProductVariationApiResponse? ->
@@ -1020,7 +1020,7 @@ class ProductRestClient(
     ) {
         val url = WOOCOMMERCE.products.pathV3
         val responseType = object : TypeToken<ProductApiResponse>() {}.type
-        val params = productModelToProductJsonBody(productModel)
+        val params = productModelToProductJsonBody(null, productModel)
 
         val request = JetpackTunnelGsonRequest.buildPostRequest(
                 wpApiEndpoint = url,
@@ -1098,8 +1098,8 @@ class ProductRestClient(
      * fields of [productModel]. This is to ensure that we do not update product fields that do not contain any changes
      */
     private fun productModelToProductJsonBody(
-        updatedProductModel: WCProductModel,
-        productModel: WCProductModel? = null
+        productModel: WCProductModel?,
+        updatedProductModel: WCProductModel
     ): HashMap<String, Any> {
         val body = HashMap<String, Any>()
 
@@ -1270,8 +1270,8 @@ class ProductRestClient(
      * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any changes
      */
     private fun variantModelToProductJsonBody(
-        updatedVariationModel: WCProductVariationModel,
-        variationModel: WCProductVariationModel? = null
+        variationModel: WCProductVariationModel?,
+        updatedVariationModel: WCProductVariationModel
     ): HashMap<String, Any> {
         val body = HashMap<String, Any>()
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 import android.content.Context
 import com.android.volley.RequestQueue
 import com.google.gson.JsonArray
+import com.google.gson.JsonParser
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction
@@ -736,7 +737,7 @@ class ProductRestClient(
                             this@ProductRestClient,
                             site,
                             url,
-                            mapOf("attributes" to variation.attributes),
+                            mapOf("attributes" to JsonParser().parse(variation.attributes).asJsonArray),
                             ProductVariationApiResponse::class.java
                     )?.handleResult()
                 }
@@ -761,7 +762,7 @@ class ProductRestClient(
                         this,
                         site,
                         url,
-                        mapOf("attributes" to product.attributes),
+                        mapOf("attributes" to JsonParser().parse(product.attributes).asJsonArray),
                         ProductApiResponse::class.java
                 )?.handleResult()
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -725,7 +725,7 @@ class ProductRestClient(
                             this@ProductRestClient,
                             site,
                             url,
-                            variantModelToProductJsonBody(variation),
+                            mapOf("attributes" to variation.attributes),
                             ProductVariationApiResponse::class.java
                     )?.handleResult()
                 }
@@ -740,7 +740,7 @@ class ProductRestClient(
                         this,
                         site,
                         url,
-                        productModelToProductJsonBody(product),
+                        mapOf("attributes" to product.attributes),
                         ProductApiResponse::class.java
                 )?.handleResult()
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -645,7 +645,7 @@ class ProductRestClient(
         val remoteProductId = updatedProductModel.remoteProductId
         val url = WOOCOMMERCE.products.id(remoteProductId).pathV3
         val responseType = object : TypeToken<ProductApiResponse>() {}.type
-        val body = productModelToProductJsonBody(storedWCProductModel, updatedProductModel)
+        val body = productModelToProductJsonBody(updatedProductModel, storedWCProductModel)
 
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, body, responseType,
                 { response: ProductApiResponse? ->
@@ -687,7 +687,7 @@ class ProductRestClient(
         val remoteVariationId = updatedProductVariationModel.remoteVariationId
         val url = WOOCOMMERCE.products.id(remoteProductId).variations.variation(remoteVariationId).pathV3
         val responseType = object : TypeToken<ProductVariationApiResponse>() {}.type
-        val body = variantModelToProductJsonBody(storedWCProductVariationModel, updatedProductVariationModel)
+        val body = variantModelToProductJsonBody(updatedProductVariationModel, storedWCProductVariationModel)
 
         val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, body, responseType,
                 { response: ProductVariationApiResponse? ->
@@ -725,7 +725,7 @@ class ProductRestClient(
                             this@ProductRestClient,
                             site,
                             url,
-                            mapOf("attributes" to variation.attributes),
+                            variantModelToProductJsonBody(variation),
                             ProductVariationApiResponse::class.java
                     )?.handleResult()
                 }
@@ -740,7 +740,7 @@ class ProductRestClient(
                         this,
                         site,
                         url,
-                        mapOf("attributes" to product.attributes),
+                        productModelToProductJsonBody(product),
                         ProductApiResponse::class.java
                 )?.handleResult()
             }
@@ -1020,7 +1020,7 @@ class ProductRestClient(
     ) {
         val url = WOOCOMMERCE.products.pathV3
         val responseType = object : TypeToken<ProductApiResponse>() {}.type
-        val params = productModelToProductJsonBody(null, productModel)
+        val params = productModelToProductJsonBody(productModel)
 
         val request = JetpackTunnelGsonRequest.buildPostRequest(
                 wpApiEndpoint = url,
@@ -1098,8 +1098,8 @@ class ProductRestClient(
      * fields of [productModel]. This is to ensure that we do not update product fields that do not contain any changes
      */
     private fun productModelToProductJsonBody(
-        productModel: WCProductModel?,
-        updatedProductModel: WCProductModel
+        updatedProductModel: WCProductModel,
+        productModel: WCProductModel? = null
     ): HashMap<String, Any> {
         val body = HashMap<String, Any>()
 
@@ -1270,8 +1270,8 @@ class ProductRestClient(
      * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any changes
      */
     private fun variantModelToProductJsonBody(
-        variationModel: WCProductVariationModel?,
-        updatedVariationModel: WCProductVariationModel
+        updatedVariationModel: WCProductVariationModel,
+        variationModel: WCProductVariationModel? = null
     ): HashMap<String, Any> {
         val body = HashMap<String, Any>()
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
 import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.Response
+import org.wordpress.android.fluxc.network.utils.getString
 
 @Suppress("PropertyName")
 class ProductVariationApiResponse : Response {
@@ -53,4 +55,65 @@ class ProductVariationApiResponse : Response {
     var dimensions: JsonElement? = null
     var attributes: JsonElement? = null
     var downloads: JsonElement? = null
+
+    fun asProductVariationModel() =
+        WCProductVariationModel().apply {
+            val response = this@ProductVariationApiResponse
+            remoteVariationId = response.id
+            permalink = response.permalink ?: ""
+
+            dateCreated = response.date_created ?: ""
+            dateModified = response.date_modified ?: ""
+
+            status = response.status ?: ""
+            description = response.description ?: ""
+            sku = response.sku ?: ""
+
+            price = response.price ?: ""
+            regularPrice = response.regular_price ?: ""
+            salePrice = response.sale_price ?: ""
+            onSale = response.on_sale
+
+            dateOnSaleFrom = response.date_on_sale_from ?: ""
+            dateOnSaleTo = response.date_on_sale_to ?: ""
+            dateOnSaleFromGmt = response.date_on_sale_from_gmt ?: ""
+            dateOnSaleToGmt = response.date_on_sale_to_gmt ?: ""
+
+            taxStatus = response.tax_status ?: ""
+            taxClass = response.tax_class ?: ""
+
+            backorders = response.backorders ?: ""
+            backordersAllowed = response.backorders_allowed
+            backordered = response.backordered
+
+            shippingClass = response.shipping_class ?: ""
+            shippingClassId = response.shipping_class_id
+
+            downloadLimit = response.download_limit
+            downloadExpiry = response.download_expiry
+
+            virtual = response.virtual
+            downloadable = response.downloadable
+            purchasable = response.purchasable
+
+            manageStock = response.manage_stock
+            stockQuantity = response.stock_quantity
+            stockStatus = response.stock_status ?: ""
+
+            attributes = response.attributes?.toString() ?: ""
+
+            weight = response.weight ?: ""
+            menuOrder = response.menu_order
+
+            attributes = response.attributes?.toString() ?: ""
+            downloads = response.downloads?.toString() ?: ""
+
+            response.dimensions?.asJsonObject?.let { json ->
+                length = json.getString("length") ?: ""
+                width = json.getString("width") ?: ""
+                height = json.getString("height") ?: ""
+            }
+
+            image = response.image?.toString() ?: ""
+        }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -50,8 +50,11 @@ object ProductSqlUtils {
             1
         } else {
             // Update
-            val oldId = productResult.id
-            WellSql.update(WCProductModel::class.java).whereId(oldId)
+            WellSql.update(WCProductModel::class.java)
+                    .where().beginGroup()
+                    .equals(WCProductModelTable.REMOTE_PRODUCT_ID, productResult.remoteProductId)
+                    .equals(WCProductModelTable.LOCAL_SITE_ID, productResult.localSiteId)
+                    .endGroup().endWhere()
                     .put(product, UpdateAllExceptId(WCProductModel::class.java)).execute()
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.persistence
 
 import com.wellsql.generated.WCAttributeTermModelTable
-import com.wellsql.generated.WCProductAttributeModelTable
+import com.wellsql.generated.WCGlobalAttributeModelTable
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
@@ -10,7 +10,7 @@ object WCGlobalAttributeSqlUtils {
     fun getCurrentAttributes(siteID: Int) =
             WellSql.select(WCGlobalAttributeModel::class.java)
                     .where()
-                    .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
+                    .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
                     .endWhere()
                     .asModel
                     ?.toList()
@@ -31,8 +31,8 @@ object WCGlobalAttributeSqlUtils {
     fun fetchSingleStoredAttribute(attributeId: Int, siteID: Int) =
         WellSql.select(WCGlobalAttributeModel::class.java)
                 .where()
-                .equals(WCProductAttributeModelTable.REMOTE_ID, attributeId)
-                .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
+                .equals(WCGlobalAttributeModelTable.REMOTE_ID, attributeId)
+                .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
                 .endWhere()
                 .asModel
                 .takeIf { it.isNotEmpty() }
@@ -41,8 +41,8 @@ object WCGlobalAttributeSqlUtils {
     fun deleteSingleStoredAttribute(attribute: WCGlobalAttributeModel, siteID: Int) = attribute.apply {
         WellSql.delete(WCGlobalAttributeModel::class.java)
                 .where()
-                .equals(WCProductAttributeModelTable.REMOTE_ID, attribute.id)
-                .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
+                .equals(WCGlobalAttributeModelTable.REMOTE_ID, attribute.id)
+                .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
                 .endWhere()
                 .execute()
     }
@@ -50,8 +50,8 @@ object WCGlobalAttributeSqlUtils {
     fun updateSingleStoredAttribute(attribute: WCGlobalAttributeModel, siteID: Int) = attribute.apply {
         WellSql.update(WCGlobalAttributeModel::class.java)
                 .where()
-                .equals(WCProductAttributeModelTable.REMOTE_ID, attribute.id)
-                .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
+                .equals(WCGlobalAttributeModelTable.REMOTE_ID, attribute.id)
+                .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
                 .endWhere()
                 .put(attribute)
                 .execute()
@@ -86,7 +86,7 @@ object WCGlobalAttributeSqlUtils {
     private fun deleteCompleteAttributesList(siteID: Int) =
             WellSql.delete(WCGlobalAttributeModel::class.java)
                     .where()
-                    .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
+                    .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
                     .endWhere()
                     .execute()
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
@@ -65,6 +65,13 @@ object WCGlobalAttributeSqlUtils {
                     }
                     ?: insertSingleAttribute(attribute)
 
+    fun updateSingleAttributeTermsMapping(attributeID: Int, termsMapping: String, siteID: Int) =
+        fetchSingleStoredAttribute(attributeID, siteID)
+                ?.let {
+                    it.termsId = termsMapping
+                    updateSingleStoredAttribute(it, siteID)
+                }
+
     fun getTerm(siteID: Int, termID: Int) =
             WellSql.select(WCAttributeTermModel::class.java)
                     .where().beginGroup()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
@@ -9,9 +9,9 @@ import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 object WCGlobalAttributeSqlUtils {
     fun getCurrentAttributes(siteID: Int) =
             WellSql.select(WCGlobalAttributeModel::class.java)
-                    .where()
+                    .where().beginGroup()
                     .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
-                    .endWhere()
+                    .endGroup().endWhere()
                     .asModel
                     ?.toList()
                     .orEmpty()
@@ -30,44 +30,47 @@ object WCGlobalAttributeSqlUtils {
 
     fun fetchSingleStoredAttribute(attributeId: Int, siteID: Int) =
         WellSql.select(WCGlobalAttributeModel::class.java)
-                .where()
+                .where().beginGroup()
                 .equals(WCGlobalAttributeModelTable.REMOTE_ID, attributeId)
                 .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
-                .endWhere()
+                .endGroup().endWhere()
                 .asModel
                 .takeIf { it.isNotEmpty() }
                 ?.first()
 
     fun deleteSingleStoredAttribute(attribute: WCGlobalAttributeModel, siteID: Int) = attribute.apply {
         WellSql.delete(WCGlobalAttributeModel::class.java)
-                .where()
+                .where().beginGroup()
                 .equals(WCGlobalAttributeModelTable.REMOTE_ID, attribute.remoteId)
                 .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
-                .endWhere()
+                .endGroup().endWhere()
                 .execute()
     }
 
     fun updateSingleStoredAttribute(attribute: WCGlobalAttributeModel, siteID: Int) = attribute.apply {
         WellSql.update(WCGlobalAttributeModel::class.java)
-                .where()
+                .where().beginGroup()
                 .equals(WCGlobalAttributeModelTable.REMOTE_ID, attribute.remoteId)
                 .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
-                .endWhere()
+                .endGroup().endWhere()
                 .put(attribute)
                 .execute()
     }
 
     fun insertOrUpdateSingleAttribute(attribute: WCGlobalAttributeModel, siteID: Int) =
             fetchSingleStoredAttribute(attribute.remoteId, siteID)
-                    ?.let { updateSingleStoredAttribute(attribute, siteID) }
+                    ?.let {
+                        attribute.id = it.id
+                        updateSingleStoredAttribute(attribute, siteID)
+                    }
                     ?: insertSingleAttribute(attribute)
 
     fun getTerm(siteID: Int, termID: Int) =
             WellSql.select(WCAttributeTermModel::class.java)
-                    .where()
+                    .where().beginGroup()
                     .equals(WCAttributeTermModelTable.REMOTE_ID, termID)
                     .equals(WCAttributeTermModelTable.LOCAL_SITE_ID, siteID)
-                    .endWhere()
+                    .endGroup().endWhere()
                     .asModel
                     ?.toList()
                     ?.firstOrNull()
@@ -85,16 +88,16 @@ object WCGlobalAttributeSqlUtils {
 
     private fun deleteCompleteAttributesList(siteID: Int) =
             WellSql.delete(WCGlobalAttributeModel::class.java)
-                    .where()
+                    .where().beginGroup()
                     .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
-                    .endWhere()
+                    .endGroup().endWhere()
                     .execute()
 
     private fun deleteAllTermsFromSingleAttribute(attributeID: Int, siteID: Int) =
             WellSql.delete(WCAttributeTermModel::class.java)
-                    .where()
+                    .where().beginGroup()
                     .equals(WCAttributeTermModelTable.LOCAL_SITE_ID, siteID)
                     .equals(WCAttributeTermModelTable.ATTRIBUTE_ID, attributeID)
-                    .endWhere()
+                    .endGroup().endWhere()
                     .execute()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
@@ -41,7 +41,7 @@ object WCGlobalAttributeSqlUtils {
     fun deleteSingleStoredAttribute(attribute: WCGlobalAttributeModel, siteID: Int) = attribute.apply {
         WellSql.delete(WCGlobalAttributeModel::class.java)
                 .where()
-                .equals(WCGlobalAttributeModelTable.REMOTE_ID, attribute.id)
+                .equals(WCGlobalAttributeModelTable.REMOTE_ID, attribute.remoteId)
                 .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
                 .endWhere()
                 .execute()
@@ -50,7 +50,7 @@ object WCGlobalAttributeSqlUtils {
     fun updateSingleStoredAttribute(attribute: WCGlobalAttributeModel, siteID: Int) = attribute.apply {
         WellSql.update(WCGlobalAttributeModel::class.java)
                 .where()
-                .equals(WCGlobalAttributeModelTable.REMOTE_ID, attribute.id)
+                .equals(WCGlobalAttributeModelTable.REMOTE_ID, attribute.remoteId)
                 .equals(WCGlobalAttributeModelTable.LOCAL_SITE_ID, siteID)
                 .endWhere()
                 .put(attribute)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
@@ -3,12 +3,12 @@ package org.wordpress.android.fluxc.persistence
 import com.wellsql.generated.WCAttributeTermModelTable
 import com.wellsql.generated.WCProductAttributeModelTable
 import com.yarolegovich.wellsql.WellSql
-import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeModel
+import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
 
-object WCProductAttributeSqlUtils {
+object WCGlobalAttributeSqlUtils {
     fun getCurrentAttributes(siteID: Int) =
-            WellSql.select(WCProductAttributeModel::class.java)
+            WellSql.select(WCGlobalAttributeModel::class.java)
                     .where()
                     .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
                     .endWhere()
@@ -16,20 +16,20 @@ object WCProductAttributeSqlUtils {
                     ?.toList()
                     .orEmpty()
 
-    fun insertFromScratchCompleteAttributesList(attributes: List<WCProductAttributeModel>, siteID: Int) {
+    fun insertFromScratchCompleteAttributesList(attributes: List<WCGlobalAttributeModel>, siteID: Int) {
         deleteCompleteAttributesList(siteID)
         WellSql.insert(attributes)
                 .asSingleTransaction(true).execute()
     }
 
-    fun insertSingleAttribute(attribute: WCProductAttributeModel) = attribute.apply {
+    fun insertSingleAttribute(attribute: WCGlobalAttributeModel) = attribute.apply {
         WellSql.insert(attribute)
                 .asSingleTransaction(true)
                 .execute()
     }
 
     fun fetchSingleStoredAttribute(attributeId: Int, siteID: Int) =
-        WellSql.select(WCProductAttributeModel::class.java)
+        WellSql.select(WCGlobalAttributeModel::class.java)
                 .where()
                 .equals(WCProductAttributeModelTable.REMOTE_ID, attributeId)
                 .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
@@ -38,8 +38,8 @@ object WCProductAttributeSqlUtils {
                 .takeIf { it.isNotEmpty() }
                 ?.first()
 
-    fun deleteSingleStoredAttribute(attribute: WCProductAttributeModel, siteID: Int) = attribute.apply {
-        WellSql.delete(WCProductAttributeModel::class.java)
+    fun deleteSingleStoredAttribute(attribute: WCGlobalAttributeModel, siteID: Int) = attribute.apply {
+        WellSql.delete(WCGlobalAttributeModel::class.java)
                 .where()
                 .equals(WCProductAttributeModelTable.REMOTE_ID, attribute.id)
                 .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
@@ -47,8 +47,8 @@ object WCProductAttributeSqlUtils {
                 .execute()
     }
 
-    fun updateSingleStoredAttribute(attribute: WCProductAttributeModel, siteID: Int) = attribute.apply {
-        WellSql.update(WCProductAttributeModel::class.java)
+    fun updateSingleStoredAttribute(attribute: WCGlobalAttributeModel, siteID: Int) = attribute.apply {
+        WellSql.update(WCGlobalAttributeModel::class.java)
                 .where()
                 .equals(WCProductAttributeModelTable.REMOTE_ID, attribute.id)
                 .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
@@ -57,7 +57,7 @@ object WCProductAttributeSqlUtils {
                 .execute()
     }
 
-    fun insertOrUpdateSingleAttribute(attribute: WCProductAttributeModel, siteID: Int) =
+    fun insertOrUpdateSingleAttribute(attribute: WCGlobalAttributeModel, siteID: Int) =
             fetchSingleStoredAttribute(attribute.id, siteID)
                     ?.let { updateSingleStoredAttribute(attribute, siteID) }
                     ?: insertSingleAttribute(attribute)
@@ -84,7 +84,7 @@ object WCProductAttributeSqlUtils {
     }
 
     private fun deleteCompleteAttributesList(siteID: Int) =
-            WellSql.delete(WCProductAttributeModel::class.java)
+            WellSql.delete(WCGlobalAttributeModel::class.java)
                     .where()
                     .equals(WCProductAttributeModelTable.LOCAL_SITE_ID, siteID)
                     .endWhere()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
@@ -3,8 +3,8 @@ package org.wordpress.android.fluxc.persistence
 import com.wellsql.generated.WCAttributeTermModelTable
 import com.wellsql.generated.WCProductAttributeModelTable
 import com.yarolegovich.wellsql.WellSql
-import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
-import org.wordpress.android.fluxc.model.product.attributes.terms.WCAttributeTermModel
+import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
+import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 
 object WCGlobalAttributeSqlUtils {
     fun getCurrentAttributes(siteID: Int) =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCGlobalAttributeSqlUtils.kt
@@ -58,7 +58,7 @@ object WCGlobalAttributeSqlUtils {
     }
 
     fun insertOrUpdateSingleAttribute(attribute: WCGlobalAttributeModel, siteID: Int) =
-            fetchSingleStoredAttribute(attribute.id, siteID)
+            fetchSingleStoredAttribute(attribute.remoteId, siteID)
                     ?.let { updateSingleStoredAttribute(attribute, siteID) }
                     ?: insertSingleAttribute(attribute)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
@@ -1,34 +1,34 @@
 package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeMapper
-import org.wordpress.android.fluxc.model.product.attributes.WCProductAttributeModel
+import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeMapper
+import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
-import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.deleteSingleStoredAttribute
-import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.getCurrentAttributes
-import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.insertFromScratchCompleteAttributesList
-import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.insertOrUpdateSingleAttribute
-import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.insertSingleAttribute
-import org.wordpress.android.fluxc.persistence.WCProductAttributeSqlUtils.updateSingleStoredAttribute
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.deleteSingleStoredAttribute
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.getCurrentAttributes
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.insertFromScratchCompleteAttributesList
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.insertOrUpdateSingleAttribute
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.insertSingleAttribute
+import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.updateSingleStoredAttribute
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WCProductAttributesStore @Inject constructor(
+class WCGlobalAttributeStore @Inject constructor(
     private val restClient: ProductAttributeRestClient,
-    private val mapper: WCProductAttributeMapper,
+    private val mapper: WCGlobalAttributeMapper,
     private val coroutineEngine: CoroutineEngine
 ) {
     suspend fun fetchStoreAttributes(
         site: SiteModel
-    ): WooResult<List<WCProductAttributeModel>> =
+    ): WooResult<List<WCGlobalAttributeModel>> =
             coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchStoreAttributes") {
                 restClient.fetchProductFullAttributesList(site)
                         .asWooResult()
@@ -49,7 +49,7 @@ class WCProductAttributesStore @Inject constructor(
     suspend fun fetchAttribute(
         site: SiteModel,
         attributeID: Long
-    ): WooResult<WCProductAttributeModel> =
+    ): WooResult<WCGlobalAttributeModel> =
             coroutineEngine.withDefaultContext(AppLog.T.API, this, "createStoreAttributes") {
                 restClient.fetchSingleAttribute(site, attributeID)
                         .asWooResult()
@@ -67,7 +67,7 @@ class WCProductAttributesStore @Inject constructor(
         type: String = "select",
         orderBy: String = "menu_order",
         hasArchives: Boolean = false
-    ): WooResult<WCProductAttributeModel> =
+    ): WooResult<WCGlobalAttributeModel> =
             coroutineEngine.withDefaultContext(AppLog.T.API, this, "createStoreAttributes") {
                 restClient.postNewAttribute(
                         site, mapOf(
@@ -94,7 +94,7 @@ class WCProductAttributesStore @Inject constructor(
         type: String = "select",
         orderBy: String = "menu_order",
         hasArchives: Boolean = false
-    ): WooResult<WCProductAttributeModel> =
+    ): WooResult<WCGlobalAttributeModel> =
             coroutineEngine.withDefaultContext(AppLog.T.API, this, "updateStoreAttributes") {
                 restClient.updateExistingAttribute(
                         site, attributeID, mapOf(
@@ -117,7 +117,7 @@ class WCProductAttributesStore @Inject constructor(
     suspend fun deleteAttribute(
         site: SiteModel,
         attributeID: Long
-    ): WooResult<WCProductAttributeModel> =
+    ): WooResult<WCGlobalAttributeModel> =
             coroutineEngine.withDefaultContext(AppLog.T.API, this, "deleteStoreAttributes") {
                 restClient.deleteExistingAttribute(site, attributeID)
                         .asWooResult()
@@ -132,7 +132,7 @@ class WCProductAttributesStore @Inject constructor(
         site: SiteModel,
         attributeID: Long,
         term: String
-    ): WooResult<WCProductAttributeModel> =
+    ): WooResult<WCGlobalAttributeModel> =
             coroutineEngine.withDefaultContext(AppLog.T.API, this, "createAttributeTerm") {
                 restClient.postNewTerm(
                         site, attributeID,
@@ -148,7 +148,7 @@ class WCProductAttributesStore @Inject constructor(
         site: SiteModel,
         attributeID: Long,
         termID: Long
-    ): WooResult<WCProductAttributeModel> =
+    ): WooResult<WCGlobalAttributeModel> =
             coroutineEngine.withDefaultContext(AppLog.T.API, this, "deleteAttributeTerm") {
                 restClient.deleteExistingTerm(site, attributeID, termID)
                         .asWooResult()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.persistence.WCGlobalAttributeSqlUtils.deleteSingleStoredAttribute
@@ -156,10 +155,4 @@ class WCGlobalAttributeStore @Inject constructor(
                         ?.let { fetchAttribute(site, attributeID) }
                         ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
-
-    private fun <T> WooPayload<T>.asWooResult() = when {
-        isError -> WooResult(error)
-        result != null -> WooResult<T>(result)
-        else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
-    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeMapper
-import org.wordpress.android.fluxc.model.product.attributes.WCGlobalAttributeModel
+import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeMapper
+import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -843,7 +843,10 @@ class WCProductStore @Inject constructor(
                     wcProductRestClient.updateProductAttributes(site, product)
                             ?.asWooResult()
                             ?.model?.asProductModel()
-                            ?.apply { ProductSqlUtils.insertOrUpdateProduct(this) }
+                            ?.apply {
+                                localSiteId = site.id
+                                ProductSqlUtils.insertOrUpdateProduct(this)
+                            }
                             ?.let { WooResult(it) }
                 } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -839,11 +839,22 @@ class WCProductStore @Inject constructor(
         product: WCProductModel
     ): WooResult<WCProductModel> =
             coroutineEngine?.withDefaultContext(T.API, this, "submitProductAttributes") {
-                    wcProductRestClient.updateAttributes(site, product)
+                    wcProductRestClient.updateProductAttributes(site, product)
                             ?.asWooResult()
                             ?.model?.asProductModel()
                             ?.let { WooResult(it) }
                 } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
+
+    suspend fun submitVariationAttributeChanges(
+        site: SiteModel,
+        variation: WCProductVariationModel
+    ): WooResult<WCProductVariationModel> =
+            coroutineEngine?.withDefaultContext(T.API, this, "submitProductAttributes") {
+                wcProductRestClient.updateVariationAttributes(site, variation)
+                        ?.asWooResult()
+                        ?.model?.asProductVariationModel()
+                        ?.let { WooResult(it) }
+            } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
 
     override fun onRegister() = AppLog.d(T.API, "WCProductStore onRegister")
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -835,13 +835,12 @@ class WCProductStore @Inject constructor(
         }
     }
 
-    suspend fun submitAttributesToProduct(
+    suspend fun submitProductAttributeChanges(
         site: SiteModel,
-        product: WCProductModel,
-        attributes: List<WCProductAttributeModel>
+        product: WCProductModel
     ): WooResult<WCProductModel> =
             coroutineEngine?.withDefaultContext(T.API, this, "submitProductAttributes") {
-                    wcProductRestClient.updateAttributes(site, product, attributes)
+                    wcProductRestClient.updateAttributes(site, product)
                             ?.asWooResult()
                             ?.model?.asProductModel()
                             ?.let { WooResult(it) }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -14,7 +14,12 @@ import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.model.attribute.WCProductAttributeModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting.NAME_ASC
@@ -829,6 +834,18 @@ class WCProductStore @Inject constructor(
                 handleDeleteProduct(action.payload as RemoteDeleteProductPayload)
         }
     }
+
+    suspend fun submitAttributesToProduct(
+        site: SiteModel,
+        product: WCProductModel,
+        attributes: List<WCProductAttributeModel>
+    ): WooResult<WCProductModel> =
+            coroutineEngine?.withDefaultContext(T.API, this, "submitProductAttributes") {
+                    wcProductRestClient.updateAttributes(site, product, attributes)
+                            ?.asWooResult()
+                            ?.model?.asProductModel()
+                            ?.let { WooResult(it) }
+                } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
 
     override fun onRegister() = AppLog.d(T.API, "WCProductStore onRegister")
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
-import org.wordpress.android.fluxc.model.attribute.WCProductAttributeModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
+import org.wordpress.android.fluxc.persistence.ProductSqlUtils.insertOrUpdateProductVariation
 import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting.NAME_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
@@ -842,6 +843,7 @@ class WCProductStore @Inject constructor(
                     wcProductRestClient.updateProductAttributes(site, product)
                             ?.asWooResult()
                             ?.model?.asProductModel()
+                            ?.apply { ProductSqlUtils.insertOrUpdateProduct(this) }
                             ?.let { WooResult(it) }
                 } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
 
@@ -853,6 +855,7 @@ class WCProductStore @Inject constructor(
                 wcProductRestClient.updateVariationAttributes(site, variation)
                         ?.asWooResult()
                         ?.model?.asProductVariationModel()
+                        ?.apply { insertOrUpdateProductVariation(this) }
                         ?.let { WooResult(it) }
             } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
 
@@ -1003,7 +1006,7 @@ class WCProductStore @Inject constructor(
                 it.remoteVariationId = payload.variation.remoteVariationId
             }
         } else {
-            val rowsAffected = ProductSqlUtils.insertOrUpdateProductVariation(payload.variation)
+            val rowsAffected = insertOrUpdateProductVariation(payload.variation)
             onVariationChanged = OnVariationChanged(rowsAffected).also {
                 it.remoteProductId = payload.variation.remoteProductId
                 it.remoteVariationId = payload.variation.remoteVariationId
@@ -1220,7 +1223,7 @@ class WCProductStore @Inject constructor(
             )
                     .also { it.error = payload.error }
         } else {
-            val rowsAffected = ProductSqlUtils.insertOrUpdateProductVariation(payload.variation)
+            val rowsAffected = insertOrUpdateProductVariation(payload.variation)
             onVariationUpdated = OnVariationUpdated(
                     rowsAffected,
                     payload.variation.remoteProductId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -854,7 +854,7 @@ class WCProductStore @Inject constructor(
         site: SiteModel,
         variation: WCProductVariationModel
     ): WooResult<WCProductVariationModel> =
-            coroutineEngine?.withDefaultContext(T.API, this, "submitProductAttributes") {
+            coroutineEngine?.withDefaultContext(T.API, this, "submitVariationAttributes") {
                 wcProductRestClient.updateVariationAttributes(site, variation)
                         ?.asWooResult()
                         ?.model?.asProductVariationModel()


### PR DESCRIPTION
Summary
==========
Finish implementation for the [Woo Issue 3512](https://github.com/woocommerce/woocommerce-android/issues/3512). This PR adds support to edit/add/remove/update all attributes from *a given product and variation*, note that this is different from editing the Global Attributes from the entire Woo Site, which was introduced by [PR 1803](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1803) and [PR 1803](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1820). This PR also addresses a lot of noted bugs within the Attributes and Terms operations

Screenshots & How to Test
==========
| Select the Woo section | Select the Products Section | Attach or Detach Attributes from a Product
| ------------- | ------------- | ------------- |
| ![Screenshot_1612377245](https://user-images.githubusercontent.com/5920403/106792790-617fd700-6635-11eb-94d7-ac6134cc30cd.png) | ![Screenshot_1612377248](https://user-images.githubusercontent.com/5920403/106792796-63e23100-6635-11eb-9160-324f748b0fbf.png) |![Screenshot_1612376305](https://user-images.githubusercontent.com/5920403/106792673-2ed5de80-6635-11eb-9d32-f03aabdb8940.png) |






To verify if the changes are working under the Woo site, go to Products > All Products > Select the updated Product on the list and go to the Attributes section on your Woo site and make sure everything is as expected.

![image](https://user-images.githubusercontent.com/5920403/106792610-1b2a7800-6635-11eb-908b-cbc93dbd8c6c.png)

 
