### PR TITLE
Adds `preview_tablet`, `preview_mobile` and `demo_url` fields in FETCH_BLOCK_LAYOUTS response

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -746,7 +746,7 @@ public class SiteStoreUnitTest {
         GutenbergLayoutCategory cat1 = new GutenbergLayoutCategory("a", "About", "About", "👋");
         GutenbergLayoutCategory cat2 = new GutenbergLayoutCategory("b", "Blog", "Blog", "📰");
         List<GutenbergLayoutCategory> categories = Arrays.asList(cat1, cat2);
-        GutenbergLayout layout = new GutenbergLayout("l", "Layout", "img", "content", categories);
+        GutenbergLayout layout = new GutenbergLayout("l", "Layout", "img", "img", "img", "content", "url", categories);
         List<GutenbergLayout> layouts = Collections.singletonList(layout);
         // Store
         SiteSqlUtils.insertOrReplaceBlockLayouts(site, categories, layouts);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutModel.kt
@@ -16,7 +16,10 @@ class GutenbergLayoutModel(
     @Column var siteId: Int = 0, // Foreign key
     @Column var title: String = "",
     @Column var preview: String = "",
-    @Column var content: String = ""
+    @Column(name = "PREVIEW_TABLET") var previewTablet: String = "",
+    @Column(name = "PREVIEW_MOBILE") var previewMobile: String = "",
+    @Column var content: String = "",
+    @Column(name = "DEMO_URL") var demoUrl: String = ""
 ) : Identifiable {
     override fun getId() = id
 
@@ -30,14 +33,20 @@ fun GutenbergLayout.transform(site: SiteModel) = GutenbergLayoutModel(
         siteId = site.id,
         title = title,
         preview = preview,
-        content = content
+        previewMobile = previewMobile,
+        previewTablet = previewTablet,
+        content = content,
+        demoUrl = demoUrl
 )
 
 fun GutenbergLayoutModel.transform(categories: List<GutenbergLayoutCategoryModel>) = GutenbergLayout(
         slug = slug,
         title = title,
         preview = preview,
+        previewTablet = previewTablet,
+        previewMobile = previewMobile,
         content = content,
+        demoUrl = demoUrl,
         categories = categories.transform()
 )
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/BlockLayoutsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/BlockLayoutsResponse.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site
 
 import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.network.Response
 
@@ -14,7 +15,10 @@ data class GutenbergLayout(
     val slug: String,
     val title: String,
     val preview: String,
+    @SerializedName("preview_tablet") val previewTablet: String,
+    @SerializedName("preview_mobile") val previewMobile: String,
     val content: String,
+    @SerializedName("demo_url") val demoUrl: String,
     val categories: List<GutenbergLayoutCategory>
 ) : Parcelable
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 136
+        return 137
     }
 
     override fun getDbName(): String {
@@ -1490,6 +1490,21 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 135 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductAttributeModel RENAME TO WCGlobalAttributeModel")
+                }
+                136 -> migrate(version) {
+                    db.execSQL("DROP TABLE IF EXISTS GutenbergLayoutModel")
+                    db.execSQL(
+                            "CREATE TABLE GutenbergLayoutModel (" +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "SLUG TEXT NOT NULL," +
+                                    "SITE_ID INTEGER," +
+                                    "TITLE TEXT NOT NULL," +
+                                    "PREVIEW TEXT NOT NULL," +
+                                    "PREVIEW_TABLET TEXT NOT NULL," +
+                                    "PREVIEW_MOBILE TEXT NOT NULL," +
+                                    "CONTENT TEXT NOT NULL," +
+                                    "DEMO_URL TEXT NOT NULL)"
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Description
Adds `preview_tablet`, `preview_mobile` and `demo_url` fields in FETCH_BLOCK_LAYOUTS response
Those fields are needed in the implementation of:
* https://github.com/wordpress-mobile/gutenberg-mobile/issues/2979
* https://github.com/wordpress-mobile/gutenberg-mobile/issues/2980

## To test

### Android App
* Use the build from https://github.com/wordpress-mobile/WordPress-Android/pull/14040
  * Note that this is still WIP but can validate the existence of the new fields
* Change between mobile/tablet/desktop mode
* **Verify** that the thumbnail mode changes
* Select a layout
* Press preview
* **Verify** that a demo url loads

### Tests
* `testFetchBlockLayouts()` and `testFetchBlockLayoutsBeta()` tests for [self-hosted](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/8192df58b69552457e05c3b5c5287f601600db17/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java) and [WPCOM](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/8192df58b69552457e05c3b5c5287f601600db17/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java) Sites.
* [`testInsertOrReplaceBlockLayouts()`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/fb77915df6fef71778f4a8646f924c5bf12cd681/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java#L743)