### PR TITLE
Issue/wpandroid 14030 jetpack backup download file

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.activity
 import com.android.volley.RequestQueue
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -558,7 +559,7 @@ class ActivityLogRestClientTest {
         val downloadId = 10L
         val response = DismissBackupDownloadResponse(downloadId, true)
 
-        initPostDismissBackupDownload(downloadId = downloadId, data = response)
+        initPostDismissBackupDownload(data = response)
 
         val payload = activityRestClient.dismissBackupDownload(site, downloadId)
 
@@ -568,8 +569,7 @@ class ActivityLogRestClientTest {
     @Test
     fun postDismissBackupDownloadOperationError() = test {
         val downloadId = 10L
-        initPostDismissBackupDownload(downloadId = downloadId, error =
-            WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
+        initPostDismissBackupDownload(error = WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
 
         val payload = activityRestClient.dismissBackupDownload(site, downloadId)
 
@@ -709,16 +709,15 @@ class ActivityLogRestClientTest {
 
     private suspend fun initPostDismissBackupDownload(
         data: DismissBackupDownloadResponse = mock(),
-        error: WPComGsonNetworkError? = null,
-        downloadId: Long
+        error: WPComGsonNetworkError? = null
     ): Response<DismissBackupDownloadResponse> {
         val response = if (error != null) Response.Error(error) else Success(data)
 
         whenever(wpComGsonRequestBuilder.syncPostRequest(
                 eq(activityRestClient),
                 urlCaptor.capture(),
-                eq(mapOf("downloadId" to downloadId.toString())),
-                eq(null),
+                anyOrNull(),
+                eq(mapOf("dismissed" to true.toString())),
                 eq(DismissBackupDownloadResponse::class.java)
         )).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -26,6 +26,8 @@ import org.wordpress.android.fluxc.persistence.ActivityLogSqlUtils
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadRequestTypes
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadResultPayload
+import org.wordpress.android.fluxc.store.ActivityLogStore.DismissBackupDownloadPayload
+import org.wordpress.android.fluxc.store.ActivityLogStore.DismissBackupDownloadResultPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchBackupDownloadStatePayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchRewindStatePayload
@@ -447,6 +449,46 @@ class ActivityLogStoreTest {
         activityLogStore.onAction(fetchAction)
 
         verify(activityLogSqlUtils).deleteBackupDownloadStatus(siteModel)
+    }
+
+    @Test
+    fun onDismissBackupDownloadActionCallRestClient() = test {
+        whenever(activityLogRestClient.dismissBackupDownload(eq(siteModel), any())).thenReturn(
+                DismissBackupDownloadResultPayload(
+                        100L,
+                        10L,
+                        true
+                )
+        )
+
+        val downloadId = 10L
+        val payload = DismissBackupDownloadPayload(siteModel, downloadId)
+        val action = ActivityLogActionBuilder.newDismissBackupDownloadAction(payload)
+        activityLogStore.onAction(action)
+
+        verify(activityLogRestClient).dismissBackupDownload(siteModel, downloadId)
+    }
+
+    @Test
+    fun emitsDismissBackupDownloadResult() = test {
+        val downloadId = 10L
+        val isDismissed = true
+
+        val payload = DismissBackupDownloadResultPayload(
+                siteModel.siteId,
+                downloadId,
+                isDismissed)
+        whenever(activityLogRestClient.dismissBackupDownload(siteModel, downloadId)).thenReturn(payload)
+
+        activityLogStore.onAction(ActivityLogActionBuilder.newDismissBackupDownloadAction(DismissBackupDownloadPayload(
+                siteModel,
+                downloadId)))
+
+        val expectedChangeEvent = ActivityLogStore.OnDismissBackupDownload(
+                downloadId,
+                isDismissed,
+                ActivityLogAction.DISMISS_BACKUP_DOWNLOAD)
+        verify(dispatcher).emitChange(eq(expectedChangeEvent))
     }
 
     private suspend fun initRestClient(

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -6,6 +6,7 @@
 /sites/$site/activity/count/group
 /sites/$site/rewind
 /sites/$site/rewind/downloads
+/sites/$site/rewind/downloads/$download_id
 
 /sites/$site/scan
 /sites/$site/scan/enqueue

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
@@ -19,5 +19,7 @@ public enum ActivityLogAction implements IAction {
     @Action(payloadType = ActivityLogStore.FetchBackupDownloadStatePayload.class)
     FETCH_BACKUP_DOWNLOAD_STATE,
     @Action(payloadType = ActivityLogStore.FetchActivityTypesPayload.class)
-    FETCH_ACTIVITY_TYPES
+    FETCH_ACTIVITY_TYPES,
+    @Action(payloadType = ActivityLogStore.DismissBackupDownloadPayload.class)
+    DISMISS_BACKUP_DOWNLOAD,
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -226,13 +226,13 @@ class ActivityLogRestClient(
         site: SiteModel,
         downloadId: Long
     ): DismissBackupDownloadResultPayload {
-        val url = WPCOMV2.sites.site(site.siteId).rewind.downloads.url
-        val params = mapOf("downloadId" to downloadId.toString())
+        val url = WPCOMV2.sites.site(site.siteId).rewind.downloads.download(downloadId).url
+        val request = mapOf("dismissed" to true.toString())
         val response = wpComGsonRequestBuilder.syncPostRequest(
                 this,
                 url,
-                params,
                 null,
+                request,
                 DismissBackupDownloadResponse::class.java)
         return when (response) {
             is Success -> DismissBackupDownloadResultPayload(site.siteId, downloadId, response.data.isDimissed)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -33,6 +33,9 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadRequestT
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadResultPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadStatusError
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadStatusErrorType
+import org.wordpress.android.fluxc.store.ActivityLogStore.DismissBackupDownloadError
+import org.wordpress.android.fluxc.store.ActivityLogStore.DismissBackupDownloadErrorType
+import org.wordpress.android.fluxc.store.ActivityLogStore.DismissBackupDownloadResultPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityTypesResultPayload
@@ -215,6 +218,31 @@ class ActivityLogRestClient(
                 )
                 val error = ActivityTypesError(errorType, response.error.message)
                 FetchedActivityTypesResultPayload(error, remoteSiteId)
+            }
+        }
+    }
+
+    suspend fun dismissBackupDownload(
+        site: SiteModel,
+        downloadId: Long
+    ): DismissBackupDownloadResultPayload {
+        val url = WPCOMV2.sites.site(site.siteId).rewind.downloads.url
+        val params = mapOf("downloadId" to downloadId.toString())
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                params,
+                null,
+                DismissBackupDownloadResponse::class.java)
+        return when (response) {
+            is Success -> DismissBackupDownloadResultPayload(site.siteId, downloadId, response.data.isDimissed)
+            is Error -> {
+                val errorType = NetworkErrorMapper.map(response.error,
+                        DismissBackupDownloadErrorType.GENERIC_ERROR,
+                        DismissBackupDownloadErrorType.INVALID_RESPONSE,
+                        DismissBackupDownloadErrorType.AUTHORIZATION_REQUIRED)
+                val error = DismissBackupDownloadError(errorType, response.error.message)
+                DismissBackupDownloadResultPayload(error, site.siteId, downloadId)
             }
         }
     }
@@ -484,4 +512,9 @@ class ActivityLogRestClient(
             val count: Int?
         )
     }
+
+    class DismissBackupDownloadResponse(
+        val downloadId: Long,
+        val isDimissed: Boolean
+    )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ActivityLogStore.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.ActivityLogAction
 import org.wordpress.android.fluxc.action.ActivityLogAction.BACKUP_DOWNLOAD
+import org.wordpress.android.fluxc.action.ActivityLogAction.DISMISS_BACKUP_DOWNLOAD
 import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_ACTIVITIES
 import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_ACTIVITY_TYPES
 import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_BACKUP_DOWNLOAD_STATE
@@ -24,6 +25,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.activity.ActivityLogRestCl
 import org.wordpress.android.fluxc.persistence.ActivityLogSqlUtils
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.API
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -43,33 +45,38 @@ class ActivityLogStore
         val actionType = action.type as? ActivityLogAction ?: return
         when (actionType) {
             FETCH_ACTIVITIES -> {
-                coroutineEngine.launch(AppLog.T.API, this, "ActivityLog: On FETCH_ACTIVITIES") {
+                coroutineEngine.launch(API, this, "ActivityLog: On FETCH_ACTIVITIES") {
                     emitChange(fetchActivities(action.payload as FetchActivityLogPayload))
                 }
             }
             FETCH_REWIND_STATE -> {
-                coroutineEngine.launch(AppLog.T.API, this, "ActivityLog: On FETCH_REWIND_STATE") {
+                coroutineEngine.launch(API, this, "ActivityLog: On FETCH_REWIND_STATE") {
                     emitChange(fetchActivitiesRewind(action.payload as FetchRewindStatePayload))
                 }
             }
             REWIND -> {
-                coroutineEngine.launch(AppLog.T.API, this, "ActivityLog: On REWIND") {
+                coroutineEngine.launch(API, this, "ActivityLog: On REWIND") {
                     emitChange(rewind(action.payload as RewindPayload))
                 }
             }
             BACKUP_DOWNLOAD -> {
-                coroutineEngine.launch(AppLog.T.API, this, "ActivityLog: On BACKUP_DOWNLOAD") {
+                coroutineEngine.launch(API, this, "ActivityLog: On BACKUP_DOWNLOAD") {
                     emitChange(backupDownload(action.payload as BackupDownloadPayload))
                 }
             }
             FETCH_BACKUP_DOWNLOAD_STATE -> {
-                coroutineEngine.launch(AppLog.T.API, this, "ActivityLog: On FETCH_BACKUP_DOWNLOAD_STATE") {
+                coroutineEngine.launch(API, this, "ActivityLog: On FETCH_BACKUP_DOWNLOAD_STATE") {
                     emitChange(fetchBackupDownloadState(action.payload as FetchBackupDownloadStatePayload))
                 }
             }
             FETCH_ACTIVITY_TYPES -> {
-                coroutineEngine.launch(AppLog.T.API, this, "ActivityLog: On FETCH_ACTIVITY_TYPES") {
+                coroutineEngine.launch(API, this, "ActivityLog: On FETCH_ACTIVITY_TYPES") {
                     emitChange(fetchActivityTypes(action.payload as FetchActivityTypesPayload))
+                }
+            }
+            DISMISS_BACKUP_DOWNLOAD -> {
+                coroutineEngine.launch(API, this, "ActivityLog: On DISMISS_BACKUP_DOWNLOAD") {
+                    emitChange(dismissBackupDownload(action.payload as DismissBackupDownloadPayload))
                 }
             }
         }
@@ -160,6 +167,13 @@ class ActivityLogStore
         return emitActivityTypesResult(payload, FETCH_ACTIVITY_TYPES)
     }
 
+    suspend fun dismissBackupDownload(backupDownloadPayload: DismissBackupDownloadPayload): OnDismissBackupDownload {
+        val payload = activityLogRestClient.dismissBackupDownload(
+                backupDownloadPayload.site,
+                backupDownloadPayload.downloadId)
+        return emitDismissBackupDownloadResult(payload, DISMISS_BACKUP_DOWNLOAD)
+    }
+
     private fun storeActivityLog(payload: FetchedActivityLogPayload, action: ActivityLogAction): OnActivityLogFetched {
         return if (payload.error != null) {
             OnActivityLogFetched(payload.error, action)
@@ -245,6 +259,20 @@ class ActivityLogStore
         }
     }
 
+    private fun emitDismissBackupDownloadResult(
+        payload: DismissBackupDownloadResultPayload,
+        action: ActivityLogAction
+    ): OnDismissBackupDownload {
+        return if (payload.error != null) {
+            OnDismissBackupDownload(payload.downloadId, payload.error, action)
+        } else {
+            OnDismissBackupDownload(
+                    downloadId = payload.downloadId,
+                    isDismissed = payload.isDismissed,
+                    causeOfChange = action)
+        }
+    }
+
     // Actions
     data class OnActivityLogFetched(
         val rowsAffected: Int,
@@ -308,6 +336,17 @@ class ActivityLogStore
             error: ActivityTypesError,
             causeOfChange: ActivityLogAction
         ) : this(remoteSiteId = remoteSiteId, causeOfChange = causeOfChange, activityTypeModels = listOf()) {
+            this.error = error
+        }
+    }
+
+    data class OnDismissBackupDownload(
+        val downloadId: Long,
+        val isDismissed: Boolean = false,
+        var causeOfChange: ActivityLogAction
+    ) : Store.OnChanged<DismissBackupDownloadError>() {
+        constructor(downloadId: Long, error: DismissBackupDownloadError, causeOfChange: ActivityLogAction) :
+                this(downloadId = downloadId, causeOfChange = causeOfChange) {
             this.error = error
         }
     }
@@ -434,6 +473,25 @@ class ActivityLogStore
         val contents: Boolean
     )
 
+    class DismissBackupDownloadPayload(
+        val site: SiteModel,
+        val downloadId: Long
+    ) : Payload<BaseRequest.BaseNetworkError>()
+
+    class DismissBackupDownloadResultPayload(
+        val siteId: Long,
+        val downloadId: Long,
+        val isDismissed: Boolean = false
+    ) : Payload<DismissBackupDownloadError>() {
+        constructor(
+            error: DismissBackupDownloadError,
+            siteId: Long,
+            downloadId: Long
+        ) : this(siteId = siteId, downloadId = downloadId) {
+            this.error = error
+        }
+    }
+
     // Errors
     enum class ActivityLogErrorType {
         GENERIC_ERROR,
@@ -493,4 +551,13 @@ class ActivityLogStore
     }
 
     class ActivityTypesError(var type: ActivityTypesErrorType, var message: String? = null) : OnChangedError
+
+    class DismissBackupDownloadError(var type: DismissBackupDownloadErrorType, var message: String? = null) :
+            OnChangedError
+
+    enum class DismissBackupDownloadErrorType {
+        GENERIC_ERROR,
+        AUTHORIZATION_REQUIRED,
+        INVALID_RESPONSE
+    }
 }


### PR DESCRIPTION
This PR adds support for dismissing a backup download
- Added new endpoint `/sites/$site/rewind/downloads/$download_id`
- Added support in ActivityLogRestClient
- Add tests

Test in WPAndroid PR