### PR TITLE
[Woo] Support decimal value in stock quantity property for Simple and Variation Products.

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -241,7 +241,7 @@ class WooUpdateProductFragment : Fragment() {
         product_length.onTextChanged { selectedProductModel?.length = it }
         product_weight.onTextChanged { selectedProductModel?.weight = it }
         product_stock_quantity.onTextChanged { text ->
-            text.toIntOrNull()?.let { selectedProductModel?.stockQuantity = it }
+            text.toDoubleOrNull()?.let { selectedProductModel?.stockQuantity = it }
         }
 
         product_sold_individually.setOnCheckedChangeListener { _, isChecked ->

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateVariationFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateVariationFragment.kt
@@ -123,7 +123,7 @@ class WooUpdateVariationFragment : Fragment() {
         product_length.onTextChanged { selectedVariationModel?.length = it }
         product_weight.onTextChanged { selectedVariationModel?.weight = it }
         product_stock_quantity.onTextChanged {
-            if (it.isNotEmpty()) { selectedVariationModel?.stockQuantity = it.toInt() }
+            if (it.isNotEmpty()) { selectedVariationModel?.stockQuantity = it.toDouble() }
         }
 
         product_manage_stock.setOnCheckedChangeListener { _, isChecked ->

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -84,6 +84,37 @@ class ProductSqlUtilsTest {
     }
 
     @Test
+    fun testInsertOrUpdateProductWithDecimalQuantity() {
+        val productModel = ProductTestUtils.generateSampleProduct(
+                remoteId = 42,
+                stockQuantity = 4.2
+        )
+        val site = SiteModel().apply { id = productModel.localSiteId }
+
+        // Test inserting product
+        ProductSqlUtils.insertOrUpdateProduct(productModel)
+        val storedProductsCount = ProductSqlUtils.getProductCountForSite(site)
+        assertEquals(1, storedProductsCount)
+
+        // Test updating product
+        val storedProduct = ProductSqlUtils.getProductByRemoteId(site, productModel.remoteProductId)
+        storedProduct?.apply {
+            stockQuantity = 4.0
+        }
+        storedProduct?.also {
+            ProductSqlUtils.insertOrUpdateProduct(it)
+        }
+
+        val updatedProductsCount = ProductSqlUtils.getProductCountForSite(site)
+        assertEquals(1, updatedProductsCount)
+
+        val updatedProduct = ProductSqlUtils.getProductByRemoteId(site, productModel.remoteProductId)
+        assertEquals(storedProduct?.id, updatedProduct?.id)
+        assertEquals(storedProduct?.name, updatedProduct?.name)
+        assertEquals(storedProduct?.virtual, updatedProduct?.virtual)
+    }
+
+    @Test
     fun testInsertOrUpdateProducts() {
         val site = SiteModel().apply { id = 2 }
         val products = ArrayList<WCProductModel>().apply {

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -21,7 +21,8 @@ object ProductTestUtils {
         virtual: Boolean = false,
         siteId: Int = 6,
         stockStatus: String = CoreProductStockStatus.IN_STOCK.value,
-        status: String = "publish"
+        status: String = "publish",
+        stockQuantity: Double = 0.0
     ): WCProductModel {
         return WCProductModel().apply {
             remoteProductId = remoteId
@@ -31,6 +32,7 @@ object ProductTestUtils {
             this.virtual = virtual
             this.stockStatus = stockStatus
             this.status = status
+            this.stockQuantity = stockQuantity
         }
     }
 
@@ -38,13 +40,15 @@ object ProductTestUtils {
         remoteId: Long,
         variationId: Long,
         siteId: Int = 6,
-        status: String = "publish"
+        status: String = "publish",
+        stockQuantity: Double = 0.0
     ): WCProductVariationModel {
         return WCProductVariationModel().apply {
             remoteProductId = remoteId
             remoteVariationId = variationId
             localSiteId = siteId
             this.status = status
+            this.stockQuantity = stockQuantity
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 140
+        return 141
     }
 
     override fun getDbName(): String {
@@ -1531,6 +1531,73 @@ open class WellSqlConfig : DefaultWellConfig {
                             " NOT NULL,SHIPPING_FIRST_NAME TEXT NOT NULL,SHIPPING_LAST_NAME TEXT NOT NULL," +
                             "SHIPPING_POSTCODE TEXT NOT NULL,SHIPPING_STATE TEXT NOT NULL,_id INTEGER" +
                             " PRIMARY KEY AUTOINCREMENT)")
+                }
+                140 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCProductModel")
+                    db.execSQL("CREATE TABLE WCProductModel (_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "LOCAL_SITE_ID INTEGER," +
+                            "REMOTE_PRODUCT_ID INTEGER," +
+                            "NAME TEXT NOT NULL," +
+                            "SLUG TEXT NOT NULL," +
+                            "PERMALINK TEXT NOT NULL," +
+                            "DATE_CREATED TEXT NOT NULL," +
+                            "DATE_MODIFIED TEXT NOT NULL," +
+                            "TYPE TEXT NOT NULL," +
+                            "STATUS TEXT NOT NULL," +
+                            "FEATURED INTEGER," +
+                            "CATALOG_VISIBILITY TEXT NOT NULL," +
+                            "DESCRIPTION TEXT NOT NULL," +
+                            "SHORT_DESCRIPTION TEXT NOT NULL," +
+                            "SKU TEXT NOT NULL," +
+                            "PRICE TEXT NOT NULL," +
+                            "REGULAR_PRICE TEXT NOT NULL," +
+                            "SALE_PRICE TEXT NOT NULL," +
+                            "ON_SALE INTEGER," +
+                            "TOTAL_SALES INTEGER," +
+                            "DATE_ON_SALE_FROM TEXT NOT NULL," +
+                            "DATE_ON_SALE_TO TEXT NOT NULL," +
+                            "DATE_ON_SALE_FROM_GMT TEXT NOT NULL," +
+                            "DATE_ON_SALE_TO_GMT TEXT NOT NULL," +
+                            "VIRTUAL INTEGER," +
+                            "DOWNLOADABLE INTEGER," +
+                            "DOWNLOAD_LIMIT INTEGER," +
+                            "DOWNLOAD_EXPIRY INTEGER," +
+                            "SOLD_INDIVIDUALLY INTEGER," +
+                            "EXTERNAL_URL TEXT NOT NULL," +
+                            "BUTTON_TEXT TEXT NOT NULL," +
+                            "TAX_STATUS TEXT NOT NULL," +
+                            "TAX_CLASS TEXT NOT NULL," +
+                            "MANAGE_STOCK INTEGER," +
+                            "STOCK_QUANTITY REAL," +
+                            "STOCK_STATUS TEXT NOT NULL," +
+                            "BACKORDERS TEXT NOT NULL," +
+                            "BACKORDERS_ALLOWED INTEGER," +
+                            "BACKORDERED INTEGER," +
+                            "SHIPPING_REQUIRED INTEGER," +
+                            "SHIPPING_TAXABLE INTEGER," +
+                            "SHIPPING_CLASS TEXT NOT NULL," +
+                            "SHIPPING_CLASS_ID INTEGER," +
+                            "REVIEWS_ALLOWED INTEGER," +
+                            "AVERAGE_RATING TEXT NOT NULL," +
+                            "RATING_COUNT INTEGER," +
+                            "PARENT_ID INTEGER," +
+                            "PURCHASE_NOTE TEXT NOT NULL," +
+                            "MENU_ORDER INTEGER," +
+                            "CATEGORIES TEXT NOT NULL," +
+                            "TAGS TEXT NOT NULL," +
+                            "IMAGES TEXT NOT NULL," +
+                            "ATTRIBUTES TEXT NOT NULL," +
+                            "VARIATIONS TEXT NOT NULL," +
+                            "DOWNLOADS TEXT NOT NULL," +
+                            "RELATED_IDS TEXT NOT NULL," +
+                            "CROSS_SELL_IDS TEXT NOT NULL," +
+                            "UPSELL_IDS TEXT NOT NULL," +
+                            "GROUPED_PRODUCT_IDS TEXT NOT NULL," +
+                            "WEIGHT TEXT NOT NULL," +
+                            "LENGTH TEXT NOT NULL," +
+                            "WIDTH TEXT NOT NULL," +
+                            "HEIGHT TEXT NOT NULL)"
+                    )
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1598,6 +1598,7 @@ open class WellSqlConfig : DefaultWellConfig {
                             "WIDTH TEXT NOT NULL," +
                             "HEIGHT TEXT NOT NULL)"
                     )
+                    db.execSQL("DROP TABLE IF EXISTS WCProductVariationModel")
                     db.execSQL("CREATE TABLE WCProductVariationModel (" +
                             "LOCAL_SITE_ID INTEGER," +
                             "REMOTE_PRODUCT_ID INTEGER," +

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1598,6 +1598,48 @@ open class WellSqlConfig : DefaultWellConfig {
                             "WIDTH TEXT NOT NULL," +
                             "HEIGHT TEXT NOT NULL)"
                     )
+                    db.execSQL("CREATE TABLE WCProductVariationModel (" +
+                            "LOCAL_SITE_ID INTEGER," +
+                            "REMOTE_PRODUCT_ID INTEGER," +
+                            "REMOTE_VARIATION_ID INTEGER," +
+                            "DATE_CREATED TEXT NOT NULL," +
+                            "DATE_MODIFIED TEXT NOT NULL," +
+                            "DESCRIPTION TEXT NOT NULL," +
+                            "PERMALINK TEXT NOT NULL," +
+                            "SKU TEXT NOT NULL," +
+                            "STATUS TEXT NOT NULL," +
+                            "PRICE TEXT NOT NULL," +
+                            "REGULAR_PRICE TEXT NOT NULL," +
+                            "SALE_PRICE TEXT NOT NULL," +
+                            "DATE_ON_SALE_FROM TEXT NOT NULL," +
+                            "DATE_ON_SALE_TO TEXT NOT NULL," +
+                            "DATE_ON_SALE_FROM_GMT TEXT NOT NULL," +
+                            "DATE_ON_SALE_TO_GMT TEXT NOT NULL," +
+                            "ON_SALE INTEGER," +
+                            "PURCHASABLE INTEGER," +
+                            "VIRTUAL INTEGER," +
+                            "DOWNLOADABLE INTEGER," +
+                            "TAX_STATUS TEXT NOT NULL," +
+                            "TAX_CLASS TEXT NOT NULL," +
+                            "DOWNLOAD_LIMIT INTEGER," +
+                            "DOWNLOAD_EXPIRY INTEGER," +
+                            "DOWNLOADS TEXT NOT NULL," +
+                            "BACKORDERS TEXT NOT NULL," +
+                            "BACKORDERS_ALLOWED INTEGER," +
+                            "BACKORDERED INTEGER," +
+                            "SHIPPING_CLASS TEXT NOT NULL," +
+                            "SHIPPING_CLASS_ID INTEGER," +
+                            "MANAGE_STOCK INTEGER," +
+                            "STOCK_QUANTITY REAL," +
+                            "STOCK_STATUS TEXT NOT NULL," +
+                            "IMAGE TEXT NOT NULL," +
+                            "WEIGHT TEXT NOT NULL," +
+                            "LENGTH TEXT NOT NULL," +
+                            "WIDTH TEXT NOT NULL," +
+                            "HEIGHT TEXT NOT NULL," +
+                            "MENU_ORDER INTEGER," +
+                            "ATTRIBUTES TEXT NOT NULL," +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT)")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -65,7 +65,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var taxClass = ""
 
     @Column var manageStock = false
-    @Column var stockQuantity = 0
+    @Column var stockQuantity = 0.0
     @Column var stockStatus = "" // instock, outofstock, onbackorder
 
     @Column var backorders = "" // no, notify, yes

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -63,7 +63,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     @Column var shippingClassId = 0
 
     @Column var manageStock = false
-    @Column var stockQuantity = 0
+    @Column var stockQuantity = 0.0
     @Column var stockStatus = ""
 
     @Column var image = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -42,7 +42,7 @@ class ProductApiResponse : Response {
     var tax_class: String? = null
 
     var manage_stock: String? = null
-    var stock_quantity = 0
+    var stock_quantity = 0.0
     var stock_status: String? = null
 
     var date_on_sale_from: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1166,7 +1166,10 @@ class ProductRestClient(
         // only allowed to change the following params if manageStock is enabled
         if (updatedProductModel.manageStock) {
             if (storedWCProductModel.stockQuantity != updatedProductModel.stockQuantity) {
-                body["stock_quantity"] = updatedProductModel.stockQuantity
+                // Conversion/rounding down because core API only accepts Int value for stock quantity.
+                // On the app side, make sure it only allows whole decimal quantity when updating, so that
+                // there's no undesirable conversion effect.
+                body["stock_quantity"] = updatedProductModel.stockQuantity.toInt()
             }
             if (storedWCProductModel.backorders != updatedProductModel.backorders) {
                 body["backorders"] = updatedProductModel.backorders
@@ -1328,7 +1331,10 @@ class ProductRestClient(
         // only allowed to change the following params if manageStock is enabled
         if (updatedVariationModel.manageStock) {
             if (storedVariationModel.stockQuantity != updatedVariationModel.stockQuantity) {
-                body["stock_quantity"] = updatedVariationModel.stockQuantity
+                // Conversion/rounding down because core API only accepts Int value for stock quantity.
+                // On the app side, make sure it only allows whole decimal quantity when updating, so that
+                // there's no undesirable conversion effect.
+                body["stock_quantity"] = updatedVariationModel.stockQuantity.toInt()
             }
             if (storedVariationModel.backorders != updatedVariationModel.backorders) {
                 body["backorders"] = updatedVariationModel.backorders

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -44,7 +44,7 @@ class ProductVariationApiResponse : Response {
     var download_expiry = 0
 
     var manage_stock = false
-    var stock_quantity = 0
+    var stock_quantity = 0.0
     var stock_status: String? = null
 
     var image: JsonElement? = null


### PR DESCRIPTION
---

### ⚠️ 👋  This PR contains database changes. To avoid complication, this should not be merged until [WooCommerce Android PR #3737](https://github.com/woocommerce/woocommerce-android/pull/3737) is ready as well. 

---


This PR is **part 1 of 3** to [fix this issue](https://github.com/woocommerce/woocommerce-android/issues/3611#issuecomment-805665832).
Required by: woocommerce/woocommerce-android#3737

The overarching goal is to make sure Woo Mobile app can display Simple and Variation products with decimal value in their stock quantity attribute. 

## What this PR does:
1. **[Persistence]** Update models to use Double instead of Int, so decimal values can be stored and displayed on the Woo Mobile side.
2. **[Networking]** Update API responses to use Double instead of Int, so that decimal values from API can be accepted in Woo Mobile.
2. **[Networking]** Because core API does not support decimal values when adding/updating a product, make sure the decimal value in models is converted back to integer before sending to the backend.


## Related tasks to be done in [WooCommerce Android PR 3737](https://github.com/woocommerce/woocommerce-android/pull/3737)
- [ ] The Woo Mobile app has to be adjusted to be able to receive and display decimal values in stock quantity.
- [ ] The Woo Mobile app has to display stock quantity attribute to be read-only, unless it is a rounded decimal (e.g: `10.0`).

---

To test:
1. Run tests in `example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt` and make sure all is OK, especially `testInsertOrUpdateProductWithDecimalQuantity()`
