### PR TITLE
Shipping Labels: update purchase logic to use the API

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -390,7 +390,7 @@ class WooShippingLabelFragment : Fragment() {
                             rateId = rate.rateId,
                             serviceId = rate.serviceId,
                             carrierId = rate.carrierId,
-                            products = order.getLineItemList().map { it.id!! }
+                            products = order.getLineItemList().map { it.productId!! }
                     )
                     val result = wcShippingLabelStore.purchaseShippingLabels(
                             site,

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -5,7 +5,7 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.AccountSettingsApiResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.PurchaseShippingLabelApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelStatusApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.PrintShippingLabelApiResponse
@@ -104,11 +104,11 @@ object WCShippingLabelTestUtils {
         return Gson().fromJson(json, AccountSettingsApiResponse::class.java)
     }
 
-    fun generateSamplePurchaseShippingLabelsApiResponse(): PurchaseShippingLabelApiResponse {
+    fun generateSamplePurchaseShippingLabelsApiResponse(): ShippingLabelStatusApiResponse {
         val json = UnitTestUtils.getStringFromResourceFile(
                 this.javaClass,
                 "wc/purchase-shipping-labels.json"
         )
-        return Gson().fromJson(json, PurchaseShippingLabelApiResponse::class.java)
+        return Gson().fromJson(json, ShippingLabelStatusApiResponse::class.java)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -5,11 +5,11 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.AccountSettingsApiResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelStatusApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.PrintShippingLabelApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.ShippingRatesApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelStatusApiResponse
 
 object WCShippingLabelTestUtils {
     private fun generateSampleShippingLabel(
@@ -108,6 +108,22 @@ object WCShippingLabelTestUtils {
         val json = UnitTestUtils.getStringFromResourceFile(
                 this.javaClass,
                 "wc/purchase-shipping-labels.json"
+        )
+        return Gson().fromJson(json, ShippingLabelStatusApiResponse::class.java)
+    }
+
+    fun generateSampleShippingLabelsStatusApiResponse(done: Boolean): ShippingLabelStatusApiResponse {
+        val json = UnitTestUtils.getStringFromResourceFile(
+                this.javaClass,
+                "wc/status-shipping-labels-${if (done) 2 else 1}.json"
+        )
+        return Gson().fromJson(json, ShippingLabelStatusApiResponse::class.java)
+    }
+
+    fun generateErrorShippingLabelsStatusApiResponse(): ShippingLabelStatusApiResponse {
+        val json = UnitTestUtils.getStringFromResourceFile(
+                this.javaClass,
+                "wc/status-shipping-labels-error.json"
         )
         return Gson().fromJson(json, ShippingLabelStatusApiResponse::class.java)
     }

--- a/example/src/test/resources/wc/status-shipping-labels-1.json
+++ b/example/src/test/resources/wc/status-shipping-labels-1.json
@@ -7,7 +7,7 @@
       "created": 1589295659638,
       "carrier_id": "usps",
       "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
+      "status": "PURCHASED",
       "package_name": "Small Flat Rate Box",
       "product_names": [
         "Polo",
@@ -25,7 +25,7 @@
       "created": 1589295659638,
       "carrier_id": "usps",
       "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
+      "status": "PURCHASED",
       "package_name": "Small Flat Rate Box",
       "product_names": [
         "Polo",

--- a/example/src/test/resources/wc/status-shipping-labels-2.json
+++ b/example/src/test/resources/wc/status-shipping-labels-2.json
@@ -1,45 +1,13 @@
 {
   "labels": [
     {
-      "label_id": 1,
-      "tracking": "9405500205309038753691",
-      "refundable_amount": 7.65,
-      "created": 1589295659638,
-      "carrier_id": "usps",
-      "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
-      "package_name": "Small Flat Rate Box",
-      "product_names": [
-        "Polo",
-        "T-Shirt"
-      ],
-      "product_ids": [
-        10,
-        11
-      ]
-    },
-    {
-      "label_id": 2,
-      "tracking": "9405500205309038753691",
-      "refundable_amount": 7.65,
-      "created": 1589295659638,
-      "carrier_id": "usps",
-      "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
-      "package_name": "Small Flat Rate Box",
-      "product_names": [
-        "Polo",
-        "T-Shirt"
-      ]
-    },
-    {
       "label_id": 3,
       "tracking": "9405500205309038753691",
       "refundable_amount": 7.65,
       "created": 1589295659638,
       "carrier_id": "usps",
       "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
+      "status": "PURCHASED",
       "package_name": "Small Flat Rate Box",
       "product_names": [
         "Polo",
@@ -57,7 +25,7 @@
       "created": 1589295659638,
       "carrier_id": "usps",
       "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
+      "status": "PURCHASED",
       "package_name": "Small Flat Rate Box",
       "product_names": [
         "Polo",
@@ -75,7 +43,7 @@
       "created": 1589295659638,
       "carrier_id": "usps",
       "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
+      "status": "PURCHASED",
       "package_name": "Small Flat Rate Box",
       "product_names": [
         "Polo",

--- a/example/src/test/resources/wc/status-shipping-labels-error.json
+++ b/example/src/test/resources/wc/status-shipping-labels-error.json
@@ -1,45 +1,14 @@
 {
   "labels": [
     {
-      "label_id": 1,
-      "tracking": "9405500205309038753691",
-      "refundable_amount": 7.65,
-      "created": 1589295659638,
-      "carrier_id": "usps",
-      "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
-      "package_name": "Small Flat Rate Box",
-      "product_names": [
-        "Polo",
-        "T-Shirt"
-      ],
-      "product_ids": [
-        10,
-        11
-      ]
-    },
-    {
-      "label_id": 2,
-      "tracking": "9405500205309038753691",
-      "refundable_amount": 7.65,
-      "created": 1589295659638,
-      "carrier_id": "usps",
-      "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
-      "package_name": "Small Flat Rate Box",
-      "product_names": [
-        "Polo",
-        "T-Shirt"
-      ]
-    },
-    {
       "label_id": 3,
       "tracking": "9405500205309038753691",
       "refundable_amount": 7.65,
       "created": 1589295659638,
       "carrier_id": "usps",
       "service_name": "USPS - Priority Mail",
-      "status": "PURCHASE_IN_PROGRESS",
+      "status": "PURCHASE_ERROR",
+      "error": "Failed",
       "package_name": "Small Flat Rate Box",
       "product_names": [
         "Polo",

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -48,7 +48,7 @@
 /connect/label/print
 /connect/label/<order_id>/
 /connect/label/<order_id>/rates
-/connect/label/<order_id>/<shippingLabelId>/
+/connect/label/<order_id>/<shippingLabels>#String
 /connect/label/<order_id>/<shippingLabelId>/refund
 
 /connect/normalize-address

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -4,7 +4,7 @@ import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.FormData
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.PurchaseShippingLabelApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelStatusApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelApiResponse
 import javax.inject.Inject
 
@@ -38,7 +38,7 @@ class WCShippingLabelMapper
     }
 
     fun map(
-        response: PurchaseShippingLabelApiResponse,
+        response: ShippingLabelStatusApiResponse,
         orderId: Long,
         origin: ShippingLabelAddress,
         destination: ShippingLabelAddress,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/LabelItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/LabelItem.kt
@@ -18,4 +18,10 @@ class LabelItem {
     val rate: BigDecimal? = null
     val currency: String? = null
     val refund: JsonElement? = null
+    val error: String? = null
+
+    companion object {
+        const val STATUS_PURCHASED = "PURCHASED"
+        const val STATUS_ERROR = "PURCHASE_ERROR"
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -277,7 +277,7 @@ constructor(
         labelIds: List<Long>
     ): WooPayload<ShippingLabelStatusApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).shippingLabels(labelIds.joinToString(separator = ",")).pathV1
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
                 this,
                 site,
                 url,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -248,6 +248,7 @@ constructor(
         val url = WOOCOMMERCE.connect.label.order(orderId).pathV1
 
         val params = mapOf(
+                "async" to true,
                 "origin" to origin.toMap(),
                 "destination" to destination.toMap(),
                 "packages" to packagesData.map { it.toMap() }
@@ -273,7 +274,7 @@ constructor(
     suspend fun fetchShippingLabelsStatus(
         site: SiteModel,
         orderId: Long,
-        labelIds: List<Int>
+        labelIds: List<Long>
     ): WooPayload<ShippingLabelStatusApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).shippingLabels(labelIds.joinToString(separator = ",")).pathV1
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -244,7 +244,7 @@ constructor(
         origin: ShippingLabelAddress,
         destination: ShippingLabelAddress,
         packagesData: List<WCShippingLabelPackageData>
-    ): WooPayload<PurchaseShippingLabelApiResponse> {
+    ): WooPayload<ShippingLabelStatusApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).pathV1
 
         val params = mapOf(
@@ -258,7 +258,30 @@ constructor(
                 site,
                 url,
                 params,
-                PurchaseShippingLabelApiResponse::class.java
+                ShippingLabelStatusApiResponse::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
+    suspend fun fetchShippingLabelsStatus(
+        site: SiteModel,
+        orderId: Long,
+        labelIds: List<Int>
+    ): WooPayload<ShippingLabelStatusApiResponse> {
+        val url = WOOCOMMERCE.connect.label.order(orderId).shippingLabels(labelIds.joinToString(separator = ",")).pathV1
+        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
+                this,
+                site,
+                url,
+                emptyMap(),
+                ShippingLabelStatusApiResponse::class.java
         )
         return when (response) {
             is JetpackSuccess -> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelStatusApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelStatusApiResponse.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
 
 import com.google.gson.annotations.SerializedName
 
-data class PurchaseShippingLabelApiResponse(
+data class ShippingLabelStatusApiResponse(
     @SerializedName("success")
     val isSuccess: Boolean = false,
     @SerializedName("labels")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import kotlinx.coroutines.delay
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidAddress
@@ -19,16 +20,22 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPaperSize
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult.ShippingOption
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult.ShippingPackage
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.SERVER_ERROR
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.LabelItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient.GetPackageTypesResponse.FormSchema.PackageOption.PackageDefinition
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelStatusApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.UpdateSettingsApiRequest
 import org.wordpress.android.fluxc.persistence.WCShippingLabelSqlUtils
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.Poller
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -294,13 +301,79 @@ class WCShippingLabelStore @Inject constructor(
             val response = restClient.purchaseShippingLabels(site, orderId, origin, destination, packagesData)
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)
-                response.result?.labels != null && response.result.labels.all { it.status == "PURCHASED" } -> {
-                    val shippingLabels = mapper.map(response.result, orderId, origin, destination, site)
-                    WCShippingLabelSqlUtils.insertOrUpdateShippingLabels(shippingLabels)
-
-                    WooResult(shippingLabels)
+                response.result?.labels != null -> {
+                    delay(2000)
+                    val labelsStatusResponse = pollShippingLabelsForPurchase(
+                            site,
+                            orderId,
+                            response.result.labels.map { it.labelId!! }
+                    )
+                    if (labelsStatusResponse.isError) {
+                        WooResult(labelsStatusResponse.error)
+                    } else {
+                        val shippingLabels = mapper.map(
+                                labelsStatusResponse.result!!,
+                                orderId,
+                                origin,
+                                destination,
+                                site
+                        )
+                        WCShippingLabelSqlUtils.insertOrUpdateShippingLabels(shippingLabels)
+                        WooResult(shippingLabels)
+                    }
                 }
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
+    private suspend fun pollShippingLabelsForPurchase(
+        site: SiteModel,
+        orderId: Long,
+        labelIds: List<Long>
+    ): WooPayload<ShippingLabelStatusApiResponse> {
+        val poller = Poller(delayInMs = 1000, maxRetries = 3)
+        val remainingLabels: MutableList<Long> = labelIds.toMutableList()
+        val doneLabels: MutableList<LabelItem> = mutableListOf()
+
+        val response = poller.poll(
+                request = {
+                    restClient.fetchShippingLabelsStatus(
+                            site,
+                            orderId,
+                            remainingLabels.toList()
+                    )
+                },
+                predicate = { response ->
+                    // Stop the polling if the response has an error after the retries
+                    if (response.isError || response.result!!.labels == null) return@poll true
+                    // Stop the polling if the purchase of one of the labels failed
+                    if (response.result.labels!!.any { it.status == LabelItem.STATUS_ERROR }) return@poll true
+
+                    val purchasedLabels = response.result.labels.filter { it.status == LabelItem.STATUS_PURCHASED }
+                    doneLabels.addAll(purchasedLabels)
+                    remainingLabels.removeAll { labelId ->
+                        purchasedLabels.any { it.labelId == labelId }
+                    }
+                    remainingLabels.isEmpty()
+                }
+        )
+
+        return when {
+            response.isError -> {
+                response
+            }
+            response.result?.labels?.any { it.status == LabelItem.STATUS_ERROR } == true -> {
+                WooPayload(
+                        WooError(
+                                API_ERROR,
+                                SERVER_ERROR,
+                                message = response.result.labels.first { it.status == LabelItem.STATUS_ERROR }.error
+                        )
+                )
+            }
+            else -> {
+                WooPayload(ShippingLabelStatusApiResponse(isSuccess = true, labels = doneLabels))
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/Poller.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/Poller.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 class Poller(private val delayInMs: Long, private val maxRetries: Int) {
     suspend fun <T : WooPayload<*>> poll(
         request: suspend () -> T,
-        predicate: (T) -> Boolean,
+        predicate: (T) -> Boolean
     ): T {
         return pollInternal(request)
                 .filter { predicate.invoke(it) }
@@ -30,7 +30,7 @@ class Poller(private val delayInMs: Long, private val maxRetries: Int) {
     }
 
     private suspend fun <T : WooPayload<*>> pollInternal(
-        request: suspend () -> T,
+        request: suspend () -> T
     ): Flow<T> {
         var retries = 0
         return flow {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/Poller.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/Poller.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.fluxc.utils
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+
+class Poller(private val delayInMs: Long, private val maxRetries: Int) {
+    suspend fun <T : WooPayload<*>> poll(
+        request: suspend () -> T,
+        predicate: (T) -> Boolean,
+    ): T {
+        return pollInternal(request)
+                .filter { predicate.invoke(it) }
+                .first()
+    }
+
+    private suspend fun <T : WooPayload<*>> pollInternal(
+        request: suspend () -> T,
+    ): Flow<T> {
+        var retries = 0
+        return flow {
+            while (retries < maxRetries) {
+                val result = request.invoke()
+                if (result.isError) {
+                    retries++
+                    if (retries == maxRetries) {
+                        emit(result)
+                    }
+                } else {
+                    retries = 0
+                    emit(result)
+                }
+                delay(delayInMs)
+            }
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/Poller.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/Poller.kt
@@ -7,6 +7,18 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 
+/**
+ * A utility class that handles polling, it allows polling a request, with a defined delay between the requests
+ * and automatic retrying on errors, the logic is as follows:
+ * 1. Invoke the request.
+ * 2. If the request fails, retry for the number of times specified by maxRetries after the specified delay
+ * 3. If the request succeeds, check the predicate agains the result
+ * 4. If it's true, then return the result.
+ * 5. If it's false, repeat from 1.
+ *
+ * @param delayInMs: the delay between requests in milliseconds
+ * @param maxRetries: the maximum number of retries when an error occurs
+ */
 class Poller(private val delayInMs: Long, private val maxRetries: Int) {
     suspend fun <T : WooPayload<*>> poll(
         request: suspend () -> T,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/Poller.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/Poller.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
  * and automatic retrying on errors, the logic is as follows:
  * 1. Invoke the request.
  * 2. If the request fails, retry for the number of times specified by maxRetries after the specified delay
- * 3. If the request succeeds, check the predicate agains the result
+ * 3. If the request succeeds, check the predicate against the result
  * 4. If it's true, then return the result.
  * 5. If it's false, repeat from 1.
  *


### PR DESCRIPTION
This implements the changes discussed in this post: p91TBi-4ND-p2, the goal is to use the async flow of the purchase API, and poll the label status endpoint afterwards until the purchase is complete.
It introduces a new class called `Poller` to make reusing the logic easier for other endpoints.

#### Testing
The [change](https://github.com/Automattic/woocommerce-services/pull/2390) to WCShip is not released yet, so you need to use the following steps:
1. Upload the following version of WCShip to your store [woocommerce-services.zip](https://github.com/wordpress-mobile/WordPress-FluxC-Android/files/6210751/woocommerce-services.zip), after releasing 1.25.11 which will contain the change, it will auto update to it.
2. Open the example app.
3. Click on Woo, then "Shipping Labels"
4. Make a SL purchase using the button "purchase shipping label"
5. Confirm that the purchase is done correctly.

And it would be nice too to review the different test cases in the unit tests.
