### PR TITLE
Fix first day of week

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -108,6 +108,13 @@ class DateUtilsTest {
         val endDateCalendar3 = DateUtils.getEndDateCalendar(endDate3, Locale.US)
         val quantity3 = DateUtils.getQuantityInWeeks(startDateCalendar3, endDateCalendar3)
         assertEquals(1, quantity3)
+
+        val startDate4 = DateUtils.getDateFromString("2019-01-14")
+        val endDate4 = DateUtils.getDateFromString("2019-01-20")
+        val startDateCalendar4 = DateUtils.getStartDateCalendar(startDate4, Locale.US)
+        val endDateCalendar4 = DateUtils.getEndDateCalendar(endDate4, Locale.US)
+        val quantity4 = DateUtils.getQuantityInWeeks(startDateCalendar4, endDateCalendar4)
+        assertEquals(2, quantity4)
     }
 
     @Test
@@ -132,6 +139,13 @@ class DateUtilsTest {
         val endDateCalendar3 = DateUtils.getEndDateCalendar(endDate3, Locale.FRANCE)
         val quantity3 = DateUtils.getQuantityInWeeks(startDateCalendar3, endDateCalendar3)
         assertEquals(1, quantity3)
+
+        val startDate4 = DateUtils.getDateFromString("2019-01-14")
+        val endDate4 = DateUtils.getDateFromString("2019-01-20")
+        val startDateCalendar4 = DateUtils.getStartDateCalendar(startDate4, Locale.FRANCE)
+        val endDateCalendar4 = DateUtils.getEndDateCalendar(endDate4, Locale.FRANCE)
+        val quantity4 = DateUtils.getQuantityInWeeks(startDateCalendar4, endDateCalendar4)
+        assertEquals(1, quantity4)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -334,4 +334,16 @@ class DateUtilsTest {
             assertEquals(expectedDateString, dateString1)
         }
     }
