### PR TITLE
Issue-3605. Example of customer fetching

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_
 import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_SEEN
 import org.wordpress.android.fluxc.action.NotificationAction.UPDATE_NOTIFICATION
 import org.wordpress.android.fluxc.example.NotificationTypeSubtypeDialog.Listener
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.notification.NotificationModel.Subkind
@@ -230,13 +231,6 @@ class NotificationsFragment : Fragment() {
         fragmentManager?.let { fm ->
             val dialog = NotificationTypeSubtypeDialog.newInstance(listener)
             dialog.show(fm, "NotificationFragment")
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: SiteSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = SiteSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "SiteSelectorDialog")
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.example.ThemeFragment
 import org.wordpress.android.fluxc.example.UploadsFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
+import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
@@ -136,4 +137,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooProductAttributeFragmentInjector(): WooProductAttributeFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooCustomersFragmentInjector(): WooCustomersFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.example.LogUtils
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
+import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
@@ -143,6 +144,12 @@ class WooCommerceFragment : Fragment() {
         attributes.setOnClickListener {
             getFirstWCSite()?.let {
                 replaceFragment(WooProductAttributeFragment())
+            } ?: showNoWCSitesToast()
+        }
+
+        customers.setOnClickListener {
+            getFirstWCSite()?.let {
+                replaceFragment(WooCustomersFragment())
             } ?: showNoWCSitesToast()
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/common/FragmentExt.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/common/FragmentExt.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.example.ui.common
+
+import androidx.fragment.app.Fragment
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+
+fun Fragment.showStoreSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
+    parentFragmentManager.let { fm ->
+        val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
+        dialog.show(fm, "StoreSelectorDialog")
+    }
+}
+
+fun Fragment.showSiteSelectorDialog(selectedPos: Int, listener: SiteSelectorDialog.Listener) {
+    parentFragmentManager.let { fm ->
+        val dialog = SiteSelectorDialog.newInstance(listener, selectedPos)
+        dialog.show(fm, "SiteSelectorDialog")
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersFragment.kt
@@ -1,0 +1,88 @@
+package org.wordpress.android.fluxc.example.ui.customer
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_customer.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog.Listener
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WCCustomerStore
+import javax.inject.Inject
+
+class WooCustomersFragment : Fragment() {
+    @Inject internal lateinit var wcCustomerStore: WCCustomerStore
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
+    private var selectedPos: Int = -1
+    private var selectedSite: SiteModel? = null
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_woo_customer, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        btnCustomerSelectSite.setOnClickListener { selectStore() }
+        btnPrintCutomer.setOnClickListener { printCustomerById() }
+        btnFetchCustomerList.setOnClickListener {
+        }
+    }
+
+    private fun printCustomerById() {
+        val site = selectedSite!!
+        showSingleLineDialog(
+                activity, "Enter the remote customer Id:", isNumeric = true
+        ) { remoteIdEditText ->
+            if (remoteIdEditText.text.isEmpty()) {
+                prependToLog("Remote Id is null so doing nothing")
+                return@showSingleLineDialog
+            }
+
+            val remoteId = remoteIdEditText.text.toString().toLong()
+            prependToLog("Submitting request to print customer with id: $remoteId")
+
+            coroutineScope.launch {
+                withContext(Dispatchers.Default) {
+                    wcCustomerStore.fetchSingleCustomer(site, remoteId)
+                }.run {
+                    error?.let { prependToLog("${it.type}: ${it.message}") }
+                    if (model != null) {
+                        prependToLog("Customer data: ${this.model}")
+                    } else {
+                        prependToLog("Customer with id $remoteId is missing")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun selectStore() {
+        showStoreSelectorDialog(selectedPos, object : Listener {
+            override fun onSiteSelected(site: SiteModel, pos: Int) {
+                selectedSite = site
+                selectedPos = pos
+                llButtonContainer.toggleSiteDependentButtons(true)
+                tvCustomerSelectedSite.text = site.name ?: site.displayName
+            }
+        })
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
@@ -97,7 +98,7 @@ class WooProductsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         stats_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -657,13 +658,6 @@ class WooProductsFragment : Fragment() {
                 }
                 else -> { }
             }
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
@@ -75,7 +76,7 @@ class WooShippingLabelFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         shipping_labels_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -402,13 +403,6 @@ class WooShippingLabelFragment : Fragment() {
                     prependToLog("The WooCommerce services plugin is not installed")
                 }
             }
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.action.WCStatsAction
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
@@ -48,7 +49,7 @@ class WooRevenueStatsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         stats_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -225,13 +226,6 @@ class WooRevenueStatsFragment : Fragment() {
                     }
                 }
             }
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCTaxStore
@@ -43,7 +44,7 @@ class WooTaxFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         taxes_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -74,13 +75,6 @@ class WooTaxFragment : Fragment() {
                     }
                 }
             }
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 }

--- a/example/src/main/res/layout/fragment_woo_customer.xml
+++ b/example/src/main/res/layout/fragment_woo_customer.xml
@@ -1,0 +1,67 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment"
+    tools:ignore="HardcodedText">
+
+    <LinearLayout
+        android:id="@+id/llButtonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Perform actions on a selected site:"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/btnCustomerSelectSite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Select Site" />
+
+            <TextView
+                android:id="@+id/tvCustomerSelectedSite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="8dp"
+                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+                android:textColor="@android:color/holo_blue_bright" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btnFetchCustomerList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Fetch Customer List" />
+
+        <Button
+            android:id="@+id/btnPrintCutomer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Print Customer" />
+
+        <Button
+            android:id="@+id/btnCreateCustomer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Create Customer" />
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -105,5 +105,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Attributes"/>
+
+                <Button
+                    android:id="@+id/customers"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Customers"/>
         </LinearLayout>
 </ScrollView>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 137
+        return 138
     }
 
     override fun getDbName(): String {
@@ -1494,6 +1494,23 @@ open class WellSqlConfig : DefaultWellConfig {
                 136 -> migrate(version) {
                     db.execSQL("CREATE TABLE DynamicCard (_id INTEGER PRIMARY KEY AUTOINCREMENT,SITE_ID INTEGER," +
                             "DYNAMIC_CARD_TYPE TEXT,STATE TEXT)")
+                }
+                137 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCCustomerModel")
+                    db.execSQL("CREATE TABLE WCCustomerModel (AVATAR_URL TEXT NOT NULL," +
+                            "DATE_CREATED TEXT NOT NULL,DATE_CREATED_GMT TEXT NOT NULL,DATE_MODIFIED TEXT NOT NULL," +
+                            "DATE_MODIFIED_GMT TEXT NOT NULL,EMAIL TEXT NOT NULL,FIRST_NAME TEXT NOT NULL," +
+                            "REMOTE_CUSTOMER_ID INTEGER,IS_PAYING_CUSTOMER INTEGER,LAST_NAME TEXT NOT NULL," +
+                            "ROLE TEXT NOT NULL,USERNAME TEXT NOT NULL,LOCAL_SITE_ID INTEGER,BILLING_ADDRESS1" +
+                            " TEXT NOT NULL,BILLING_ADDRESS2 TEXT NOT NULL,BILLING_CITY TEXT NOT NULL," +
+                            "BILLING_COMPANY TEXT NOT NULL,BILLING_COUNTRY TEXT NOT NULL,BILLING_EMAIL" +
+                            " TEXT NOT NULL,BILLING_FIRST_NAME TEXT NOT NULL,BILLING_LAST_NAME TEXT " +
+                            "NOT NULL,BILLING_PHONE TEXT NOT NULL,BILLING_POSTCODE TEXT NOT NULL,BILLING_STATE" +
+                            " TEXT NOT NULL,SHIPPING_ADDRESS1 TEXT NOT NULL,SHIPPING_ADDRESS2 TEXT NOT NULL," +
+                            "SHIPPING_CITY TEXT NOT NULL,SHIPPING_COMPANY TEXT NOT NULL,SHIPPING_COUNTRY TEXT" +
+                            " NOT NULL,SHIPPING_FIRST_NAME TEXT NOT NULL,SHIPPING_LAST_NAME TEXT NOT NULL," +
+                            "SHIPPING_POSTCODE TEXT NOT NULL,SHIPPING_STATE TEXT NOT NULL,_id INTEGER" +
+                            " PRIMARY KEY AUTOINCREMENT)")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
@@ -55,4 +55,19 @@ data class WCCustomerModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     override fun setId(id: Int) {
         this.id = id
     }
+
+    override fun toString(): String {
+        return "WCCustomerModel(id=$id, avatarUrl='$avatarUrl', dateCreated='$dateCreated', " +
+                "dateCreatedGmt='$dateCreatedGmt', dateModified='$dateModified', dateModifiedGmt='$dateModifiedGmt'," +
+                " email='$email', firstName='$firstName', remoteCustomerId=$remoteCustomerId, " +
+                "isPayingCustomer=$isPayingCustomer, lastName='$lastName', role='$role', username='$username', " +
+                "localSiteId=$localSiteId, billingAddress1='$billingAddress1', billingAddress2='$billingAddress2'," +
+                " billingCity='$billingCity', billingCompany='$billingCompany', billingCountry='$billingCountry'," +
+                " billingEmail='$billingEmail', billingFirstName='$billingFirstName', billingLastName='$billingLastName'," +
+                " billingPhone='$billingPhone', billingPostcode='$billingPostcode', billingState='$billingState', " +
+                "shippingAddress1='$shippingAddress1', shippingAddress2='$shippingAddress2', " +
+                "shippingCity='$shippingCity', shippingCompany='$shippingCompany', shippingCountry='$shippingCountry', " +
+                "shippingFirstName='$shippingFirstName', shippingLastName='$shippingLastName', " +
+                "shippingPostcode='$shippingPostcode', shippingState='$shippingState')"
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
@@ -57,17 +57,41 @@ data class WCCustomerModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     }
 
     override fun toString(): String {
-        return "WCCustomerModel(id=$id, avatarUrl='$avatarUrl', dateCreated='$dateCreated', " +
-                "dateCreatedGmt='$dateCreatedGmt', dateModified='$dateModified', dateModifiedGmt='$dateModifiedGmt'," +
-                " email='$email', firstName='$firstName', remoteCustomerId=$remoteCustomerId, " +
-                "isPayingCustomer=$isPayingCustomer, lastName='$lastName', role='$role', username='$username', " +
-                "localSiteId=$localSiteId, billingAddress1='$billingAddress1', billingAddress2='$billingAddress2'," +
-                " billingCity='$billingCity', billingCompany='$billingCompany', billingCountry='$billingCountry'," +
-                " billingEmail='$billingEmail', billingFirstName='$billingFirstName', billingLastName='$billingLastName'," +
-                " billingPhone='$billingPhone', billingPostcode='$billingPostcode', billingState='$billingState', " +
-                "shippingAddress1='$shippingAddress1', shippingAddress2='$shippingAddress2', " +
-                "shippingCity='$shippingCity', shippingCompany='$shippingCompany', shippingCountry='$shippingCountry', " +
-                "shippingFirstName='$shippingFirstName', shippingLastName='$shippingLastName', " +
-                "shippingPostcode='$shippingPostcode', shippingState='$shippingState')"
+        return "WCCustomerModel(" +
+                "id=$id, " +
+                "avatarUrl='$avatarUrl', " +
+                "dateCreated='$dateCreated', " +
+                "dateCreatedGmt='$dateCreatedGmt', " +
+                "dateModified='$dateModified', " +
+                "dateModifiedGmt='$dateModifiedGmt', " +
+                "email='$email', " +
+                "firstName='$firstName', " +
+                "remoteCustomerId=$remoteCustomerId, " +
+                "isPayingCustomer=$isPayingCustomer, " +
+                "lastName='$lastName', " +
+                "role='$role', " +
+                "username='$username', " +
+                "localSiteId=$localSiteId, " +
+                "billingAddress1='$billingAddress1', " +
+                "billingAddress2='$billingAddress2', " +
+                "billingCity='$billingCity', " +
+                "billingCompany='$billingCompany', " +
+                "billingCountry='$billingCountry', " +
+                "billingEmail='$billingEmail', " +
+                "billingFirstName='$billingFirstName', " +
+                "billingLastName='$billingLastName', " +
+                "billingPhone='$billingPhone', " +
+                "billingPostcode='$billingPostcode', " +
+                "billingState='$billingState', " +
+                "shippingAddress1='$shippingAddress1', " +
+                "shippingAddress2='$shippingAddress2', " +
+                "shippingCity='$shippingCity', " +
+                "shippingCompany='$shippingCompany', " +
+                "shippingCountry='$shippingCountry', " +
+                "shippingFirstName='$shippingFirstName', " +
+                "shippingLastName='$shippingLastName', " +
+                "shippingPostcode='$shippingPostcode', " +
+                "shippingState='$shippingState'" +
+                ")"
     }
 }

--- a/tests/api/src/test/java/APITesting_WCCustomer.java
+++ b/tests/api/src/test/java/APITesting_WCCustomer.java
@@ -12,7 +12,6 @@ import io.restassured.specification.RequestSpecification;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.oauth2;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 
 public class APITesting_WCCustomer {
     private RequestSpecification mRequestSpec;
@@ -41,19 +40,12 @@ public class APITesting_WCCustomer {
                 .get()
                 .then()
                 .statusCode(200)
-                .body("data", hasSize(50));
-    }
-
-    @Test
-    public void canGetCustomers() {
-        given()
-                .spec(this.mRequestSpec)
-                .queryParam("path", "/wc/v3/customers")
-                .when()
-                .get()
-                .then()
-                .statusCode(200)
-                .body("data", hasSize(50));
+                .body("data.id", equalTo(1),
+                        "data.first_name", equalTo(""),
+                        "data.last_name", equalTo(""),
+                        "data.avatar_url",
+                        equalTo("https://secure.gravatar.com/avatar/fb409f96c4ccb689c8b1d42342dae3c7?s=96&d=mm&r=g")
+                     );
     }
 
     @Test


### PR DESCRIPTION
Following the [feedback](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1903#issuecomment-788913802) I got, I've decided to split the "example" part into 3 subtasks. 1 PR per each functionality:
* Fetching by id (the current one)
* Fetching a list
* Creation

It's still just 1 commit here because it was already like that when I got the feedback =(

Part number 7 of [#3605](https://github.com/woocommerce/woocommerce-android/issues/3605), contains an example of the usage of FluxC functionality of fetching a single customer by id.

**Testing:**
1. Open the example
2. Sign in
3. Click "WOO" button
4. Scroll down and click "CUSTOMERS" button
5. Select site
6. Click "print customer"
7. Look into the logs

<img src="https://user-images.githubusercontent.com/4923871/109674449-fa980400-7b87-11eb-8ffd-2c1d8d51d616.png" width="300"/><img src="https://user-images.githubusercontent.com/4923871/109674474-fff54e80-7b87-11eb-9c1c-1426f4f1177d.png" width="300"/>
<img src="https://user-images.githubusercontent.com/4923871/109674495-04216c00-7b88-11eb-94ad-3b470e0c3411.png" width="300"/><img src="https://user-images.githubusercontent.com/4923871/109674515-08e62000-7b88-11eb-9b28-38c15c6e6362.png" width="300"/>
<img src="https://user-images.githubusercontent.com/4923871/109674542-0edc0100-7b88-11eb-945f-e4298b3f164d.png" width="300"/>
