### PR TITLE
Improve Attributes JSON data error handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,9 @@ workflows:
       - Firebase Test:
           name: Mocked Connected Tests
           results-history-name: CircleCI FluxC Mocked Tests
-          package: org.wordpress.android.fluxc.mocked
+          package: org.wordpress.android.fluxc
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
-          timeout: 10m
+          timeout: 30m
           num-flaky-test-attempts: 0
           post-slack-status: false
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,12 +138,12 @@ workflows:
       - Lint
       - Unit Tests
       - Firebase Test:
-          name: Connected Tests
-          results-history-name: CircleCI FluxC Tests
-          package: org.wordpress.android.fluxc
+          name: Mocked Connected Tests
+          results-history-name: CircleCI FluxC Mocked Tests
+          package: org.wordpress.android.fluxc.mocked
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
-          timeout: 30m
-          num-flaky-test-attempts: 1
+          timeout: 10m
+          num-flaky-test-attempts: 0
           post-slack-status: false
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,9 @@ workflows:
       - Firebase Test:
           name: Mocked Connected Tests
           results-history-name: CircleCI FluxC Mocked Tests
-          package: org.wordpress.android.fluxc
+          package: org.wordpress.android.fluxc.mocked
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
-          timeout: 30m
+          timeout: 10m
           num-flaky-test-attempts: 0
           post-slack-status: false
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,12 +138,12 @@ workflows:
       - Lint
       - Unit Tests
       - Firebase Test:
-          name: Mocked Connected Tests
-          results-history-name: CircleCI FluxC Mocked Tests
-          package: org.wordpress.android.fluxc.mocked
+          name: Connected Tests
+          results-history-name: CircleCI FluxC Tests
+          package: org.wordpress.android.fluxc
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
-          timeout: 10m
-          num-flaky-test-attempts: 0
+          timeout: 30m
+          num-flaky-test-attempts: 1
           post-slack-status: false
   nightly:
     triggers:

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1235,7 +1235,7 @@ class ProductRestClient(
                         body["attributes"] = it
                     }
                 } catch (ex: Exception) {
-                    body["attributes"] = storedWCProductModel.attributes
+                    body["attributes"] = JsonArray()
                 }
             }
         }
@@ -1338,7 +1338,7 @@ class ProductRestClient(
                         body["attributes"] = it
                     }
                 } catch (ex: Exception) {
-                    body["attributes"] = storedVariationModel.attributes
+                    body["attributes"] = JsonArray()
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1230,12 +1230,10 @@ class ProductRestClient(
         }
         if (storedWCProductModel.attributes != updatedProductModel.attributes) {
             JsonParser().apply {
-                try {
-                    parse(updatedProductModel.attributes).asJsonArray.let {
-                        body["attributes"] = it
-                    }
+                body["attributes"] = try {
+                    parse(updatedProductModel.attributes).asJsonArray
                 } catch (ex: Exception) {
-                    body["attributes"] = JsonArray()
+                     JsonArray()
                 }
             }
         }
@@ -1333,12 +1331,10 @@ class ProductRestClient(
         }
         if (storedVariationModel.attributes != updatedVariationModel.attributes) {
             JsonParser().apply {
-                try {
-                    parse(updatedVariationModel.attributes).asJsonArray.let {
-                        body["attributes"] = it
-                    }
+                body["attributes"] = try {
+                    parse(updatedVariationModel.attributes).asJsonArray
                 } catch (ex: Exception) {
-                    body["attributes"] = JsonArray()
+                     JsonArray()
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1332,7 +1332,15 @@ class ProductRestClient(
             body["menu_order"] = updatedVariationModel.menuOrder
         }
         if (storedVariationModel.attributes != updatedVariationModel.attributes) {
-            body["attributes"] = JsonParser().parse(updatedVariationModel.attributes).asJsonArray
+            JsonParser().apply {
+                try {
+                    parse(updatedVariationModel.attributes).asJsonArray.let {
+                        body["attributes"] = it
+                    }
+                } catch (ex: Exception) {
+                    body["attributes"] = storedVariationModel.attributes
+                }
+            }
         }
         return body
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1229,7 +1229,15 @@ class ProductRestClient(
             }
         }
         if (storedWCProductModel.attributes != updatedProductModel.attributes) {
-            body["attributes"] = JsonParser().parse(updatedProductModel.attributes).asJsonArray
+            JsonParser().apply {
+                try {
+                    parse(updatedProductModel.attributes).asJsonArray.let {
+                        body["attributes"] = it
+                    }
+                } catch (ex: Exception) {
+                    body["attributes"] = storedWCProductModel.attributes
+                }
+            }
         }
 
         return body

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1233,7 +1233,7 @@ class ProductRestClient(
                 body["attributes"] = try {
                     parse(updatedProductModel.attributes).asJsonArray
                 } catch (ex: Exception) {
-                     JsonArray()
+                    JsonArray()
                 }
             }
         }
@@ -1334,7 +1334,7 @@ class ProductRestClient(
                 body["attributes"] = try {
                     parse(updatedVariationModel.attributes).asJsonArray
                 } catch (ex: Exception) {
-                     JsonArray()
+                    JsonArray()
                 }
             }
         }


### PR DESCRIPTION
Summary
==========
Fix for the `ReleaseStack_WCProductTest#testUpdateDownloadableFiles` test. After the Attributes parameter addition when updating a Product or Product Variation, no treatment was added for scenarios where the new Attributes JSON value is null, this fix introduces simple handling to set an empty JSON array instead of trying to parse a null value as JSON.

How to Test
==========
Just make sure the test `ReleaseStack_WCProductTest#testUpdateDownloadableFiles` no longer fails at the `Connected Tests` CircleCI Job.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
