### PR TITLE
Woo: Shipping rates endpoint

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -148,5 +148,5 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
     // Multidex
-    implementation 'com.android.support:multidex:1.0.3'
+    implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -27,6 +27,8 @@ import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.io.File
@@ -191,6 +193,33 @@ class WooShippingLabelFragment : Fragment() {
                 coroutineScope.launch {
                     val result = withContext(Dispatchers.Default) {
                         wcShippingLabelStore.getPackageTypes(site)
+                    }
+                    result.error?.let {
+                        prependToLog("${it.type}: ${it.message}")
+                    }
+                    result.model?.let {
+                        prependToLog("$it")
+                    }
+                }
+            }
+        }
+
+        get_shipping_rates.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    val result = withContext(Dispatchers.Default) {
+                        wcShippingLabelStore.getShippingRates(site, 5332L,
+                            ShippingLabelAddress(
+                                    "Company", "Ondrej Ruttkay", "", "US", "NY", "42 Jewel St.", "", "Brooklyn", "11222"
+                            ),
+                            ShippingLabelAddress(
+                                    "Company", "Ondrej Ruttkay", "", "US", "NY", "82 Jewel St.", "", "Brooklyn", "11222"
+                            ),
+                            listOf(
+                                    ShippingLabelPackage("Krabka 1", "medium_flat_box_top", 10f, 10f, 10f, 10f, false),
+                                    ShippingLabelPackage("Krabka 2", "medium_flat_box_side", 5f, 5f, 5f, 5f, false),
+                            )
+                        )
                     }
                     result.error?.let {
                         prependToLog("${it.type}: ${it.message}")

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -75,6 +75,13 @@
             android:text="Get packages"/>
 
         <Button
+            android:id="@+id/get_shipping_rates"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Get shipping rates"/>
+
+        <Button
             android:id="@+id/get_shipping_plugin_info"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.AccountS
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.PrintShippingLabelApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.ShippingRatesApiResponse
 
 object WCShippingLabelTestUtils {
     private fun generateSampleShippingLabel(
@@ -83,6 +84,15 @@ object WCShippingLabelTestUtils {
         )
         val responseType = object : TypeToken<GetPackageTypesResponse>() {}.type
         return Gson().fromJson(json, responseType) as? GetPackageTypesResponse
+    }
+
+    fun generateSampleGetShippingRatesApiResponse(): ShippingRatesApiResponse? {
+        val json = UnitTestUtils.getStringFromResourceFile(
+                this.javaClass,
+                "wc/shipping-labels-carriers.json"
+        )
+        val responseType = object : TypeToken<ShippingRatesApiResponse>() {}.type
+        return Gson().fromJson(json, responseType) as? ShippingRatesApiResponse
     }
 
     fun generateSampleAccountSettingsApiResponse(): AccountSettingsApiResponse {

--- a/example/src/test/resources/wc/shipping-labels-carriers.json
+++ b/example/src/test/resources/wc/shipping-labels-carriers.json
@@ -1,0 +1,33 @@
+{
+  "success": true,
+  "rates": {
+    "default_box": {
+      "default": {
+        "shipment_id": "shp_0a9b3ff983c6427eaf1e24cb344de36a",
+        "rates": [{
+          "rate_id": "rate_cb976896a09c4171a93ace57ed66ce5b",
+          "service_id": "MediaMail",
+          "carrier_id": "usps",
+          "title": "USPS - Media Mail",
+          "rate": 3.86,
+          "retail_rate": 3.86,
+          "is_selected": false,
+          "delivery_days": 2,
+          "delivery_date_guaranteed": false,
+          "delivery_date": null
+        }, {
+          "rate_id": "rate_1b202bd43a8c4c929c73bb46989ef745",
+          "service_id": "FEDEX_GROUND",
+          "carrier_id": "fedex",
+          "title": "FedEx - Ground",
+          "rate": 21.55,
+          "retail_rate": 21.55,
+          "is_selected": false,
+          "delivery_days": 1,
+          "delivery_date_guaranteed": true,
+          "delivery_date": "2020-03-23T23:59:00.000Z"
+        }]
+      }
+    }
+  }
+}

--- a/example/src/test/resources/wc/shipping-labels-carriers.json
+++ b/example/src/test/resources/wc/shipping-labels-carriers.json
@@ -3,29 +3,69 @@
   "rates": {
     "default_box": {
       "default": {
-        "shipment_id": "shp_0a9b3ff983c6427eaf1e24cb344de36a",
         "rates": [{
           "rate_id": "rate_cb976896a09c4171a93ace57ed66ce5b",
           "service_id": "MediaMail",
           "carrier_id": "usps",
+          "shipment_id": "shp_0a9b3ff983c6427eaf1e24cb344de36a",
           "title": "USPS - Media Mail",
-          "rate": 3.86,
-          "retail_rate": 3.86,
+          "rate": 3.5,
+          "insurance": 100,
+          "retail_rate": 3.5,
           "is_selected": false,
           "delivery_days": 2,
           "delivery_date_guaranteed": false,
-          "delivery_date": null
+          "delivery_date": null,
+          "tracking": false,
+          "free_pickup": false
         }, {
           "rate_id": "rate_1b202bd43a8c4c929c73bb46989ef745",
           "service_id": "FEDEX_GROUND",
           "carrier_id": "fedex",
           "title": "FedEx - Ground",
-          "rate": 21.55,
-          "retail_rate": 21.55,
+          "shipment_id": "shp_0a9b3ff983c6427eaf1e24cb344de36a",
+          "rate": 21.5,
+          "insurance": 100,
+          "retail_rate": 21.5,
           "is_selected": false,
           "delivery_days": 1,
           "delivery_date_guaranteed": true,
-          "delivery_date": "2020-03-23T23:59:00.000Z"
+          "delivery_date": null,
+          "tracking": false,
+          "free_pickup": false
+        }]
+      },
+      "with_signature": {
+        "rates": [{
+          "rate_id": "rate_cb976896a09c4171a93ace57ed66ce5b",
+          "service_id": "MediaMail",
+          "carrier_id": "usps",
+          "shipment_id": "shp_0a9b3ff983c6427eaf1e24cb344de36a",
+          "title": "USPS - Media Mail",
+          "rate": 13.5,
+          "insurance": 100,
+          "retail_rate": 13.5,
+          "is_selected": false,
+          "delivery_days": 2,
+          "delivery_date_guaranteed": false,
+          "delivery_date": null,
+          "tracking": true,
+          "free_pickup": true
+        }, {
+          "rate_id": "rate_1b202bd43a8c4c929c73bb46989ef745",
+          "service_id": "FEDEX_GROUND",
+          "carrier_id": "fedex",
+          "title": "FedEx - Ground",
+          "shipment_id": "shp_0a9b3ff983c6427eaf1e24cb344de36a",
+          "rate": 121.5,
+          "insurance": 100,
+          "retail_rate": 121.5,
+          "is_selected": false,
+          "delivery_days": 1,
+          "delivery_date_guaranteed": true,
+          "delivery_date": null,
+          "tracking": true,
+          "free_pickup": true
         }]
       }
     }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -43,6 +43,7 @@
 
 /connect/label/print
 /connect/label/<order_id>/
+/connect/label/<order_id>/rates
 /connect/label/<order_id>/<shippingLabelId>/
 /connect/label/<order_id>/<shippingLabelId>/refund
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -150,6 +150,16 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
         }
     }
 
+    data class ShippingLabelPackage(
+        val id: String,
+        @SerializedName("box_id") val boxId: String,
+        val height: Float,
+        val length: Float,
+        val width: Float,
+        val weight: Float,
+        @SerializedName("is_letter") val isLetter: Boolean = false
+    )
+
     class SelectedPackage {
         @SerializedName("default_box") val defaultBox: DefaultBox? = null
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingRatesResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingRatesResult.kt
@@ -1,13 +1,12 @@
 package org.wordpress.android.fluxc.model.shippinglabels
 
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.ShippingRatesApiResponse.Box.ShippingOption.Rate
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.ShippingRatesApiResponse.ShippingOption.Rate
 
 data class WCShippingRatesResult(
     val packageRates: List<ShippingPackage>
 ) {
     data class ShippingOption(
         val optionId: String,
-        val shipmentId: String,
         val rates: List<Rate>
     )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingRatesResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingRatesResult.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.ShippingRatesApiResponse.Box.ShippingOption.Rate
+
+data class WCShippingRatesResult(
+    val packageRates: List<ShippingPackage>
+) {
+    data class ShippingOption(
+        val optionId: String,
+        val shipmentId: String,
+        val rates: List<Rate>
+    )
+
+    data class ShippingPackage(
+        val boxId: String,
+        val shippingOptions: List<ShippingOption>
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -237,7 +237,7 @@ constructor(
             }
 
         data class ShippingOption(
-            val rates: List<Rate>,
+            val rates: List<Rate>
         ) {
             data class Rate(
                 val title: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
@@ -17,8 +18,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse.Companion
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.network.utils.toMap
+import java.math.BigDecimal
+import java.util.Date
 import java.util.Locale
 import javax.inject.Singleton
 
@@ -181,11 +185,86 @@ constructor(
         }
     }
 
+    suspend fun getShippingRates(
+        site: SiteModel,
+        orderId: Long,
+        origin: ShippingLabelAddress,
+        destination: ShippingLabelAddress,
+        packages: List<ShippingLabelPackage>
+    ): WooPayload<ShippingRatesApiResponse> {
+        val url = WOOCOMMERCE.connect.label.order(orderId).rates.pathV1
+
+        val params = mapOf(
+            "origin" to origin.toMap(),
+            "destination" to destination.toMap(),
+            "packages" to packages.map { it.toMap() }
+        )
+
+        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
+                this,
+                site,
+                url,
+                params,
+                ShippingRatesApiResponse::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
     data class PrintShippingLabelApiResponse(
         val mimeType: String,
         val b64Content: String,
         val success: Boolean
     )
+
+    data class ShippingRatesApiResponse(
+        @SerializedName("success") val isSuccess: Boolean,
+        @SerializedName("rates") private val boxesJson: JsonElement
+    ) {
+        companion object {
+            private val gson by lazy { Gson() }
+        }
+
+        data class Box(
+            private val shippingOptionsJson: JsonElement
+        ) {
+            data class ShippingOption(
+                @SerializedName("shipment_id") val shipmentId: String,
+                val rates: List<Rate>
+            ) {
+                data class Rate(
+                    @SerializedName("rate_id") val rateId: String,
+                    @SerializedName("service_id") val serviceId: String,
+                    @SerializedName("carrier_id") val carrierId: String,
+                    val title: String,
+                    val rate: BigDecimal,
+                    @SerializedName("retail_rate") val retailRate: BigDecimal,
+                    @SerializedName("is_selected") val isSelected: Boolean,
+                    @SerializedName("delivery_days") val deliveryDays: Int,
+                    @SerializedName("delivery_date_guaranteed") val deliveryDateGuaranteed: Boolean,
+                    @SerializedName("delivery_date") val deliveryDate: Date?
+                )
+            }
+
+            val shippingOptions: Map<String, ShippingOption>
+                get() {
+                    val responseType = object : TypeToken<Map<String, ShippingOption>>() {}.type
+                    return gson.fromJson(shippingOptionsJson, responseType) as? Map<String, ShippingOption> ?: emptyMap()
+                }
+        }
+
+        val boxes: Map<String, Box>
+            get() {
+                val responseType = object : TypeToken<Map<String, Box>>() {}.type
+                return gson.fromJson(boxesJson, responseType) as? Map<String, Box> ?: emptyMap()
+            }
+    }
 
     data class VerifyAddressResponse(
         @SerializedName("success") val isSuccess: Boolean,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse.Companion
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.network.utils.toMap
 import java.math.BigDecimal
@@ -231,39 +230,32 @@ constructor(
             private val gson by lazy { Gson() }
         }
 
-        data class Box(
-            private val shippingOptionsJson: JsonElement
-        ) {
-            data class ShippingOption(
-                @SerializedName("shipment_id") val shipmentId: String,
-                val rates: List<Rate>
-            ) {
-                data class Rate(
-                    @SerializedName("rate_id") val rateId: String,
-                    @SerializedName("service_id") val serviceId: String,
-                    @SerializedName("carrier_id") val carrierId: String,
-                    val title: String,
-                    val rate: BigDecimal,
-                    @SerializedName("retail_rate") val retailRate: BigDecimal,
-                    @SerializedName("is_selected") val isSelected: Boolean,
-                    @SerializedName("delivery_days") val deliveryDays: Int,
-                    @SerializedName("delivery_date_guaranteed") val deliveryDateGuaranteed: Boolean,
-                    @SerializedName("delivery_date") val deliveryDate: Date?
-                )
-            }
-
-            val shippingOptions: Map<String, ShippingOption>
-                get() {
-                    val responseType = object : TypeToken<Map<String, ShippingOption>>() {}.type
-                    return gson.fromJson(shippingOptionsJson, responseType) as? Map<String, ShippingOption> ?: emptyMap()
-                }
-        }
-
-        val boxes: Map<String, Box>
+        val boxes: Map<String, Map<String, ShippingOption>>
             get() {
-                val responseType = object : TypeToken<Map<String, Box>>() {}.type
-                return gson.fromJson(boxesJson, responseType) as? Map<String, Box> ?: emptyMap()
+                val responseType = object : TypeToken<Map<String, Map<String, ShippingOption>>>() {}.type
+                return gson.fromJson(boxesJson, responseType) as? Map<String, Map<String, ShippingOption>> ?: emptyMap()
             }
+
+        data class ShippingOption(
+            val rates: List<Rate>,
+        ) {
+            data class Rate(
+                val title: String,
+                val insurance: BigDecimal,
+                val rate: BigDecimal,
+                @SerializedName("rate_id") val rateId: String,
+                @SerializedName("service_id") val serviceId: String,
+                @SerializedName("carrier_id") val carrierId: String,
+                @SerializedName("shipment_id") val shipmentId: String,
+                @SerializedName("tracking") val hasTracking: Boolean,
+                @SerializedName("retail_rate") val retailRate: BigDecimal,
+                @SerializedName("is_selected") val isSelected: Boolean,
+                @SerializedName("free_pickup") val isPickupFree: Boolean,
+                @SerializedName("delivery_days") val deliveryDays: Int,
+                @SerializedName("delivery_date_guaranteed") val deliveryDateGuaranteed: Boolean,
+                @SerializedName("delivery_date") val deliveryDate: Date?
+            )
+        }
     }
 
     data class VerifyAddressResponse(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse.FormSchema.PackageOption.PackageDefinition
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.ShippingRatesApiResponse.Box
 import org.wordpress.android.fluxc.persistence.WCShippingLabelSqlUtils
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
@@ -173,8 +172,8 @@ class WCShippingLabelStore @Inject constructor(
                     val packageRates: List<ShippingPackage> = response.result.boxes.map { box ->
                         ShippingPackage(
                             box.key,
-                            box.value.shippingOptions.entries.map { option ->
-                                ShippingOption(option.key, option.value.shipmentId, option.value.rates)
+                            box.value.entries.map { option ->
+                                ShippingOption(option.key, option.value.rates)
                             }
                         )
                     }


### PR DESCRIPTION
This PR adds the support for retrieving shipping rates.

**To test:**
1. Go to Woo -> Shipping labels -> Select site
2. Tap on Get shipping rates
3. Wait for the data to be loaded
4. Enter package size parameters
5. Notice a response is printed in the log

**Unit tests:**

Run **WCShippingLabelStoreTest** tests.