### PR TITLE
WCS account settings endpoint

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -211,6 +211,20 @@ class WooShippingLabelFragment : Fragment() {
                     result.error?.let {
                         prependToLog("${it.type}: ${it.message}")
                     }
+                    result.model?.let {
+                        prependToLog("$it")
+                    }
+                }
+            }
+        }
+
+        get_account_settings.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    val result = wcShippingLabelStore.getAccountSettings(site)
+                    result.error?.let {
+                        prependToLog("${it.type}: ${it.message}")
+                    }
                     if (result.model != null) {
                         prependToLog("${result.model}")
                     } else {

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -80,5 +80,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Get shipping plugin info"/>
+
+        <Button
+            android:id="@+id/get_account_settings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Get account settings"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -185,11 +185,13 @@ class WCShippingLabelStoreTest {
                         PredefinedOption("USPS Priority Mail Flat Rate Boxes",
                                 listOf(
                                         PredefinedPackage(
+                                                "small_flat_box",
                                                 "Small Flat Rate Box",
                                                 false,
                                                 "21.91 x 13.65 x 4.13"
                                         ),
                                         PredefinedPackage(
+                                                "medium_flat_box_top",
                                                 "Medium Flat Rate Box 1, Top Loading",
                                                 false,
                                                 "28.57 x 22.22 x 15.24"
@@ -199,6 +201,7 @@ class WCShippingLabelStoreTest {
                         PredefinedOption(
                                 "DHL Express",
                                 listOf(PredefinedPackage(
+                                        "LargePaddedPouch",
                                         "Large Padded Pouch",
                                         true,
                                         "30.22 x 35.56 x 2.54"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -13,7 +13,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.shippinglabels.WCAccountSettings
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.Valid
 import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult
@@ -302,7 +302,7 @@ class WCShippingLabelStoreTest {
         return store.getPackageTypes(site)
     }
 
-    private suspend fun getAccountSettings(isError: Boolean = false): WooResult<WCAccountSettings> {
+    private suspend fun getAccountSettings(isError: Boolean = false): WooResult<WCShippingAccountSettings> {
         if (isError) {
             whenever(restClient.getAccountSettings(any())).thenReturn(WooPayload(error))
         } else {

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.AccountSettingsApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.PrintShippingLabelApiResponse
@@ -82,5 +83,13 @@ object WCShippingLabelTestUtils {
         )
         val responseType = object : TypeToken<GetPackageTypesResponse>() {}.type
         return Gson().fromJson(json, responseType) as? GetPackageTypesResponse
+    }
+
+    fun generateSampleAccountSettingsApiResponse(): AccountSettingsApiResponse {
+        val json = UnitTestUtils.getStringFromResourceFile(
+                this.javaClass,
+                "wc/shipping-labels-account-settings.json"
+        )
+        return Gson().fromJson(json, AccountSettingsApiResponse::class.java)
     }
 }

--- a/example/src/test/resources/wc/shipping-labels-account-settings.json
+++ b/example/src/test/resources/wc/shipping-labels-account-settings.json
@@ -1,0 +1,38 @@
+{
+  "success": true,
+  "storeOptions": {
+    "currency_symbol": "$",
+    "dimension_unit": "in",
+    "weight_unit": "oz",
+    "origin_country": "US"
+  },
+  "formData": {
+    "selected_payment_method_id": 4144354,
+    "enabled": true,
+    "email_receipts": true,
+    "paper_size": "letter"
+  },
+  "formMeta": {
+    "can_manage_payments": true,
+    "can_edit_settings": true,
+    "master_user_name": "John Doe",
+    "master_user_login": "jhon",
+    "master_user_wpcom_login": "jhon",
+    "master_user_email": "jhon@email.com",
+    "payment_methods": [
+      {
+        "payment_method_id": 4144354,
+        "name": "John Doe",
+        "card_type": "visa",
+        "card_digits": "5454",
+        "expiry": "2023-12-31"
+      }
+    ],
+    "warnings": {
+      "payment_methods": false
+    }
+  },
+  "userMeta": {
+    "last_box_id": "small_flat_box"
+  }
+}

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -49,6 +49,8 @@
 /connect/normalize-address
 /connect/packages
 
+/connect/account/settings
+
 /leaderboards
 
 /data/countries

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAccountSettings.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAccountSettings.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+import com.google.gson.annotations.SerializedName
+
+data class WCAccountSettings(
+    val canManagePayments: Boolean,
+    val selectedPaymentMethodId: Int?,
+    val paymentMethods: List<WCPaymentMethod>,
+    val lastUsedBoxId: String?
+)
+
+data class WCPaymentMethod(
+    @SerializedName("payment_method_id")
+    val paymentMethodId: Int,
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("card_type")
+    val cardType: String,
+    @SerializedName("card_digits")
+    val cardDigits: String,
+    @SerializedName("expiry")
+    val expiry: String
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCPackagesResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCPackagesResult.kt
@@ -15,6 +15,7 @@ data class WCPackagesResult(
         val predefinedPackages: List<PredefinedPackage>
     ) {
         data class PredefinedPackage(
+            val id: String,
             val title: String,
             val isLetter: Boolean,
             val dimensions: String

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.model.shippinglabels
 
 import com.google.gson.annotations.SerializedName
 
-data class WCAccountSettings(
+data class WCShippingAccountSettings(
     val canManagePayments: Boolean,
     val selectedPaymentMethodId: Int?,
     val paymentMethods: List<WCPaymentMethod>,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.model.shippinglabels.WCPaymentMethod
+
+data class AccountSettingsApiResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("formData") val formData: FormData,
+    @SerializedName("formMeta") val formMeta: FormMeta,
+    @SerializedName("userMeta") val userMeta: UserMeta
+) {
+    data class FormData(
+        @SerializedName("selected_payment_method_id") val selectedPaymentId: Int?
+    )
+
+    data class FormMeta(
+        @SerializedName("can_manage_payments") val canManagePayments: Boolean,
+        @SerializedName("payment_methods") val paymentMethods: List<WCPaymentMethod>
+    )
+
+    data class UserMeta(
+        @SerializedName("last_box_id") val lastBoxId: String?
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
@@ -15,7 +15,7 @@ data class AccountSettingsApiResponse(
 
     data class FormMeta(
         @SerializedName("can_manage_payments") val canManagePayments: Boolean,
-        @SerializedName("payment_methods") val paymentMethods: List<WCPaymentMethod>
+        @SerializedName("payment_methods") val paymentMethods: List<WCPaymentMethod>?
     )
 
     data class UserMeta(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -159,6 +159,28 @@ constructor(
         }
     }
 
+    suspend fun getAccountSettings(
+        site: SiteModel
+    ) : WooPayload<AccountSettingsApiResponse> {
+        val url = WOOCOMMERCE.connect.account.settings.pathV1
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                emptyMap(),
+                AccountSettingsApiResponse::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
     data class PrintShippingLabelApiResponse(
         val mimeType: String,
         val b64Content: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -161,7 +161,7 @@ constructor(
 
     suspend fun getAccountSettings(
         site: SiteModel
-    ) : WooPayload<AccountSettingsApiResponse> {
+    ): WooPayload<AccountSettingsApiResponse> {
         val url = WOOCOMMERCE.connect.account.settings.pathV1
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.shippinglabels.WCAccountSettings
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidRequest
@@ -194,7 +194,7 @@ class WCShippingLabelStore @Inject constructor(
 
     suspend fun getAccountSettings(
         site: SiteModel
-    ): WooResult<WCAccountSettings> {
+    ): WooResult<WCShippingAccountSettings> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "getAccountSettings") {
             val response = restClient.getAccountSettings(site)
             return@withDefaultContext when {
@@ -202,7 +202,7 @@ class WCShippingLabelStore @Inject constructor(
                     WooResult(response.error)
                 }
                 response.result?.success == true -> {
-                    WooResult(WCAccountSettings(
+                    WooResult(WCShippingAccountSettings(
                             canManagePayments = response.result.formMeta.canManagePayments,
                             selectedPaymentMethodId = response.result.formData.selectedPaymentId,
                             paymentMethods = response.result.formMeta.paymentMethods,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -205,7 +205,7 @@ class WCShippingLabelStore @Inject constructor(
                     WooResult(WCShippingAccountSettings(
                             canManagePayments = response.result.formMeta.canManagePayments,
                             selectedPaymentMethodId = response.result.formData.selectedPaymentId,
-                            paymentMethods = response.result.formMeta.paymentMethods,
+                            paymentMethods = response.result.formMeta.paymentMethods.orEmpty(),
                             lastUsedBoxId = response.result.userMeta.lastBoxId
                     ))
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -174,7 +174,12 @@ class WCShippingLabelStore @Inject constructor(
         packageIds.forEach { packageId ->
             packageDefinitions.firstOrNull { it.id == packageId }?.let { definition ->
                 predefinedPackages.add(
-                    PredefinedPackage(definition.name, definition.isLetter, definition.outerDimensions)
+                        PredefinedPackage(
+                                id = definition.id,
+                                title = definition.name,
+                                isLetter = definition.isLetter,
+                                dimensions = definition.outerDimensions
+                        )
                 )
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -194,7 +194,7 @@ class WCShippingLabelStore @Inject constructor(
 
     suspend fun getAccountSettings(
         site: SiteModel
-    ) : WooResult<WCAccountSettings> {
+    ): WooResult<WCAccountSettings> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "getAccountSettings") {
             val response = restClient.getAccountSettings(site)
             return@withDefaultContext when {


### PR DESCRIPTION
This PR is a requirement for Shipping Labels project, and needed right now for the ticket https://github.com/woocommerce/woocommerce-android/issues/3019.
It adds fetching the endpoint: `/wc/v1/connect/account/settings` to get the last used package id.

I also added an `id` field to the `PredefinedPackage` class, to expose the box id.

The endpoint returns also an object `storeOptions` which contains the different units used by the store, but as the same information si already returned by the settings/general and settings/products endpoints, I didn't expose it.

#### Testing

1. Run the example app & login
2. Go to Woo
3. Click on "Shipping Labels"
4. Click on "Get account settings"
5. Confirm the account settings are printed in the log.