### PR TITLE
Issue-3605. Fetch a customer

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -124,6 +124,7 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'androidx.test:core:1.3.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.assertj:assertj-core:3.15.0'

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -1,0 +1,98 @@
+package org.wordpress.android.fluxc.model.customer
+
+import org.junit.Test
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.dto.CustomerApiResponse
+import kotlin.test.assertEquals
+
+class WCCustomerMapperTest {
+    val mapper = WCCustomerMapper()
+
+    @Test
+    fun `mapper maps to correct customer model`() {
+        // given
+        val remoteId = 13L
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val billing = CustomerApiResponse.Billing(
+                address1 = "address1",
+                address2 = "address2",
+                city = "city",
+                company = "company",
+                country = "country",
+                email = "email",
+                firstName = "firstName",
+                lastName = "lastName",
+                phone = "phone",
+                postcode = "postcode",
+                state = "state"
+        )
+        val shipping = CustomerApiResponse.Shipping(
+                address1 = "address1",
+                address2 = "address2",
+                city = "city",
+                company = "company",
+                country = "country",
+                firstName = "firstName",
+                lastName = "lastName",
+                postcode = "postcode",
+                state = "state"
+        )
+        val response = CustomerApiResponse(
+                avatarUrl = "avatarUrl",
+                billing = billing,
+                dateCreated = "dateCreated",
+                dateCreatedGmt = "dateCreatedGmt",
+                dateModified = "dateModified",
+                dateModifiedGmt = "dateModifiedGmt",
+                email = "email",
+                firstName = "firstName",
+                id = remoteId,
+                isPayingCustomer = true,
+                lastName = "lastName",
+                role = "role",
+                shipping = shipping,
+                username = "username"
+        )
+
+        // when
+        val result = mapper.map(site, response)
+
+        // then
+        with(result) {
+            assertEquals("avatarUrl", avatarUrl)
+            assertEquals("dateCreated", dateCreated)
+            assertEquals("dateCreatedGmt", dateCreatedGmt)
+            assertEquals("dateModified", dateModified)
+            assertEquals("dateModifiedGmt", dateModifiedGmt)
+            assertEquals("email", email)
+            assertEquals("firstName", firstName)
+            assertEquals(remoteCustomerId, remoteCustomerId)
+            assertEquals(true, isPayingCustomer)
+            assertEquals("lastName", lastName)
+            assertEquals("role", role)
+            assertEquals("username", username)
+
+            assertEquals("address1", shippingAddress1)
+            assertEquals("address2", shippingAddress2)
+            assertEquals("city", shippingCity)
+            assertEquals("company", shippingCompany)
+            assertEquals("country", shippingCountry)
+            assertEquals("firstName", shippingFirstName)
+            assertEquals("lastName", shippingLastName)
+            assertEquals("postcode", shippingPostcode)
+            assertEquals("state", shippingState)
+
+            assertEquals("address1", billingAddress1)
+            assertEquals("address2", billingAddress2)
+            assertEquals("city", billingCity)
+            assertEquals("company", billingCompany)
+            assertEquals("country", billingCountry)
+            assertEquals("firstName", billingFirstName)
+            assertEquals("lastName", billingLastName)
+            assertEquals("postcode", billingPostcode)
+            assertEquals("state", billingState)
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/CustomerSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/CustomerSqlUtilsTest.kt
@@ -1,0 +1,86 @@
+package org.wordpress.android.fluxc.persistence
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.customer.WCCustomerModel
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class CustomerSqlUtilsTest {
+    val site = SiteModel().apply {
+        email = "test@example.org"
+        name = "Test Site"
+        siteId = 24
+    }
+
+    @Before
+    fun setUp() {
+        val appContext = ApplicationProvider.getApplicationContext<Context>()
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(WCCustomerModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE
+        )
+        WellSql.init(config)
+        config.reset()
+    }
+
+    @Test
+    fun `get customer by remote id returns null when there is no customer stored`() {
+        // given
+        val remoteCustomerId = 1L
+
+        // when & then
+        assertNull(CustomerSqlUtils.getCustomerByRemoteId(site, remoteCustomerId))
+    }
+
+    @Test
+    fun `get customer by remote id returns customer when there its stored`() {
+        // given
+        val remoteCustomerId = 1L
+        val username = "userName"
+        val customer = WCCustomerModel().apply {
+            this.remoteCustomerId = remoteCustomerId
+            this.localSiteId = site.id
+            this.username = username
+        }
+
+        // when
+        CustomerSqlUtils.insertOrUpdateCustomer(customer)
+
+        // then
+        val storedCustomer = CustomerSqlUtils.getCustomerByRemoteId(site, remoteCustomerId)
+        assertEquals(storedCustomer!!.remoteCustomerId, remoteCustomerId)
+        assertEquals(storedCustomer.localSiteId, site.id)
+        assertEquals(storedCustomer.username, username)
+    }
+
+    @Test
+    fun `get customer by remote id returns null when there another customer stored`() {
+        // given
+        val remoteCustomerId = 1L
+        val username = "userName"
+        val customer = WCCustomerModel().apply {
+            this.remoteCustomerId = remoteCustomerId
+            this.localSiteId = 3
+            this.username = username
+        }
+
+        // when
+        CustomerSqlUtils.insertOrUpdateCustomer(customer)
+
+        // then
+        val storedCustomer = CustomerSqlUtils.getCustomerByRemoteId(site, remoteCustomerId)
+        assertNull(storedCustomer)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/WCCustomerStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/WCCustomerStoreTest.kt
@@ -1,0 +1,94 @@
+package org.wordpress.android.fluxc.store
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.customer.WCCustomerMapper
+import org.wordpress.android.fluxc.model.customer.WCCustomerModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.CustomerRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.dto.CustomerApiResponse
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCCustomerStoreTest {
+    private val restClient: CustomerRestClient = mock()
+    private val mapper: WCCustomerMapper = mock()
+
+    private lateinit var store: WCCustomerStore
+
+    @Before
+    fun setUp() {
+        val appContext = ApplicationProvider.getApplicationContext<Context>()
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(WCCustomerModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE
+        )
+        WellSql.init(config)
+        config.reset()
+
+        store = WCCustomerStore(
+                restClient,
+                initCoroutineEngine(),
+                mapper
+        )
+    }
+
+    @Test
+    fun `fetch single customer with success returns success`() = test {
+        // given
+        val siteModelId = 1
+        val remoteCustomerId = 2L
+        val siteModel = SiteModel().apply { id = siteModelId }
+
+        val response: CustomerApiResponse = mock()
+        whenever(restClient.fetchSingleCustomer(siteModel, remoteCustomerId))
+                .thenReturn(WooPayload(response))
+        val model: WCCustomerModel = mock()
+        whenever(mapper.map(siteModel, response)).thenReturn(model)
+
+        // when
+        val result = store.fetchSingleCustomer(siteModel, remoteCustomerId)
+
+        // then
+        assertFalse(result.isError)
+        assertEquals(result.model, model)
+    }
+
+    @Test
+    fun `fetch single customer with error returns error`() = test {
+        // given
+        val siteModelId = 1
+        val remoteCustomerId = 2L
+        val siteModel = SiteModel().apply { id = siteModelId }
+
+        val error = WooError(INVALID_RESPONSE, NETWORK_ERROR, "Invalid site ID")
+        whenever(restClient.fetchSingleCustomer(siteModel, remoteCustomerId)).thenReturn(WooPayload(error))
+
+        // when
+        val result = store.fetchSingleCustomer(siteModel, remoteCustomerId)
+
+        // then
+        assertTrue(result.isError)
+        assertEquals(result.error, error)
+    }
+}

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -26,6 +26,10 @@
 /products/tags/<id>/
 /products/tags/batch/
 
+/customers/<id>
+/customers/
+/customers/<id>/downloads
+
 /reports/orders/totals/
 /reports/revenue/stats/
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.fluxc.model.customer
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.dto.CustomerApiResponse
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WCCustomerMapper @Inject constructor() {
+    fun map(site: SiteModel, resp: CustomerApiResponse): WCCustomerModel {
+        return WCCustomerModel().apply {
+            localSiteId = site.id
+            avatarUrl = resp.avatarUrl ?: ""
+            dateCreated = resp.dateCreated ?: ""
+            dateCreatedGmt = resp.dateCreatedGmt ?: ""
+            dateModified = resp.dateModified ?: ""
+            dateModifiedGmt = resp.dateModifiedGmt ?: ""
+            email = resp.email ?: ""
+            firstName = resp.firstName ?: ""
+            remoteCustomerId = resp.id ?: 0
+            isPayingCustomer = resp.isPayingCustomer
+            lastName = resp.lastName ?: ""
+            role = resp.role ?: ""
+            username = resp.username ?: ""
+
+            billingAddress1 = resp.billing?.address1 ?: ""
+            billingAddress2 = resp.billing?.address2 ?: ""
+            billingCompany = resp.billing?.company ?: ""
+            billingCountry = resp.billing?.country ?: ""
+            billingCity = resp.billing?.city ?: ""
+            billingEmail = resp.billing?.email ?: ""
+            billingFirstName = resp.billing?.firstName ?: ""
+            billingLastName = resp.billing?.lastName ?: ""
+            billingPhone = resp.billing?.phone ?: ""
+            billingPostcode = resp.billing?.postcode ?: ""
+            billingState = resp.billing?.state ?: ""
+
+            shippingAddress1 = resp.billing?.address1 ?: ""
+            shippingAddress2 = resp.billing?.address2 ?: ""
+            shippingCity = resp.billing?.city ?: ""
+            shippingCompany = resp.billing?.company ?: ""
+            shippingCountry = resp.billing?.country ?: ""
+            shippingFirstName = resp.billing?.firstName ?: ""
+            shippingLastName = resp.billing?.lastName ?: ""
+            shippingPostcode = resp.billing?.postcode ?: ""
+            shippingState = resp.billing?.state ?: ""
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.fluxc.model.customer
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+/**
+ * Single Woo customer - see https://woocommerce.github.io/woocommerce-rest-api-docs/#customer-properties
+ */
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+data class WCCustomerModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var avatarUrl: String = ""
+    @Column var dateCreated: String = ""
+    @Column var dateCreatedGmt: String = ""
+    @Column var dateModified: String = ""
+    @Column var dateModifiedGmt: String = ""
+    @Column var email: String = ""
+    @Column var firstName: String = ""
+    @Column var remoteCustomerId: Long = 0L
+    @Column var isPayingCustomer: Boolean = false
+        @JvmName("setIsPayingCustomer")
+        set
+    @Column var lastName: String = ""
+    @Column var role: String = ""
+    @Column var username: String = ""
+
+    @Column var localSiteId = 0
+
+    @Column var billingAddress1: String = ""
+    @Column var billingAddress2: String = ""
+    @Column var billingCity: String = ""
+    @Column var billingCompany: String = ""
+    @Column var billingCountry: String = ""
+    @Column var billingEmail: String = ""
+    @Column var billingFirstName: String = ""
+    @Column var billingLastName: String = ""
+    @Column var billingPhone: String = ""
+    @Column var billingPostcode: String = ""
+    @Column var billingState: String = ""
+
+    @Column var shippingAddress1: String = ""
+    @Column var shippingAddress2: String = ""
+    @Column var shippingCity: String = ""
+    @Column var shippingCompany: String = ""
+    @Column var shippingCountry: String = ""
+    @Column var shippingFirstName: String = ""
+    @Column var shippingLastName: String = ""
+    @Column var shippingPostcode: String = ""
+    @Column var shippingState: String = ""
+
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.CustomerRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.data.WCDataRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsRestClient
@@ -67,6 +68,17 @@ class ReleaseWCNetworkModule {
         token: AccessToken,
         userAgent: UserAgent
     ) = OrderStatsRestClient(appContext, dispatcher, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideCustomerRestClient(
+        appContext: Context,
+        requestBuilder: JetpackTunnelGsonRequestBuilder,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = CustomerRestClient(appContext, requestBuilder, dispatcher, requestQueue, token, userAgent)
 
     @Singleton
     @Provides

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.customer
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.dto.CustomerApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Singleton
+
+@Singleton
+class CustomerRestClient(
+    appContext: Context,
+    private val requestBuilder: JetpackTunnelGsonRequestBuilder,
+    dispatcher: Dispatcher,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    /**
+     * Makes a GET call to `/wc/v3/customers/[remoteCustomerId]` to fetch a single customer
+     *
+     * @param [remoteCustomerId] Unique server id of the customer to fetch
+     */
+    suspend fun fetchSingleCustomer(site: SiteModel, remoteCustomerId: Long): WooPayload<CustomerApiResponse> {
+        val url = WOOCOMMERCE.customers.id(remoteCustomerId).pathV3
+
+        val response = requestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                emptyMap(),
+                CustomerApiResponse::class.java
+        )
+
+        return when (response) {
+            is JetpackSuccess -> WooPayload(response.data)
+            is JetpackError -> WooPayload(response.error.toWooError())
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/dto/CustomerApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/dto/CustomerApiResponse.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.dto
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+
+data class CustomerApiResponse(
+    @SerializedName("avatar_url") val avatarUrl: String? = null,
+    @SerializedName("billing") val billing: Billing? = null,
+    @SerializedName("date_created") val dateCreated: String? = null,
+    @SerializedName("date_created_gmt") val dateCreatedGmt: String? = null,
+    @SerializedName("date_modified") val dateModified: String? = null,
+    @SerializedName("date_modified_gmt") val dateModifiedGmt: String? = null,
+    @SerializedName("email") val email: String? = null,
+    @SerializedName("first_name") val firstName: String? = null,
+    @SerializedName("id") val id: Long? = null,
+    @SerializedName("is_paying_customer") val isPayingCustomer: Boolean = false,
+    @SerializedName("last_name") val lastName: String? = null,
+    @SerializedName("role") val role: String? = null,
+    @SerializedName("shipping") val shipping: Shipping? = null,
+    @SerializedName("username") val username: String? = null
+) : Response {
+    data class Billing(
+        @SerializedName("address_1") val address1: String? = null,
+        @SerializedName("address_2") val address2: String? = null,
+        @SerializedName("city") val city: String? = null,
+        @SerializedName("company") val company: String? = null,
+        @SerializedName("country") val country: String? = null,
+        @SerializedName("email") val email: String? = null,
+        @SerializedName("first_name") val firstName: String? = null,
+        @SerializedName("last_name") val lastName: String? = null,
+        @SerializedName("phone") val phone: String? = null,
+        @SerializedName("postcode") val postcode: String? = null,
+        @SerializedName("state") val state: String? = null
+    )
+
+    data class Shipping(
+        @SerializedName("address_1") val address1: String? = null,
+        @SerializedName("address_2") val address2: String? = null,
+        @SerializedName("city") val city: String? = null,
+        @SerializedName("company") val company: String? = null,
+        @SerializedName("country") val country: String? = null,
+        @SerializedName("first_name") val firstName: String? = null,
+        @SerializedName("last_name") val lastName: String? = null,
+        @SerializedName("postcode") val postcode: String? = null,
+        @SerializedName("state") val state: String? = null
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/CustomerSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/CustomerSqlUtils.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.WCCustomerModelTable
+import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.customer.WCCustomerModel
+
+object CustomerSqlUtils {
+    fun getCustomerByRemoteId(site: SiteModel, remoteProductId: Long): WCCustomerModel? {
+        return WellSql.select(WCCustomerModel::class.java)
+                .where()
+                .beginGroup()
+                .equals(WCCustomerModelTable.REMOTE_CUSTOMER_ID, remoteProductId)
+                .equals(WCCustomerModelTable.LOCAL_SITE_ID, site.id)
+                .endGroup()
+                .endWhere()
+                .asModel.firstOrNull()
+    }
+
+    fun insertOrUpdateCustomer(customer: WCCustomerModel): Int {
+        val customerResult = WellSql.select(WCCustomerModel::class.java)
+                .where().beginGroup()
+                .equals(WCCustomerModelTable.ID, customer.id)
+                .or()
+                .beginGroup()
+                .equals(WCCustomerModelTable.REMOTE_CUSTOMER_ID, customer.remoteCustomerId)
+                .equals(WCCustomerModelTable.LOCAL_SITE_ID, customer.localSiteId)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+
+        return if (customerResult == null) {
+            // Insert
+            WellSql.insert(customer).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            WellSql.update(WCCustomerModel::class.java)
+                    .where().beginGroup()
+                    .equals(WCCustomerModelTable.REMOTE_CUSTOMER_ID, customerResult.remoteCustomerId)
+                    .equals(WCCustomerModelTable.LOCAL_SITE_ID, customerResult.localSiteId)
+                    .endGroup().endWhere()
+                    .put(customer, UpdateAllExceptId(WCCustomerModel::class.java)).execute()
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCCustomerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCCustomerStore.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.customer.WCCustomerMapper
+import org.wordpress.android.fluxc.model.customer.WCCustomerModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.CustomerRestClient
+import org.wordpress.android.fluxc.persistence.CustomerSqlUtils
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WCCustomerStore @Inject constructor(
+    private val restClient: CustomerRestClient,
+    private val coroutineEngine: CoroutineEngine,
+    private val mapper: WCCustomerMapper
+) {
+    /**
+     * return a cached customer with provided remote id or null if not in cache
+     */
+    fun getCustomerByRemoteId(site: SiteModel, remoteCustomerId: Long) =
+            CustomerSqlUtils.getCustomerByRemoteId(site, remoteCustomerId)
+
+    /**
+     * returns a customer with provided remote id
+     */
+    suspend fun fetchSingleCustomer(site: SiteModel, remoteCustomerId: Long): WooResult<WCCustomerModel> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchSingleCustomer") {
+            val response = restClient.fetchSingleCustomer(site, remoteCustomerId)
+            return@withDefaultContext when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> {
+                    val customer = mapper.map(site, response.result)
+                    CustomerSqlUtils.insertOrUpdateCustomer(customer)
+                    WooResult(customer)
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+}

--- a/tests/api/src/test/java/APITesting_WCCustomer.java
+++ b/tests/api/src/test/java/APITesting_WCCustomer.java
@@ -1,0 +1,43 @@
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.oauth2;
+import static org.hamcrest.Matchers.hasSize;
+
+public class APITesting_WCCustomer {
+    private RequestSpecification mRequestSpec;
+
+    @Before
+    public void setup() {
+        Map<String, String> pathParams = new HashMap<>();
+        pathParams.put("json", "true");
+        pathParams.put("locale", "en_US");
+        pathParams.put("status", "any");
+
+        RequestSpecBuilder requestBuilder = new RequestSpecBuilder()
+                .setBaseUri("https://public-api.wordpress.com")
+                .setBasePath("rest/v1.1/jetpack-blogs/173063404/rest-api/")
+                .addQueryParams(pathParams)
+                .setAuth(oauth2(System.getenv("API_TEST_OAUTH_KEY")));
+        this.mRequestSpec = requestBuilder.build();
+    }
+
+    @Test
+    public void canGetSingleCustomer() {
+        given()
+                .spec(this.mRequestSpec)
+                .queryParam("path", "/wc/v3/customers/1")
+                .when()
+                .get()
+                .then()
+                .statusCode(200)
+                .body("data", hasSize(50));
+    }
+}

--- a/tests/api/src/test/java/APITesting_WCCustomer.java
+++ b/tests/api/src/test/java/APITesting_WCCustomer.java
@@ -9,7 +9,7 @@ import io.restassured.specification.RequestSpecification;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.oauth2;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.equalTo;
 
 public class APITesting_WCCustomer {
     private RequestSpecification mRequestSpec;
@@ -38,6 +38,11 @@ public class APITesting_WCCustomer {
                 .get()
                 .then()
                 .statusCode(200)
-                .body("data", hasSize(50));
+                .body("data.id", equalTo(1),
+                        "data.first_name", equalTo(""),
+                        "data.last_name", equalTo(""),
+                        "data.avatar_url",
+                        equalTo("https://secure.gravatar.com/avatar/fb409f96c4ccb689c8b1d42342dae3c7?s=96&d=mm&r=g")
+                     );
     }
 }


### PR DESCRIPTION
#3605 1 and 2

I've decided that with a coroutines-based approach it's ok to put tests in the same PR as well because it's way cleaner and shorter than the event bus.

* Description. An API call, caching, models, and DTOs for `/customers/{id}` endpoint