### PR TITLE
Issue/backup download formattable range type

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
@@ -114,4 +114,12 @@ class FormattableContentMapperTest {
         val formattableJson = formattableContentMapper.mapFormattableContentListToJson(formattableList)
         assertEquals(jsonContentArray, formattableJson)
     }
+
+    @Test
+    fun mapsRewindDownloadReadyTypeToRewindDownloadReadyFormattableRangeType() {
+        val response = UnitTestUtils
+                .getStringFromResourceFile(this.javaClass, "notifications/rewind-download-ready.json")
+        val formattableContent = formattableContentMapper.mapToFormattableContent(response)
+        assertEquals(FormattableRangeType.REWIND_DOWNLOAD_READY, formattableContent.ranges!![0].rangeType())
+    }
 }

--- a/example/src/test/resources/notifications/rewind-download-ready.json
+++ b/example/src/test/resources/notifications/rewind-download-ready.json
@@ -1,0 +1,36 @@
+{
+  "text": "Jetpack has finished preparing a downloadable backup of your site, Kirby Atomic Business Site, as requested by kirbyzzzzz. Head over to the site’s Backups to download it.",
+  "ranges": [
+    {
+      "url": "https://wordpress.com/backup/kirbyatomicbusinesssite.wpcomstaging.com",
+      "indices": [
+        140,
+        154
+      ],
+      "id": "9",
+      "parent": null,
+      "type": "rewind_download_ready",
+      "site_id": 174754732
+    },
+    {
+      "type": "user",
+      "indices": [
+        111,
+        121
+      ],
+      "id": 182550502,
+      "parent": null,
+      "url": "http://testweb18.wordpress.com"
+    },
+    {
+      "type": "site",
+      "indices": [
+        67,
+        93
+      ],
+      "id": 174754732,
+      "parent": null,
+      "url": "https://kirbyatomicbusinesssite.wpcomstaging.com"
+    }
+  ]
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -82,10 +82,7 @@ data class FormattableRange(
     @SerializedName("indices") val indices: List<Int>? = null
 ) {
     fun rangeType(): FormattableRangeType {
-        return if (type != null)
-            FormattableRangeType.fromString(type)
-        else
-           FormattableRangeType.fromString(section)
+        return if (type != null) FormattableRangeType.fromString(type) else FormattableRangeType.fromString(section)
     }
 }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -82,7 +82,10 @@ data class FormattableRange(
     @SerializedName("indices") val indices: List<Int>? = null
 ) {
     fun rangeType(): FormattableRangeType {
-        return if (type != null) FormattableRangeType.fromString(type) else FormattableRangeType.fromString(section)
+        return if (type != null)
+            FormattableRangeType.fromString(type)
+        else
+           FormattableRangeType.fromString(section)
     }
 }
 
@@ -101,6 +104,7 @@ enum class FormattableRangeType {
     MATCH,
     MEDIA,
     B,
+    REWIND_DOWNLOAD_READY,
     UNKNOWN;
 
     companion object {
@@ -120,6 +124,7 @@ enum class FormattableRangeType {
                 "match" -> MATCH
                 "media" -> MEDIA
                 "b" -> B
+                "rewind_download_ready" -> REWIND_DOWNLOAD_READY
                 else -> UNKNOWN
             }
         }


### PR DESCRIPTION
This PR adds REWIND_DOWNLOAD_READY to the `FormattableRangeType` enum. This is in preparation to support notification detail linking in WPAndroid.

**To test**
- Test in [WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14075)