### PR TITLE
Merge hotfix 1.10.1 into trunk

### DIFF
--- a/example/src/test/resources/wc/lineitems.json
+++ b/example/src/test/resources/wc/lineitems.json
@@ -108,6 +108,10 @@
       },
       {
         "display_value": []
+      },
+      {
+        "display_key": "",
+        "display_value": "empty key"
       }
     ],
     "sku":"woo-vneck-tee",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -123,10 +123,11 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
          */
         fun getAttributesAsString(): String {
             return getAttributeList()
-                    .takeWhile {
+                    .filter {
                         // Don't include null, empty, or the "_reduced_stock" key
                         // skipping "_reduced_stock" is a temporary workaround until "type" is added to the response.
-                        it.value != null && it.value.isNotEmpty() && it.key != null && it.key.first().toString() != "_"
+                        it.value != null && it.value.isNotEmpty() && it.key != null && it.key.isNotEmpty()
+                                && it.key.first().toString() != "_"
                     }.joinToString { it.value?.capitalize(Locale.getDefault()) ?: "" }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -126,8 +126,8 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
                     .filter {
                         // Don't include null, empty, or the "_reduced_stock" key
                         // skipping "_reduced_stock" is a temporary workaround until "type" is added to the response.
-                        it.value != null && it.value.isNotEmpty() && it.key != null && it.key.isNotEmpty()
-                                && it.key.first().toString() != "_"
+                        it.value != null && it.value.isNotEmpty() && it.key != null &&
+                                it.key.isNotEmpty() && it.key.first().toString() != "_"
                     }.joinToString { it.value?.capitalize(Locale.getDefault()) ?: "" }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -317,7 +317,25 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return productIds
     }
 
-    fun getNumVariations() = parseJson(variations).size
+    fun getNumVariations(): Int {
+        return try {
+            if (variations.isNotEmpty()) {
+                val jsonElement = Gson().fromJson(variations, JsonElement::class.java)
+                when {
+                    jsonElement.isJsonArray -> {
+                        jsonElement.asJsonArray.size()
+                    }
+                    jsonElement.isJsonObject -> {
+                        jsonElement.asJsonObject.entrySet().size
+                    }
+                    else -> 0
+                }
+            } else 0
+        } catch (e: JsonParseException) {
+            AppLog.e(T.API, e)
+            0
+        }
+    }
 
     fun getGroupedProductIdList() = parseJson(groupedProductIds)
 


### PR DESCRIPTION
We just cut a hotfix from the `1.10.0` tag (used by the `release/6.0` branch of WCiOS currently in beta) to fix 2 issues #1870 and #1871 and create hotfix `1.10.1`.

So now it's time to merge the `1.10.1` hotfix back into `trunk`. (I'll create a tag once approved.)