### PR TITLE
Issue/13326 scan store suspendable functions

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
@@ -71,7 +71,7 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
 
         mCountDownLatch = CountDownLatch(1)
         val fetchedScanStatePayload = runBlocking { scanStore.fetchScanState(payload) }
-        val scanStateForSite = scanStore.getScanStateForSite(site)
+        val scanStateForSite = runBlocking { scanStore.getScanStateForSite(site) }
 
         assertNotNull(fetchedScanStatePayload)
         assertNotNull(scanStateForSite)
@@ -101,7 +101,7 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
 
         scanSqlUtils.replaceScanState(site, model)
 
-        val scanState = scanStore.getScanStateForSite(site)
+        val scanState = runBlocking { scanStore.getScanStateForSite(site) }
 
         assertNotNull(scanState)
         assertEquals(model.state, scanState?.state)
@@ -134,7 +134,7 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
 
         scanSqlUtils.replaceScanState(site, model)
 
-        val scanState = scanStore.getScanStateForSite(site)
+        val scanState = runBlocking { scanStore.getScanStateForSite(site) }
 
         assertNotNull(scanState)
         assertEquals(model.state, scanState?.state)
@@ -168,7 +168,7 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
 
         mCountDownLatch = CountDownLatch(1)
         val scanHistoryPayload = runBlocking { scanStore.fetchScanHistory(payload) }
-        val dbContent = scanStore.getScanHistoryForSite(site)
+        val dbContent = runBlocking { scanStore.getScanHistoryForSite(site) }
 
         assertNotNull(scanHistoryPayload)
         assertNull(scanHistoryPayload.error)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
@@ -158,7 +158,7 @@ class ScanStoreTest {
     }
 
     @Test
-    fun `get scan state returns state and threats from the db`() {
+    fun `get scan state returns state and threats from the db`() = test {
         val scanStateModel = ScanStateModel(State.IDLE, hasCloud = true, threats = listOf(threatInCurrentState))
         whenever(scanSqlUtils.getScanStateForSite(siteModel)).thenReturn(scanStateModel)
         whenever(threatSqlUtils.getThreats(siteModel, listOf(CURRENT))).thenReturn(listOf(threatInCurrentState))

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:1.0.0"
 
     // WordPress libs
-    implementation ('org.wordpress:utils:1.26') {
+    implementation ('org.wordpress:utils:1.30.3-beta.1') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"


### PR DESCRIPTION
This PR makes `getScanStateForSite`, `getThreatModelByThreatId`, `getScanHistoryForSite` and `addOrUpdateScanStateModelForSite` suspend functions.

Can be tested with https://github.com/wordpress-mobile/WordPress-Android/pull/14010.