### PR TITLE
Update eventbus to v3.2.0

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     kapt project(':fluxc-processor')
 
     // External libs
-    api 'org.greenrobot:eventbus:3.1.1'
+    api 'org.greenrobot:eventbus:3.2.0'
     api 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.0'
     api 'com.android.volley:volley:1.1.1'


### PR DESCRIPTION
Updates eventBus to v3.2.0

The release notes can be found [here](https://greenrobot.org/release/eventbus-3-2/). There are no breaking changes. The new version should be more performant (measuring the difference is IMO not worth it).

We've verified the v3.2.0 works in the Woo app. As soon as the [new version gets tested in WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/14272), we can safely merge this PR. 



