### PR TITLE
Woo Shipping Labels: purchase labels

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -235,8 +235,10 @@ class WooShippingLabelFragment : Fragment() {
                         return@launch
                     }
                     if (origin == null || destination == null) {
-                        prependToLog("Invalid origin or destination address:\n" +
-                                "Origin:\n$origin\nDestination:\n$destination")
+                        prependToLog(
+                                "Invalid origin or destination address:\n" +
+                                        "Origin:\n$origin\nDestination:\n$destination"
+                        )
                         return@launch
                     }
                     var name: String
@@ -261,25 +263,30 @@ class WooShippingLabelFragment : Fragment() {
 
                                         val box: ShippingLabelPackage?
                                         if (height == null || width == null || length == null || weight == null) {
-                                            prependToLog("Invalid package parameters:\n" +
-                                                "Height: $height\nWidth: $width\nLength: $length\nWeight: $weight")
+                                            prependToLog(
+                                                    "Invalid package parameters:\n" +
+                                                            "Height: $height\n" +
+                                                            "Width: $width\n" +
+                                                            "Length: $length\n" +
+                                                            "Weight: $weight"
+                                            )
                                         } else {
                                             box = ShippingLabelPackage(
-                                                name,
-                                                "medium_flat_box_top",
-                                                height!!,
-                                                length!!,
-                                                width!!,
-                                                weight!!
+                                                    name,
+                                                    "medium_flat_box_top",
+                                                    height!!,
+                                                    length!!,
+                                                    width!!,
+                                                    weight!!
                                             )
 
                                             coroutineScope.launch {
                                                 val result = wcShippingLabelStore.getShippingRates(
-                                                    site,
-                                                    order.remoteOrderId,
-                                                    origin,
-                                                    destination,
-                                                    listOf(box)
+                                                        site,
+                                                        order.remoteOrderId,
+                                                        origin,
+                                                        destination,
+                                                        listOf(box)
                                                 )
 
                                                 result.error?.let {
@@ -319,6 +326,9 @@ class WooShippingLabelFragment : Fragment() {
                         return@launch
                     }
 
+                    val boxId = showSingleLineDialog(
+                            requireActivity(), "Enter box Id", defaultValue = "medium_flat_box_top"
+                    )
                     val height = showSingleLineDialog(requireActivity(), "Enter height:", isNumeric = true)
                             ?.toFloat()
                     val width = showSingleLineDialog(requireActivity(), "Enter width:", isNumeric = true)
@@ -327,17 +337,21 @@ class WooShippingLabelFragment : Fragment() {
                             ?.toFloat()
                     val weight = showSingleLineDialog(requireActivity(), "Enter weight:", isNumeric = true)
                             ?.toFloat()
-                    if (height == null || width == null || length == null || weight == null) {
+                    if (boxId == null || height == null || width == null || length == null || weight == null) {
                         prependToLog(
                                 "Invalid package parameters:\n" +
-                                        "Height: $height\nWidth: $width\nLength: $length\nWeight: $weight"
+                                        "BoxId: $boxId\n" +
+                                        "Height: $height\n" +
+                                        "Width: $width\n" +
+                                        "Length: $length\n" +
+                                        "Weight: $weight"
                         )
                     }
                     prependToLog("Retrieving rates")
 
                     val box = ShippingLabelPackage(
                             "default",
-                            "medium_flat_box_top",
+                            boxId!!,
                             height!!,
                             length!!,
                             width!!,
@@ -355,6 +369,12 @@ class WooShippingLabelFragment : Fragment() {
                                 "Getting rates failed: " +
                                         "${ratesResult.error.type}: ${ratesResult.error.message}"
                         )
+                        return@launch
+                    }
+                    if (ratesResult.model!!.packageRates.isEmpty() ||
+                            ratesResult.model!!.packageRates.first().shippingOptions.isEmpty() ||
+                            ratesResult.model!!.packageRates.first().shippingOptions.first().rates.isEmpty()) {
+                        prependToLog("Couldn't find rates for the given input, please try with different parameters")
                         return@launch
                     }
                     val rate = ratesResult.model!!.packageRates.first().shippingOptions.first().rates.first()
@@ -384,11 +404,13 @@ class WooShippingLabelFragment : Fragment() {
                     }
                     result.model?.let {
                         val label = it.first()
-                        prependToLog("Purchased a shipping label with the following details:\n" +
-                                "Order Id: ${label.localOrderId}\n" +
-                                "Products: ${label.productNames}\n" +
-                                "Label Id: ${label.remoteShippingLabelId}\n" +
-                                "Price: ${label.rate}")
+                        prependToLog(
+                                "Purchased a shipping label with the following details:\n" +
+                                        "Order Id: ${label.localOrderId}\n" +
+                                        "Products: ${label.productNames}\n" +
+                                        "Label Id: ${label.remoteShippingLabelId}\n" +
+                                        "Price: ${label.rate}"
+                        )
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -46,7 +46,6 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageDa
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPaperSize
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.io.File
@@ -484,7 +483,8 @@ class WooShippingLabelFragment : Fragment() {
         }
     }
 
-    private suspend fun loadData(site: SiteModel, orderId: Long) : Triple<WCOrderModel?, ShippingLabelAddress?, ShippingLabelAddress?> {
+    private suspend fun loadData(site: SiteModel, orderId: Long):
+            Triple<WCOrderModel?, ShippingLabelAddress?, ShippingLabelAddress?> {
         prependToLog("Loading shipping data...")
 
         dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(site))

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -35,13 +35,18 @@ import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
-import org.wordpress.android.fluxc.store.WCOrderStore
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
-import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageData
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPaperSize
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.io.File
@@ -221,89 +226,68 @@ class WooShippingLabelFragment : Fragment() {
         get_shipping_rates.setOnClickListener {
             selectedSite?.let { site ->
                 coroutineScope.launch {
-                    prependToLog("Loading shipping data...")
+                    val orderId = showSingleLineDialog(requireActivity(), "Enter order id:", isNumeric = true)
+                            ?.toLong() ?: return@launch
 
-                    dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(site))
+                    val (order, origin, destination) = loadData(site, orderId)
 
-                    val payload = FetchOrdersPayload(site, loadMore = false)
-                    dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
-
-                    delay(5000)
-
-                    val origin = wooCommerceStore.getSiteSettings(site)?.let {
-                        ShippingLabelAddress(
-                            address = it.address,
-                            city = it.city,
-                            postcode = it.postalCode,
-                            state = it.stateCode,
-                            country = it.countryCode
-                        )
+                    if (order == null) {
+                        prependToLog("Couldn't retrieve order data")
+                        return@launch
                     }
-
-                    val order = wcOrderStore.getOrdersForSite(site).firstOrNull()
-                    val destination = order?.getShippingAddress()?.let {
-                        ShippingLabelAddress(
-                            address = it.address1,
-                            city = it.city,
-                            postcode = it.postcode,
-                            state = it.state,
-                            country = it.country
-                        )
-                    }
-
                     if (origin == null || destination == null) {
                         prependToLog("Invalid origin or destination address:\n" +
                                 "Origin:\n$origin\nDestination:\n$destination")
-                    } else {
-                        var name: String
-                        showSingleLineDialog(activity, "Enter package name:") { text ->
-                            name = text.text.toString()
+                        return@launch
+                    }
+                    var name: String
+                    showSingleLineDialog(activity, "Enter package name:") { text ->
+                        name = text.text.toString()
 
-                            var height: Float?
-                            showSingleLineDialog(activity, "Enter height:", isNumeric = true) { h ->
-                                height = h.text.toString().toFloatOrNull()
+                        var height: Float?
+                        showSingleLineDialog(activity, "Enter height:", isNumeric = true) { h ->
+                            height = h.text.toString().toFloatOrNull()
 
-                                var width: Float?
-                                showSingleLineDialog(activity, "Enter width:", isNumeric = true) { w ->
-                                    width = w.text.toString().toFloatOrNull()
+                            var width: Float?
+                            showSingleLineDialog(activity, "Enter width:", isNumeric = true) { w ->
+                                width = w.text.toString().toFloatOrNull()
 
-                                    var length: Float?
-                                    showSingleLineDialog(activity, "Enter length:", isNumeric = true) { l ->
-                                        length = l.text.toString().toFloatOrNull()
+                                var length: Float?
+                                showSingleLineDialog(activity, "Enter length:", isNumeric = true) { l ->
+                                    length = l.text.toString().toFloatOrNull()
 
-                                        var weight: Float?
-                                        showSingleLineDialog(activity, "Enter weight:", isNumeric = true) { t ->
-                                            weight = t.text.toString().toFloatOrNull()
+                                    var weight: Float?
+                                    showSingleLineDialog(activity, "Enter weight:", isNumeric = true) { t ->
+                                        weight = t.text.toString().toFloatOrNull()
 
-                                            val box: ShippingLabelPackage?
-                                            if (height == null || width == null || length == null || weight == null) {
-                                                prependToLog("Invalid package parameters:\n" +
-                                                    "Height: $height\nWidth: $width\nLength: $length\nWeight: $weight")
-                                            } else {
-                                                box = ShippingLabelPackage(
-                                                    name,
-                                                    "medium_flat_box_top",
-                                                    height!!,
-                                                    length!!,
-                                                    width!!,
-                                                    weight!!
+                                        val box: ShippingLabelPackage?
+                                        if (height == null || width == null || length == null || weight == null) {
+                                            prependToLog("Invalid package parameters:\n" +
+                                                "Height: $height\nWidth: $width\nLength: $length\nWeight: $weight")
+                                        } else {
+                                            box = ShippingLabelPackage(
+                                                name,
+                                                "medium_flat_box_top",
+                                                height!!,
+                                                length!!,
+                                                width!!,
+                                                weight!!
+                                            )
+
+                                            coroutineScope.launch {
+                                                val result = wcShippingLabelStore.getShippingRates(
+                                                    site,
+                                                    order.remoteOrderId,
+                                                    origin,
+                                                    destination,
+                                                    listOf(box)
                                                 )
 
-                                                coroutineScope.launch {
-                                                    val result = wcShippingLabelStore.getShippingRates(
-                                                        site,
-                                                        order.remoteOrderId,
-                                                        origin,
-                                                        destination,
-                                                        listOf(box)
-                                                    )
-
-                                                    result.error?.let {
-                                                        prependToLog("${it.type}: ${it.message}")
-                                                    }
-                                                    result.model?.let {
-                                                        prependToLog("$it")
-                                                    }
+                                                result.error?.let {
+                                                    prependToLog("${it.type}: ${it.message}")
+                                                }
+                                                result.model?.let {
+                                                    prependToLog("$it")
                                                 }
                                             }
                                         }
@@ -311,6 +295,101 @@ class WooShippingLabelFragment : Fragment() {
                                 }
                             }
                         }
+                    }
+                }
+            }
+        }
+
+        purchase_label.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    val orderId = showSingleLineDialog(requireActivity(), "Enter order id:", isNumeric = true)
+                            ?.toLong() ?: return@launch
+
+                    val (order, origin, destination) = loadData(site, orderId)
+
+                    if (order == null) {
+                        prependToLog("Couldn't retrieve order data")
+                        return@launch
+                    }
+                    if (origin == null || destination == null) {
+                        prependToLog(
+                                "Invalid origin or destination address:\n" +
+                                        "Origin:\n$origin\nDestination:\n$destination"
+                        )
+                        return@launch
+                    }
+
+                    val height = showSingleLineDialog(requireActivity(), "Enter height:", isNumeric = true)
+                            ?.toFloat()
+                    val width = showSingleLineDialog(requireActivity(), "Enter width:", isNumeric = true)
+                            ?.toFloat()
+                    val length = showSingleLineDialog(requireActivity(), "Enter length:", isNumeric = true)
+                            ?.toFloat()
+                    val weight = showSingleLineDialog(requireActivity(), "Enter weight:", isNumeric = true)
+                            ?.toFloat()
+                    if (height == null || width == null || length == null || weight == null) {
+                        prependToLog(
+                                "Invalid package parameters:\n" +
+                                        "Height: $height\nWidth: $width\nLength: $length\nWeight: $weight"
+                        )
+                    }
+                    prependToLog("Retrieving rates")
+
+                    val box = ShippingLabelPackage(
+                            "default",
+                            "medium_flat_box_top",
+                            height!!,
+                            length!!,
+                            width!!,
+                            weight!!
+                    )
+                    val ratesResult = wcShippingLabelStore.getShippingRates(
+                            site,
+                            order.remoteOrderId,
+                            origin,
+                            destination,
+                            listOf(box)
+                    )
+                    if (ratesResult.isError) {
+                        prependToLog(
+                                "Getting rates failed: " +
+                                        "${ratesResult.error.type}: ${ratesResult.error.message}"
+                        )
+                        return@launch
+                    }
+                    val rate = ratesResult.model!!.packageRates.first().shippingOptions.first().rates.first()
+                    val packageData = WCShippingLabelPackageData(
+                            id = "default",
+                            boxId = "medium_flat_box_top",
+                            length = length,
+                            height = height,
+                            width = width,
+                            weight = weight,
+                            shipmentId = rate.shipmentId,
+                            rateId = rate.rateId,
+                            serviceId = rate.serviceId,
+                            carrierId = rate.carrierId,
+                            products = order.getLineItemList().map { it.id!! }
+                    )
+                    val result = wcShippingLabelStore.purchaseShippingLabels(
+                            site,
+                            order.remoteOrderId,
+                            origin,
+                            destination,
+                            listOf(packageData)
+                    )
+
+                    result.error?.let {
+                        prependToLog("${it.type}: ${it.message}")
+                    }
+                    result.model?.let {
+                        val label = it.first()
+                        prependToLog("Purchased a shipping label with the following details:\n" +
+                                "Order Id: ${label.localOrderId}\n" +
+                                "Products: ${label.productNames}\n" +
+                                "Label Id: ${label.remoteShippingLabelId}\n" +
+                                "Price: ${label.rate}")
                     }
                 }
             }
@@ -403,6 +482,40 @@ class WooShippingLabelFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private suspend fun loadData(site: SiteModel, orderId: Long) : Triple<WCOrderModel?, ShippingLabelAddress?, ShippingLabelAddress?> {
+        prependToLog("Loading shipping data...")
+
+        dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(site))
+
+        val payload = FetchOrdersByIdsPayload(site, listOf(RemoteId(orderId)))
+        dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersByIdsAction(payload))
+
+        delay(5000)
+
+        val origin = wooCommerceStore.getSiteSettings(site)?.let {
+            ShippingLabelAddress(
+                    address = it.address,
+                    city = it.city,
+                    postcode = it.postalCode,
+                    state = it.stateCode,
+                    country = it.countryCode
+            )
+        }
+
+        val order = wcOrderStore.getOrderByIdentifier(OrderIdentifier(site.id, orderId))
+        val destination = order?.getShippingAddress()?.let {
+            ShippingLabelAddress(
+                    address = it.address1,
+                    city = it.city,
+                    postcode = it.postcode,
+                    state = it.state,
+                    country = it.country
+            )
+        }
+
+        return Triple(order, origin, destination)
     }
 
     private fun showSiteSelectorDialog(selectedPos: Int, listener: StoreSelectorDialog.Listener) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
@@ -4,6 +4,8 @@ import android.text.InputType
 import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
 typealias AlertTextListener = (EditText) -> Unit
 
@@ -21,5 +23,27 @@ fun showSingleLineDialog(
     alert.setMessage(message)
     alert.setView(editText)
     alert.setPositiveButton(android.R.string.ok) { _, _ -> alertTextListener(editText) }
+    alert.show()
+}
+
+suspend fun showSingleLineDialog(
+    activity: FragmentActivity,
+    message: String,
+    isNumeric: Boolean = false
+): String? = suspendCancellableCoroutine { continuation ->
+    val alert = AlertDialog.Builder(activity)
+    val editText = EditText(activity)
+    editText.setSingleLine()
+    if (isNumeric) editText.inputType = InputType.TYPE_CLASS_NUMBER
+    alert.setMessage(message)
+    alert.setView(editText)
+    alert.setPositiveButton(android.R.string.ok) { _, _ ->
+        continuation.resume(editText.text.toString().ifEmpty { null })
+    }
+    alert.setOnDismissListener {
+        if (continuation.isActive) {
+            continuation.resume(null)
+        }
+    }
     alert.show()
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
@@ -29,11 +29,13 @@ fun showSingleLineDialog(
 suspend fun showSingleLineDialog(
     activity: FragmentActivity,
     message: String,
-    isNumeric: Boolean = false
+    isNumeric: Boolean = false,
+    defaultValue: String = ""
 ): String? = suspendCancellableCoroutine { continuation ->
     val alert = AlertDialog.Builder(activity)
     val editText = EditText(activity)
     editText.setSingleLine()
+    editText.setText(defaultValue)
     if (isNumeric) editText.inputType = InputType.TYPE_CLASS_NUMBER
     alert.setMessage(message)
     alert.setView(editText)

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -82,6 +82,13 @@
             android:text="Get shipping rates"/>
 
         <Button
+            android:id="@+id/purchase_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Purchase a shipping label" />
+
+        <Button
             android:id="@+id/get_shipping_plugin_info"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -130,7 +130,7 @@ class WCShippingLabelStoreTest {
 
     private val purchaseLabelPackagesData = listOf(
             WCShippingLabelPackageData(
-                    id ="id1",
+                    id = "id1",
                     boxId = "medium_flat_box_top",
                     height = 10f,
                     width = 10f,

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.Shi
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.DESTINATION
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type.ORIGIN
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageData
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult.ShippingOption
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult.ShippingPackage
@@ -79,6 +80,9 @@ class WCShippingLabelStoreTest {
 
     private val sampleShippingRatesApiResponse = WCShippingLabelTestUtils.generateSampleGetShippingRatesApiResponse()
 
+    private val samplePurchaseShippingLabelsResponse =
+            WCShippingLabelTestUtils.generateSamplePurchaseShippingLabelsApiResponse()
+
     private val originAddress = ShippingLabelAddress(
             "Company",
             "Ondrej Ruttkay",
@@ -103,7 +107,7 @@ class WCShippingLabelStoreTest {
             "11222"
     )
 
-    val packages = listOf(
+    private val packages = listOf(
             ShippingLabelPackage(
                     "Krabka 1",
                     "medium_flat_box_top",
@@ -121,6 +125,22 @@ class WCShippingLabelStoreTest {
                     5f,
                     5f,
                     false
+            )
+    )
+
+    private val purchaseLabelPackagesData = listOf(
+            WCShippingLabelPackageData(
+                    id ="id1",
+                    boxId = "medium_flat_box_top",
+                    height = 10f,
+                    width = 10f,
+                    length = 10f,
+                    weight = 10f,
+                    shipmentId = "shp_id",
+                    rateId = "rate_id",
+                    serviceId = "service-1",
+                    carrierId = "usps",
+                    products = listOf(10)
             )
     )
 
@@ -384,6 +404,30 @@ class WCShippingLabelStoreTest {
         assertThat(invalidRequestResult.error).isEqualTo(error)
     }
 
+    @Test
+    fun `purchase shipping label`() = test {
+        val result = purchaseLabel()
+        val shippingLabelModels = mapper.map(
+                samplePurchaseShippingLabelsResponse,
+                orderId,
+                originAddress,
+                destAddress,
+                site
+        )
+        assertThat(result.model!!.size).isEqualTo(shippingLabelModels.size)
+        assertThat(result.model!!.first().localOrderId).isEqualTo(shippingLabelModels.first().localOrderId)
+        assertThat(result.model!!.first().localSiteId).isEqualTo(shippingLabelModels.first().localSiteId)
+        assertThat(result.model!!.first().remoteShippingLabelId)
+                .isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
+        assertThat(result.model!!.first().carrierId).isEqualTo(shippingLabelModels.first().carrierId)
+        assertThat(result.model!!.first().packageName).isEqualTo(shippingLabelModels.first().packageName)
+        assertThat(result.model!!.first().refundableAmount).isEqualTo(shippingLabelModels.first().refundableAmount)
+
+        val invalidRequestResult = purchaseLabel(isError = true)
+        assertThat(invalidRequestResult.model).isNull()
+        assertThat(invalidRequestResult.error).isEqualTo(error)
+    }
+
     private suspend fun fetchShippingLabelsForOrder(): WooResult<List<WCShippingLabelModel>> {
         val fetchShippingLabelsPayload = WooPayload(sampleShippingLabelApiResponse)
         whenever(restClient.fetchShippingLabelsForOrder(orderId, site)).thenReturn(fetchShippingLabelsPayload)
@@ -461,5 +505,15 @@ class WCShippingLabelStoreTest {
             whenever(restClient.getAccountSettings(any())).thenReturn(accountSettingsPayload)
         }
         return store.getAccountSettings(site)
+    }
+
+    private suspend fun purchaseLabel(isError: Boolean = false): WooResult<List<WCShippingLabelModel>> {
+        if (isError) {
+            whenever(restClient.purchaseShippingLabels(any(), any(), any(), any(), any())).thenReturn(WooPayload(error))
+        } else {
+            val response = WooPayload(samplePurchaseShippingLabelsResponse)
+            whenever(restClient.purchaseShippingLabels(any(), any(), any(), any(), any())).thenReturn(response)
+        }
+        return store.purchaseShippingLabels(site, orderId, originAddress, destAddress, purchaseLabelPackagesData)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -5,6 +5,7 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.AccountSettingsApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.PurchaseShippingLabelApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.PrintShippingLabelApiResponse
@@ -101,5 +102,13 @@ object WCShippingLabelTestUtils {
                 "wc/shipping-labels-account-settings.json"
         )
         return Gson().fromJson(json, AccountSettingsApiResponse::class.java)
+    }
+
+    fun generateSamplePurchaseShippingLabelsApiResponse(): PurchaseShippingLabelApiResponse {
+        val json = UnitTestUtils.getStringFromResourceFile(
+                this.javaClass,
+                "wc/purchase-shipping-labels.json"
+        )
+        return Gson().fromJson(json, PurchaseShippingLabelApiResponse::class.java)
     }
 }

--- a/example/src/test/resources/wc/purchase-shipping-labels.json
+++ b/example/src/test/resources/wc/purchase-shipping-labels.json
@@ -1,0 +1,91 @@
+{
+  "labels": [
+    {
+      "label_id": 1,
+      "tracking": "9405500205309038753691",
+      "refundable_amount": 7.65,
+      "created": 1589295659638,
+      "carrier_id": "usps",
+      "service_name": "USPS - Priority Mail",
+      "status": "PURCHASED",
+      "package_name": "Small Flat Rate Box",
+      "product_names": [
+        "Polo",
+        "T-Shirt"
+      ],
+      "product_ids": [
+        10,
+        11
+      ]
+    },
+    {
+      "label_id": 2,
+      "tracking": "9405500205309038753691",
+      "refundable_amount": 7.65,
+      "created": 1589295659638,
+      "carrier_id": "usps",
+      "service_name": "USPS - Priority Mail",
+      "status": "PURCHASED",
+      "package_name": "Small Flat Rate Box",
+      "product_names": [
+        "Polo",
+        "T-Shirt"
+      ]
+    },
+    {
+      "label_id": 3,
+      "tracking": "9405500205309038753691",
+      "refundable_amount": 7.65,
+      "created": 1589295659638,
+      "carrier_id": "usps",
+      "service_name": "USPS - Priority Mail",
+      "status": "PURCHASED",
+      "package_name": "Small Flat Rate Box",
+      "product_names": [
+        "Polo",
+        "T-Shirt"
+      ],
+      "product_ids": [
+        10,
+        11
+      ]
+    },
+    {
+      "label_id": 4,
+      "tracking": "9405500205309038753691",
+      "refundable_amount": 7.65,
+      "created": 1589295659638,
+      "carrier_id": "usps",
+      "service_name": "USPS - Priority Mail",
+      "status": "PURCHASED",
+      "package_name": "Small Flat Rate Box",
+      "product_names": [
+        "Polo",
+        "T-Shirt"
+      ],
+      "product_ids": [
+        10,
+        11
+      ]
+    },
+    {
+      "label_id": 5,
+      "tracking": "9405500205309038753691",
+      "refundable_amount": 7.65,
+      "created": 1589295659638,
+      "carrier_id": "usps",
+      "service_name": "USPS - Priority Mail",
+      "status": "PURCHASED",
+      "package_name": "Small Flat Rate Box",
+      "product_names": [
+        "Polo",
+        "T-Shirt"
+      ],
+      "product_ids": [
+        10,
+        11
+      ]
+    }
+  ],
+  "success": true
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.model.shippinglabels
 
 import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.FormData
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.PurchaseShippingLabelApiResponse
@@ -38,7 +37,13 @@ class WCShippingLabelMapper
         } ?: emptyList()
     }
 
-    fun map(response: PurchaseShippingLabelApiResponse, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, site: SiteModel): List<WCShippingLabelModel> {
+    fun map(
+        response: PurchaseShippingLabelApiResponse,
+        orderId: Long,
+        origin: ShippingLabelAddress,
+        destination: ShippingLabelAddress,
+        site: SiteModel
+    ): List<WCShippingLabelModel> {
         val gson = Gson()
         return response.labels?.map { labelItem ->
             WCShippingLabelModel().apply {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -48,7 +48,7 @@ class WCShippingLabelMapper
                 serviceName = labelItem.serviceName ?: ""
                 status = labelItem.status ?: ""
                 packageName = labelItem.packageName ?: ""
-                rate = labelItem.rate?.toFloat() ?: 0F
+                rate = labelItem.rate?.toFloat() ?: labelItem.refundableAmount?.toFloat() ?: 0F
                 refundableAmount = labelItem.refundableAmount?.toFloat() ?: 0F
                 currency = labelItem.currency ?: ""
                 productNames = labelItem.productNames.toString()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -1,6 +1,11 @@
 package org.wordpress.android.fluxc.model.shippinglabels
 
+import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.FormData
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.PurchaseShippingLabelApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
 import javax.inject.Inject
 
@@ -27,6 +32,32 @@ class WCShippingLabelMapper
                 paperSize = response.paperSize ?: ""
                 storeOptions = response.storeOptions.toString()
                 formData = response.formData.toString()
+
+                localSiteId = site.id
+            }
+        } ?: emptyList()
+    }
+
+    fun map(response: PurchaseShippingLabelApiResponse, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, site: SiteModel): List<WCShippingLabelModel> {
+        val gson = Gson()
+        return response.labels?.map { labelItem ->
+            WCShippingLabelModel().apply {
+                remoteShippingLabelId = labelItem.labelId ?: 0L
+                trackingNumber = labelItem.trackingNumber ?: ""
+                carrierId = labelItem.carrierId ?: ""
+                serviceName = labelItem.serviceName ?: ""
+                status = labelItem.status ?: ""
+                packageName = labelItem.packageName ?: ""
+                rate = labelItem.rate?.toFloat() ?: 0F
+                refundableAmount = labelItem.refundableAmount?.toFloat() ?: 0F
+                currency = labelItem.currency ?: ""
+                productNames = labelItem.productNames.toString()
+                productIds = labelItem.productIds.toString()
+                refund = labelItem.refund.toString()
+                dateCreated = labelItem.dateCreated?.toString() ?: ""
+
+                localOrderId = orderId
+                formData = gson.toJson(FormData(origin = origin, destination = destination))
 
                 localSiteId = site.id
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -127,11 +127,11 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
      * product details associated with the order.
      * (nested under [selectedPackage] -> [DefaultBox] -> List of [ProductItem]).
      */
-    class FormData {
-        val origin: ShippingLabelAddress? = null
-        val destination: ShippingLabelAddress? = null
+    class FormData(
+        val origin: ShippingLabelAddress? = null,
+        val destination: ShippingLabelAddress? = null,
         @SerializedName("selected_packages") val selectedPackage: SelectedPackage? = null
-    }
+    )
 
     data class ShippingLabelAddress(
         val company: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPackageData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPackageData.kt
@@ -13,5 +13,5 @@ data class WCShippingLabelPackageData(
     @SerializedName("rate_id") val rateId: String,
     @SerializedName("service_id") val serviceId: String,
     @SerializedName("carrier_id") val carrierId: String,
-    val products: List<Int>
+    val products: List<Long>
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPackageData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPackageData.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+import com.google.gson.annotations.SerializedName
+
+data class WCShippingLabelPackageData(
+    val id: String,
+    @SerializedName("box_id") val boxId: String,
+    val length: Float,
+    val width: Float,
+    val height: Float,
+    val weight: Float,
+    @SerializedName("shipment_id") val shipmentId: String,
+    @SerializedName("rate_id") val rateId: String,
+    @SerializedName("service_id") val serviceId: String,
+    @SerializedName("carrier_id") val carrierId: String,
+    val products: List<Int>
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/LabelItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/LabelItem.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
+
+import com.google.gson.JsonElement
+import com.google.gson.annotations.SerializedName
+import java.math.BigDecimal
+
+class LabelItem {
+    @SerializedName("label_id") val labelId: Long? = null
+    @SerializedName("tracking") val trackingNumber: String? = null
+    @SerializedName("carrier_id") val carrierId: String? = null
+    @SerializedName("service_name") val serviceName: String? = null
+    @SerializedName("created_date") val dateCreated: Long? = null
+    @SerializedName("package_name") val packageName: String? = null
+    @SerializedName("product_names") val productNames: List<String>? = emptyList()
+    @SerializedName("product_ids") val productIds: List<Long>? = emptyList()
+    @SerializedName("refundable_amount") val refundableAmount: BigDecimal? = null
+    val status: String? = null
+    val rate: BigDecimal? = null
+    val currency: String? = null
+    val refund: JsonElement? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/PurchaseShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/PurchaseShippingLabelApiResponse.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
+
+import com.google.gson.annotations.SerializedName
+import java.math.BigDecimal
+
+data class PurchaseShippingLabelApiResponse(
+    @SerializedName("success")
+    val isSuccess: Boolean = false,
+    @SerializedName("labels")
+    val labels: List<LabelItem>? = null
+) {
+    class LabelItem {
+        @SerializedName("label_id") val labelId: Long? = null
+        @SerializedName("tracking") val trackingNumber: String? = null
+        @SerializedName("carrier_id") val carrierId: String? = null
+        @SerializedName("service_name") val serviceName: String? = null
+        @SerializedName("created") val dateCreated: Long? = null
+        @SerializedName("package_name") val packageName: String? = null
+        @SerializedName("refundable_amount") val refundableAmount: BigDecimal? = null
+        @SerializedName("status") val status: String? = null
+        @SerializedName("commercial_invoice_url") val invoiceUrl: String? = null
+        @SerializedName("is_letter") val isLetter: Boolean? = null
+        @SerializedName("product_ids") val productIds: List<Long>? = emptyList()
+        @SerializedName("product_names") val productNames: List<String>? = emptyList()
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/PurchaseShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/PurchaseShippingLabelApiResponse.kt
@@ -8,19 +8,4 @@ data class PurchaseShippingLabelApiResponse(
     val isSuccess: Boolean = false,
     @SerializedName("labels")
     val labels: List<LabelItem>? = null
-) {
-    class LabelItem {
-        @SerializedName("label_id") val labelId: Long? = null
-        @SerializedName("tracking") val trackingNumber: String? = null
-        @SerializedName("carrier_id") val carrierId: String? = null
-        @SerializedName("service_name") val serviceName: String? = null
-        @SerializedName("created") val dateCreated: Long? = null
-        @SerializedName("package_name") val packageName: String? = null
-        @SerializedName("refundable_amount") val refundableAmount: BigDecimal? = null
-        @SerializedName("status") val status: String? = null
-        @SerializedName("commercial_invoice_url") val invoiceUrl: String? = null
-        @SerializedName("is_letter") val isLetter: Boolean? = null
-        @SerializedName("product_ids") val productIds: List<Long>? = emptyList()
-        @SerializedName("product_names") val productNames: List<String>? = emptyList()
-    }
-}
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/PurchaseShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/PurchaseShippingLabelApiResponse.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
 
 import com.google.gson.annotations.SerializedName
-import java.math.BigDecimal
 
 data class PurchaseShippingLabelApiResponse(
     @SerializedName("success")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
@@ -14,20 +14,4 @@ class ShippingLabelApiResponse : Response {
     val labelsData: List<LabelItem>? = null
 
     val success: Boolean? = null
-
-    class LabelItem {
-        @SerializedName("label_id") val labelId: Long? = null
-        @SerializedName("tracking") val trackingNumber: String? = null
-        @SerializedName("carrier_id") val carrierId: String? = null
-        @SerializedName("service_name") val serviceName: String? = null
-        @SerializedName("created_date") val dateCreated: Long? = null
-        @SerializedName("package_name") val packageName: String? = null
-        @SerializedName("product_names") val productNames: List<String>? = emptyList()
-        @SerializedName("product_ids") val productIds: List<Long>? = emptyList()
-        @SerializedName("refundable_amount") val refundableAmount: BigDecimal? = null
-        val status: String? = null
-        val rate: BigDecimal? = null
-        val currency: String? = null
-        val refund: JsonElement? = null
-    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelApiResponse.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
 
 import com.google.gson.JsonElement
-import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.network.Response
-import java.math.BigDecimal
 
 class ShippingLabelApiResponse : Response {
     val orderId: Long? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -295,7 +295,10 @@ class WCShippingLabelStore @Inject constructor(
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)
                 response.result?.labels != null && response.result.labels.all { it.status == "PURCHASED" } -> {
-                    WooResult(mapper.map(response.result, orderId, origin, destination, site))
+                    val shippingLabels = mapper.map(response.result, orderId, origin, destination, site)
+                    WCShippingLabelSqlUtils.insertOrUpdateShippingLabels(shippingLabels)
+
+                    WooResult(shippingLabels)
                 }
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -14,10 +14,11 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelMapper
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageData
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPaperSize
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult.ShippingOption
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult.ShippingPackage
-import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPaperSize
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -173,10 +174,10 @@ class WCShippingLabelStore @Inject constructor(
                 response.result?.isSuccess == true -> {
                     val packageRates: List<ShippingPackage> = response.result.boxes.map { box ->
                         ShippingPackage(
-                            box.key,
-                            box.value.entries.map { option ->
-                                ShippingOption(option.key, option.value.rates)
-                            }
+                                box.key,
+                                box.value.entries.map { option ->
+                                    ShippingOption(option.key, option.value.rates)
+                                }
                         )
                     }
                     WooResult(WCShippingRatesResult(packageRates))
@@ -277,6 +278,25 @@ class WCShippingLabelStore @Inject constructor(
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)
                 response.result == true -> WooResult(true)
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
+    suspend fun purchaseShippingLabels(
+        site: SiteModel,
+        orderId: Long,
+        origin: ShippingLabelAddress,
+        destination: ShippingLabelAddress,
+        packagesData: List<WCShippingLabelPackageData>
+    ): WooResult<List<WCShippingLabelModel>> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "purchaseShippingLabels") {
+            val response = restClient.purchaseShippingLabels(site, orderId, origin, destination, packagesData)
+            return@withDefaultContext when {
+                response.isError -> WooResult(response.error)
+                response.result?.labels != null && response.result.labels.all { it.status == "PURCHASED" } -> {
+                    WooResult(mapper.map(response.result, orderId, origin, destination, site))
+                }
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }


### PR DESCRIPTION
This adds support for purchasing shipping labels.

To test:
1. Create an order that satisfies shipping label creation in your store.
2. Open the example app.
3. Click on Woo -> Shipping Labels.
4. Click on purchase a shipping label.
5. Enter the order and package details.
6. Confirm that the shipping label details are printed in the console.