### PR TITLE
Jetpack Section: Update Activity Log Page Size

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -105,7 +105,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         )
 
         assertNotNull(fetchActivities)
-        assertEquals(fetchActivities.rowsAffected, PAGE_SIZE) // All activities are persisted.
+        assertEquals(fetchActivities.rowsAffected, ALL_SITE_ACTIVITIES) // All activities are persisted.
         assertEquals(activityLogForSite.size, 0) // Non retrieved, all activities are non-rewindable.
     }
 
@@ -365,6 +365,6 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
     }
 
     companion object {
-        private const val PAGE_SIZE = 20
+        private const val ALL_SITE_ACTIVITIES = 20
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -164,7 +164,7 @@ class ActivityLogStoreTest {
         val rowsAffected = 1
         val activityModels = listOf<ActivityLogModel>(mock())
 
-        val action = initRestClient(activityModels, rowsAffected, totalItems = 100)
+        val action = initRestClient(activityModels, rowsAffected, totalItems = 500)
         whenever(activityLogSqlUtils.insertOrUpdateActivities(any(), any())).thenReturn(rowsAffected)
 
         activityLogStore.onAction(action)
@@ -467,6 +467,6 @@ class ActivityLogStoreTest {
 
     companion object {
         private const val OFFSET = 0
-        private const val PAGE_SIZE = 20
+        private const val PAGE_SIZE = 100
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -28,7 +28,7 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val ACTIVITY_LOG_PAGE_SIZE = 20
+private const val ACTIVITY_LOG_PAGE_SIZE = 100
 
 @Singleton
 class ActivityLogStore


### PR DESCRIPTION
Parent [WordPress-Android#13629](https://github.com/wordpress-mobile/WordPress-Android/issues/13629)

This PR updates activity log page size from `20` to `100`. This is done since the API enhancement is not ready yet. As such, and
in order to avoid some of the scrolling issues on the 'Backups' screen the activity log page size has been increase to 100 (x5 increase).

This PR will not be fixing the scrolling issues on the 'Backups' screen. It will just make them harder to appear. To avoid any
scrolling issue and API enhancement in required.

To test:
- Trigger the `ReleaseStack_ActivityLogTestJetpack` connected test suite and verify that all tests pass.