### PR TITLE
Fixed crash when trying to parse variations field in WCProductModel

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -317,7 +317,25 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return productIds
     }
 
-    fun getNumVariations() = parseJson(variations).size
+    fun getNumVariations(): Int {
+        return try {
+            if (variations.isNotEmpty()) {
+                val jsonElement = Gson().fromJson(variations, JsonElement::class.java)
+                when {
+                    jsonElement.isJsonArray -> {
+                        jsonElement.asJsonArray.size()
+                    }
+                    jsonElement.isJsonObject -> {
+                        jsonElement.asJsonObject.entrySet().size
+                    }
+                    else -> 0
+                }
+            } else 0
+        } catch (e: JsonParseException) {
+            AppLog.e(T.API, e)
+            0
+        }
+    }
 
     fun getGroupedProductIdList() = parseJson(groupedProductIds)
 


### PR DESCRIPTION
Fixes woocommerce/woocommerce-android#3553 by parsing just the size of the `variations` instead of trying to parse the values of the `variations` array.

#### To test
- Open the example app and click on `Woo` - > `Products` -> `Fetch Single product`.
- Enter a productId for a variable product and ensure that the variations count is displayed correctly.
- Enter a productId for a simple product and ensure that the product is fetched correctly.

This PR is a hotfix and should be merged to the release branch so that we can release another beta. cc @AliSoftware 