### PR TITLE
Issue/1919 hack week cleanup example main

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -9,16 +9,7 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/example/gradle.properties-example
+++ b/example/gradle.properties-example
@@ -1,7 +1,6 @@
 # OAuth credentials for example app
 wp.OAUTH.APP.ID = wp
 wp.OAUTH.APP.SECRET = wp
-wp.EXAMPLE_LOG_FONT_SIZE_SP = 12
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/gradle.properties-example
+++ b/example/gradle.properties-example
@@ -1,5 +1,7 @@
 # OAuth credentials for example app
 wp.OAUTH.APP.ID = wp
 wp.OAUTH.APP.SECRET = wp
+wp.EXAMPLE_LOG_FONT_SIZE_SP = 12
+
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
@@ -20,7 +20,7 @@ class MainExampleActivity : FragmentActivity(), HasAndroidInjector {
 
         setContentView(R.layout.activity_example)
 
-        // enable developers to set a custom font size
+        // enable developers to set a custom font size for the log (previously it was always 12sp)
         val logFontSz = BuildConfig.EXAMPLE_LOG_FONT_SIZE_SP.toFloat()
         log.setTextSize(TypedValue.COMPLEX_UNIT_SP, logFontSz)
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.example
 
 import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
-import android.util.TypedValue
 import androidx.fragment.app.FragmentActivity
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
@@ -19,10 +18,6 @@ class MainExampleActivity : FragmentActivity(), HasAndroidInjector {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_example)
-
-        // enable developers to set a custom font size for the log (previously it was always 12sp)
-        val logFontSz = BuildConfig.EXAMPLE_LOG_FONT_SIZE_SP.toFloat()
-        log.setTextSize(TypedValue.COMPLEX_UNIT_SP, logFontSz)
 
         if (savedInstanceState == null) {
             val mf = MainFragment()

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.example
 
 import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
+import android.util.TypedValue
 import androidx.fragment.app.FragmentActivity
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
@@ -18,6 +19,10 @@ class MainExampleActivity : FragmentActivity(), HasAndroidInjector {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_example)
+
+        // enable developers to set a custom font size
+        val logFontSz = BuildConfig.EXAMPLE_LOG_FONT_SIZE_SP.toFloat()
+        log.setTextSize(TypedValue.COMPLEX_UNIT_SP, logFontSz)
 
         if (savedInstanceState == null) {
             val mf = MainFragment()

--- a/example/src/main/res/layout/fragment_account.xml
+++ b/example/src/main/res/layout/fragment_account.xml
@@ -1,25 +1,27 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              tools:context="org.wordpress.android.fluxc.example.AccountFragment">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    android:orientation="vertical"
+    tools:context="org.wordpress.android.fluxc.example.AccountFragment"
+    tools:ignore="HardcodedText">
 
     <Button
         android:id="@+id/account_settings"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Set Display Name" />
 
     <Button
         android:id="@+id/account_infos_button"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch Account" />
 
     <Button
         android:id="@+id/account_email_verification"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Send Verification Email" />
 

--- a/example/src/main/res/layout/fragment_comments.xml
+++ b/example/src/main/res/layout/fragment_comments.xml
@@ -1,31 +1,33 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              tools:context="org.wordpress.android.fluxc.example.CommentsFragment">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    android:orientation="vertical"
+    tools:context="org.wordpress.android.fluxc.example.CommentsFragment"
+    tools:ignore="HardcodedText">
 
     <Button
         android:id="@+id/fetch_comments"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch comments from first site" />
 
     <Button
         android:id="@+id/reply_to_comment"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Reply to first comment" />
 
     <Button
         android:id="@+id/like_comment"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Like/Unlike first comment" />
 
     <Button
         android:id="@+id/show_link_address"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Show link address" />
 

--- a/example/src/main/res/layout/fragment_editor_theme.xml
+++ b/example/src/main/res/layout/fragment_editor_theme.xml
@@ -3,24 +3,26 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
     android:orientation="vertical"
-    tools:context=".EditorThemeFragment">
+    tools:context=".EditorThemeFragment"
+    tools:ignore="HardcodedText">
 
     <Button
         android:id="@+id/fetch_theme"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch Theme From First Site" />
 
     <Button
         android:id="@+id/fetch_cached_theme"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch Cached Theme For First Site" />
 
     <Button
         android:id="@+id/clear_cache"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Clear Cache For First Site" />
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_experiments.xml
+++ b/example/src/main/res/layout/fragment_experiments.xml
@@ -2,7 +2,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_margin="@dimen/activity_start_end_margin"
+    android:orientation="vertical"
+    tools:ignore="HardcodedText">
 
     <TextView
         android:layout_width="wrap_content"
@@ -12,9 +14,9 @@
 
     <Spinner
         android:id="@+id/platform_spinner"
+        style="@style/Widget.AppCompat.Spinner.Underlined"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        style="@style/Widget.AppCompat.Spinner.Underlined"/>
+        android:layout_height="wrap_content" />
 
     <TextView
         android:layout_width="wrap_content"
@@ -45,21 +47,21 @@
 
     <Button
         android:id="@+id/fetch_assignments"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch assignments"
         tools:ignore="HardcodedText" />
 
     <Button
         android:id="@+id/get_cached_assignments"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Get cached assignments"
         tools:ignore="HardcodedText" />
 
     <Button
         android:id="@+id/clear_cached_assignments"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Clear cached assignments"
         tools:ignore="HardcodedText" />

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -50,97 +50,97 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:layout_gravity="left"
+            android:layout_marginEnd="8dp"
             android:layout_weight="1">
 
             <Button
                 android:id="@+id/account"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Account" />
 
             <Button
                 android:id="@+id/sites"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Sites" />
 
             <Button
                 android:id="@+id/posts"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Posts" />
 
             <Button
                 android:id="@+id/comments"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Comments" />
 
             <Button
                 android:id="@+id/media"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Media" />
 
             <Button
                 android:id="@+id/taxonomies"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Taxonomies" />
 
             <Button
                 android:id="@+id/uploads"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Uploads" />
 
             <Button
                 android:id="@+id/themes"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Themes" />
 
         </LinearLayout>
 
         <LinearLayout
+            android:layout_marginStart="8dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:layout_gravity="right"
             android:layout_weight="1">
 
             <Button
                 android:id="@+id/woo"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
                 android:text="Woo" />
 
             <Button
                 android:id="@+id/notifs"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
                 android:text="Notifications"/>
 
             <Button
                 android:id="@+id/reactnative"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
                 android:text="React Native"/>
 
             <Button
                 android:id="@+id/editortheme"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
                 android:text="Editor Theme" />
 
             <Button
                 android:id="@+id/experiments"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
                 android:text="Experiments" />

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -2,6 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_margin="@dimen/activity_start_end_margin"
     tools:context="org.wordpress.android.fluxc.example.MainFragment"
     tools:ignore="HardcodedText">
 
@@ -50,7 +51,7 @@
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
+                android:layout_marginEnd="@dimen/activity_start_end_half_margin"
                 android:layout_weight="1"
                 android:orientation="vertical">
 
@@ -107,7 +108,7 @@
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
+                android:layout_marginStart="@dimen/activity_start_end_half_margin"
                 android:layout_weight="1"
                 android:orientation="vertical">
 

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -6,40 +6,36 @@
     tools:context="org.wordpress.android.fluxc.example.MainFragment"
     tools:ignore="HardcodedText">
 
-    <RelativeLayout
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <Button
             android:id="@+id/sign_in_fetch_sites_button"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:text="Sign In And Fetch Sites" />
+            android:text="Sign In &amp; Fetch Sites" />
 
         <Button
             android:id="@+id/signout"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
             android:text="Sign Out" />
 
         <Button
             android:id="@+id/signed_out_actions"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/sign_in_fetch_sites_button"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentLeft="true"
             android:text="Signed Out Actions" />
-    </RelativeLayout>
+    </LinearLayout>
 
     <ImageView
         android:id="@+id/divider1"
         android:layout_width="match_parent"
         android:layout_height="2dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
         android:background="@color/material_grey_600" />
 
     <LinearLayout
@@ -115,35 +111,30 @@
                 android:id="@+id/woo"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
                 android:text="Woo" />
 
             <Button
                 android:id="@+id/notifs"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
                 android:text="Notifications" />
 
             <Button
                 android:id="@+id/reactnative"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
                 android:text="React Native" />
 
             <Button
                 android:id="@+id/editortheme"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
                 android:text="Editor Theme" />
 
             <Button
                 android:id="@+id/experiments"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
                 android:text="Experiments" />
         </LinearLayout>
     </LinearLayout>

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -1,9 +1,10 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              tools:context="org.wordpress.android.fluxc.example.MainFragment">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="org.wordpress.android.fluxc.example.MainFragment"
+    tools:ignore="HardcodedText">
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -13,26 +14,26 @@
             android:id="@+id/sign_in_fetch_sites_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Sign In And Fetch Sites"
-            android:layout_alignParentTop="true" />
+            android:layout_alignParentTop="true"
+            android:text="Sign In And Fetch Sites" />
 
         <Button
             android:id="@+id/signout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Sign Out"
             android:layout_alignParentTop="true"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true" />
+            android:text="Sign Out" />
 
         <Button
             android:id="@+id/signed_out_actions"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Signed Out Actions"
             android:layout_below="@+id/sign_in_fetch_sites_button"
+            android:layout_alignParentStart="true"
             android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true" />
+            android:text="Signed Out Actions" />
     </RelativeLayout>
 
     <ImageView
@@ -49,9 +50,9 @@
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:layout_marginEnd="8dp"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            android:orientation="vertical">
 
             <Button
                 android:id="@+id/account"
@@ -104,11 +105,11 @@
         </LinearLayout>
 
         <LinearLayout
-            android:layout_marginStart="8dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_weight="1">
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
 
             <Button
                 android:id="@+id/woo"
@@ -122,14 +123,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
-                android:text="Notifications"/>
+                android:text="Notifications" />
 
             <Button
                 android:id="@+id/reactnative"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
-                android:text="React Native"/>
+                android:text="React Native" />
 
             <Button
                 android:id="@+id/editortheme"

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -35,17 +35,14 @@
                 android:text="Signed Out Actions" />
         </LinearLayout>
 
-        <ImageView
+        <View
             android:id="@+id/divider1"
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            android:layout_marginTop="4dp"
-            android:layout_marginBottom="4dp"
-            android:background="@color/material_grey_600" />
+            style="@style/Divider" />
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:baselineAligned="false"
             android:orientation="horizontal">
 
             <LinearLayout

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -1,8 +1,7 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
+    android:layout_height="wrap_content"
     tools:context="org.wordpress.android.fluxc.example.MainFragment"
     tools:ignore="HardcodedText">
 
@@ -11,131 +10,137 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <Button
-            android:id="@+id/sign_in_fetch_sites_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Sign In &amp; Fetch Sites" />
-
-        <Button
-            android:id="@+id/signout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Sign Out" />
-
-        <Button
-            android:id="@+id/signed_out_actions"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Signed Out Actions" />
-    </LinearLayout>
-
-    <ImageView
-        android:id="@+id/divider1"
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:layout_marginTop="4dp"
-        android:layout_marginBottom="4dp"
-        android:background="@color/material_grey_600" />
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_weight="1"
             android:orientation="vertical">
 
             <Button
-                android:id="@+id/account"
+                android:id="@+id/sign_in_fetch_sites_button"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Account" />
+                android:text="Sign In &amp; Fetch Sites" />
 
             <Button
-                android:id="@+id/sites"
+                android:id="@+id/signout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Sites" />
+                android:text="Sign Out" />
 
             <Button
-                android:id="@+id/posts"
+                android:id="@+id/signed_out_actions"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Posts" />
-
-            <Button
-                android:id="@+id/comments"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Comments" />
-
-            <Button
-                android:id="@+id/media"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Media" />
-
-            <Button
-                android:id="@+id/taxonomies"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Taxonomies" />
-
-            <Button
-                android:id="@+id/uploads"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Uploads" />
-
-            <Button
-                android:id="@+id/themes"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Themes" />
-
+                android:text="Signed Out Actions" />
         </LinearLayout>
+
+        <ImageView
+            android:id="@+id/divider1"
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="4dp"
+            android:background="@color/material_grey_600" />
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_weight="1"
-            android:orientation="vertical">
+            android:orientation="horizontal">
 
-            <Button
-                android:id="@+id/woo"
-                android:layout_width="match_parent"
+            <LinearLayout
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Woo" />
+                android:layout_marginEnd="8dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
 
-            <Button
-                android:id="@+id/notifs"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Notifications" />
+                <Button
+                    android:id="@+id/account"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Account" />
 
-            <Button
-                android:id="@+id/reactnative"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="React Native" />
+                <Button
+                    android:id="@+id/sites"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Sites" />
 
-            <Button
-                android:id="@+id/editortheme"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Editor Theme" />
+                <Button
+                    android:id="@+id/posts"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Posts" />
 
-            <Button
-                android:id="@+id/experiments"
-                android:layout_width="match_parent"
+                <Button
+                    android:id="@+id/comments"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Comments" />
+
+                <Button
+                    android:id="@+id/media"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Media" />
+
+                <Button
+                    android:id="@+id/taxonomies"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Taxonomies" />
+
+                <Button
+                    android:id="@+id/uploads"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Uploads" />
+
+                <Button
+                    android:id="@+id/themes"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Themes" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Experiments" />
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/woo"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Woo" />
+
+                <Button
+                    android:id="@+id/notifs"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Notifications" />
+
+                <Button
+                    android:id="@+id/reactnative"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="React Native" />
+
+                <Button
+                    android:id="@+id/editortheme"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Editor Theme" />
+
+                <Button
+                    android:id="@+id/experiments"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Experiments" />
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_media.xml
+++ b/example/src/main/res/layout/fragment_media.xml
@@ -4,8 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:ignore="HardcodedText"
     android:layout_margin="@dimen/activity_start_end_margin"
+    tools:ignore="HardcodedText"
     tools:context="org.wordpress.android.fluxc.example.MediaFragment">
 
     <Button

--- a/example/src/main/res/layout/fragment_media.xml
+++ b/example/src/main/res/layout/fragment_media.xml
@@ -4,36 +4,38 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    tools:ignore="HardcodedText"
+    android:layout_margin="@dimen/activity_start_end_margin"
     tools:context="org.wordpress.android.fluxc.example.MediaFragment">
 
     <Button
         android:id="@+id/fetch_media_list"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch First Page" />
 
     <Button
         android:id="@+id/fetch_specified_media"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch" />
 
     <Button
         android:id="@+id/upload_media"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Upload" />
 
     <Button
         android:id="@+id/cancel_upload"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
         android:text="Cancel" />
 
     <Button
         android:id="@+id/delete_media"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Delete" />
 

--- a/example/src/main/res/layout/fragment_notifications.xml
+++ b/example/src/main/res/layout/fragment_notifications.xml
@@ -1,57 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="8dp"
-    android:layout_marginBottom="10dp"
+    android:layout_margin="@dimen/activity_start_end_margin"
     android:orientation="vertical"
-    tools:context=".NotificationsFragment">
+    tools:context=".NotificationsFragment"
+    tools:ignore="HardcodedText">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"
         android:text="Perform actions for user:"
-        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
 
     <Button
         android:id="@+id/notifs_fetch_all"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Fetch All Notifications from API"/>
+        android:text="Fetch All Notifications from API" />
 
     <Button
         android:id="@+id/notifs_delete_all"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Delete All Notifications (DB)"/>
+        android:text="Delete All Notifications (DB)" />
 
     <Button
         android:id="@+id/notifs_delete_half"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Delete half of Notifications (DB)"/>
+        android:text="Delete half of Notifications (DB)" />
 
     <Button
         android:id="@+id/notifs_mark_seen"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Mark Notifications Seen"/>
+        android:text="Mark Notifications Seen" />
 
     <Button
         android:id="@+id/notifs_by_type_subtype"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Get Notifications by type or subtype (db)"/>
+        android:text="Get Notifications by type or subtype (db)" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"
         android:text="Perform actions on a selected site:"
-        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -60,66 +59,68 @@
 
         <Button
             android:id="@+id/notifs_select_site"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Select Site"/>
+            android:layout_weight="1"
+            android:paddingEnd="@dimen/activity_start_end_half_margin"
+            android:text="Select Site" />
 
         <TextView
             android:id="@+id/notif_selected_site"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:paddingLeft="10dp"
-            android:paddingStart="10dp"
+            android:layout_weight="1"
+            android:paddingStart="@dimen/activity_start_end_half_margin"
             android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-            android:textColor="@android:color/holo_blue_bright"/>
+            android:textColor="@android:color/holo_blue_bright" />
     </LinearLayout>
 
     <Button
         android:id="@+id/notifs_fetch_for_site"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
-        android:text="Get Notifications (db)"/>
+        android:text="Get Notifications (db)" />
 
     <Button
         android:id="@+id/notifs_mark_all_read"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
-        android:text="Mark all unread notifications as read"/>
+        android:text="Mark all unread notifications as read" />
 
     <Button
         android:id="@+id/notifs_has_unread"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
-        android:text="Check unread Notifications (db)"/>
+        android:text="Check unread Notifications (db)" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"
         android:text="Actions on the first notification for the selected site:"
-        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
+        android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
 
     <Button
         android:id="@+id/notifs_fetch_first"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
-        android:text="Fetch Notification From API"/>
+        android:text="Fetch Notification From API" />
 
     <Button
         android:id="@+id/notifs_mark_read"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
-        android:text="Mark Read"/>
+        android:text="Mark Read" />
 
     <Button
         android:id="@+id/notifs_update_first"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
-        android:text="Update Notification (DB)"/>
+        android:text="Update Notification (DB)" />
 </LinearLayout>

--- a/example/src/main/res/layout/fragment_posts.xml
+++ b/example/src/main/res/layout/fragment_posts.xml
@@ -3,6 +3,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
+    tools:ignore="HardcodedText"
               tools:context="org.wordpress.android.fluxc.example.PostsFragment">
 
     <Button

--- a/example/src/main/res/layout/fragment_posts.xml
+++ b/example/src/main/res/layout/fragment_posts.xml
@@ -1,26 +1,27 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-    tools:ignore="HardcodedText"
-              tools:context="org.wordpress.android.fluxc.example.PostsFragment">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    android:orientation="vertical"
+    tools:context="org.wordpress.android.fluxc.example.PostsFragment"
+    tools:ignore="HardcodedText">
 
     <Button
         android:id="@+id/fetch_first_site_posts"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch posts from first site" />
 
     <Button
         android:id="@+id/create_new_post_first_site"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Create a new post on first site" />
 
     <Button
         android:id="@+id/delete_a_post_from_first_site"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Delete a post from first site" />
 

--- a/example/src/main/res/layout/fragment_signed_out_actions.xml
+++ b/example/src/main/res/layout/fragment_signed_out_actions.xml
@@ -3,65 +3,67 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
+    tools:ignore="HardcodedText"
+    android:layout_margin="@dimen/activity_start_end_margin"
               tools:context="org.wordpress.android.fluxc.example.CommentsFragment">
 
     <Button
         android:id="@+id/new_account"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Create New Account" />
 
     <Button
         android:id="@+id/magic_link_email"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Send Magic Link E-mail" />
 
     <Button
         android:id="@+id/magic_link_signup"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Send Magic Link Signup E-mail" />
 
     <Button
         android:id="@+id/check_url_wpcom"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Check if URL is WPCom site (or Jetpack)" />
 
     <Button
         android:id="@+id/fetch_wpcom_site"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch WP.com (or Jetpack) Site" />
 
     <Button
         android:id="@+id/domain_suggestions"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Domain suggestions (results differ if authenticated)" />
 
     <Button
         android:id="@+id/connect_site_info"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Connect Site Info" />
 
     <Button
         android:id="@+id/plans_info"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Plans info" />
 
     <Button
         android:id="@+id/whats_new_info"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="What's new info" />
 
     <Button
         android:id="@+id/fetch_auth_options"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch Auth Options" />
 

--- a/example/src/main/res/layout/fragment_sites.xml
+++ b/example/src/main/res/layout/fragment_sites.xml
@@ -1,49 +1,52 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="horizontal"
-              tools:context="org.wordpress.android.fluxc.example.SitesFragment">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    android:orientation="horizontal"
+    tools:context="org.wordpress.android.fluxc.example.SitesFragment"
+    tools:ignore="HardcodedText">
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:layout_weight="1">
+        android:layout_marginEnd="@dimen/activity_start_end_half_margin"
+        android:layout_weight="1"
+        android:orientation="vertical">
 
         <Button
             android:id="@+id/fetch_profile"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Fetch Profile" />
 
         <Button
             android:id="@+id/new_site"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Create New Site" />
 
         <Button
             android:id="@+id/update_first_site"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Fetch first site" />
 
         <Button
             android:id="@+id/update_all_sites"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Fetch all sites" />
 
         <Button
             android:id="@+id/log_sites"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Log Sites" />
 
         <Button
             android:id="@+id/export_first_site"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Export First Site" />
 
@@ -55,19 +58,19 @@
 
         <Button
             android:id="@+id/delete_first_site_db"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Delete First Site (DB Only)"/>
+            android:text="Delete First Site (DB Only)" />
 
         <Button
             android:id="@+id/fetch_plans"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Fetch First Site Plans" />
 
         <Button
             android:id="@+id/fetch_editors"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Fetch First Site Editors" />
 
@@ -76,12 +79,12 @@
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:gravity="right">
+        android:layout_marginStart="@dimen/activity_start_end_half_margin"
+        android:layout_weight="1">
 
         <Button
             android:id="@+id/fetch_xposts"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Fetch XPosts" />
 

--- a/example/src/main/res/layout/fragment_taxonomies.xml
+++ b/example/src/main/res/layout/fragment_taxonomies.xml
@@ -3,23 +3,25 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    tools:ignore="HardcodedText"
               tools:context="org.wordpress.android.fluxc.example.TaxonomiesFragment">
 
     <Button
         android:id="@+id/fetch_categories"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch categories from first site" />
 
     <Button
         android:id="@+id/fetch_tags"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch tags from first site" />
 
     <Button
         android:id="@+id/create_category"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Create new category on first site" />
 

--- a/example/src/main/res/layout/fragment_themes.xml
+++ b/example/src/main/res/layout/fragment_themes.xml
@@ -1,32 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    android:orientation="vertical"
+    tools:ignore="HardcodedText">
 
     <Button
         android:id="@+id/fetch_wpcom_themes"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch WP.com themes" />
 
     <Button
         android:id="@+id/fetch_installed_themes"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch installed themes" />
 
     <Button
         android:id="@+id/fetch_current_theme_jp"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch current theme Jetpack" />
 
     <Button
         android:id="@+id/fetch_current_theme_wpcom"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Fetch current theme WP.com" />
 
@@ -34,29 +36,30 @@
         android:id="@+id/theme_id"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="Enter the theme's id here" />
+        android:hint="Enter the theme's id here"
+        android:inputType="number" />
 
     <Button
         android:id="@+id/activate_theme_wpcom"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Activate theme WP.com" />
 
     <Button
         android:id="@+id/activate_theme_jp"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Activate theme Jetpack" />
 
     <Button
         android:id="@+id/install_theme_jp"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Install WP.com theme on Jetpack site" />
 
     <Button
         android:id="@+id/delete_theme_jp"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Delete theme on Jetpack site" />
 

--- a/example/src/main/res/layout/fragment_uploads.xml
+++ b/example/src/main/res/layout/fragment_uploads.xml
@@ -1,20 +1,21 @@
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
     android:orientation="vertical"
-    tools:context="org.wordpress.android.fluxc.example.MediaFragment">
+    tools:context="org.wordpress.android.fluxc.example.MediaFragment"
+    tools:ignore="HardcodedText">
 
     <Button
         android:id="@+id/upload_media_post"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Upload post with local media" />
 
     <Button
         android:id="@+id/cancel_upload"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
         android:text="Cancel" />

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -36,13 +36,9 @@
                     android:layout_height="wrap_content"
                     android:text="Fetch WC product settings"/>
 
-                <ImageView
+                <View
                     android:id="@+id/divider1"
-                    android:layout_width="match_parent"
-                    android:layout_height="2dp"
-                    android:layout_marginTop="2dp"
-                    android:layout_marginBottom="2dp"
-                    android:background="@color/material_grey_600"/>
+                    style="@style/Divider" />
 
                 <Button
                     android:id="@+id/orders"

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    tools:ignore="HardcodedText"
+    android:layout_margin="@dimen/activity_start_end_margin"
     tools:context="org.wordpress.android.fluxc.example.ui.WooCommerceFragment">
 
         <LinearLayout
@@ -12,25 +14,25 @@
 
                 <Button
                     android:id="@+id/log_sites"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Log Sites"/>
 
                 <Button
                     android:id="@+id/log_woo_api_versions"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Log Woo API versions"/>
 
                 <Button
                     android:id="@+id/fetch_settings"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Fetch WC site settings"/>
 
                 <Button
                     android:id="@+id/fetch_product_settings"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Fetch WC product settings"/>
 
@@ -38,71 +40,73 @@
                     android:id="@+id/divider1"
                     android:layout_width="match_parent"
                     android:layout_height="2dp"
+                    android:layout_marginTop="2dp"
+                    android:layout_marginBottom="2dp"
                     android:background="@color/material_grey_600"/>
 
                 <Button
                     android:id="@+id/orders"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Orders"/>
 
                 <Button
                     android:id="@+id/products"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Products"/>
 
                 <Button
                     android:id="@+id/stats"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Stats"/>
 
                 <Button
                     android:id="@+id/stats_revenue"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Revenue Stats"/>
 
                 <Button
                     android:id="@+id/refunds"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Refunds"/>
 
                 <Button
                     android:id="@+id/gateways"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Gateways"/>
 
                 <Button
                     android:id="@+id/taxes"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Taxes"/>
 
                 <Button
                     android:id="@+id/shipping_labels"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Shipping Labels"/>
 
                 <Button
                     android:id="@+id/leaderboards"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Leadearboards"/>
 
                 <Button
                     android:id="@+id/countries"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Countries"/>
 
                 <Button
                     android:id="@+id/attributes"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Attributes"/>
         </LinearLayout>

--- a/example/src/main/res/values/dimens.xml
+++ b/example/src/main/res/values/dimens.xml
@@ -2,4 +2,6 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="activity_start_end_margin">8dp</dimen>
+    <dimen name="activity_start_end_half_margin">4dp</dimen>
 </resources>

--- a/example/src/main/res/values/styles.xml
+++ b/example/src/main/res/values/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Divider">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">1dp</item>
+        <item name="android:layout_marginTop">4dp</item>
+        <item name="android:layout_marginBottom">4dp</item>
+        <item name="android:background">@color/material_grey_600</item>
+    </style>
+</resources>

--- a/example/src/main/res/values/styles.xml
+++ b/example/src/main/res/values/styles.xml
@@ -4,8 +4,8 @@
     <style name="Divider">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">1dp</item>
-        <item name="android:layout_marginTop">4dp</item>
-        <item name="android:layout_marginBottom">4dp</item>
+        <item name="android:layout_marginTop">6dp</item>
+        <item name="android:layout_marginBottom">6dp</item>
         <item name="android:background">@color/material_grey_600</item>
     </style>
 </resources>


### PR DESCRIPTION
This is a first pass at cleaning up the example app, as per #1919. There are a ton of screens to tackle, but this first simply tackles the main fragment and the initial fragments launched from the main one. So: 

* Main
* Account
* Sites
* Comments
* Media
* Taxonomies
* Uploads
* Themes
* Woo
* Notifications
* Editor theme
* Experiments

A few before-and-after examples:

![woo](https://user-images.githubusercontent.com/3903757/110541297-8d3f2280-80f5-11eb-893a-0ada256f4d55.png)

![example](https://user-images.githubusercontent.com/3903757/110541301-8dd7b900-80f5-11eb-943e-764622766d63.png)

![sites](https://user-images.githubusercontent.com/3903757/110541291-8ca68c00-80f5-11eb-9eaf-f1939d1e27a5.png)
