### PR TITLE
Add support for dismissing backup download file notice

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ActivityLogStoreTest.kt
@@ -450,7 +450,7 @@ class ActivityLogStoreTest {
 
         verify(activityLogSqlUtils).deleteBackupDownloadStatus(siteModel)
     }
-    
+
     @Test
     fun onDismissBackupDownloadActionCallRestClient() = test {
         whenever(activityLogRestClient.dismissBackupDownload(eq(siteModel), any())).thenReturn(

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -6,6 +6,7 @@
 /sites/$site/activity/count/group
 /sites/$site/rewind
 /sites/$site/rewind/downloads
+/sites/$site/rewind/downloads/$download_id
 
 /sites/$site/scan
 /sites/$site/scan/enqueue

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ActivityLogAction.java
@@ -19,5 +19,7 @@ public enum ActivityLogAction implements IAction {
     @Action(payloadType = ActivityLogStore.FetchBackupDownloadStatePayload.class)
     FETCH_BACKUP_DOWNLOAD_STATE,
     @Action(payloadType = ActivityLogStore.FetchActivityTypesPayload.class)
-    FETCH_ACTIVITY_TYPES
+    FETCH_ACTIVITY_TYPES,
+    @Action(payloadType = ActivityLogStore.DismissBackupDownloadPayload.class)
+    DISMISS_BACKUP_DOWNLOAD
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -33,6 +33,9 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadRequestT
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadResultPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadStatusError
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadStatusErrorType
+import org.wordpress.android.fluxc.store.ActivityLogStore.DismissBackupDownloadError
+import org.wordpress.android.fluxc.store.ActivityLogStore.DismissBackupDownloadErrorType
+import org.wordpress.android.fluxc.store.ActivityLogStore.DismissBackupDownloadResultPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchedActivityTypesResultPayload
@@ -215,6 +218,31 @@ class ActivityLogRestClient(
                 )
                 val error = ActivityTypesError(errorType, response.error.message)
                 FetchedActivityTypesResultPayload(error, remoteSiteId)
+            }
+        }
+    }
+
+    suspend fun dismissBackupDownload(
+        site: SiteModel,
+        downloadId: Long
+    ): DismissBackupDownloadResultPayload {
+        val url = WPCOMV2.sites.site(site.siteId).rewind.downloads.download(downloadId).url
+        val request = mapOf("dismissed" to true.toString())
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                request,
+                DismissBackupDownloadResponse::class.java)
+        return when (response) {
+            is Success -> DismissBackupDownloadResultPayload(site.siteId, downloadId, response.data.isDimissed)
+            is Error -> {
+                val errorType = NetworkErrorMapper.map(response.error,
+                        DismissBackupDownloadErrorType.GENERIC_ERROR,
+                        DismissBackupDownloadErrorType.INVALID_RESPONSE,
+                        DismissBackupDownloadErrorType.AUTHORIZATION_REQUIRED)
+                val error = DismissBackupDownloadError(errorType, response.error.message)
+                DismissBackupDownloadResultPayload(error, site.siteId, downloadId)
             }
         }
     }
@@ -484,4 +512,9 @@ class ActivityLogRestClient(
             val count: Int?
         )
     }
+    
+    class DismissBackupDownloadResponse(
+        val downloadId: Long,
+        val isDimissed: Boolean
+    )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -235,7 +235,10 @@ class ActivityLogRestClient(
                 request,
                 DismissBackupDownloadResponse::class.java)
         return when (response) {
-            is Success -> DismissBackupDownloadResultPayload(site.siteId, downloadId, response.data.isDimissed)
+            is Success -> DismissBackupDownloadResultPayload(
+                    site.siteId,
+                    response.data.downloadId,
+                    response.data.isDismissed)
             is Error -> {
                 val errorType = NetworkErrorMapper.map(response.error,
                         DismissBackupDownloadErrorType.GENERIC_ERROR,
@@ -512,9 +515,9 @@ class ActivityLogRestClient(
             val count: Int?
         )
     }
-    
+
     class DismissBackupDownloadResponse(
         val downloadId: Long,
-        val isDimissed: Boolean
+        val isDismissed: Boolean
     )
 }


### PR DESCRIPTION
This PR adds support for dismissing a backup download file notice. 

-Added new endpoint /sites/$site/rewind/downloads/$download_id
-Added support in ActivityLogRestClient
-Add tests

Test in WPAndroid PR