### PR TITLE
Pass the correct id when updating Woo Product Settings

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCProductSettingsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCProductSettingsSqlUtils.kt
@@ -17,7 +17,7 @@ object WCProductSettingsSqlUtils {
             WellSql.insert(settings).asSingleTransaction(true).execute()
             1
         } else {
-            val oldId = settings.id
+            val oldId = result.id
             WellSql.update(WCProductSettingsModel::class.java).whereId(oldId)
                     .put(settings, UpdateAllExceptId(WCProductSettingsModel::class.java)).execute()
         }


### PR DESCRIPTION
Currently when changing the product settings, the new changes are not reflected on the app. The cause is that we were passing a wrong id to the SQL request. This PR fixes this.

This was reported in the issue https://github.com/woocommerce/woocommerce-android/issues/3575

#### Testing
1. Open the example app.
2. Click on Woo, then "Fetch WC product settings"
3. Check that the current settings are logged.
4. Go to wp-admin -> WooCommerce -> Settings -> Products
5. Change the measurement units.
6. Go back to the example app, and click on "Fetch WC product settings"
7. Confirm that the new settings are printed.