### PR TITLE
Issue/1917 hack week change log font size

### DIFF
--- a/example/gradle.properties-example
+++ b/example/gradle.properties-example
@@ -1,5 +1,7 @@
 # OAuth credentials for example app
 wp.OAUTH.APP.ID = wp
 wp.OAUTH.APP.SECRET = wp
+wp.EXAMPLE_LOG_FONT_SIZE_SP = 12
+
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
@@ -20,7 +20,7 @@ class MainExampleActivity : FragmentActivity(), HasAndroidInjector {
 
         setContentView(R.layout.activity_example)
 
-        // enable developers to set a custom font size
+        // enable developers to set a custom font size for the log (previously it was always 12sp)
         val logFontSz = BuildConfig.EXAMPLE_LOG_FONT_SIZE_SP.toFloat()
         log.setTextSize(TypedValue.COMPLEX_UNIT_SP, logFontSz)
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.example
 
 import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
+import android.util.TypedValue
 import androidx.fragment.app.FragmentActivity
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
@@ -18,6 +19,10 @@ class MainExampleActivity : FragmentActivity(), HasAndroidInjector {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_example)
+
+        // enable developers to set a custom font size
+        val logFontSz = BuildConfig.EXAMPLE_LOG_FONT_SIZE_SP.toFloat()
+        log.setTextSize(TypedValue.COMPLEX_UNIT_SP, logFontSz)
 
         if (savedInstanceState == null) {
             val mf = MainFragment()


### PR DESCRIPTION
Closes #1917 - the hard-coded 12sp font size for the example app's log is too tiny for people like me to see clearly, so this small PR adds the ability to set a custom font size in the example app's `build.gradle`.

**Note:** I'd be happy to close this PR and simply change the log font size to something more reasonable (like, say, 14sp or 16sp) in the layout file, but wasn't sure if most of us were fine with 12sp.