+
+    @Test
+    fun testGetConstantForLastDayOfWeekUSLocale() {
+        val constant = DateUtils.getConstantForLastDayOfWeek(Calendar.getInstance(Locale.US))
+        assertEquals(Calendar.SATURDAY, constant)
+    }
+
+    @Test
+    fun testGetConstantForLastDayOfWeekFranceLocale() {
+        val constant = DateUtils.getConstantForLastDayOfWeek(Calendar.getInstance(Locale.FRANCE))
+        assertEquals(Calendar.SUNDAY, constant)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -262,39 +262,6 @@ class DateUtilsTest {
     }
 
     @Test
-    fun testGetStartDayOfCurrentWeekForSite() {
-        val site = SiteModel().apply { id = 1 }
-
-        // test get start date for current day
-        for (offset in -20..20) {
-            site.timezone = offset.toString()
-
-            val fieldISO = WeekFields.of(Locale.ROOT).dayOfWeek()
-
-            // Setting a zone id where the start of the week is always Sunday
-            val zoneId = ZoneId.of("America/New_York")
-
-            val expectedDate = LocalDateTime.now(ZoneId.of("UTC"))
-                    // Adds the offset that are being tested
-                    // This is a way to add the offset using LocalDateTime without changing the zone
-                    .plusHours(offset.toLong())
-                    .atZone(zoneId)
-                    .with(fieldISO, 1)
-                    .toLocalDate()
-                    .atStartOfDay()
-                    .atZone(zoneId)
-                    .toInstant()
-
-            val expectedDateString = DateUtils.formatDate(DATE_TIME_FORMAT_START, Date.from(expectedDate))
-            // format the current date to string
-            // get the formatted date string for the site in the format yyyy-MM-ddThh:mm:ss
-            // get the expected start date string for the site in the format yyyy-MM-ddThh:mm:ss
-            val dateString1 = DateUtils.getFirstDayOfCurrentWeekBySite(site)
-            assertEquals(expectedDateString, dateString1)
-        }
-    }
-
-    @Test
     fun testGetStartDayOfCurrentMonthForSite() {
         val site = SiteModel().apply { id = 1 }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -6,9 +6,7 @@ import org.wordpress.android.fluxc.utils.DateUtils
 import org.wordpress.android.fluxc.utils.SiteUtils
 import java.text.SimpleDateFormat
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.ZoneId
-import java.time.temporal.WeekFields
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -111,6 +111,30 @@ class DateUtilsTest {
     }
 
     @Test
+    fun testGetQuantityInWeeksFranceLocale() {
+        val startDate = DateUtils.getDateFromString("2019-01-13")
+        val endDate = DateUtils.getDateFromString("2019-01-20")
+        val startDateCalendar = DateUtils.getStartDateCalendar(startDate, Locale.FRANCE)
+        val endDateCalendar = DateUtils.getEndDateCalendar(endDate, Locale.FRANCE)
+        val quantity = DateUtils.getQuantityInWeeks(startDateCalendar, endDateCalendar)
+        assertEquals(2, quantity)
+
+        val startDate2 = DateUtils.getDateFromString("2018-12-01")
+        val endDate2 = DateUtils.getDateFromString("2018-12-31")
+        val startDateCalendar2 = DateUtils.getStartDateCalendar(startDate2, Locale.FRANCE)
+        val endDateCalendar2 = DateUtils.getEndDateCalendar(endDate2, Locale.FRANCE)
+        val quantity2 = DateUtils.getQuantityInWeeks(startDateCalendar2, endDateCalendar2)
+        assertEquals(6, quantity2)
+
+        val startDate3 = DateUtils.getDateFromString("2018-10-22")
+        val endDate3 = DateUtils.getDateFromString("2018-10-22")
+        val startDateCalendar3 = DateUtils.getStartDateCalendar(startDate3, Locale.FRANCE)
+        val endDateCalendar3 = DateUtils.getEndDateCalendar(endDate3, Locale.FRANCE)
+        val quantity3 = DateUtils.getQuantityInWeeks(startDateCalendar3, endDateCalendar3)
+        assertEquals(1, quantity3)
+    }
+
+    @Test
     fun testGetQuantityInMonths() {
         val startDate = DateUtils.getDateFromString("2018-12-13")
         val endDate = DateUtils.getDateFromString("2019-01-20")

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -311,4 +311,100 @@ class DateUtilsTest {
         val constant = DateUtils.getConstantForLastDayOfWeek(Calendar.getInstance(Locale.FRANCE))
         assertEquals(Calendar.SUNDAY, constant)
     }
+
+    @Test
+    fun testGetFirstDayOfWeekForWednesdayUSLocale() {
+        val cal = Calendar.getInstance(Locale.US)
+        // 2021-03-08 00:00:00 Monday
+        cal.time = Date(1615183200000)
+
+        val result = DateUtils.getFirstDayOfCurrentWeek(cal)
+
+        // Monday
+        assertEquals("2021-03-07", result)
+    }
+
+    @Test
+    fun testGetFirstDayOfWeekForSundayUSLocale() {
+        val cal = Calendar.getInstance(Locale.US)
+        // 2021-03-07 00:00:00 Sunday
+        cal.time = Date(1615096800000)
+
+        val result = DateUtils.getFirstDayOfCurrentWeek(cal)
+
+        // Monday
+        assertEquals("2021-03-07", result)
+    }
+
+    @Test
+    fun testGetFirstDayOfWeekForSaturdayUSLocale() {
+        val cal = Calendar.getInstance(Locale.US)
+        // 2021-03-13 00:00:00 Saturday
+        cal.time = Date(1615615200000)
+
+        val result = DateUtils.getFirstDayOfCurrentWeek(cal)
+
+        // Monday
+        assertEquals("2021-03-07", result)
+    }
+
+    @Test
+    fun testGetFirstDayOfWeekAcrossMonthsUSLocale() {
+        val cal = Calendar.getInstance(Locale.US)
+        // 2021-04-01 00:00:00 Thursday April
+        cal.time = Date(1617256800000)
+
+        val result = DateUtils.getFirstDayOfCurrentWeek(cal)
+
+        // Monday March
+        assertEquals("2021-03-28", result)
+    }
+
+    @Test
+    fun testGetFirstDayOfWeekForWednesdayFranceLocale() {
+        val cal = Calendar.getInstance(Locale.FRANCE)
+        // 2021-03-08 00:00:00 Monday
+        cal.time = Date(1615183200000)
+
+        val result = DateUtils.getFirstDayOfCurrentWeek(cal)
+
+        // Monday
+        assertEquals("2021-03-08", result)
+    }
+
+    @Test
+    fun testGetFirstDayOfWeekForSundayFranceLocale() {
+        val cal = Calendar.getInstance(Locale.FRANCE)
+        // 2021-03-07 00:00:00 Sunday
+        cal.time = Date(1615096800000)
+
+        val result = DateUtils.getFirstDayOfCurrentWeek(cal)
+
+        // Monday
+        assertEquals("2021-03-01", result)
+    }
+
+    @Test
+    fun testGetFirstDayOfWeekForSaturdayFranceLocale() {
+        val cal = Calendar.getInstance(Locale.FRANCE)
+        // 2021-03-13 00:00:00 Saturday
+        cal.time = Date(1615615200000)
+
+        val result = DateUtils.getFirstDayOfCurrentWeek(cal)
+
+        // Monday
+        assertEquals("2021-03-08", result)
+    }
+
+    @Test
+    fun testGetFirstDayOfWeekAcrossMonthsFranceLocale() {
+        val cal = Calendar.getInstance(Locale.FRANCE)
+        // 2021-04-01 00:00:00 Thursday April
+        cal.time = Date(1617256800000)
+
+        val result = DateUtils.getFirstDayOfCurrentWeek(cal)
+
+        // Monday March
+        assertEquals("2021-03-29", result)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/DateUtilsTest.kt
@@ -87,25 +87,25 @@ class DateUtilsTest {
     }
 
     @Test
-    fun testGetQuantityInWeeks() {
+    fun testGetQuantityInWeeksUSLocale() {
         val startDate = DateUtils.getDateFromString("2019-01-13")
         val endDate = DateUtils.getDateFromString("2019-01-20")
-        val startDateCalendar = DateUtils.getStartDateCalendar(startDate)
-        val endDateCalendar = DateUtils.getEndDateCalendar(endDate)
+        val startDateCalendar = DateUtils.getStartDateCalendar(startDate, Locale.US)
+        val endDateCalendar = DateUtils.getEndDateCalendar(endDate, Locale.US)
         val quantity = DateUtils.getQuantityInWeeks(startDateCalendar, endDateCalendar)
         assertEquals(2, quantity)
 
         val startDate2 = DateUtils.getDateFromString("2018-12-01")
         val endDate2 = DateUtils.getDateFromString("2018-12-31")
-        val startDateCalendar2 = DateUtils.getStartDateCalendar(startDate2)
-        val endDateCalendar2 = DateUtils.getEndDateCalendar(endDate2)
+        val startDateCalendar2 = DateUtils.getStartDateCalendar(startDate2, Locale.US)
+        val endDateCalendar2 = DateUtils.getEndDateCalendar(endDate2, Locale.US)
         val quantity2 = DateUtils.getQuantityInWeeks(startDateCalendar2, endDateCalendar2)
         assertEquals(6, quantity2)
 
         val startDate3 = DateUtils.getDateFromString("2018-10-22")
         val endDate3 = DateUtils.getDateFromString("2018-10-22")
-        val startDateCalendar3 = DateUtils.getStartDateCalendar(startDate3)
-        val endDateCalendar3 = DateUtils.getEndDateCalendar(endDate3)
+        val startDateCalendar3 = DateUtils.getStartDateCalendar(startDate3, Locale.US)
+        val endDateCalendar3 = DateUtils.getEndDateCalendar(endDate3, Locale.US)
         val quantity3 = DateUtils.getQuantityInWeeks(startDateCalendar3, endDateCalendar3)
         assertEquals(1, quantity3)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.utils.PreferenceUtils
 import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -487,7 +488,7 @@ class WCStatsStore @Inject constructor(
         val apiUnit = OrderStatsApiUnit.convertToVisitorsStatsApiUnit(payload.granularity)
         val startDate = payload.startDate ?: when (payload.granularity) {
             StatsGranularity.DAYS -> DateUtils.getStartOfCurrentDay()
-            StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeek()
+            StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeek(Calendar.getInstance(Locale.getDefault()))
             StatsGranularity.MONTHS -> DateUtils.getFirstDayOfCurrentMonth()
             StatsGranularity.YEARS -> DateUtils.getFirstDayOfCurrentYear()
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -275,9 +275,9 @@ object DateUtils {
         return formatDate(DATE_FORMAT_DEFAULT, cal.time)
     }
 
-    fun getFirstDayOfCurrentWeek(): String {
-        val cal = Calendar.getInstance(Locale.ROOT)
-        cal.set(Calendar.DAY_OF_WEEK, cal.getActualMinimum(Calendar.DAY_OF_WEEK))
+    fun getFirstDayOfCurrentWeek(locale: Locale = Locale.getDefault()): String {
+        val cal = Calendar.getInstance(locale)
+        cal.set(Calendar.DAY_OF_WEEK, cal.firstDayOfWeek)
         return formatDate(DATE_FORMAT_DEFAULT, cal.time)
     }
 
@@ -293,10 +293,10 @@ object DateUtils {
         return formatDate(DATE_FORMAT_DEFAULT, cal.time)
     }
 
-    fun getFirstDayOfCurrentWeekBySite(site: SiteModel): String {
-        val cal = Calendar.getInstance(Locale.ROOT)
+    fun getFirstDayOfCurrentWeekBySite(site: SiteModel, locale: Locale = Locale.getDefault()): String {
+        val cal = Calendar.getInstance(locale)
         cal.time = getCurrentDateFromSite(site)
-        cal.set(Calendar.DAY_OF_WEEK, cal.getActualMinimum(Calendar.DAY_OF_WEEK))
+        cal.set(Calendar.DAY_OF_WEEK, cal.firstDayOfWeek)
         return formatDate(DATE_TIME_FORMAT_START, cal.time)
     }
 
@@ -314,10 +314,10 @@ object DateUtils {
         return formatDate(DATE_TIME_FORMAT_START, cal.time)
     }
 
-    fun getLastDayOfCurrentWeekForSite(site: SiteModel): String {
-        val cal = Calendar.getInstance(Locale.ROOT)
+    fun getLastDayOfCurrentWeekForSite(site: SiteModel, locale: Locale = Locale.getDefault()): String {
+        val cal = Calendar.getInstance(locale)
         cal.time = getCurrentDateFromSite(site)
-        cal.set(Calendar.DAY_OF_WEEK, cal.getActualMaximum(Calendar.DAY_OF_WEEK))
+        cal.set(Calendar.DAY_OF_WEEK, getConstantForLastDayOfWeek(cal))
         return formatDate(DATE_TIME_FORMAT_END, cal.time)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -275,8 +275,7 @@ object DateUtils {
         return formatDate(DATE_FORMAT_DEFAULT, cal.time)
     }
 
-    fun getFirstDayOfCurrentWeek(locale: Locale = Locale.getDefault()): String {
-        val cal = Calendar.getInstance(locale)
+    fun getFirstDayOfCurrentWeek(cal: Calendar): String {
         cal.set(Calendar.DAY_OF_WEEK, cal.firstDayOfWeek)
         return formatDate(DATE_FORMAT_DEFAULT, cal.time)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -76,8 +76,8 @@ object DateUtils {
      * The start date time is set to 00:00:00
      *
      */
-    fun getStartDateCalendar(startDate: Date): Calendar {
-        val cal1 = Calendar.getInstance()
+    fun getStartDateCalendar(startDate: Date, locale: Locale = Locale.getDefault()): Calendar {
+        val cal1 = Calendar.getInstance(locale)
         cal1.time = startDate
         cal1.set(Calendar.HOUR_OF_DAY, 0)
         cal1.set(Calendar.MINUTE, 0)
@@ -94,8 +94,8 @@ object DateUtils {
      * The end date time is set to 23:59:59
      *
      */
-    fun getEndDateCalendar(endDate: Date): Calendar {
-        val cal2 = Calendar.getInstance()
+    fun getEndDateCalendar(endDate: Date, locale: Locale = Locale.getDefault()): Calendar {
+        val cal2 = Calendar.getInstance(locale)
         cal2.time = endDate
         cal2.set(Calendar.HOUR_OF_DAY, 23)
         cal2.set(Calendar.MINUTE, 59)
@@ -137,10 +137,10 @@ object DateUtils {
          *
          * */
         if (startDateCalendar.get(Calendar.DAY_OF_WEEK) > 1) {
-            startDateCalendar.set(Calendar.DAY_OF_WEEK, 1)
+            startDateCalendar.set(Calendar.DAY_OF_WEEK, startDateCalendar.firstDayOfWeek)
         }
         if (endDateCalendar.get(Calendar.DAY_OF_WEEK) < 1) {
-            endDateCalendar.set(Calendar.DAY_OF_WEEK, 7)
+            endDateCalendar.set(Calendar.DAY_OF_WEEK, getConstantForLastDayOfWeek(endDateCalendar))
         }
 
         val diffInDays = getQuantityInDays(startDateCalendar, endDateCalendar).toDouble()
@@ -333,6 +333,18 @@ object DateUtils {
         cal.time = getCurrentDateFromSite(site)
         cal.set(Calendar.DAY_OF_YEAR, cal.getActualMaximum(Calendar.DAY_OF_YEAR))
         return formatDate(DATE_TIME_FORMAT_END, cal.time)
+    }
+
+    /**
+     * Returns (#Calendar.DAY_OF_WEEK) constant for last day of week.
+     */
+    fun getConstantForLastDayOfWeek(calendar: Calendar): Int {
+        val lastDay = calendar.firstDayOfWeek + 6
+        return if (lastDay > 7) {
+            lastDay % 8 + 1
+        } else {
+            lastDay
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-android/issues/3472

Note - I recommend reviewing this PR by commits.

DateUtils class is a bit tricky to use, since AFAICT it doesn't take into account user's Locale (or timezone) in most methods. 

This PR is trying to fix getter for first/last day of week. FirstDayOfWeek is dependant on Locale - eg. in US a week starts with Sunday but in France with Monday. 

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/90557ea25977c6311f41fb2360e0681295d98e4e - Adds Locale as parameter so we can provide Locale from tests. Fixes "getQuantityInWeeks" so it takes into account locale dependant firstDayOfWeek.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/23134262d1c8ad657db91fb1566da7bd2deb90cb - Add tests for the previous commit.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/be0f34cf647e0a1f0ac2a327d0e6074acb345e39 - Add a test for one more edge case.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/2e86b824f73453dfc87415a20117cbb07d267821 - add tests for getConstantForLastDayOfWeek(..) introduced in the first commit.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/3bedec22f391d8cf81f6a99dd43460484effaf1f - Removes non-deterministic test which relies on VM's settings. This test never passed on my machine but it passes on CI. It doesn't feel like unit test and it's dependant on local environment. I wasn't able to easily come up with a fix, so I decided to replace it with simpler tests in https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/4b5875bb61375e772e6ee52b9b96bab41361506a.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/8d8ced271bcdd8fde1d982d3bfb58804edc81c1a - Makes getFirstDayOfWeek and getLastDayOfWeek methods Locale aware.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/fe118a57e83ff01b30ee4a7bfaa2fecd2f881c27 - Passes Calendar as parameter to make the methods unit testable. Ideally, we'd refactor this whole class from static (object) singleton into an injectable class. We'd also use injectable dateTimeProvider/calendarProvider instead of using static methods. However, this felt like a huge change and not worth the effort at the moment.


To test:
- Run the tests
- [Test WCAndroid app](https://github.com/woocommerce/woocommerce-android/pull/3706)


