### PR TITLE
Handles null emoji value in GutenbergLayoutCategory

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -759,6 +759,22 @@ public class SiteStoreUnitTest {
     }
 
     @Test
+    public void testInsertBlockLayoutWithNullCategoryEmoji() {
+        // Test data
+        SiteModel site = generateWPComSite();
+        GutenbergLayoutCategory cat = new GutenbergLayoutCategory("a", "About", "About", null);
+        List<GutenbergLayoutCategory> categories = Collections.singletonList(cat);
+        GutenbergLayout layout = new GutenbergLayout("l", "Layout", "img", "img", "img", "content", "url", categories);
+        List<GutenbergLayout> layouts = Collections.singletonList(layout);
+        // Store
+        SiteSqlUtils.insertOrReplaceBlockLayouts(site, categories, layouts);
+        // Retrieve
+        List<GutenbergLayoutCategory> retrievedCategories = SiteSqlUtils.getBlockLayoutCategories(site);
+        // Check
+        assertEquals(retrievedCategories.get(0).getEmoji(), "");
+    }
+
+    @Test
     public void testJetpackSelfHostedAndForceXMLRPC() {
         SiteModel jetpackSite = generateJetpackSiteOverXMLRPC();
         jetpackSite.setOrigin(SiteModel.ORIGIN_WPCOM_REST);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutCategoryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/layouts/GutenbergLayoutCategoryModel.kt
@@ -30,7 +30,7 @@ fun GutenbergLayoutCategory.transform(site: SiteModel) = GutenbergLayoutCategory
         siteId = site.id,
         title = title,
         description = description,
-        emoji = emoji
+        emoji = emoji ?: ""
 )
 
 fun GutenbergLayoutCategoryModel.transform() = GutenbergLayoutCategory(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/BlockLayoutsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/BlockLayoutsResponse.kt
@@ -27,5 +27,5 @@ data class GutenbergLayoutCategory(
     val slug: String,
     val title: String,
     val description: String,
-    val emoji: String
+    val emoji: String?
 ) : Parcelable


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/WordPress-Android/issues/14152 and https://github.com/wordpress-mobile/WordPress-Android/issues/14150

Fixes crash: https://sentry.io/share/issue/84d9ff222a3248ccab6c168bf7de8361/

To test:
* Run the newly added test case `testInsertBlockLayoutWithNullCategoryEmoji`
* Since this was patched on the server the issue does not occur anymore (internal ref: `pb3aDo-Pe-p2`). In my understanding it is not easy to recreate the misconfiguration on a sandbox environment to test this properly.