### PR TITLE
Pass only non null filters in the fetch sites payload in the connected test

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestJetpack.java
@@ -498,7 +498,9 @@ public class ReleaseStack_SiteTestJetpack extends ReleaseStack_Base {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.SITE_CHANGED;
 
-        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(new FetchSitesPayload(filters)));
+        FetchSitesPayload fetchSitesPayload = filters == null
+                ? new FetchSitesPayload() : new FetchSitesPayload(filters);
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(fetchSitesPayload));
 
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
         assertTrue(mSiteStore.getSitesCount() > 0);


### PR DESCRIPTION
This PR fixes [this failing connected test](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-FluxC-Android/4308/workflows/cb60c8b6-634b-4b04-9574-f30ea6dcba5f/jobs/11428/artifacts). 

@NonNull annotation was added in [this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1936) to `FetchSitesPayload` but `ReleaseStack_SiteTestJetpack` connected test kept passing `null` filters in the `authenticateWPComAndFetchSites` resulting in this failure.

To test: 

Make sure that the mentioned connected test passes.