### PR TITLE
Issue-3605. Example of customer creation

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/FragmentExt.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/FragmentExt.kt
@@ -11,8 +11,8 @@ fun Fragment.prependToLog(s: String) {
 }
 
 fun Fragment.replaceFragment(fragment: Fragment) {
-    fragmentManager?.beginTransaction()
-            ?.replace(R.id.fragment_container, fragment)
-            ?.addToBackStack(null)
-            ?.commit()
+    parentFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, fragment)
+            .addToBackStack(null)
+            .commit()
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_
 import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_SEEN
 import org.wordpress.android.fluxc.action.NotificationAction.UPDATE_NOTIFICATION
 import org.wordpress.android.fluxc.example.NotificationTypeSubtypeDialog.Listener
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.notification.NotificationModel.Subkind
@@ -230,13 +231,6 @@ class NotificationsFragment : Fragment() {
         fragmentManager?.let { fm ->
             val dialog = NotificationTypeSubtypeDialog.newInstance(listener)
             dialog.show(fm, "NotificationFragment")
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: SiteSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = SiteSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "SiteSelectorDialog")
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.example.ThemeFragment
 import org.wordpress.android.fluxc.example.UploadsFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
+import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
@@ -136,4 +137,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooProductAttributeFragmentInjector(): WooProductAttributeFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooCustomersFragmentInjector(): WooCustomersFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.example.UploadsFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
 import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
+import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearchFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
@@ -140,4 +141,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooCustomersFragmentInjector(): WooCustomersFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooCustomersSearchInjector(): WooCustomersSearchFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.example.LogUtils
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
+import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
@@ -143,6 +144,12 @@ class WooCommerceFragment : Fragment() {
         attributes.setOnClickListener {
             getFirstWCSite()?.let {
                 replaceFragment(WooProductAttributeFragment())
+            } ?: showNoWCSitesToast()
+        }
+
+        customers.setOnClickListener {
+            getFirstWCSite()?.let {
+                replaceFragment(WooCustomersFragment())
             } ?: showNoWCSitesToast()
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/common/FragmentExt.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/common/FragmentExt.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.example.ui.common
+
+import androidx.fragment.app.Fragment
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+
+fun Fragment.showStoreSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
+    parentFragmentManager.let { fm ->
+        val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
+        dialog.show(fm, "StoreSelectorDialog")
+    }
+}
+
+fun Fragment.showSiteSelectorDialog(selectedPos: Int, listener: SiteSelectorDialog.Listener) {
+    parentFragmentManager.let { fm ->
+        val dialog = SiteSelectorDialog.newInstance(listener, selectedPos)
+        dialog.show(fm, "SiteSelectorDialog")
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersFragment.kt
@@ -14,8 +14,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog.Listener
 import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearchBuilderFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -44,6 +46,7 @@ class WooCustomersFragment : Fragment() {
         btnCustomerSelectSite.setOnClickListener { selectStore() }
         btnPrintCutomer.setOnClickListener { printCustomerById() }
         btnFetchCustomerList.setOnClickListener {
+            replaceFragment(WooCustomersSearchBuilderFragment.newInstance(selectedSite!!.id))
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersFragment.kt
@@ -1,0 +1,88 @@
+package org.wordpress.android.fluxc.example.ui.customer
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_customer.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog.Listener
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WCCustomerStore
+import javax.inject.Inject
+
+class WooCustomersFragment : Fragment() {
+    @Inject internal lateinit var wcCustomerStore: WCCustomerStore
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
+    private var selectedPos: Int = -1
+    private var selectedSite: SiteModel? = null
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_woo_customer, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        btnCustomerSelectSite.setOnClickListener { selectStore() }
+        btnPrintCutomer.setOnClickListener { printCustomerById() }
+        btnFetchCustomerList.setOnClickListener {
+        }
+    }
+
+    private fun printCustomerById() {
+        val site = selectedSite!!
+        showSingleLineDialog(
+                activity, "Enter the remote customer Id:", isNumeric = true
+        ) { remoteIdEditText ->
+            if (remoteIdEditText.text.isEmpty()) {
+                prependToLog("Remote Id is null so doing nothing")
+                return@showSingleLineDialog
+            }
+
+            val remoteId = remoteIdEditText.text.toString().toLong()
+            prependToLog("Submitting request to print customer with id: $remoteId")
+
+            coroutineScope.launch {
+                withContext(Dispatchers.Default) {
+                    wcCustomerStore.fetchSingleCustomer(site, remoteId)
+                }.run {
+                    error?.let { prependToLog("${it.type}: ${it.message}") }
+                    if (model != null) {
+                        prependToLog("Customer data: ${this.model}")
+                    } else {
+                        prependToLog("Customer with id $remoteId is missing")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun selectStore() {
+        showStoreSelectorDialog(selectedPos, object : Listener {
+            override fun onSiteSelected(site: SiteModel, pos: Int) {
+                selectedSite = site
+                selectedPos = pos
+                llButtonContainer.toggleSiteDependentButtons(true)
+                tvCustomerSelectedSite.text = site.name ?: site.displayName
+            }
+        })
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersSearchBuilderFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersSearchBuilderFragment.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.fluxc.example.ui.customer
+
+import android.content.Context
+import android.os.Bundle
+import android.text.Editable
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_customers_search_builder.*
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearchFragment
+import org.wordpress.android.util.ToastUtils
+
+class WooCustomersSearchBuilderFragment : Fragment() {
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(layout.fragment_woo_customers_search_builder, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        btnCustomerSearch.setOnClickListener {
+            WooCustomersSearchFragment.newInstance(
+                    siteId = requireArguments().getInt(KEY_SELECTED_SITE_ID),
+                    searchParams = buildParams()
+            )
+        }
+    }
+
+    private fun buildParams() = WooCustomersSearchFragment.SearchParams(
+            searchQuery = etCustomerSearch.text?.toString(),
+            includeIds = etCustomerInclude.text.toIds(),
+            excludeIds = etCustomerExclude.text.toIds(),
+            email = etCustomerEmail.text?.toString(),
+            role = etCustomerRole.text?.toString()
+    )
+
+    private fun Editable?.toIds(): List<Int> {
+        return try {
+            this?.toString()?.split(",\\s*")?.map { it.toInt() } ?: emptyList()
+        } catch (e: Exception) {
+            ToastUtils.showToast(requireContext(), "Wrongly formatted ids")
+            emptyList()
+        }
+    }
+
+    companion object {
+        fun newInstance(siteId: Int) = WooCustomersSearchFragment().apply {
+            arguments = Bundle().apply { putInt(KEY_SELECTED_SITE_ID, siteId) }
+        }
+    }
+}
+
+private const val KEY_SELECTED_SITE_ID = "selected_site_id"

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/SearchCustomerListDescriptor.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/SearchCustomerListDescriptor.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.example.ui.customer.search
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.customer.WCCustomerListDescriptor
+import org.wordpress.android.fluxc.model.list.ListConfig
+
+class SearchCustomerListDescriptor(
+    customerSite: SiteModel,
+    customerSearchQuery: String? = null,
+    customerEmail: String? = null,
+    customerRole: String? = null,
+    customerRemoteCustomerIds: List<Long>? = null,
+    customerExcludedCustomerIds: List<Long>? = null
+) : WCCustomerListDescriptor(
+        customerSite,
+        customerSearchQuery,
+        customerEmail,
+        customerRole,
+        customerRemoteCustomerIds,
+        customerExcludedCustomerIds
+) {
+    override val config = ListConfig(
+            networkPageSize = PAGE_SIZE,
+            initialLoadSize = PAGE_SIZE,
+            dbPageSize = PAGE_SIZE,
+            prefetchDistance = 3
+    )
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersListItemDataSource.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersListItemDataSource.kt
@@ -1,37 +1,107 @@
 package org.wordpress.android.fluxc.example.ui.customer.search
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.MainExampleActivity
+import org.wordpress.android.fluxc.generated.ListActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.customer.WCCustomerListDescriptor
+import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 import org.wordpress.android.fluxc.model.list.datasource.ListItemDataSourceInterface
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
+import org.wordpress.android.fluxc.store.ListStore.ListError
+import org.wordpress.android.fluxc.store.ListStore.ListErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCCustomerStore
 import javax.inject.Inject
 
+const val PAGE_SIZE = 15
+
 class WooCustomersListItemDataSource
 @Inject
-constructor(val store: WCCustomerStore) : ListItemDataSourceInterface<WCCustomerListDescriptor, Long, CustomerListItemType> {
+constructor(
+    private val store: WCCustomerStore,
+    private val dispatcher: Dispatcher,
+    private val activity: MainExampleActivity
+) : ListItemDataSourceInterface<WCCustomerListDescriptor, Long, CustomerListItemType> {
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
     override fun getItemsAndFetchIfNecessary(
         listDescriptor: WCCustomerListDescriptor,
         itemIdentifiers: List<Long>
     ): List<CustomerListItemType> {
-        TODO("Not yet implemented")
+        val storedCustomers = store.getCustomerByRemoteIds(listDescriptor.site, itemIdentifiers)
+        coroutineScope.launch {
+            val remoteIdToFetch = itemIdentifiers - storedCustomers.map { it.remoteCustomerId }
+            val payload = store.fetchCustomers(listDescriptor.site, remoteCustomerIds = remoteIdToFetch)
+            dispatchWhenFetched(listDescriptor, payload, 0)
+        }
+        return itemIdentifiers.map { remoteId ->
+            val customer = storedCustomers.firstOrNull { it.remoteCustomerId == remoteId }
+            if (customer == null) {
+                CustomerListItemType.LoadingItem(remoteId)
+            } else {
+                CustomerListItemType.CustomerItem(
+                        remoteCustomerId = customer.remoteCustomerId,
+                        firstName = customer.firstName,
+                        lastName = customer.lastName,
+                        email = customer.email,
+                        role = customer.role
+                )
+            }
+        }
     }
 
     override fun getItemIdentifiers(
         listDescriptor: WCCustomerListDescriptor,
         remoteItemIds: List<RemoteId>,
         isListFullyFetched: Boolean
-    ): List<Long> {
-        TODO("Not yet implemented")
-    }
+    ): List<Long> = remoteItemIds.map { it.value }
 
     override fun fetchList(listDescriptor: WCCustomerListDescriptor, offset: Long) {
-//        store.fetchCustomers(
-//                site = listDescriptor.site,
-//                searchQuery = listDescriptor.searchQuery,
-//                email = listDescriptor.email,
-//                role = listDescriptor.role,
-//                remoteCustomerIds = listDescriptor.remoteCustomerIds,
-//                excludedCustomerIds = listDescriptor.excludedCustomerIds
-//        )
+        coroutineScope.launch {
+            val payload = store.fetchCustomers(
+                    offset = offset,
+                    pageSize = PAGE_SIZE,
+                    site = listDescriptor.site,
+                    searchQuery = listDescriptor.searchQuery,
+                    email = listDescriptor.email,
+                    role = listDescriptor.role,
+                    remoteCustomerIds = listDescriptor.remoteCustomerIds,
+                    excludedCustomerIds = listDescriptor.excludedCustomerIds
+            )
+
+            when {
+                payload.isError -> {
+                    activity.prependToLog("couldn't fetch customers ${payload.error}")
+                }
+                payload.model.isNullOrEmpty() -> {
+                    activity.prependToLog("Customers list is empty")
+                }
+                else -> {
+                    activity.prependToLog("Fetched ${payload.model!!.size} customers")
+                }
+            }
+
+            dispatchWhenFetched(listDescriptor, payload, offset)
+        }
+    }
+
+    private fun dispatchWhenFetched(
+        listDescriptor: WCCustomerListDescriptor,
+        payload: WooResult<List<WCCustomerModel>>,
+        offset: Long
+    ) {
+        dispatcher.dispatch(ListActionBuilder.newFetchedListItemsAction(FetchedListItemsPayload(
+                listDescriptor = listDescriptor,
+                remoteItemIds = payload.model?.map { it.remoteCustomerId } ?: emptyList(),
+                loadedMore = offset > 0,
+                canLoadMore = payload.model?.size == PAGE_SIZE,
+                error = payload.error?.let { fetchError ->
+                    ListError(type = GENERIC_ERROR, message = fetchError.message)
+                }
+        )))
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersListItemDataSource.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersListItemDataSource.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.fluxc.example.ui.customer.search
+
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.customer.WCCustomerListDescriptor
+import org.wordpress.android.fluxc.model.list.datasource.ListItemDataSourceInterface
+import org.wordpress.android.fluxc.store.WCCustomerStore
+import javax.inject.Inject
+
+class WooCustomersListItemDataSource
+@Inject
+constructor(val store: WCCustomerStore) : ListItemDataSourceInterface<WCCustomerListDescriptor, Long, CustomerListItemType> {
+    override fun getItemsAndFetchIfNecessary(
+        listDescriptor: WCCustomerListDescriptor,
+        itemIdentifiers: List<Long>
+    ): List<CustomerListItemType> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getItemIdentifiers(
+        listDescriptor: WCCustomerListDescriptor,
+        remoteItemIds: List<RemoteId>,
+        isListFullyFetched: Boolean
+    ): List<Long> {
+        TODO("Not yet implemented")
+    }
+
+    override fun fetchList(listDescriptor: WCCustomerListDescriptor, offset: Long) {
+//        store.fetchCustomers(
+//                site = listDescriptor.site,
+//                searchQuery = listDescriptor.searchQuery,
+//                email = listDescriptor.email,
+//                role = listDescriptor.role,
+//                remoteCustomerIds = listDescriptor.remoteCustomerIds,
+//                excludedCustomerIds = listDescriptor.excludedCustomerIds
+//        )
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchAdapter.kt
@@ -1,0 +1,100 @@
+package org.wordpress.android.fluxc.example.ui.customer.search
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.paging.PagedListAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import kotlinx.android.synthetic.main.list_item_woo_customer.view.*
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.ui.customer.search.CustomerListItemType.CustomerItem
+import org.wordpress.android.fluxc.example.ui.customer.search.CustomerListItemType.LoadingItem
+import javax.inject.Inject
+
+private const val VIEW_TYPE_ITEM = 0
+private const val VIEW_TYPE_LOADING = 1
+
+class WooCustomersSearchAdapter @Inject constructor(context: Context) :
+        PagedListAdapter<CustomerListItemType, ViewHolder>(customerListDiffItemCallback) {
+    private val layoutInflater = LayoutInflater.from(context)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return when (viewType) {
+            VIEW_TYPE_ITEM -> CustomerItemViewHolder(inflateView(R.layout.list_item_woo_customer, parent))
+            VIEW_TYPE_LOADING -> LoadingViewHolder(inflateView(R.layout.list_item_skeleton, parent))
+            else -> throw IllegalStateException("View type $viewType is not supported")
+        }
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = getItem(position)
+        if (holder is CustomerItemViewHolder) {
+            holder.onBind((item as CustomerItem))
+        }
+    }
+
+    private fun inflateView(@LayoutRes layoutId: Int, parent: ViewGroup) = layoutInflater.inflate(
+            layoutId,
+            parent,
+            false
+    )
+
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is CustomerItem -> VIEW_TYPE_ITEM
+            is LoadingItem -> VIEW_TYPE_LOADING
+            else -> throw IllegalStateException("item at position $position is not supported")
+        }
+    }
+
+    private class LoadingViewHolder(view: View) : RecyclerView.ViewHolder(view)
+    private class CustomerItemViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
+        @SuppressLint("SetTextI18n")
+        fun onBind(item: CustomerItem) {
+            view.tvCustomerRemoteId.text = item.remoteCustomerId.toString()
+            view.tvCustomerName.text = "${item.firstName} ${item.lastName}"
+            view.tvCustomerEmail.text = item.email
+            view.tvCustomerRole.text = item.role
+        }
+    }
+}
+
+private val customerListDiffItemCallback = object : DiffUtil.ItemCallback<CustomerListItemType>() {
+    override fun areItemsTheSame(oldItem: CustomerListItemType, newItem: CustomerListItemType): Boolean {
+        if (oldItem == newItem && oldItem is LoadingItem) return true
+
+        if (oldItem is CustomerItem && newItem is CustomerItem) {
+            return oldItem.remoteCustomerId == newItem.remoteCustomerId
+        }
+
+        return false
+    }
+
+    override fun areContentsTheSame(oldItem: CustomerListItemType, newItem: CustomerListItemType): Boolean {
+        if (oldItem == newItem && oldItem is LoadingItem) return true
+
+        if (oldItem is CustomerItem && newItem is CustomerItem) {
+            return oldItem.firstName == newItem.firstName &&
+                    oldItem.lastName == newItem.lastName &&
+                    oldItem.email == newItem.email &&
+                    oldItem.role == newItem.role
+        }
+        return false
+    }
+}
+
+sealed class CustomerListItemType {
+    object LoadingItem : CustomerListItemType()
+    data class CustomerItem(
+        val remoteCustomerId: Long,
+        val firstName: String?,
+        val lastName: String,
+        val email: String,
+        val role: String
+    ) : CustomerListItemType()
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchAdapter.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.example.ui.customer.search
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -11,6 +10,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import kotlinx.android.synthetic.main.list_item_woo_customer.view.*
+import org.wordpress.android.fluxc.example.MainExampleActivity
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.ui.customer.search.CustomerListItemType.CustomerItem
 import org.wordpress.android.fluxc.example.ui.customer.search.CustomerListItemType.LoadingItem
@@ -19,7 +19,7 @@ import javax.inject.Inject
 private const val VIEW_TYPE_ITEM = 0
 private const val VIEW_TYPE_LOADING = 1
 
-class WooCustomersSearchAdapter @Inject constructor(context: Context) :
+class WooCustomersSearchAdapter @Inject constructor(context: MainExampleActivity) :
         PagedListAdapter<CustomerListItemType, ViewHolder>(customerListDiffItemCallback) {
     private val layoutInflater = LayoutInflater.from(context)
 
@@ -56,40 +56,41 @@ class WooCustomersSearchAdapter @Inject constructor(context: Context) :
     private class CustomerItemViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
         @SuppressLint("SetTextI18n")
         fun onBind(item: CustomerItem) {
-            view.tvCustomerRemoteId.text = item.remoteCustomerId.toString()
-            view.tvCustomerName.text = "${item.firstName} ${item.lastName}"
-            view.tvCustomerEmail.text = item.email
-            view.tvCustomerRole.text = item.role
+            with(view) {
+                tvCustomerRemoteId.text = item.remoteCustomerId.toString()
+                tvCustomerName.text = "${item.firstName} ${item.lastName}"
+                tvCustomerEmail.text = item.email
+                tvCustomerRole.text = item.role
+            }
         }
     }
 }
 
 private val customerListDiffItemCallback = object : DiffUtil.ItemCallback<CustomerListItemType>() {
     override fun areItemsTheSame(oldItem: CustomerListItemType, newItem: CustomerListItemType): Boolean {
-        if (oldItem == newItem && oldItem is LoadingItem) return true
-
-        if (oldItem is CustomerItem && newItem is CustomerItem) {
-            return oldItem.remoteCustomerId == newItem.remoteCustomerId
+        if (oldItem is LoadingItem && newItem is LoadingItem) return oldItem.remoteCustomerId == newItem.remoteCustomerId
+        return if (oldItem is CustomerItem && newItem is CustomerItem) {
+            oldItem.remoteCustomerId == newItem.remoteCustomerId
+        } else {
+            false
         }
-
-        return false
     }
 
     override fun areContentsTheSame(oldItem: CustomerListItemType, newItem: CustomerListItemType): Boolean {
-        if (oldItem == newItem && oldItem is LoadingItem) return true
-
-        if (oldItem is CustomerItem && newItem is CustomerItem) {
-            return oldItem.firstName == newItem.firstName &&
+        if (oldItem is LoadingItem && newItem is LoadingItem) return true
+        return if (oldItem is CustomerItem && newItem is CustomerItem) {
+            oldItem.firstName == newItem.firstName &&
                     oldItem.lastName == newItem.lastName &&
                     oldItem.email == newItem.email &&
                     oldItem.role == newItem.role
+        } else {
+            false
         }
-        return false
     }
 }
 
 sealed class CustomerListItemType {
-    object LoadingItem : CustomerListItemType()
+    data class LoadingItem(val remoteCustomerId: Long) : CustomerListItemType()
     data class CustomerItem(
         val remoteCustomerId: Long,
         val firstName: String?,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchAdapter.kt
@@ -57,7 +57,7 @@ class WooCustomersSearchAdapter @Inject constructor(context: MainExampleActivity
         @SuppressLint("SetTextI18n")
         fun onBind(item: CustomerItem) {
             with(view) {
-                tvCustomerRemoteId.text = item.remoteCustomerId.toString()
+                tvCustomerRemoteId.text = "ID: ${item.remoteCustomerId}"
                 tvCustomerName.text = "${item.firstName} ${item.lastName}"
                 tvCustomerEmail.text = item.email
                 tvCustomerRole.text = item.role
@@ -68,7 +68,9 @@ class WooCustomersSearchAdapter @Inject constructor(context: MainExampleActivity
 
 private val customerListDiffItemCallback = object : DiffUtil.ItemCallback<CustomerListItemType>() {
     override fun areItemsTheSame(oldItem: CustomerListItemType, newItem: CustomerListItemType): Boolean {
-        if (oldItem is LoadingItem && newItem is LoadingItem) return oldItem.remoteCustomerId == newItem.remoteCustomerId
+        if (oldItem is LoadingItem && newItem is LoadingItem) {
+            return oldItem.remoteCustomerId == newItem.remoteCustomerId
+        }
         return if (oldItem is CustomerItem && newItem is CustomerItem) {
             oldItem.remoteCustomerId == newItem.remoteCustomerId
         } else {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchBuilderFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchBuilderFragment.kt
@@ -1,24 +1,17 @@
-package org.wordpress.android.fluxc.example.ui.customer
+package org.wordpress.android.fluxc.example.ui.customer.search
 
-import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_customers_search_builder.*
 import org.wordpress.android.fluxc.example.R.layout
-import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearchFragment
+import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.util.ToastUtils
 
 class WooCustomersSearchBuilderFragment : Fragment() {
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(layout.fragment_woo_customers_search_builder, container, false)
 
@@ -26,9 +19,11 @@ class WooCustomersSearchBuilderFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         btnCustomerSearch.setOnClickListener {
-            WooCustomersSearchFragment.newInstance(
-                    siteId = requireArguments().getInt(KEY_SELECTED_SITE_ID),
-                    searchParams = buildParams()
+            replaceFragment(
+                    WooCustomersSearchFragment.newInstance(
+                            siteId = requireArguments().getInt(KEY_SELECTED_SITE_ID),
+                            searchParams = buildParams()
+                    )
             )
         }
     }
@@ -41,9 +36,10 @@ class WooCustomersSearchBuilderFragment : Fragment() {
             role = etCustomerRole.text?.toString()
     )
 
-    private fun Editable?.toIds(): List<Int> {
+    private fun Editable?.toIds(): List<Long> {
         return try {
-            this?.toString()?.split(",\\s*")?.map { it.toInt() } ?: emptyList()
+            if (this.isNullOrEmpty()) return emptyList()
+            this.toString().split(",\\s*").map { it.toLong() }
         } catch (e: Exception) {
             ToastUtils.showToast(requireContext(), "Wrongly formatted ids")
             emptyList()
@@ -51,7 +47,7 @@ class WooCustomersSearchBuilderFragment : Fragment() {
     }
 
     companion object {
-        fun newInstance(siteId: Int) = WooCustomersSearchFragment().apply {
+        fun newInstance(siteId: Int) = WooCustomersSearchBuilderFragment().apply {
             arguments = Bundle().apply { putInt(KEY_SELECTED_SITE_ID, siteId) }
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchFragment.kt
@@ -95,7 +95,7 @@ class WooCustomersSearchFragment : Fragment() {
         val includeIds: List<Long>,
         val excludeIds: List<Long>,
         val email: String?,
-        val role: String?,
+        val role: String?
     ) : Parcelable
 }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchFragment.kt
@@ -1,0 +1,106 @@
+package org.wordpress.android.fluxc.example.ui.customer.search
+
+import android.content.Context
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.synthetic.main.fragment_woo_customers_search.*
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.model.customer.WCCustomerListDescriptor
+import org.wordpress.android.fluxc.store.ListStore
+import org.wordpress.android.fluxc.store.WCCustomerStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class WooCustomersSearchFragment : Fragment() {
+    @Inject internal lateinit var wcCustomerStore: WCCustomerStore
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+    @Inject internal lateinit var listStore: ListStore
+    @Inject internal lateinit var listItemDataSource: WooCustomersListItemDataSource
+    @Inject internal lateinit var customersAdapter: WooCustomersSearchAdapter
+
+    private val siteId by lazy { requireArguments().getInt(KEY_SELECTED_SITE_ID) }
+    private val pagedListWrapper by lazy {
+        val descriptor = WCCustomerListDescriptor(getSelectedSite())
+        listStore.getList(
+                listDescriptor = descriptor,
+                dataSource = listItemDataSource,
+                lifecycle = lifecycle
+        )
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(layout.fragment_woo_customers_search, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        loadList()
+
+        srlCustomersSearch.setOnRefreshListener { pagedListWrapper.fetchFirstPage() }
+        rvCustomersSearch.apply {
+            adapter = customersAdapter
+            layoutManager = LinearLayoutManager(context)
+            itemAnimator = DefaultItemAnimator()
+            addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+        }
+    }
+
+    private fun loadList() {
+        val lifecycleOwner = viewLifecycleOwner
+        with(pagedListWrapper) {
+            data.removeObservers(lifecycleOwner)
+            isLoadingMore.removeObservers(lifecycleOwner)
+            isFetchingFirstPage.removeObservers(lifecycleOwner)
+            listError.removeObservers(lifecycleOwner)
+            isEmpty.removeObservers(lifecycleOwner)
+
+            fetchFirstPage()
+            isLoadingMore.observe(lifecycleOwner, {})
+            isFetchingFirstPage.observe(lifecycleOwner, {
+                srlCustomersSearch?.isRefreshing = it == true
+            })
+            data.observe(lifecycleOwner, {
+                it?.let { orderListData ->
+                    customersAdapter.submitList(orderListData)
+                }
+            })
+        }
+    }
+
+    private fun getSelectedSite() = wooCommerceStore.getWooCommerceSites().find { it.id == siteId }!!
+
+    companion object {
+        fun newInstance(siteId: Int, searchParams: SearchParams) = WooCustomersSearchFragment().apply {
+            arguments = Bundle().apply {
+                putInt(KEY_SELECTED_SITE_ID, siteId)
+                putParcelable(KEY_SEARCH_PARAMS, searchParams)
+            }
+        }
+    }
+
+    @Parcelize
+    data class SearchParams(
+        val searchQuery: String?,
+        val includeIds: List<Int>,
+        val excludeIds: List<Int>,
+        val email: String?,
+        val role: String?,
+    ) : Parcelable
+}
+
+private const val KEY_SELECTED_SITE_ID = "selected_site_id"
+private const val KEY_SEARCH_PARAMS = "search_params"

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
@@ -97,7 +98,7 @@ class WooProductsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         stats_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -657,13 +658,6 @@ class WooProductsFragment : Fragment() {
                 }
                 else -> { }
             }
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
@@ -75,7 +76,7 @@ class WooShippingLabelFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         shipping_labels_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -402,13 +403,6 @@ class WooShippingLabelFragment : Fragment() {
                     prependToLog("The WooCommerce services plugin is not installed")
                 }
             }
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.action.WCStatsAction
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
@@ -48,7 +49,7 @@ class WooRevenueStatsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         stats_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -225,13 +226,6 @@ class WooRevenueStatsFragment : Fragment() {
                     }
                 }
             }
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCTaxStore
@@ -43,7 +44,7 @@ class WooTaxFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         taxes_select_site.setOnClickListener {
-            showSiteSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
                 override fun onSiteSelected(site: SiteModel, pos: Int) {
                     selectedSite = site
                     selectedPos = pos
@@ -74,13 +75,6 @@ class WooTaxFragment : Fragment() {
                     }
                 }
             }
-        }
-    }
-
-    private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {
-        fragmentManager?.let { fm ->
-            val dialog = StoreSelectorDialog.newInstance(listener, selectedPos)
-            dialog.show(fm, "StoreSelectorDialog")
         }
     }
 }

--- a/example/src/main/res/layout/fragment_woo_customer.xml
+++ b/example/src/main/res/layout/fragment_woo_customer.xml
@@ -1,0 +1,67 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment"
+    tools:ignore="HardcodedText">
+
+    <LinearLayout
+        android:id="@+id/llButtonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Perform actions on a selected site:"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/btnCustomerSelectSite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Select Site" />
+
+            <TextView
+                android:id="@+id/tvCustomerSelectedSite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="8dp"
+                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+                android:textColor="@android:color/holo_blue_bright" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btnFetchCustomerList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Fetch Customer List" />
+
+        <Button
+            android:id="@+id/btnPrintCutomer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Print Customer" />
+
+        <Button
+            android:id="@+id/btnCreateCustomer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Create Customer" />
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woo_customers_search.xml
+++ b/example/src/main/res/layout/fragment_woo_customers_search.xml
@@ -1,13 +1,7 @@
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/srlCustomersSearch"
+<androidx.recyclerview.widget.RecyclerView android:id="@+id/rvCustomersSearch"
+    android:layout_height="match_parent"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rvCustomersSearch"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:clipToPadding="false"
-        android:scrollbars="vertical" />
-
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    android:scrollbars="vertical"
+    tools:listitem="@layout/list_item_woo_customer"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" />

--- a/example/src/main/res/layout/fragment_woo_customers_search.xml
+++ b/example/src/main/res/layout/fragment_woo_customers_search.xml
@@ -1,0 +1,13 @@
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/srlCustomersSearch"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvCustomersSearch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:scrollbars="vertical" />
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/example/src/main/res/layout/fragment_woo_customers_search_builder.xml
+++ b/example/src/main/res/layout/fragment_woo_customers_search_builder.xml
@@ -93,7 +93,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
-        android:hint="ids comma separated, e.g. 1, 3, 16"
+        android:hint="email"
         android:inputType="textEmailAddress"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/tvCustomerEmail"
@@ -116,7 +116,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
-        android:hint="ids comma separated, e.g. 1, 3, 16"
+        android:hint="role"
         android:inputType="text"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/tvCustomerRole"
@@ -126,9 +126,10 @@
         android:id="@+id/btnCustomerSearch"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
         android:text="SEARCH"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/etCustomerRole" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/layout/fragment_woo_customers_search_builder.xml
+++ b/example/src/main/res/layout/fragment_woo_customers_search_builder.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:ignore="HardcodedText">
+
+    <TextView
+        android:id="@+id/tvCustomerSearch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginEnd="8dp"
+        android:text="Search:"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/etCustomerSearch"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/etCustomerSearch" />
+
+    <EditText
+        android:id="@+id/etCustomerSearch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:hint="Search by text"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/tvCustomerSearch"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tvCustomerInclude"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:text="Include IDs:"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/etCustomerInclude"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/etCustomerInclude" />
+
+    <EditText
+        android:id="@+id/etCustomerInclude"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:hint="ids comma separated, e.g. 1, 3, 16"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/tvCustomerInclude"
+        app:layout_constraintTop_toBottomOf="@+id/etCustomerSearch" />
+
+    <TextView
+        android:id="@+id/tvCustomerExclude"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:text="Exclude IDs:"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/etCustomerExclude"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/etCustomerExclude" />
+
+    <EditText
+        android:id="@+id/etCustomerExclude"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:hint="ids comma separated, e.g. 1, 3, 16"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/tvCustomerExclude"
+        app:layout_constraintTop_toBottomOf="@+id/etCustomerInclude" />
+
+    <TextView
+        android:id="@+id/tvCustomerEmail"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:text="Email:"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/etCustomerEmail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/etCustomerEmail" />
+
+    <EditText
+        android:id="@+id/etCustomerEmail"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:hint="ids comma separated, e.g. 1, 3, 16"
+        android:inputType="textEmailAddress"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/tvCustomerEmail"
+        app:layout_constraintTop_toBottomOf="@+id/etCustomerExclude" />
+
+    <TextView
+        android:id="@+id/tvCustomerRole"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:text="Role:"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/etCustomerRole"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/etCustomerRole" />
+
+    <EditText
+        android:id="@+id/etCustomerRole"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:hint="ids comma separated, e.g. 1, 3, 16"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/tvCustomerRole"
+        app:layout_constraintTop_toBottomOf="@+id/etCustomerEmail" />
+
+    <Button
+        android:id="@+id/btnCustomerSearch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="SEARCH"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -105,5 +105,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Attributes"/>
+
+                <Button
+                    android:id="@+id/customers"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Customers"/>
         </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/list_item_woo_customer.xml
+++ b/example/src/main/res/layout/list_item_woo_customer.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/tvCustomerRemoteId"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="1231414" />
+
+    <TextView
+        android:id="@+id/tvCustomerName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Marlin Bryant" />
+
+    <TextView
+        android:id="@+id/tvCustomerEmail"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        app:layout_constraintEnd_toEndOf="@+id/tvCustomerName"
+        app:layout_constraintTop_toBottomOf="@+id/tvCustomerName"
+        tools:text="marlin@gmail.com" />
+
+    <TextView
+        android:id="@+id/tvCustomerRole"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        app:layout_constraintEnd_toEndOf="@+id/tvCustomerEmail"
+        app:layout_constraintTop_toBottomOf="@+id/tvCustomerEmail"
+        tools:text="Role" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/CustomerSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/CustomerSqlUtilsTest.kt
@@ -120,6 +120,39 @@ class CustomerSqlUtilsTest {
     }
 
     @Test
+    fun `get customers by remote ids returns null when no customers stored`() {
+        // when & then
+        assertTrue(CustomerSqlUtils.getCustomerByRemoteIds(site, listOf(1)).isEmpty())
+    }
+
+    @Test
+    fun `get customers by remote ids returns customers with remote ids`() {
+        // given
+        val usernameOne = "userNameOne"
+        val usernameTwo = "userNameTwo"
+        val customerOne = WCCustomerModel().apply {
+            this.remoteCustomerId = 1L
+            this.localSiteId = site.id
+            this.username = usernameOne
+        }
+        val customerTwo = WCCustomerModel().apply {
+            this.remoteCustomerId = 2L
+            this.localSiteId = site.id
+            this.username = usernameTwo
+        }
+
+        // when
+        CustomerSqlUtils.insertOrUpdateCustomer(customerOne)
+        CustomerSqlUtils.insertOrUpdateCustomer(customerTwo)
+
+        // then
+        val customerByRemoteIds = CustomerSqlUtils.getCustomerByRemoteIds(site, listOf(1, 2, 3))
+        assertEquals(customerByRemoteIds.size, 2)
+        assertEquals(customerByRemoteIds[0], customerOne)
+        assertEquals(customerByRemoteIds[1], customerTwo)
+    }
+
+    @Test
     fun `delete customers for site deletes all customers for the site`() {
         // given
         val usernameOne = "userNameOne"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,7 +28,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 137
+        return 138
     }
 
     override fun getDbName(): String {
@@ -1494,6 +1494,23 @@ open class WellSqlConfig : DefaultWellConfig {
                 136 -> migrate(version) {
                     db.execSQL("CREATE TABLE DynamicCard (_id INTEGER PRIMARY KEY AUTOINCREMENT,SITE_ID INTEGER," +
                             "DYNAMIC_CARD_TYPE TEXT,STATE TEXT)")
+                }
+                137 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCCustomerModel")
+                    db.execSQL("CREATE TABLE WCCustomerModel (AVATAR_URL TEXT NOT NULL," +
+                            "DATE_CREATED TEXT NOT NULL,DATE_CREATED_GMT TEXT NOT NULL,DATE_MODIFIED TEXT NOT NULL," +
+                            "DATE_MODIFIED_GMT TEXT NOT NULL,EMAIL TEXT NOT NULL,FIRST_NAME TEXT NOT NULL," +
+                            "REMOTE_CUSTOMER_ID INTEGER,IS_PAYING_CUSTOMER INTEGER,LAST_NAME TEXT NOT NULL," +
+                            "ROLE TEXT NOT NULL,USERNAME TEXT NOT NULL,LOCAL_SITE_ID INTEGER,BILLING_ADDRESS1" +
+                            " TEXT NOT NULL,BILLING_ADDRESS2 TEXT NOT NULL,BILLING_CITY TEXT NOT NULL," +
+                            "BILLING_COMPANY TEXT NOT NULL,BILLING_COUNTRY TEXT NOT NULL,BILLING_EMAIL" +
+                            " TEXT NOT NULL,BILLING_FIRST_NAME TEXT NOT NULL,BILLING_LAST_NAME TEXT " +
+                            "NOT NULL,BILLING_PHONE TEXT NOT NULL,BILLING_POSTCODE TEXT NOT NULL,BILLING_STATE" +
+                            " TEXT NOT NULL,SHIPPING_ADDRESS1 TEXT NOT NULL,SHIPPING_ADDRESS2 TEXT NOT NULL," +
+                            "SHIPPING_CITY TEXT NOT NULL,SHIPPING_COMPANY TEXT NOT NULL,SHIPPING_COUNTRY TEXT" +
+                            " NOT NULL,SHIPPING_FIRST_NAME TEXT NOT NULL,SHIPPING_LAST_NAME TEXT NOT NULL," +
+                            "SHIPPING_POSTCODE TEXT NOT NULL,SHIPPING_STATE TEXT NOT NULL,_id INTEGER" +
+                            " PRIMARY KEY AUTOINCREMENT)")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerListDescriptor.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerListDescriptor.kt
@@ -1,0 +1,43 @@
+package org.wordpress.android.fluxc.model.customer
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.list.ListConfig
+import org.wordpress.android.fluxc.model.list.ListDescriptor
+import org.wordpress.android.fluxc.model.list.ListDescriptorTypeIdentifier
+import org.wordpress.android.fluxc.model.list.ListDescriptorUniqueIdentifier
+
+class WCCustomerListDescriptor(
+    val site: SiteModel,
+    val searchQuery: String? = null,
+    val email: String? = null,
+    val role: String? = null,
+    val remoteCustomerIds: List<Long>? = null,
+    val excludedCustomerIds: List<Long>? = null
+) : ListDescriptor {
+    override val config: ListConfig = ListConfig.default
+
+    override val uniqueIdentifier: ListDescriptorUniqueIdentifier by lazy {
+        ListDescriptorUniqueIdentifier(calculateListTypeHash(site.id))
+    }
+
+    override val typeIdentifier: ListDescriptorTypeIdentifier by lazy {
+        calculateTypeIdentifier(site.id)
+    }
+
+    companion object {
+        @JvmStatic
+        fun calculateTypeIdentifier(localSiteId: Int) =
+                ListDescriptorTypeIdentifier(calculateListTypeHash(localSiteId))
+
+        private fun calculateListTypeHash(localSiteId: Int) = "woo-site-customer-list$localSiteId".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || javaClass != other.javaClass) return false
+        val that = other as WCCustomerListDescriptor
+        return uniqueIdentifier == that.uniqueIdentifier
+    }
+
+    override fun hashCode() = uniqueIdentifier.value
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerListDescriptor.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerListDescriptor.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.fluxc.model.list.ListDescriptor
 import org.wordpress.android.fluxc.model.list.ListDescriptorTypeIdentifier
 import org.wordpress.android.fluxc.model.list.ListDescriptorUniqueIdentifier
 
-class WCCustomerListDescriptor(
+open class WCCustomerListDescriptor(
     val site: SiteModel,
     val searchQuery: String? = null,
     val email: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
@@ -55,4 +55,19 @@ data class WCCustomerModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     override fun setId(id: Int) {
         this.id = id
     }
+
+    override fun toString(): String {
+        return "WCCustomerModel(id=$id, avatarUrl='$avatarUrl', dateCreated='$dateCreated', " +
+                "dateCreatedGmt='$dateCreatedGmt', dateModified='$dateModified', dateModifiedGmt='$dateModifiedGmt'," +
+                " email='$email', firstName='$firstName', remoteCustomerId=$remoteCustomerId, " +
+                "isPayingCustomer=$isPayingCustomer, lastName='$lastName', role='$role', username='$username', " +
+                "localSiteId=$localSiteId, billingAddress1='$billingAddress1', billingAddress2='$billingAddress2'," +
+                " billingCity='$billingCity', billingCompany='$billingCompany', billingCountry='$billingCountry'," +
+                " billingEmail='$billingEmail', billingFirstName='$billingFirstName', billingLastName='$billingLastName'," +
+                " billingPhone='$billingPhone', billingPostcode='$billingPostcode', billingState='$billingState', " +
+                "shippingAddress1='$shippingAddress1', shippingAddress2='$shippingAddress2', " +
+                "shippingCity='$shippingCity', shippingCompany='$shippingCompany', shippingCountry='$shippingCountry', " +
+                "shippingFirstName='$shippingFirstName', shippingLastName='$shippingLastName', " +
+                "shippingPostcode='$shippingPostcode', shippingState='$shippingState')"
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerModel.kt
@@ -57,17 +57,41 @@ data class WCCustomerModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     }
 
     override fun toString(): String {
-        return "WCCustomerModel(id=$id, avatarUrl='$avatarUrl', dateCreated='$dateCreated', " +
-                "dateCreatedGmt='$dateCreatedGmt', dateModified='$dateModified', dateModifiedGmt='$dateModifiedGmt'," +
-                " email='$email', firstName='$firstName', remoteCustomerId=$remoteCustomerId, " +
-                "isPayingCustomer=$isPayingCustomer, lastName='$lastName', role='$role', username='$username', " +
-                "localSiteId=$localSiteId, billingAddress1='$billingAddress1', billingAddress2='$billingAddress2'," +
-                " billingCity='$billingCity', billingCompany='$billingCompany', billingCountry='$billingCountry'," +
-                " billingEmail='$billingEmail', billingFirstName='$billingFirstName', billingLastName='$billingLastName'," +
-                " billingPhone='$billingPhone', billingPostcode='$billingPostcode', billingState='$billingState', " +
-                "shippingAddress1='$shippingAddress1', shippingAddress2='$shippingAddress2', " +
-                "shippingCity='$shippingCity', shippingCompany='$shippingCompany', shippingCountry='$shippingCountry', " +
-                "shippingFirstName='$shippingFirstName', shippingLastName='$shippingLastName', " +
-                "shippingPostcode='$shippingPostcode', shippingState='$shippingState')"
+        return "WCCustomerModel(" +
+                "id=$id, " +
+                "avatarUrl='$avatarUrl', " +
+                "dateCreated='$dateCreated', " +
+                "dateCreatedGmt='$dateCreatedGmt', " +
+                "dateModified='$dateModified', " +
+                "dateModifiedGmt='$dateModifiedGmt', " +
+                "email='$email', " +
+                "firstName='$firstName', " +
+                "remoteCustomerId=$remoteCustomerId, " +
+                "isPayingCustomer=$isPayingCustomer, " +
+                "lastName='$lastName', " +
+                "role='$role', " +
+                "username='$username', " +
+                "localSiteId=$localSiteId, " +
+                "billingAddress1='$billingAddress1', " +
+                "billingAddress2='$billingAddress2', " +
+                "billingCity='$billingCity', " +
+                "billingCompany='$billingCompany', " +
+                "billingCountry='$billingCountry', " +
+                "billingEmail='$billingEmail', " +
+                "billingFirstName='$billingFirstName', " +
+                "billingLastName='$billingLastName', " +
+                "billingPhone='$billingPhone', " +
+                "billingPostcode='$billingPostcode', " +
+                "billingState='$billingState', " +
+                "shippingAddress1='$shippingAddress1', " +
+                "shippingAddress2='$shippingAddress2', " +
+                "shippingCity='$shippingCity', " +
+                "shippingCompany='$shippingCompany', " +
+                "shippingCountry='$shippingCountry', " +
+                "shippingFirstName='$shippingFirstName', " +
+                "shippingLastName='$shippingLastName', " +
+                "shippingPostcode='$shippingPostcode', " +
+                "shippingState='$shippingState'" +
+                ")"
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
@@ -95,12 +95,12 @@ class CustomerRestClient(
             putIfNotEmpty("context" to context)
         }
 
-        remoteCustomerIds?.let { ids ->
-            params.put("include", ids.map { it }.joinToString())
+        if (!remoteCustomerIds.isNullOrEmpty()) {
+            params["include"] = remoteCustomerIds.map { it }.joinToString()
         }
 
-        excludedCustomerIds?.let { excludedIds ->
-            params.put("exclude", excludedIds.map { it }.joinToString())
+        if (!excludedCustomerIds.isNullOrEmpty()) {
+            params["exclude"] = excludedCustomerIds.map { it }.joinToString()
         }
 
         val response = requestBuilder.syncGetRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
@@ -63,7 +63,7 @@ class CustomerRestClient(
         site: SiteModel,
         pageSize: Int,
         sortType: CustomerSorting = NAME_ASC,
-        offset: Int = 0,
+        offset: Long = 0,
         searchQuery: String? = null,
         email: String? = null,
         role: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/CustomerSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/CustomerSqlUtils.kt
@@ -25,6 +25,15 @@ object CustomerSqlUtils {
                 .endWhere()
                 .asModel
     }
+
+    fun getCustomerByRemoteIds(site: SiteModel, remoteCustomerId: List<Long>): List<WCCustomerModel> {
+        return WellSql.select(WCCustomerModel::class.java)
+                .where().beginGroup()
+                .isIn(WCCustomerModelTable.REMOTE_CUSTOMER_ID, remoteCustomerId)
+                .equals(WCCustomerModelTable.LOCAL_SITE_ID, site.id)
+                .endGroup().endWhere()
+                .asModel
+    }
     // endregion
 
     // region insert-update

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCCustomerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCCustomerStore.kt
@@ -34,6 +34,12 @@ class WCCustomerStore @Inject constructor(
             CustomerSqlUtils.getCustomerByRemoteId(site, remoteCustomerId)
 
     /**
+     * returns a cached customers with provided remote ids or empty list if not in cache
+     */
+    fun getCustomerByRemoteIds(site: SiteModel, remoteCustomerId: List<Long>) =
+            CustomerSqlUtils.getCustomerByRemoteIds(site, remoteCustomerId)
+
+    /**
      * returns a customer with provided remote id
      */
     suspend fun fetchSingleCustomer(site: SiteModel, remoteCustomerId: Long): WooResult<WCCustomerModel> {
@@ -57,7 +63,7 @@ class WCCustomerStore @Inject constructor(
     suspend fun fetchCustomers(
         site: SiteModel,
         pageSize: Int = DEFAULT_CUSTOMER_PAGE_SIZE,
-        offset: Int = 0,
+        offset: Long = 0,
         sortType: CustomerSorting = DEFAULT_CUSTOMER_SORTING,
         searchQuery: String? = null,
         email: String? = null,
@@ -90,7 +96,7 @@ class WCCustomerStore @Inject constructor(
                     val customers = response.result.map { mapper.mapToModel(site, it) }
                     if (isCachingNeeded) {
                         // clear cache if it's the first page for the site
-                        if (offset == 0) CustomerSqlUtils.deleteCustomersForSite(site)
+                        if (offset == 0L) CustomerSqlUtils.deleteCustomersForSite(site)
                         CustomerSqlUtils.insertOrUpdateCustomers(customers)
                     }
                     WooResult(customers)

--- a/tests/api/src/test/java/APITesting_WCCustomer.java
+++ b/tests/api/src/test/java/APITesting_WCCustomer.java
@@ -12,7 +12,6 @@ import io.restassured.specification.RequestSpecification;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.oauth2;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 
 public class APITesting_WCCustomer {
     private RequestSpecification mRequestSpec;
@@ -41,19 +40,12 @@ public class APITesting_WCCustomer {
                 .get()
                 .then()
                 .statusCode(200)
-                .body("data", hasSize(50));
-    }
-
-    @Test
-    public void canGetCustomers() {
-        given()
-                .spec(this.mRequestSpec)
-                .queryParam("path", "/wc/v3/customers")
-                .when()
-                .get()
-                .then()
-                .statusCode(200)
-                .body("data", hasSize(50));
+                .body("data.id", equalTo(1),
+                        "data.first_name", equalTo(""),
+                        "data.last_name", equalTo(""),
+                        "data.avatar_url",
+                        equalTo("https://secure.gravatar.com/avatar/fb409f96c4ccb689c8b1d42342dae3c7?s=96&d=mm&r=g")
+                     );
     }
 
     @Test


### PR DESCRIPTION
Part number 0 of [#3605](https://github.com/woocommerce/woocommerce-android/issues/3605), contains an example of the usage of FluxC functionality to create a customer

**Testing:**
1. Open the example
2. Sign in
3. Click "WOO" button
4. Scroll down and click "CUSTOMERS" button
5. Select site
6. Click "FETCH CUSTOMER LIST"
7. Use search params you need
8. Click "SEARCH" button

<img src="https://user-images.githubusercontent.com/4923871/109984544-ef261380-7d14-11eb-9deb-5effabd57e03.png" width="300"/>
