### PR TITLE
Issue/wpandroid 13328 backup restore empty response

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -426,6 +426,36 @@ class ActivityLogStoreTest {
         assertEquals(backupDownloadStatusModel, backDownloadStatusFromDb)
     }
 
+    @Test
+    fun storeFetchedEmptyRewindStatusRemoveFromDb() = test {
+        val rewindStatusModel = mock<RewindStatusModel>()
+        val payload = FetchedRewindStatePayload(null, siteModel)
+        whenever(activityLogRestClient.fetchActivityRewind(siteModel)).thenReturn(payload)
+
+        val fetchAction = ActivityLogActionBuilder.newFetchRewindStateAction(FetchRewindStatePayload(siteModel))
+        activityLogStore.onAction(fetchAction)
+
+        verify(activityLogSqlUtils).deleteRewindStatus(siteModel)
+        val expectedChangeEvent = ActivityLogStore.OnRewindStatusFetched(ActivityLogAction.FETCH_REWIND_STATE)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
+    @Test
+    fun storeFetchedEmptyBackupDownloadStatusRemoveFromDb() = test {
+        val backupDownloadStatusModel = mock<BackupDownloadStatusModel>()
+        val payload = FetchedBackupDownloadStatePayload(null, siteModel)
+        whenever(activityLogRestClient.fetchBackupDownloadState(siteModel)).thenReturn(payload)
+
+        val fetchAction =
+                ActivityLogActionBuilder.newFetchBackupDownloadStateAction(FetchBackupDownloadStatePayload(siteModel))
+        activityLogStore.onAction(fetchAction)
+
+        verify(activityLogSqlUtils).deleteBackupDownloadStatus(siteModel)
+        val expectedChangeEvent =
+                ActivityLogStore.OnBackupDownloadStatusFetched(ActivityLogAction.FETCH_BACKUP_DOWNLOAD_STATE)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
     private suspend fun initRestClient(
         activityModels: List<ActivityLogModel>,
         rowsAffected: Int,

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -428,7 +428,6 @@ class ActivityLogStoreTest {
 
     @Test
     fun storeFetchedEmptyRewindStatusRemoveFromDb() = test {
-        val rewindStatusModel = mock<RewindStatusModel>()
         val payload = FetchedRewindStatePayload(null, siteModel)
         whenever(activityLogRestClient.fetchActivityRewind(siteModel)).thenReturn(payload)
 
@@ -442,7 +441,6 @@ class ActivityLogStoreTest {
 
     @Test
     fun storeFetchedEmptyBackupDownloadStatusRemoveFromDb() = test {
-        val backupDownloadStatusModel = mock<BackupDownloadStatusModel>()
         val payload = FetchedBackupDownloadStatePayload(null, siteModel)
         whenever(activityLogRestClient.fetchBackupDownloadState(siteModel)).thenReturn(payload)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -428,30 +428,25 @@ class ActivityLogStoreTest {
 
     @Test
     fun storeFetchedEmptyRewindStatusRemoveFromDb() = test {
-        val payload = FetchedRewindStatePayload(null, siteModel)
-        whenever(activityLogRestClient.fetchActivityRewind(siteModel)).thenReturn(payload)
+        whenever(activityLogRestClient.fetchActivityRewind(siteModel))
+                .thenReturn(FetchedRewindStatePayload(null, siteModel))
 
         val fetchAction = ActivityLogActionBuilder.newFetchRewindStateAction(FetchRewindStatePayload(siteModel))
         activityLogStore.onAction(fetchAction)
 
         verify(activityLogSqlUtils).deleteRewindStatus(siteModel)
-        val expectedChangeEvent = ActivityLogStore.OnRewindStatusFetched(ActivityLogAction.FETCH_REWIND_STATE)
-        verify(dispatcher).emitChange(eq(expectedChangeEvent))
     }
 
     @Test
     fun storeFetchedEmptyBackupDownloadStatusRemoveFromDb() = test {
-        val payload = FetchedBackupDownloadStatePayload(null, siteModel)
-        whenever(activityLogRestClient.fetchBackupDownloadState(siteModel)).thenReturn(payload)
+        whenever(activityLogRestClient.fetchBackupDownloadState(siteModel))
+                .thenReturn(FetchedBackupDownloadStatePayload(null, siteModel))
 
         val fetchAction =
                 ActivityLogActionBuilder.newFetchBackupDownloadStateAction(FetchBackupDownloadStatePayload(siteModel))
         activityLogStore.onAction(fetchAction)
 
         verify(activityLogSqlUtils).deleteBackupDownloadStatus(siteModel)
-        val expectedChangeEvent =
-                ActivityLogStore.OnBackupDownloadStatusFetched(ActivityLogAction.FETCH_BACKUP_DOWNLOAD_STATE)
-        verify(dispatcher).emitChange(eq(expectedChangeEvent))
     }
 
     private suspend fun initRestClient(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -100,7 +100,7 @@ class ActivityLogSqlUtils
         return WellSql
                 .delete(RewindStatusBuilder::class.java)
                 .where()
-                .equals(ActivityLogTable.LOCAL_SITE_ID, site.id)
+                .equals(RewindStatusTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
                 .execute()
     }
@@ -109,7 +109,7 @@ class ActivityLogSqlUtils
         return WellSql
                 .delete(BackupDownloadStatusBuilder::class.java)
                 .where()
-                .equals(ActivityLogTable.LOCAL_SITE_ID, site.id)
+                .equals(BackupDownloadStatusTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
                 .execute()
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -96,6 +96,24 @@ class ActivityLogSqlUtils
                 .execute()
     }
 
+    fun deleteRewindStatus(site: SiteModel): Int {
+        return WellSql
+                .delete(RewindStatusBuilder::class.java)
+                .where()
+                .equals(ActivityLogTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .execute()
+    }
+
+    fun deleteBackupDownloadStatus(site: SiteModel): Int {
+        return WellSql
+                .delete(BackupDownloadStatusBuilder::class.java)
+                .where()
+                .equals(ActivityLogTable.LOCAL_SITE_ID, site.id)
+                .endWhere()
+                .execute()
+    }
+
     fun replaceRewindStatus(site: SiteModel, rewindStatusModel: RewindStatusModel) {
         val rewindStatusBuilder = rewindStatusModel.toBuilder(site)
         WellSql.delete(RewindStatusBuilder::class.java)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -183,6 +183,8 @@ class ActivityLogStore
         } else {
             if (payload.rewindStatusModelResponse != null) {
                 activityLogSqlUtils.replaceRewindStatus(payload.site, payload.rewindStatusModelResponse)
+            } else {
+                activityLogSqlUtils.deleteRewindStatus(payload.site)
             }
             OnRewindStatusFetched(action)
         }
@@ -195,6 +197,8 @@ class ActivityLogStore
         } else {
             if (payload.backupDownloadStatusModelResponse != null) {
                 activityLogSqlUtils.replaceBackupDownloadStatus(payload.site, payload.backupDownloadStatusModelResponse)
+            } else {
+                activityLogSqlUtils.deleteBackupDownloadStatus(payload.site)
             }
             OnBackupDownloadStatusFetched(action)
         }


### PR DESCRIPTION
Parent issues: wp-android [13328](https://github.com/wordpress-mobile/WordPress-Android/issues/13328) & [13329](https://github.com/wordpress-mobile/WordPress-Android/issues/13329)

This PR adds support for:
(1) Deleting rows from `BackupDownloadStatusTable` when the fetch payload is null
(2) Deleting rows from `RewindStatusTable` when the fetch payload is null
(3) Add two new tests

**To Test**
- Test in [WPAndroid PR ](https://github.com/wordpress-mobile/WordPress-Android/pull/13944)


