### PR TITLE
Upgrade Lazysodium to v5.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,11 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
+        mavenCentral {
+            content {
+                includeModule("com.goterl", "lazysodium-android")
+            }
+        }
     }
 
     task checkstyle(type: Checkstyle) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/LogEncrypterTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/LogEncrypterTest.kt
@@ -2,8 +2,8 @@ package org.wordpress.android.fluxc
 
 import android.util.Base64
 import android.util.Base64.DEFAULT
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream
-import com.goterl.lazycode.lazysodium.utils.KeyPair
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.KeyPair
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.example.di;
 import android.content.Context;
 import android.text.TextUtils;
 
-import com.goterl.lazycode.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.exceptions.SodiumException;
 
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLoggingKey;

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -104,8 +104,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
     // Encrypted Logging
-    api "com.goterl.lazycode:lazysodium-android:4.1.0@aar"
-    api "net.java.dev.jna:jna:4.5.1@aar"
+    api "com.goterl:lazysodium-android:5.0.2@aar"
+    api "net.java.dev.jna:jna:5.8.0@aar"
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
-import com.goterl.lazycode.lazysodium.interfaces.Box
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream
-import com.goterl.lazycode.lazysodium.utils.KeyPair
+import com.goterl.lazysodium.interfaces.Box
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.KeyPair
 
 /**
  * A class representing an Encrypted Secret Stream Key.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptionUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptionUtils.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
-import com.goterl.lazycode.lazysodium.LazySodiumAndroid
-import com.goterl.lazycode.lazysodium.SodiumAndroid
+import com.goterl.lazysodium.LazySodiumAndroid
+import com.goterl.lazysodium.SodiumAndroid
 
 /**
  * Convenience helpers for Encrypted Logging

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
@@ -1,9 +1,9 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
 import android.util.Base64
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream.State
-import com.goterl.lazycode.lazysodium.utils.Key
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.interfaces.SecretStream.State
+import com.goterl.lazysodium.utils.Key
 import dagger.Reusable
 import javax.inject.Inject
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/SecretStreamKey.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/SecretStreamKey.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
-import com.goterl.lazycode.lazysodium.interfaces.Box
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream
-import com.goterl.lazycode.lazysodium.utils.Key
+import com.goterl.lazysodium.interfaces.Box
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.Key
 
 /**
  * A class representing an unencrypted Secret Stream Key.

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.instaflux;
 import android.content.Context;
 import android.text.TextUtils;
 
-import com.goterl.lazycode.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.exceptions.SodiumException;
 
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLoggingKey;
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptionUtils;


### PR DESCRIPTION
### Description
Lazysodium (which is one my projects), is out-of-date. Combined with the fact that Bintray/jCenter is [being deprecated](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), version 5 of Lazysodium has fully migrated away from Bintray/jCenter (save for one dependency) so is now ready for consumption by dependant projects such as WordPress. 

### Changes
- As Lazysodium's package ID changed due to Maven Central's more rigorous procedures, I have found and replaced all instances of the package ID being changed.
- I am not sure how WordPress is going to handle the move away from jCenter, so what I have done is solely imported Lazysodium from Maven Central for now.


### Tested
- [x] Ran tests locally
- [ ] Tried to run the connected android tests but they complained of some variables not being found from `BuildConfig`.