### PR TITLE
Return comment filter with response and add a limit option for local comment requests.

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -413,7 +413,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     @SuppressWarnings("unused")
     @Subscribe
     public void onCommentChanged(OnCommentChanged event) {
-        List<CommentModel> comments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
+        List<CommentModel> comments = mCommentStore.getCommentsForSite(sSite, true, 0, CommentStatus.ALL);
         if (event.isError()) {
             AppLog.i(T.TESTS, "event error type: " + event.error.type);
             if (mNextEvent == TestEvents.COMMENT_CHANGED_UNKNOWN_COMMENT) {
@@ -474,7 +474,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch = new CountDownLatch(1);
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        mComments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
+        mComments = mCommentStore.getCommentsForSite(sSite, true, 0, CommentStatus.ALL);
     }
 
     private void fetchFirstPosts() throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -299,7 +299,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @SuppressWarnings("unused")
     @Subscribe
     public void onCommentChanged(OnCommentChanged event) {
-        List<CommentModel> comments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
+        List<CommentModel> comments = mCommentStore.getCommentsForSite(sSite, true, 0, CommentStatus.ALL);
         if (event.isError()) {
             AppLog.i(T.TESTS, "event error type: " + event.error.type);
             if (mNextEvent == TestEvents.COMMENT_CHANGED_UNKNOWN_COMMENT) {
@@ -347,7 +347,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(payload));
         // Wait for a network response / onChanged event
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-        mComments = mCommentStore.getCommentsForSite(sSite, true, CommentStatus.ALL);
+        mComments = mCommentStore.getCommentsForSite(sSite, true, 0, CommentStatus.ALL);
     }
 
     private void fetchFirstPosts() throws InterruptedException {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CommentsFragment.java
@@ -105,12 +105,12 @@ public class CommentsFragment extends Fragment {
     }
 
     private CommentModel getFirstComment() {
-        List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), false, CommentStatus.ALL);
+        List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), false, 0, CommentStatus.ALL);
         if (comments.size() == 0) {
             prependToLog("There is no comments on this site or comments haven't been fetched.");
             return null;
         }
-        return mCommentStore.getCommentsForSite(getFirstSite(), false, CommentStatus.ALL).get(0);
+        return mCommentStore.getCommentsForSite(getFirstSite(), false, 0, CommentStatus.ALL).get(0);
     }
 
     private void fetchCommentsFirstSite() {
@@ -151,7 +151,7 @@ public class CommentsFragment extends Fragment {
                 prependToLog("Comment " + (getFirstComment().getILike() ? "liked ツ" : "unliked (ಥ﹏ಥ)"));
             } else {
                 prependToLog("OnCommentChanged: rowsAffected=" + event.rowsAffected);
-                List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), false,
+                List<CommentModel> comments = mCommentStore.getCommentsForSite(getFirstSite(), false, 0,
                         CommentStatus.ALL);
                 for (CommentModel comment : comments) {
                     prependToLog(comment.getAuthorName() + " @" + comment.getDatePublished());

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentSqlUtilsTest.kt
@@ -135,7 +135,6 @@ class CommentSqlUtilsTest {
         )
                 .isEqualTo(65)
 
-
         val numCommentsDeleted = CommentSqlUtils.removeDeletedComments(
                 site,
                 freshComments,

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentSqlUtilsTest.kt
@@ -1,0 +1,188 @@
+package org.wordpress.android.fluxc.comment
+
+import com.yarolegovich.wellsql.SelectQuery
+import com.yarolegovich.wellsql.WellSql
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.CommentStatus.ALL
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.CommentSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import java.util.ArrayList
+import java.util.Random
+
+@RunWith(RobolectricTestRunner::class)
+class CommentSqlUtilsTest {
+    private val mRandom = Random(System.currentTimeMillis())
+
+    val site = SiteModel()
+    @Before fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config: WellSqlConfig = SingleStoreWellSqlConfigForTests(appContext, CommentModel::class.java)
+        WellSql.init(config)
+        config.reset()
+
+        site.id = 1
+        site.siteId = 2
+    }
+
+    // Attempts to insert null then verifies there is no media
+    @Test fun `removeDeletedComments correctly removes deleted comments with mixed statuses from mixed list`() {
+        val commentsInDb = generateCommentModels(40, ALL)
+        val freshComments = generateCommentModels(33, ALL)
+        freshComments.removeIf { it.remoteCommentId == 5L }
+        freshComments.removeIf { it.remoteCommentId == 15L }
+        freshComments.removeIf { it.remoteCommentId == 20L }
+
+        commentsInDb.forEach {
+            CommentSqlUtils.insertOrUpdateComment(it)
+        }
+
+        Assertions.assertThat(
+                CommentSqlUtils.getCommentsForSite(
+                        site,
+                        SelectQuery.ORDER_DESCENDING,
+                        APPROVED,
+                        UNAPPROVED
+                ).size
+        )
+                .isEqualTo(40)
+
+        val numCommentsDeleted = CommentSqlUtils.removeDeletedComments(site, freshComments, false, false, APPROVED, UNAPPROVED)
+        val cleanedComments = CommentSqlUtils.getCommentsForSite(
+                site,
+                SelectQuery.ORDER_DESCENDING,
+                APPROVED,
+                UNAPPROVED
+        )
+
+        Assertions.assertThat(numCommentsDeleted).isEqualTo(3)
+        Assertions.assertThat(cleanedComments.size).isEqualTo(37)
+        Assertions.assertThat(cleanedComments.find { it.remoteCommentId == 5L }).isNull()
+        Assertions.assertThat(cleanedComments.find { it.remoteCommentId == 15L }).isNull()
+        Assertions.assertThat(cleanedComments.find { it.remoteCommentId == 20L }).isNull()
+    }
+
+    // Attempts to insert null then verifies there is no media
+    @Test fun `removeDeletedComments trims deleted comments from bottom of DB when reaching the end of dataset`() {
+        val commentsInDb = generateCommentModels(50, ALL)
+        val freshComments = generateCommentModels(29, ALL, 31)
+
+        commentsInDb.forEach {
+            CommentSqlUtils.insertOrUpdateComment(it)
+        }
+
+        Assertions.assertThat(
+                CommentSqlUtils.getCommentsForSite(
+                        site,
+                        SelectQuery.ORDER_DESCENDING,
+                        APPROVED,
+                        UNAPPROVED
+                ).size
+        )
+                .isEqualTo(50)
+
+        val numCommentsDeleted = CommentSqlUtils.removeDeletedComments(
+                site,
+                freshComments,
+                true,
+                false,
+                APPROVED,
+                UNAPPROVED
+        )
+        val cleanedComments = CommentSqlUtils.getCommentsForSite(
+                site,
+                SelectQuery.ORDER_DESCENDING,
+                APPROVED,
+                UNAPPROVED
+        )
+
+        Assertions.assertThat(numCommentsDeleted).isEqualTo(20)
+        Assertions.assertThat(cleanedComments.size).isEqualTo(30)
+        freshComments.forEach {
+            CommentSqlUtils.insertOrUpdateComment(it)
+        }
+
+        Assertions.assertThat(
+                CommentSqlUtils.getCommentsForSite(
+                        site,
+                        SelectQuery.ORDER_DESCENDING,
+                        APPROVED,
+                        UNAPPROVED
+                ).size
+        )
+                .isEqualTo(59)
+    }
+
+
+    // Attempts to insert null then verifies there is no media
+    @Test fun `removeDeletedComments trims deleted comments from the top of DB when begining of dataset excludes them`() {
+        val commentsInDb = generateCommentModels(50, ALL)
+        val freshComments = generateCommentModels(30, ALL, 3)
+
+        commentsInDb.forEach {
+            CommentSqlUtils.insertOrUpdateComment(it)
+        }
+
+        Assertions.assertThat(
+                CommentSqlUtils.getCommentsForSite(
+                        site,
+                        SelectQuery.ORDER_DESCENDING,
+                        APPROVED,
+                        UNAPPROVED
+                ).size
+        )
+                .isEqualTo(50)
+
+        val numCommentsDeleted = CommentSqlUtils.removeDeletedComments(site, freshComments, false, true, ALL)
+//        val cleanedComments = CommentSqlUtils.getCommentsForSite(
+//                site,
+//                SelectQuery.ORDER_DESCENDING,
+//                APPROVED,
+//                UNAPPROVED
+//        )
+
+        Assertions.assertThat(numCommentsDeleted).isEqualTo(3)
+//        Assertions.assertThat(cleanedComments.size).isEqualTo(30)
+//        freshComments.forEach {
+//            CommentSqlUtils.insertOrUpdateComment(it)
+//        }
+//
+//        Assertions.assertThat(
+//                CommentSqlUtils.getCommentsForSite(
+//                        site,
+//                        SelectQuery.ORDER_DESCENDING,
+//                        APPROVED,
+//                        UNAPPROVED
+//                ).size
+//        )
+//                .isEqualTo(59)
+    }
+
+    private fun generateCommentModels(num: Int, status: CommentStatus, startId: Int = 1): ArrayList<CommentModel> {
+        val commentModels = ArrayList<CommentModel>()
+        for (i in 0 until num) {
+            val comment = CommentModel()
+            comment.remoteCommentId = startId + i.toLong()
+            comment.publishedTimestamp = startId + i.toLong()
+            comment.localSiteId = 1
+            comment.remoteSiteId = 2
+            if (status == ALL) {
+                comment.status = if (i % 2 == 0) APPROVED.toString() else CommentStatus.UNAPPROVED.toString()
+            } else {
+                comment.status = status.toString()
+            }
+            commentModels.add(comment)
+        }
+        return commentModels
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
@@ -33,6 +33,7 @@ public class CommentModel extends Payload<BaseNetworkError> implements Identifia
     @Column private String mPostTitle;
     @Column private String mStatus;
     @Column private String mDatePublished;
+    @Column private long mPublishedTimestamp;
     @Column private String mContent;
     @Column private String mUrl;
 
@@ -167,5 +168,13 @@ public class CommentModel extends Payload<BaseNetworkError> implements Identifia
 
     public void setUrl(String url) {
         mUrl = url;
+    }
+
+    public long getPublishedTimestamp() {
+        return mPublishedTimestamp;
+    }
+
+    public void setPublishedTimestamp(long publishedTimestamp) {
+        mPublishedTimestamp = publishedTimestamp;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestRe
 import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsResponsePayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentResponsePayload;
 import org.wordpress.android.fluxc.utils.CommentErrorUtils;
+import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -281,6 +282,7 @@ public class CommentRestClient extends BaseWPComRestClient {
         comment.setContent(response.content);
         comment.setILike(response.i_like);
         comment.setUrl(response.URL);
+        comment.setPublishedTimestamp(DateTimeUtils.timestampFromIso8601(response.date));
 
         if (response.author != null) {
             comment.setAuthorUrl(response.author.URL);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -41,7 +41,7 @@ public class CommentRestClient extends BaseWPComRestClient {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
     }
 
-    public void fetchComments(final SiteModel site, final int number, final int offset, CommentStatus status) {
+    public void fetchComments(final SiteModel site, final int number, final int offset, final CommentStatus status) {
         String url = WPCOMREST.sites.site(site.getSiteId()).comments.getUrlV1_1();
         Map<String, String> params = new HashMap<>();
         params.put("status", status.toString());
@@ -55,7 +55,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                     public void onResponse(CommentsWPComRestResponse response) {
                         List<CommentModel> comments = commentsResponseToCommentList(response, site);
                         FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(comments, site, number,
-                                offset);
+                                offset, status);
                         mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentsAction(payload));
                     }
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -43,7 +43,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);
     }
 
-    public void fetchComments(final SiteModel site, final int number, final int offset, CommentStatus status) {
+    public void fetchComments(final SiteModel site, final int number, final int offset, final CommentStatus status) {
         List<Object> params = new ArrayList<>(4);
         Map<String, Object> commentParams = new HashMap<>();
         commentParams.put("number", number);
@@ -63,7 +63,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
                     public void onResponse(Object response) {
                         List<CommentModel> comments = commentsResponseToCommentList(response, site);
                         FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(comments, site, number,
-                                offset);
+                                offset, status);
                         mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentsAction(payload));
                     }
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -80,7 +80,7 @@ public class CommentSqlUtils {
             return 0;
         }
 
-        if (!Arrays.asList(statuses).contains(CommentStatus.ALL)) {
+        if (Arrays.asList(statuses).contains(CommentStatus.ALL)) {
             return removeComments(site);
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -24,17 +24,17 @@ public class CommentSqlUtils {
 
         // If the comment already exist and has an id, we want to update it.
         commentResult = WellSql.select(CommentModel.class).where()
-                .beginGroup()
-                .equals(CommentModelTable.ID, comment.getId())
-                .endGroup().endWhere().getAsModel();
+                               .beginGroup()
+                               .equals(CommentModelTable.ID, comment.getId())
+                               .endGroup().endWhere().getAsModel();
 
         // If it's not a new comment, try to find the "remote" comment
         if (commentResult.isEmpty()) {
             commentResult = WellSql.select(CommentModel.class).where()
-                    .beginGroup()
-                    .equals(CommentModelTable.REMOTE_COMMENT_ID, comment.getRemoteCommentId())
-                    .equals(CommentModelTable.LOCAL_SITE_ID, comment.getLocalSiteId())
-                    .endGroup().endWhere().getAsModel();
+                                   .beginGroup()
+                                   .equals(CommentModelTable.REMOTE_COMMENT_ID, comment.getRemoteCommentId())
+                                   .equals(CommentModelTable.LOCAL_SITE_ID, comment.getLocalSiteId())
+                                   .endGroup().endWhere().getAsModel();
         }
 
         if (commentResult.isEmpty()) {
@@ -45,7 +45,7 @@ public class CommentSqlUtils {
             // update
             int oldId = commentResult.get(0).getId();
             return WellSql.update(CommentModel.class).whereId(oldId)
-                    .put(comment, new UpdateAllExceptId<>(CommentModel.class)).execute();
+                          .put(comment, new UpdateAllExceptId<>(CommentModel.class)).execute();
         }
     }
 
@@ -61,8 +61,8 @@ public class CommentSqlUtils {
         }
 
         return WellSql.delete(CommentModel.class)
-                .where().equals(CommentModelTable.ID, comment.getId()).endWhere()
-                .execute();
+                      .where().equals(CommentModelTable.ID, comment.getId()).endWhere()
+                      .execute();
     }
 
     public static int removeComments(SiteModel site) {
@@ -71,8 +71,8 @@ public class CommentSqlUtils {
         }
 
         return WellSql.delete(CommentModel.class)
-                .where().equals(CommentModelTable.LOCAL_SITE_ID, site.getId()).endWhere()
-                .execute();
+                      .where().equals(CommentModelTable.LOCAL_SITE_ID, site.getId()).endWhere()
+                      .execute();
     }
 
     public static int removeCommentsWithFilters(SiteModel site, CommentStatus... statuses) {
@@ -98,7 +98,7 @@ public class CommentSqlUtils {
 
     public static CommentModel getCommentByLocalCommentId(int localId) {
         List<CommentModel> results = WellSql.select(CommentModel.class)
-                .where().equals(CommentModelTable.ID, localId).endWhere().getAsModel();
+                                            .where().equals(CommentModelTable.ID, localId).endWhere().getAsModel();
         if (results.isEmpty()) {
             return null;
         }
@@ -107,10 +107,10 @@ public class CommentSqlUtils {
 
     public static CommentModel getCommentBySiteAndRemoteId(SiteModel site, long remoteCommentId) {
         List<CommentModel> results = WellSql.select(CommentModel.class)
-                .where()
-                .equals(CommentModelTable.REMOTE_COMMENT_ID, remoteCommentId)
-                .equals(CommentModelTable.LOCAL_SITE_ID, site.getId())
-                .endWhere().getAsModel();
+                                            .where()
+                                            .equals(CommentModelTable.REMOTE_COMMENT_ID, remoteCommentId)
+                                            .equals(CommentModelTable.LOCAL_SITE_ID, site.getId())
+                                            .endWhere().getAsModel();
         if (results.isEmpty()) {
             return null;
         }
@@ -118,14 +118,24 @@ public class CommentSqlUtils {
     }
 
     private static SelectQuery<CommentModel> getCommentsQueryForSite(SiteModel site, CommentStatus... statuses) {
+        return getCommentsQueryForSite(site, 0, 0, statuses);
+    }
+
+    private static SelectQuery<CommentModel> getCommentsQueryForSite(SiteModel site, int limit, int offset,
+                                                                     CommentStatus... statuses) {
         if (site == null) {
             return null;
         }
 
+        SelectQuery<CommentModel> query = WellSql.select(CommentModel.class);
+
+        if (limit > 0) {
+            query.limit(limit);
+        }
+
         ConditionClauseBuilder<SelectQuery<CommentModel>> selectQueryBuilder =
-                WellSql.select(CommentModel.class)
-                        .where().beginGroup()
-                        .equals(CommentModelTable.LOCAL_SITE_ID, site.getId());
+                query.where().beginGroup()
+                     .equals(CommentModelTable.LOCAL_SITE_ID, site.getId());
 
         // Check if statuses contains ALL
         if (!Arrays.asList(statuses).contains(CommentStatus.ALL)) {
@@ -135,11 +145,16 @@ public class CommentSqlUtils {
     }
 
     public static List<CommentModel> getCommentsForSite(SiteModel site, @Order int order, CommentStatus... statuses) {
+        return getCommentsForSite(site, order, 0, 0, statuses);
+    }
+
+    public static List<CommentModel> getCommentsForSite(SiteModel site, @Order int order, int limit, int offset,
+                                                        CommentStatus... statuses) {
         if (site == null) {
             return Collections.emptyList();
         }
 
-        return getCommentsQueryForSite(site, statuses)
+        return getCommentsQueryForSite(site, limit, offset, statuses)
                 .orderBy(CommentModelTable.DATE_PUBLISHED, order)
                 .getAsModel();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -88,7 +88,7 @@ public class CommentSqlUtils {
             public int compare(CommentModel o1, CommentModel o2) {
                 long x = o2.getPublishedTimestamp();
                 long y = o1.getPublishedTimestamp();
-                return (y < y) ? -1 : ((x == y) ? 0 : 1);
+                return (x < y) ? -1 : ((x == y) ? 0 : 1);
             }
         });
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -117,7 +117,7 @@ public class CommentSqlUtils {
                                            .equals(CommentModelTable.LOCAL_SITE_ID, site.getId())
                                            .isIn(CommentModelTable.STATUS, targetStatuses)
                                            .isNotIn(CommentModelTable.REMOTE_COMMENT_ID, remoteIds)
-                                           .greaterThen(CommentModelTable.PUBLISHED_TIMESTAMP, startOfRange)
+                                           .greaterThenOrEqual(CommentModelTable.PUBLISHED_TIMESTAMP, startOfRange)
                                            .endWhere()
                                            .execute();
         }
@@ -129,7 +129,7 @@ public class CommentSqlUtils {
                                            .equals(CommentModelTable.LOCAL_SITE_ID, site.getId())
                                            .isIn(CommentModelTable.STATUS, targetStatuses)
                                            .isNotIn(CommentModelTable.REMOTE_COMMENT_ID, remoteIds)
-                                           .lessThen(CommentModelTable.PUBLISHED_TIMESTAMP, endOfRange)
+                                           .lessThenOrEqual(CommentModelTable.PUBLISHED_TIMESTAMP, endOfRange)
                                            .endWhere()
                                            .execute();
         }
@@ -140,8 +140,8 @@ public class CommentSqlUtils {
                                              .equals(CommentModelTable.LOCAL_SITE_ID, site.getId())
                                              .isIn(CommentModelTable.STATUS, targetStatuses)
                                              .isNotIn(CommentModelTable.REMOTE_COMMENT_ID, remoteIds)
-                                             .lessThen(CommentModelTable.PUBLISHED_TIMESTAMP, startOfRange)
-                                             .greaterThen(CommentModelTable.PUBLISHED_TIMESTAMP, endOfRange)
+                                             .lessThenOrEqual(CommentModelTable.PUBLISHED_TIMESTAMP, startOfRange)
+                                             .greaterThenOrEqual(CommentModelTable.PUBLISHED_TIMESTAMP, endOfRange)
                                              .endWhere()
                                              .execute();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -75,6 +75,23 @@ public class CommentSqlUtils {
                 .execute();
     }
 
+    public static int removeCommentsWithFilters(SiteModel site, CommentStatus... statuses) {
+        if (site == null) {
+            return 0;
+        }
+
+        if (!Arrays.asList(statuses).contains(CommentStatus.ALL)) {
+            return removeComments(site);
+        }
+
+        return WellSql.delete(CommentModel.class)
+                      .where()
+                      .equals(CommentModelTable.LOCAL_SITE_ID, site.getId())
+                      .isIn(CommentModelTable.STATUS, Arrays.asList(statuses))
+                      .endWhere()
+                      .execute();
+    }
+
     public static int deleteAllComments() {
         return WellSql.delete(CommentModel.class).execute();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -118,10 +118,10 @@ public class CommentSqlUtils {
     }
 
     private static SelectQuery<CommentModel> getCommentsQueryForSite(SiteModel site, CommentStatus... statuses) {
-        return getCommentsQueryForSite(site, 0, 0, statuses);
+        return getCommentsQueryForSite(site, 0, statuses);
     }
 
-    private static SelectQuery<CommentModel> getCommentsQueryForSite(SiteModel site, int limit, int offset,
+    private static SelectQuery<CommentModel> getCommentsQueryForSite(SiteModel site, int limit,
                                                                      CommentStatus... statuses) {
         if (site == null) {
             return null;
@@ -145,16 +145,16 @@ public class CommentSqlUtils {
     }
 
     public static List<CommentModel> getCommentsForSite(SiteModel site, @Order int order, CommentStatus... statuses) {
-        return getCommentsForSite(site, order, 0, 0, statuses);
+        return getCommentsForSite(site, order, 0, statuses);
     }
 
-    public static List<CommentModel> getCommentsForSite(SiteModel site, @Order int order, int limit, int offset,
+    public static List<CommentModel> getCommentsForSite(SiteModel site, @Order int order, int limit,
                                                         CommentStatus... statuses) {
         if (site == null) {
             return Collections.emptyList();
         }
 
-        return getCommentsQueryForSite(site, limit, offset, statuses)
+        return getCommentsQueryForSite(site, limit, statuses)
                 .orderBy(CommentModelTable.DATE_PUBLISHED, order)
                 .getAsModel();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 137
+        return 138
     }
 
     override fun getDbName(): String {
@@ -1494,6 +1494,8 @@ open class WellSqlConfig : DefaultWellConfig {
                 136 -> migrate(version) {
                     db.execSQL("CREATE TABLE DynamicCard (_id INTEGER PRIMARY KEY AUTOINCREMENT,SITE_ID INTEGER," +
                             "DYNAMIC_CARD_TYPE TEXT,STATE TEXT)")
+                } 137 -> migrate(version) {
+                db.execSQL("ALTER TABLE CommentModel ADD PUBLISHED_TIMESTAMP INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1494,8 +1494,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 136 -> migrate(version) {
                     db.execSQL("CREATE TABLE DynamicCard (_id INTEGER PRIMARY KEY AUTOINCREMENT,SITE_ID INTEGER," +
                             "DYNAMIC_CARD_TYPE TEXT,STATE TEXT)")
-                } 137 -> migrate(version) {
-                db.execSQL("ALTER TABLE CommentModel ADD PUBLISHED_TIMESTAMP INTEGER")
+                }
+                137 -> migrate(version) {
+                    db.execSQL("ALTER TABLE CommentModel ADD PUBLISHED_TIMESTAMP INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -425,7 +425,7 @@ public class CommentStore extends Store {
         if (!payload.isError()) {
             // Clear existing comments in case some were deleted on the server. Only remove them if we request the
             // first comments (offset == 0).
-            if (payload.offset == 0 && payload.requestedStatus == CommentStatus.ALL) {
+            if (payload.offset == 0) {
                 CommentSqlUtils.removeCommentsWithFilters(payload.site, payload.requestedStatus);
             }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -186,6 +186,22 @@ public class CommentStore extends Store {
     // Getters
 
     /**
+     * Get a limited list of comment for a specific site.
+     *
+     * @param site Site model to get comment for.
+     * @param orderByDateAscending If true order the results by ascending published date.
+     *                             If false, order the results by descending published date.
+     * @param statuses Array of status or CommentStatus.ALL to get all of them.
+     * @param limit Maximum number of comments to return. 0 is unlimited.
+     */
+    @SuppressLint("WrongConstant")
+    public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending, int limit,
+                                                 CommentStatus... statuses) {
+        @Order int order = orderByDateAscending ? SelectQuery.ORDER_ASCENDING : SelectQuery.ORDER_DESCENDING;
+        return CommentSqlUtils.getCommentsForSite(site, order, limit, statuses);
+    }
+
+    /**
      * Get a list of comment for a specific site.
      *
      * @param site Site model to get comment for.
@@ -193,13 +209,6 @@ public class CommentStore extends Store {
      *                             If false, order the results by descending published date.
      * @param statuses Array of status or CommentStatus.ALL to get all of them.
      */
-    @SuppressLint("WrongConstant")
-    public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending, int limit, int offset,
-                                                 CommentStatus... statuses) {
-        @Order int order = orderByDateAscending ? SelectQuery.ORDER_ASCENDING : SelectQuery.ORDER_DESCENDING;
-        return CommentSqlUtils.getCommentsForSite(site, order, limit, offset, statuses);
-    }
-
     @SuppressLint("WrongConstant")
     public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending,
                                                  CommentStatus... statuses) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -186,7 +186,7 @@ public class CommentStore extends Store {
     // Getters
 
     /**
-     * Get a limited list of comment for a specific site.
+     * Get a list of comment for a specific site.
      *
      * @param site Site model to get comment for.
      * @param orderByDateAscending If true order the results by ascending published date.
@@ -417,8 +417,9 @@ public class CommentStore extends Store {
         int rowsAffected = 0;
         OnCommentChanged event = new OnCommentChanged(rowsAffected);
         if (!payload.isError()) {
-            // Find comments deleted on the server and remove them from local DB.
-            CommentSqlUtils.removeDeletedComments(payload.site, payload.comments, payload.number, payload.offset,
+            // Find comments that were deleted or moved to a different status on the server and remove them from
+            // local DB.
+            CommentSqlUtils.removeCommentGaps(payload.site, payload.comments, payload.number, payload.offset,
                     payload.requestedStatus);
 
             for (CommentModel comment : payload.comments) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -98,13 +98,15 @@ public class CommentStore extends Store {
         @NonNull public final SiteModel site;
         public final int number;
         public final int offset;
+        public final CommentStatus requestedStatus;
 
         public FetchCommentsResponsePayload(@NonNull List<CommentModel> comments, @NonNull SiteModel site, int number,
-                                            int offset) {
+                                            int offset, CommentStatus status) {
             this.comments = comments;
             this.site = site;
             this.number = number;
             this.offset = offset;
+            this.requestedStatus = status;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -194,6 +194,13 @@ public class CommentStore extends Store {
      * @param statuses Array of status or CommentStatus.ALL to get all of them.
      */
     @SuppressLint("WrongConstant")
+    public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending, int limit, int offset,
+                                                 CommentStatus... statuses) {
+        @Order int order = orderByDateAscending ? SelectQuery.ORDER_ASCENDING : SelectQuery.ORDER_DESCENDING;
+        return CommentSqlUtils.getCommentsForSite(site, order, limit, offset, statuses);
+    }
+
+    @SuppressLint("WrongConstant")
     public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending,
                                                  CommentStatus... statuses) {
         @Order int order = orderByDateAscending ? SelectQuery.ORDER_ASCENDING : SelectQuery.ORDER_DESCENDING;
@@ -418,7 +425,7 @@ public class CommentStore extends Store {
         if (!payload.isError()) {
             // Clear existing comments in case some were deleted on the server. Only remove them if we request the
             // first comments (offset == 0).
-            if (payload.offset == 0) {
+            if (payload.offset == 0 && payload.requestedStatus == CommentStatus.ALL) {
                 CommentSqlUtils.removeCommentsWithFilters(payload.site, payload.requestedStatus);
             }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -166,6 +166,7 @@ public class CommentStore extends Store {
     public static class OnCommentChanged extends OnChanged<CommentError> {
         public int rowsAffected;
         public CommentAction causeOfChange;
+        public CommentStatus requestedStatus;
         public List<Integer> changedCommentsLocalIds = new ArrayList<>();
         public OnCommentChanged(int rowsAffected) {
             this.rowsAffected = rowsAffected;
@@ -428,6 +429,7 @@ public class CommentStore extends Store {
         }
         event.causeOfChange = CommentAction.FETCH_COMMENTS;
         event.error = payload.error;
+        event.requestedStatus = payload.requestedStatus;
         emitChange(event);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -419,7 +419,7 @@ public class CommentStore extends Store {
             // Clear existing comments in case some were deleted on the server. Only remove them if we request the
             // first comments (offset == 0).
             if (payload.offset == 0) {
-                CommentSqlUtils.removeComments(payload.site);
+                CommentSqlUtils.removeCommentsWithFilters(payload.site, payload.requestedStatus);
             }
 
             for (CommentModel comment : payload.comments) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -165,6 +165,7 @@ public class CommentStore extends Store {
 
     public static class OnCommentChanged extends OnChanged<CommentError> {
         public int rowsAffected;
+        public int offset;
         public CommentAction causeOfChange;
         public CommentStatus requestedStatus;
         public List<Integer> changedCommentsLocalIds = new ArrayList<>();
@@ -430,6 +431,7 @@ public class CommentStore extends Store {
         event.causeOfChange = CommentAction.FETCH_COMMENTS;
         event.error = payload.error;
         event.requestedStatus = payload.requestedStatus;
+        event.offset = payload.offset;
         emitChange(event);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -26,7 +26,7 @@ public class CommentErrorUtils {
     public static FetchCommentsResponsePayload commentErrorToFetchCommentsPayload(BaseNetworkError error,
                                                                                   SiteModel site) {
         FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(new ArrayList<CommentModel>(), site,
-                0, 0);
+                0, 0, null);
         payload.error = new CommentError(genericToCommentError(error), getErrorMessage(error));
         return payload;
     }


### PR DESCRIPTION
This is a counterpart to [this](https://github.com/wordpress-mobile/WordPress-Android/pull/14140) wpandroid PR.

This PR adds a `CommentStatus` to payload returned when requesting all comments. `CommentStatus` can be null when we don't need to match specific action to a specific CommentStatus.

This PR also adds a logic for detection of comments that were removed from server or moved to a different status.

In addition this PR adds a limit option when requesting site comments.