### PR TITLE
Add System status endpoint client

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedWCNetworkModule.kt
@@ -8,11 +8,13 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -68,4 +70,15 @@ class MockedWCNetworkModule {
         token: AccessToken,
         userAgent: UserAgent
     ) = WooPluginRestClient(dispatcher, wpComBuilder, appContext, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideWooSystemRestClient(
+        appContext: Context,
+        requestBuilder: JetpackTunnelGsonRequestBuilder,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = WooSystemRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -99,9 +99,9 @@ class WooCommerceStoreTest {
     private suspend fun getPlugin(isError: Boolean = false): WooResult<WCPluginModel> {
         val payload = WooPayload(response)
         if (isError) {
-            whenever(restClient.fetchActivePlugins(any())).thenReturn(WooPayload(error))
+            whenever(restClient.fetchInstalledPlugins(any())).thenReturn(WooPayload(error))
         } else {
-            whenever(restClient.fetchActivePlugins(any())).thenReturn(payload)
+            whenever(restClient.fetchInstalledPlugins(any())).thenReturn(payload)
         }
         return wooCommerceStore.fetchWooCommerceServicesPluginInfo(site)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse.ActivePluginModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse.SystemPluginModel
 import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils.WCPluginModel
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -40,8 +40,11 @@ class WooCommerceStoreTest {
 
     private val response = ActivePluginsResponse(
             listOf(
-                    ActivePluginModel("WooCommerce Shipping &amp; Tax", "1.0"),
-                    ActivePluginModel("Other Plugin", "2.0")
+                    SystemPluginModel("WooCommerce Shipping &amp; Tax", "1.0"),
+                    SystemPluginModel("Other Plugin", "2.0")
+            ),
+            listOf(
+                    SystemPluginModel("Inactive", "1.0")
             )
     )
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -19,9 +19,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse.PluginModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse.ActivePluginModel
 import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils.WCPluginModel
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -33,15 +33,15 @@ import kotlin.test.assertEquals
 @RunWith(RobolectricTestRunner::class)
 class WooCommerceStoreTest {
     private val appContext = RuntimeEnvironment.application.applicationContext
-    private val restClient = mock<WooPluginRestClient>()
+    private val restClient = mock<WooSystemRestClient>()
     private val wooCommerceStore = WooCommerceStore(appContext, Dispatcher(), initCoroutineEngine(), restClient, mock())
     private val error = WooError(INVALID_RESPONSE, NETWORK_ERROR, "Invalid site ID")
     private val site = SiteModel().apply { id = 1 }
 
-    private val response = FetchPluginsResponse(
+    private val response = ActivePluginsResponse(
             listOf(
-                    PluginModel("woocommerce-services", "1.0", true, "Woo Services"),
-                    PluginModel("other", "2.0", false, "Other Plugin")
+                    ActivePluginModel("WooCommerce Shipping &amp; Tax", "1.0"),
+                    ActivePluginModel("Other Plugin", "2.0")
             )
     )
 
@@ -96,9 +96,9 @@ class WooCommerceStoreTest {
     private suspend fun getPlugin(isError: Boolean = false): WooResult<WCPluginModel> {
         val payload = WooPayload(response)
         if (isError) {
-            whenever(restClient.fetchInstalledPlugins(any())).thenReturn(WooPayload(error))
+            whenever(restClient.fetchActivePlugins(any())).thenReturn(WooPayload(error))
         } else {
-            whenever(restClient.fetchInstalledPlugins(any())).thenReturn(payload)
+            whenever(restClient.fetchActivePlugins(any())).thenReturn(payload)
         }
         return wooCommerceStore.fetchWooCommerceServicesPluginInfo(site)
     }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -61,3 +61,4 @@
 /leaderboards
 
 /data/countries
+/system_status

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/module/ReleaseWCNetworkModule.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClie
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.ProductAttributeRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.ShippingLabelRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient
 import javax.inject.Named
 import javax.inject.Singleton
@@ -146,6 +147,17 @@ class ReleaseWCNetworkModule {
         token: AccessToken,
         userAgent: UserAgent
     ) = WooPluginRestClient(dispatcher, wpComBuilder, appContext, requestQueue, token, userAgent)
+
+    @Singleton
+    @Provides
+    fun provideWooSystemRestClient(
+        appContext: Context,
+        requestBuilder: JetpackTunnelGsonRequestBuilder,
+        dispatcher: Dispatcher,
+        @Named("regular") requestQueue: RequestQueue,
+        token: AccessToken,
+        userAgent: UserAgent
+    ) = WooSystemRestClient(dispatcher, requestBuilder, appContext, requestQueue, token, userAgent)
 
     @Singleton
     @Provides

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.system
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Singleton
+
+@Singleton
+class WooSystemRestClient
+constructor(
+    dispatcher: Dispatcher,
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
+    appContext: Context?,
+    requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchInstalledPlugins(site: SiteModel): WooPayload<ActivePluginsResponse> {
+        val url = WOOCOMMERCE.system_status.pathV3
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                mapOf("_fields" to "active_plugins"),
+                ActivePluginsResponse::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
+    data class ActivePluginsResponse(val plugins: List<PluginModel>) {
+        data class PluginModel(
+            val name: String,
+            val version: String
+        )
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import javax.inject.Singleton
 
-@Singleton
 class WooSystemRestClient
 constructor(
     dispatcher: Dispatcher,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -5,13 +5,9 @@ import com.android.volley.RequestQueue
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
-import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
@@ -30,7 +26,7 @@ constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    suspend fun fetchInstalledPlugins(site: SiteModel): WooPayload<ActivePluginsResponse> {
+    suspend fun fetchActivePlugins(site: SiteModel): WooPayload<ActivePluginsResponse> {
         val url = WOOCOMMERCE.system_status.pathV3
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
@@ -50,8 +46,10 @@ constructor(
         }
     }
 
-    data class ActivePluginsResponse(val plugins: List<PluginModel>) {
-        data class PluginModel(
+    data class ActivePluginsResponse(
+        @SerializedName("active_plugins") val plugins: List<ActivePluginModel>
+    ) {
+        data class ActivePluginModel(
             val name: String,
             val version: String
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
-import javax.inject.Singleton
 
 class WooSystemRestClient
 constructor(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -33,7 +33,7 @@ constructor(
                 this,
                 site,
                 url,
-                mapOf("_fields" to "active_plugins"),
+                mapOf("_fields" to "active_plugins,inactive_plugins"),
                 ActivePluginsResponse::class.java
         )
         return when (response) {
@@ -47,11 +47,16 @@ constructor(
     }
 
     data class ActivePluginsResponse(
-        @SerializedName("active_plugins") val plugins: List<ActivePluginModel>
+        @SerializedName("active_plugins") private val activePlugins: List<SystemPluginModel>,
+        @SerializedName("inactive_plugins") private val inactivePlugins: List<SystemPluginModel>
     ) {
-        data class ActivePluginModel(
+        val plugins: List<SystemPluginModel>
+            get() = activePlugins.map { it.copy(isActive = true) } + inactivePlugins
+
+        data class SystemPluginModel(
             val name: String,
-            val version: String
+            val version: String,
+            val isActive: Boolean = false
         )
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 
+@Singleton
 class WooSystemRestClient
 constructor(
     dispatcher: Dispatcher,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Singleton
 
 @Singleton
 class WooSystemRestClient

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -24,7 +24,7 @@ constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    suspend fun fetchActivePlugins(site: SiteModel): WooPayload<ActivePluginsResponse> {
+    suspend fun fetchInstalledPlugins(site: SiteModel): WooPayload<ActivePluginsResponse> {
         val url = WOOCOMMERCE.system_status.pathV3
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
@@ -8,6 +8,7 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse.PluginModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse.ActivePluginModel
 
 object WCPluginSqlUtils {
     fun insertOrUpdate(data: List<WCPluginModel>) {
@@ -54,6 +55,14 @@ object WCPluginSqlUtils {
                 active = networkModel.isActive,
                 displayName = networkModel.displayName,
                 slug = networkModel.slug,
+                version = networkModel.version
+        )
+
+        constructor(site: SiteModel, networkModel: ActivePluginModel) : this(
+                localSiteId = site.id,
+                active = true,
+                displayName = networkModel.name,
+                slug = networkModel.name,
                 version = networkModel.version
         )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCPluginSqlUtils.kt
@@ -8,7 +8,7 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient.FetchPluginsResponse.PluginModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse.ActivePluginModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse.SystemPluginModel
 
 object WCPluginSqlUtils {
     fun insertOrUpdate(data: List<WCPluginModel>) {
@@ -58,9 +58,9 @@ object WCPluginSqlUtils {
                 version = networkModel.version
         )
 
-        constructor(site: SiteModel, networkModel: ActivePluginModel) : this(
+        constructor(site: SiteModel, networkModel: SystemPluginModel) : this(
                 localSiteId = site.id,
-                active = true,
+                active = networkModel.isActive,
                 displayName = networkModel.name,
                 slug = networkModel.name,
                 version = networkModel.version

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -163,7 +163,7 @@ open class WooCommerceStore @Inject constructor(
         site: SiteModel
     ): WooResult<WCPluginModel> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchWooCommerceServicesPluginInfo") {
-            val response = systemRestClient.fetchActivePlugins(site)
+            val response = systemRestClient.fetchInstalledPlugins(site)
             return@withDefaultContext when {
                 response.isError -> {
                     WooResult(response.error)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -42,7 +42,6 @@ open class WooCommerceStore @Inject constructor(
     private val appContext: Context,
     dispatcher: Dispatcher,
     private val coroutineEngine: CoroutineEngine,
-    private val pluginRestClient: WooPluginRestClient,
     private val systemRestClient: WooSystemRestClient,
     private val wcCoreRestClient: WooCommerceRestClient
 ) : Store(dispatcher) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.plugins.WooPluginRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils


### PR DESCRIPTION
This PR adds the `wc/v3/system_status` endpoint client and it only requests the list of active plugins on the site. It's an in-place replacement for the `WooPluginRestClient` and it supports the loading of the installed & active plugins for users with the _Store manager_ role (previously, shipping label creation wasn't available to them).

I kept the original client because it contains other information and allows to also load inactive plugins, which could be useful in the future. The system status endpoint doesn't have any `slug` property, so I just used the name instead in the database. 

Since the Store method signatures haven't changed, all that's needed in the Woo app is to update the FluxC version.

**To test:**
1. Log in
2. Tap on the Woo button
3. Tap on the Shipping labels button
4. Select site with WCShip extension
5. Tap on Get shipping plugin info button
6. Verify the correct plugin's information is printed