### PR TITLE
Shipping Labels account settings enhancements

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
@@ -6,6 +6,7 @@ data class WCShippingAccountSettings(
     val isCreatingLabelsEnabled: Boolean,
     val isEmailReceiptEnabled: Boolean,
     val paperSize: WCShippingLabelPaperSize,
+    val canEditSettings: Boolean,
     val canManagePayments: Boolean,
     val storeOwnerName: String,
     val storeOwnerUserName: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPaperSize.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPaperSize.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model.shippinglabels
 
 enum class WCShippingLabelPaperSize(val stringValue: String) {
+    A4("a4"),
     LABEL("label"),
     LEGAL("legal"),
     LETTER("letter");

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
@@ -17,6 +17,7 @@ data class AccountSettingsApiResponse(
     )
 
     data class FormMeta(
+        @SerializedName("can_edit_settings") val canEditSettings: Boolean,
         @SerializedName("can_manage_payments") val canManagePayments: Boolean,
         @SerializedName("master_user_name") val storeOwnerName: String,
         @SerializedName("master_user_login") val storeOwnerUserName: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -242,6 +242,7 @@ class WCShippingLabelStore @Inject constructor(
                                     isCreatingLabelsEnabled = response.result.formData.isCreatingLabelsEnabled,
                                     isEmailReceiptEnabled = response.result.formData.isPaymentReceiptEnabled,
                                     paperSize = WCShippingLabelPaperSize.fromString(response.result.formData.paperSize),
+                                    canEditSettings = response.result.formMeta.canEditSettings,
                                     canManagePayments = response.result.formMeta.canManagePayments,
                                     storeOwnerName = response.result.formMeta.storeOwnerName,
                                     storeOwnerUserName = response.result.formMeta.storeOwnerUserName,


### PR DESCRIPTION
This just adds two more things to the SL account settings:
1. Exposes the field `can_edit_settings`, even if it's always true (as explained here: p91TBi-4uy-p2), to keep better compatibility, we'll use it for controlling the display of settings.
2. Adds the paper size type A4.