### PR TITLE
Replace isButton with isMobileButton in the Note response

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
@@ -45,7 +45,7 @@ class FormattableContentMapperTest {
                 .getStringFromResourceFile(this.javaClass, "notifications/body-response.json")
         val formattableContent = formattableContentMapper.mapToFormattableContent(notificationBodyResponse)
         assertEquals("This site was created by Author", formattableContent.text)
-        assertTrue(formattableContent.meta!!.isButton == true)
+        assertTrue(formattableContent.meta!!.isMobileButton == true)
         assertEquals(2, formattableContent.ranges!!.size)
         with(formattableContent.ranges!![0]) {
             assertEquals(FormattableRangeType.USER, this.rangeType())

--- a/example/src/test/resources/notifications/body-response.json
+++ b/example/src/test/resources/notifications/body-response.json
@@ -51,7 +51,7 @@
     "titles": {
       "home": "Title"
     },
-    "button": true
+    "is_mobile_button": true
   },
   "type": "user"
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -43,7 +43,7 @@ data class FormattableMeta(
     @SerializedName("ids") val ids: Ids? = null,
     @SerializedName("links") val links: Links? = null,
     @SerializedName("titles") val titles: Titles? = null,
-    @SerializedName("button") val isButton: Boolean? = null
+    @SerializedName("is_mobile_button") val isMobileButton: Boolean? = null
 ) {
     data class Ids(
         @SerializedName("site") val site: Long? = null,


### PR DESCRIPTION
The note response from the API has changed. It should now be sending the `isMobileButton` field