### PR TITLE
Shipping Labels Settings: expose more details, and allow updating

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -10,7 +10,13 @@ import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.EditText
+import android.widget.Spinner
 import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
@@ -27,6 +33,8 @@ import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPaperSize
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.io.File
@@ -230,6 +238,62 @@ class WooShippingLabelFragment : Fragment() {
                     } else {
                         prependToLog("The WooCommerce services plugin is not installed")
                     }
+                }
+            }
+        }
+        update_account_settings.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    val result = wcShippingLabelStore.getAccountSettings(site)
+                    result.error?.let {
+                        prependToLog("Can't fetch account settings\n${it.type}: ${it.message}")
+                    }
+                    if (result.model != null) {
+                        showAccountSettingsDialog(site, result.model!!)
+                    } else {
+                        prependToLog("The WooCommerce services plugin is not installed")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showAccountSettingsDialog(selectedSite: SiteModel, accountSettings: WCShippingAccountSettings) {
+        val dialog = AlertDialog.Builder(requireContext()).let {
+            it.setView(R.layout.dialog_wc_shipping_label_settings)
+            it.show()
+        }
+        dialog.findViewById<CheckBox>(R.id.enabled_checkbox)?.isChecked = accountSettings.isCreatingLabelsEnabled
+        dialog.findViewById<EditText>(R.id.payment_method_id)?.setText(
+                accountSettings.selectedPaymentMethodId?.toString() ?: ""
+        )
+        dialog.findViewById<CheckBox>(R.id.email_receipts_checkbox)?.isChecked = accountSettings.isEmailReceiptEnabled
+        dialog.findViewById<Spinner>(R.id.paper_size_spinner)?.let {
+            val items = listOf("label", "legal", "letter")
+            it.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, items)
+            it.setSelection(items.indexOf(accountSettings.paperSize.stringValue))
+        }
+        dialog.findViewById<Button>(R.id.save_button)?.setOnClickListener {
+            dialog.hide()
+            coroutineScope.launch {
+                val result = wcShippingLabelStore.updateAccountSettings(
+                        selectedSite,
+                        isCreatingLabelsEnabled = dialog.findViewById<CheckBox>(R.id.enabled_checkbox)?.isChecked,
+                        selectedPaymentMethodId = dialog.findViewById<EditText>(R.id.payment_method_id)?.text
+                                ?.toString()?.ifEmpty { null }?.toInt(),
+                        isEmailReceiptEnabled = dialog.findViewById<CheckBox>(R.id.email_receipts_checkbox)?.isChecked,
+                        paperSize = dialog.findViewById<Spinner>(R.id.paper_size_spinner)?.selectedItem?.let {
+                            WCShippingLabelPaperSize.fromString(it as String)
+                        }
+                )
+                dialog.dismiss()
+                result.error?.let {
+                    prependToLog("${it.type}: ${it.message}")
+                }
+                if (result.model == true) {
+                    prependToLog("Settings updated")
+                } else {
+                    prependToLog("The WooCommerce services plugin is not installed")
                 }
             }
         }

--- a/example/src/main/res/layout/dialog_wc_shipping_label_settings.xml
+++ b/example/src/main/res/layout/dialog_wc_shipping_label_settings.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <CheckBox
+        android:id="@+id/enabled_checkbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Enable creating labels" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Selected Payment Method Id" />
+
+    <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/payment_method_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="number"
+        app:textHint="Selected Payment Method Id" />
+
+    <CheckBox
+        android:id="@+id/email_receipts_checkbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Email receipts" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Paper size" />
+
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/paper_size_spinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <Button
+        android:id="@+id/save_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:text="Save" />
+
+</LinearLayout>

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -87,5 +87,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Get account settings"/>
+
+        <Button
+            android:id="@+id/update_account_settings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update account settings"/>
     </LinearLayout>
 </ScrollView>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
@@ -3,10 +3,17 @@ package org.wordpress.android.fluxc.model.shippinglabels
 import com.google.gson.annotations.SerializedName
 
 data class WCShippingAccountSettings(
+    val isCreatingLabelsEnabled: Boolean,
+    val isEmailReceiptEnabled: Boolean,
+    val paperSize: String,
     val canManagePayments: Boolean,
+    val storeOwnerName: String,
+    val storeOwnerUserName: String,
+    val storeOwnerWpcomUserName: String,
+    val storeOwnerWpcomEmail: String,
     val selectedPaymentMethodId: Int?,
     val paymentMethods: List<WCPaymentMethod>,
-    val lastUsedBoxId: String?
+    val lastUsedBoxId: String?,
 )
 
 data class WCPaymentMethod(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
@@ -13,7 +13,7 @@ data class WCShippingAccountSettings(
     val storeOwnerWpcomEmail: String,
     val selectedPaymentMethodId: Int?,
     val paymentMethods: List<WCPaymentMethod>,
-    val lastUsedBoxId: String?,
+    val lastUsedBoxId: String?
 )
 
 data class WCPaymentMethod(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 data class WCShippingAccountSettings(
     val isCreatingLabelsEnabled: Boolean,
     val isEmailReceiptEnabled: Boolean,
-    val paperSize: String,
+    val paperSize: WCShippingLabelPaperSize,
     val canManagePayments: Boolean,
     val storeOwnerName: String,
     val storeOwnerUserName: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPaperSize.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPaperSize.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+enum class WCShippingLabelPaperSize(val stringValue: String) {
+    LABEL("label"),
+    LEGAL("legal"),
+    LETTER("letter");
+
+    companion object {
+        fun fromString(value: String): WCShippingLabelPaperSize {
+            // When the value is unknown, WCS in wp-admin uses Label by default
+            return WCShippingLabelPaperSize.values().find { it.stringValue == value } ?: LABEL
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
@@ -10,11 +10,18 @@ data class AccountSettingsApiResponse(
     @SerializedName("userMeta") val userMeta: UserMeta
 ) {
     data class FormData(
-        @SerializedName("selected_payment_method_id") val selectedPaymentId: Int?
+        @SerializedName("enabled") val isCreatingLabelsEnabled: Boolean,
+        @SerializedName("selected_payment_method_id") val selectedPaymentId: Int?,
+        @SerializedName("paper_size") val paperSize: String,
+        @SerializedName("email_receipts") val isPaymentReceiptEnabled: Boolean
     )
 
     data class FormMeta(
         @SerializedName("can_manage_payments") val canManagePayments: Boolean,
+        @SerializedName("master_user_name") val storeOwnerName: String,
+        @SerializedName("master_user_login") val storeOwnerUserName: String,
+        @SerializedName("master_user_wpcom_login") val storeOwnerWpcomUserName: String,
+        @SerializedName("master_user_email") val storeOwnerWpcomEmail: String,
         @SerializedName("payment_methods") val paymentMethods: List<WCPaymentMethod>?
     )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.android.volley.RequestQueue
 import com.google.gson.Gson
 import com.google.gson.JsonElement
+import com.google.gson.JsonObject
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
@@ -174,6 +175,26 @@ constructor(
         return when (response) {
             is JetpackSuccess -> {
                 WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
+    suspend fun updateAccountSettings(site: SiteModel, request: UpdateSettingsApiRequest): WooPayload<Boolean> {
+        val url = WOOCOMMERCE.connect.account.settings.pathV1
+
+        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
+                this,
+                site,
+                url,
+                request.toMap(),
+                JsonObject::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data!!["success"].asBoolean)
             }
             is JetpackError -> {
                 WooPayload(response.error.toWooError())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/UpdateSettingsApiRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/UpdateSettingsApiRequest.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateSettingsApiRequest(
+    @SerializedName("selected_payment_method_id")
+    val selectedPaymentMethodId: Int?,
+    @SerializedName("enabled")
+    val isCreatingLabelsEnabled: Boolean?,
+    @SerializedName("paper_size")
+    val paperSize: String?,
+    @SerializedName("email_receipts")
+    val isEmailReceiptEnabled: Boolean?
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -203,7 +203,14 @@ class WCShippingLabelStore @Inject constructor(
                 }
                 response.result?.success == true -> {
                     WooResult(WCShippingAccountSettings(
+                            isCreatingLabelsEnabled = response.result.formData.isCreatingLabelsEnabled,
+                            isEmailReceiptEnabled = response.result.formData.isPaymentReceiptEnabled,
+                            paperSize = response.result.formData.paperSize,
                             canManagePayments = response.result.formMeta.canManagePayments,
+                            storeOwnerName = response.result.formMeta.storeOwnerName,
+                            storeOwnerUserName = response.result.formMeta.storeOwnerUserName,
+                            storeOwnerWpcomUserName = response.result.formMeta.storeOwnerWpcomUserName,
+                            storeOwnerWpcomEmail = response.result.formMeta.storeOwnerWpcomEmail,
                             selectedPaymentMethodId = response.result.formData.selectedPaymentId,
                             paymentMethods = response.result.formMeta.paymentMethods.orEmpty(),
                             lastUsedBoxId = response.result.userMeta.lastBoxId


### PR DESCRIPTION
This is needed for https://github.com/woocommerce/woocommerce-android/issues/3536, and the rest of SL tasks, it adds the following:
1. Exposes more details from the settings endpoint: store owner details and other settings.
2. Add the ability to update the account settings.

#### Testing
1. Open the example app and login.
2. Click on Woo, then Shipping Labels.
3. Click on "Update account settings"
4. Confirm that a dialog with different settings is displayed.
5. Confirm that the values in the dialog match the current settings.
6. Update some settings.
7. Click on Save.
8. Confirm that `Settings Updated` is printed.
9. Confirm in wp-admin that the settings were updated.