### PR TITLE
Make attributeList a mutable field instead of a lazy single instance

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -91,9 +91,9 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
 
     private val gson by lazy { Gson() }
 
-    val attributeList by lazy {
-        gson.fromJson(attributes, Array<ProductVariantOption>::class.java)
-    }
+    private val attributeList
+        get() = gson.fromJson(attributes, Array<ProductVariantOption>::class.java)
+
     fun addVariant(newAttribute: ProductVariantOption) =
             mutableListOf<ProductVariantOption>()
                     .apply {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -91,7 +91,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
 
     private val gson by lazy { Gson() }
 
-    private val attributeList
+    val attributeList
         get() = gson.fromJson(attributes, Array<ProductVariantOption>::class.java)
 
     fun addVariant(newAttribute: ProductVariantOption) =


### PR DESCRIPTION
Fix issue #1932 by making the `attributeList` property inside `WCProductVariationModel` a fieldless read-only value instead of a locked single instance.

This issue is currently blocking some scenarios for the Variation Attributes tasks.