### PR TITLE
Shipping label creation eligibility

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -462,7 +462,7 @@ class WooShippingLabelFragment : Fragment() {
                         val label = it.first()
                         prependToLog(
                                 "Purchased a shipping label with the following details:\n" +
-                                        "Order Id: ${label.localOrderId}\n" +
+                                        "Order Id: ${label.remoteOrderId}\n" +
                                         "Products: ${label.productNames}\n" +
                                         "Label Id: ${label.remoteShippingLabelId}\n" +
                                         "Price: ${label.rate}"

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -201,6 +201,61 @@ class WooShippingLabelFragment : Fragment() {
             }
         }
 
+        check_creation_eligibility.setOnClickListener {
+            selectedSite?.let {
+                coroutineScope.launch {
+                    val orderId = showSingleLineDialog(requireActivity(), "Order Id?", isNumeric = true)?.toLong()
+                    if (orderId == null) {
+                        prependToLog("Please enter a valid order id")
+                        return@launch
+                    }
+                    val canCreatePackage = showSingleLineDialog(
+                            requireActivity(),
+                            "Can Create Package? (true or false)"
+                    ).toBoolean()
+                    val canCreatePaymentMethod = showSingleLineDialog(
+                            requireActivity(),
+                            "Can Create Payment Method? (true or false)"
+                    ).toBoolean()
+                    val canCreateCustomsForm = showSingleLineDialog(
+                            requireActivity(),
+                            "Can Create Customs Form? (true or false)"
+                    ).toBoolean()
+
+                    var eligibility = wcShippingLabelStore.isOrderEligibleForShippingLabelCreation(
+                            site = it,
+                            orderId = orderId,
+                            canCreatePackage = canCreatePackage,
+                            canCreatePaymentMethod = canCreatePaymentMethod,
+                            canCreateCustomsForm = canCreateCustomsForm
+                    )
+                    if (eligibility == null) {
+                        prependToLog("Fetching eligibility")
+                        val result = wcShippingLabelStore.fetchShippingLabelCreationEligibility(
+                                site = it,
+                                orderId = orderId,
+                                canCreatePackage = canCreatePackage,
+                                canCreatePaymentMethod = canCreatePaymentMethod,
+                                canCreateCustomsForm = canCreateCustomsForm
+                        )
+                        if (result.isError) {
+                            prependToLog("${result.error.type}: ${result.error.message}")
+                            return@launch
+                        }
+                        eligibility = result.model!!
+                    }
+
+                    prependToLog(
+                            "The order is ${if (!eligibility.isEligible) "not " else ""}eligible " +
+                                    "for Shipping Labels Creation"
+                    )
+                    if (!eligibility.isEligible) {
+                        prependToLog("Reason for non eligibility: ${eligibility.reason}")
+                    }
+                }
+            }
+        }
+
         verify_address.setOnClickListener {
             selectedSite?.let { site ->
                 replaceFragment(WooVerifyAddressFragment.newInstance(site))

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -64,6 +64,13 @@
             android:text="Print Shipping Label" />
 
         <Button
+            android:id="@+id/check_creation_eligibility"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Check Label Creation Eligibility" />
+
+        <Button
             android:id="@+id/verify_address"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelSqlUtilsTest.kt
@@ -54,7 +54,7 @@ class WCShippingLabelSqlUtilsTest {
         var savedShippingLabels = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
         assertEquals(savedShippingLabels.size, 1)
         assertEquals(savedShippingLabels[0].localSiteId, shippingLabel.localSiteId)
-        assertEquals(savedShippingLabels[0].localOrderId, shippingLabel.localOrderId)
+        assertEquals(savedShippingLabels[0].remoteOrderId, shippingLabel.remoteOrderId)
         assertEquals(savedShippingLabels[0].remoteShippingLabelId, shippingLabel.remoteShippingLabelId)
         assertEquals(savedShippingLabels[0].serviceName, shippingLabel.serviceName)
         assertNotNull(savedShippingLabels[0].refund)
@@ -69,7 +69,7 @@ class WCShippingLabelSqlUtilsTest {
         savedShippingLabels = WCShippingLabelSqlUtils.getShippingClassesForOrder(site.id, orderId)
         assertEquals(savedShippingLabels.size, 1)
         assertEquals(savedShippingLabels[0].localSiteId, shippingLabel.localSiteId)
-        assertEquals(savedShippingLabels[0].localOrderId, shippingLabel.localOrderId)
+        assertEquals(savedShippingLabels[0].remoteOrderId, shippingLabel.remoteOrderId)
         assertEquals(savedShippingLabels[0].remoteShippingLabelId, shippingLabel.remoteShippingLabelId)
         assertEquals(savedShippingLabels[0].serviceName, shippingLabel.serviceName)
         assertEquals(savedShippingLabels[0].refund, shippingLabel.refund)
@@ -128,7 +128,7 @@ class WCShippingLabelSqlUtilsTest {
         val savedShippingLabelExists = WCShippingLabelSqlUtils.getShippingLabelById(
                 site.id, orderId, shippingLabelId + 1
         )
-        assertEquals(shippingLabels[0].localOrderId, savedShippingLabelExists?.localOrderId)
+        assertEquals(shippingLabels[0].remoteOrderId, savedShippingLabelExists?.remoteOrderId)
         assertEquals(shippingLabels[0].remoteShippingLabelId, savedShippingLabelExists?.remoteShippingLabelId)
         assertEquals(shippingLabels[0].localSiteId, savedShippingLabelExists?.localSiteId)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -181,7 +181,7 @@ class WCShippingLabelStoreTest {
         val shippingLabelModels = mapper.map(sampleShippingLabelApiResponse!!, site)
 
         assertThat(result.model?.size).isEqualTo(shippingLabelModels.size)
-        assertThat(result.model?.first()?.localOrderId).isEqualTo(shippingLabelModels.first().localOrderId)
+        assertThat(result.model?.first()?.remoteOrderId).isEqualTo(shippingLabelModels.first().remoteOrderId)
         assertThat(result.model?.first()?.localSiteId).isEqualTo(shippingLabelModels.first().localSiteId)
         assertThat(result.model?.first()?.remoteShippingLabelId)
                 .isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
@@ -189,7 +189,6 @@ class WCShippingLabelStoreTest {
         assertThat(result.model?.first()?.packageName).isEqualTo(shippingLabelModels.first().packageName)
         assertThat(result.model?.first()?.refundableAmount).isEqualTo(shippingLabelModels.first().refundableAmount)
         assertThat(result.model?.first()?.rate).isEqualTo(shippingLabelModels.first().rate)
-        assertThat(result.model?.first()?.paperSize).isEqualTo(shippingLabelModels.first().paperSize)
         assertThat(result.model?.first()?.getProductNameList()?.size)
                 .isEqualTo(shippingLabelModels.first().getProductNameList().size)
         assertThat(result.model?.first()?.getProductIdsList()?.size)
@@ -210,7 +209,7 @@ class WCShippingLabelStoreTest {
 
         val shippingLabelModels = mapper.map(sampleShippingLabelApiResponse!!, site)
         assertThat(storedShippingLabelsList.size).isEqualTo(shippingLabelModels.size)
-        assertThat(storedShippingLabelsList.first().localOrderId).isEqualTo(shippingLabelModels.first().localOrderId)
+        assertThat(storedShippingLabelsList.first().remoteOrderId).isEqualTo(shippingLabelModels.first().remoteOrderId)
         assertThat(storedShippingLabelsList.first().localSiteId).isEqualTo(shippingLabelModels.first().localSiteId)
         assertThat(storedShippingLabelsList.first().remoteShippingLabelId)
                 .isEqualTo(shippingLabelModels.first().remoteShippingLabelId)
@@ -219,7 +218,6 @@ class WCShippingLabelStoreTest {
         assertThat(storedShippingLabelsList.first().refundableAmount)
                 .isEqualTo(shippingLabelModels.first().refundableAmount)
         assertThat(storedShippingLabelsList.first().rate).isEqualTo(shippingLabelModels.first().rate)
-        assertThat(storedShippingLabelsList.first().paperSize).isEqualTo(shippingLabelModels.first().paperSize)
         assertNotNull(storedShippingLabelsList.first().refund)
         assertThat(storedShippingLabelsList.first().getProductNameList().size)
                 .isEqualTo(shippingLabelModels.first().getProductNameList().size)
@@ -463,7 +461,7 @@ class WCShippingLabelStoreTest {
                         .map { it.labelId!! })
 
         assertThat(result.model!!.size).isEqualTo(shippingLabelModels.size)
-        assertThat(result.model!!.first().localOrderId).isEqualTo(shippingLabelModels.first().localOrderId)
+        assertThat(result.model!!.first().remoteOrderId).isEqualTo(shippingLabelModels.first().remoteOrderId)
         assertThat(result.model!!.first().localSiteId).isEqualTo(shippingLabelModels.first().localSiteId)
         assertThat(result.model!!.first().remoteShippingLabelId)
                 .isEqualTo(shippingLabelModels.first().remoteShippingLabelId)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelTestUtils.kt
@@ -23,14 +23,13 @@ object WCShippingLabelTestUtils {
         rate: Float = 7.65F,
         refundableAmount: Float = 7.65F,
         currency: String = "USD",
-        paperSize: String = "label",
         refund: String? = null,
         productNames: String = "[Woo T-shirt, Herman Chair]",
         productIds: String = "[60, 61, 62]"
     ): WCShippingLabelModel {
         return WCShippingLabelModel().apply {
             localSiteId = siteId
-            localOrderId = orderId
+            remoteOrderId = orderId
             remoteShippingLabelId = remoteId
             this.carrierId = carrierId
             this.serviceName = serviceName
@@ -39,7 +38,6 @@ object WCShippingLabelTestUtils {
             this.rate = rate
             this.refundableAmount = refundableAmount
             this.currency = currency
-            this.paperSize = paperSize
             this.productNames = productNames
             this.productIds = productIds
             refund?.let { this.refund = it }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -52,6 +52,7 @@
 /connect/label/<order_id>/rates
 /connect/label/<order_id>/<shippingLabels>#String
 /connect/label/<order_id>/<shippingLabelId>/refund
+/connect/label/<order_id>/creation_eligibility
 
 /connect/normalize-address
 /connect/packages

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1655,14 +1655,37 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE CommentModel ADD PARENT_ID INTEGER")
                 }
                 143 -> migrate(version) {
-                    db.execSQL("CREATE TABLE WCShippingLabelCreationEligibility (" +
-                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
-                            "LOCAL_SITE_ID INTEGER," +
-                            "REMOTE_ORDER_ID INTEGER," +
-                            "CAN_CREATE_PACKAGE BOOLEAN," +
-                            "CAN_CREATE_PAYMENT_METHOD BOOLEAN," +
-                            "CAN_CREATE_CUSTOMS_FORM BOOLEAN," +
-                            "IS_ELIGIBLE BOOLEAN)")
+                    db.execSQL(
+                            "CREATE TABLE WCShippingLabelCreationEligibility (" +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "REMOTE_ORDER_ID INTEGER," +
+                                    "CAN_CREATE_PACKAGE BOOLEAN," +
+                                    "CAN_CREATE_PAYMENT_METHOD BOOLEAN," +
+                                    "CAN_CREATE_CUSTOMS_FORM BOOLEAN," +
+                                    "IS_ELIGIBLE BOOLEAN)"
+                    )
+                    db.execSQL("DROP TABLE IF EXISTS WCShippingLabelModel")
+                    db.execSQL(
+                            "CREATE TABLE WCShippingLabelModel (" +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "REMOTE_ORDER_ID INTEGER," +
+                                    "REMOTE_SHIPPING_LABEL_ID INTEGER," +
+                                    "CARRIER_ID TEXT NOT NULL," +
+                                    "PRODUCT_NAMES TEXT NULL," +
+                                    "TRACKING_NUMBER TEXT NOT NULL," +
+                                    "SERVICE_NAME TEXT NOT NULL," +
+                                    "STATUS TEXT NOT NULL," +
+                                    "PACKAGE_NAME TEXT NOT NULL," +
+                                    "RATE REAL NOT NULL," +
+                                    "REFUNDABLE_AMOUNT REAL NOT NULL," +
+                                    "CURRENCY TEXT NOT NULL," +
+                                    "FORM_DATA TEXT NOT NULL," +
+                                    "REFUND TEXT NULL," +
+                                    "PRODUCT_IDS TEXT," +
+                                    "DATE_CREATED TEXT)"
+                    )
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1663,7 +1663,8 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "CAN_CREATE_PACKAGE BOOLEAN," +
                                     "CAN_CREATE_PAYMENT_METHOD BOOLEAN," +
                                     "CAN_CREATE_CUSTOMS_FORM BOOLEAN," +
-                                    "IS_ELIGIBLE BOOLEAN)"
+                                    "IS_ELIGIBLE BOOLEAN," +
+                                    "REASON TEXT)"
                     )
                     db.execSQL("DROP TABLE IF EXISTS WCShippingLabelModel")
                     db.execSQL(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 143
+        return 144
     }
 
     override fun getDbName(): String {
@@ -1653,6 +1653,16 @@ open class WellSqlConfig : DefaultWellConfig {
                 142 -> migrate(version) {
                     db.execSQL("ALTER TABLE CommentModel ADD HAS_PARENT BOOLEAN")
                     db.execSQL("ALTER TABLE CommentModel ADD PARENT_ID INTEGER")
+                }
+                143 -> migrate(version) {
+                    db.execSQL("CREATE TABLE WCShippingLabelCreationEligibility (" +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "LOCAL_SITE_ID INTEGER," +
+                            "REMOTE_ORDER_ID INTEGER," +
+                            "CAN_CREATE_PACKAGE BOOLEAN," +
+                            "CAN_CREATE_PAYMENT_METHOD BOOLEAN," +
+                            "CAN_CREATE_CUSTOMS_FORM BOOLEAN," +
+                            "IS_ELIGIBLE BOOLEAN)")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelCreationEligibility.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelCreationEligibility.kt
@@ -18,7 +18,6 @@ class WCShippingLabelCreationEligibility(@PrimaryKey @Column private var id: Int
         set
     @Column var reason: String? = null
 
-
     override fun setId(id: Int) {
         this.id = id
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelCreationEligibility.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelCreationEligibility.kt
@@ -16,6 +16,7 @@ class WCShippingLabelCreationEligibility(@PrimaryKey @Column private var id: Int
     @Column var isEligible = false
         @JvmName("setIsEligible")
         set
+    @Column var reason: String? = null
 
 
     override fun setId(id: Int) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelCreationEligibility.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelCreationEligibility.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+class WCShippingLabelCreationEligibility(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var remoteOrderId = 0L
+    @Column var canCreatePackage = false
+    @Column var canCreatePaymentMethod = false
+    @Column var canCreateCustomsForm = false
+    @Column var isEligible = false
+        @JvmName("setIsEligible")
+        set
+
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    override fun getId(): Int = id
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -27,9 +27,7 @@ class WCShippingLabelMapper
                 refund = labelItem.refund.toString()
                 dateCreated = labelItem.dateCreated?.toString() ?: ""
 
-                localOrderId = response.orderId ?: 0L
-                paperSize = response.paperSize ?: ""
-                storeOptions = response.storeOptions.toString()
+                remoteOrderId = response.orderId ?: 0L
                 formData = response.formData.toString()
 
                 localSiteId = site.id
@@ -61,7 +59,7 @@ class WCShippingLabelMapper
                 refund = labelItem.refund.toString()
                 dateCreated = labelItem.dateCreated?.toString() ?: ""
 
-                localOrderId = orderId
+                remoteOrderId = orderId
                 formData = gson.toJson(FormData(origin = origin, destination = destination))
 
                 localSiteId = site.id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -13,7 +13,7 @@ import java.math.BigDecimal
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var localSiteId = 0
-    @Column var localOrderId = 0L // The local db unique identifier for the parent order object
+    @Column var remoteOrderId = 0L // The remote identifier for the parent order object
     @Column var remoteShippingLabelId = 0L // The unique identifier for this note on the server
     @Column var trackingNumber = ""
     @Column var carrierId = ""
@@ -24,12 +24,10 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     @Column var rate = 0F
     @Column var refundableAmount = 0F
     @Column var currency = ""
-    @Column var paperSize = ""
     @Column var productNames = "" // list of product names the shipping label was purchased for
     @Column var productIds = "" // list of product ids the shipping label was purchased for
 
     @Column var formData = "" // map containing package and product details related to that shipping label
-    @Column var storeOptions = "" // map containing store settings such as currency and dimensions
 
     @Column var refund = "" // map containing refund information for a shipping label
 
@@ -57,14 +55,6 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
      * Returns the product details for the order wrapped in a list of [ProductItem]
      */
     fun getProductItems() = getFormData()?.selectedPackage?.defaultBox?.productItems ?: emptyList()
-
-    /**
-     * Returns the store details such as currency, country and dimensions wrapped in [StoreOptions]
-     */
-    fun getStoreOptionsModel(): StoreOptions? {
-        val responseType = object : TypeToken<StoreOptions>() {}.type
-        return gson.fromJson(storeOptions, responseType) as? StoreOptions
-    }
 
     /**
      * Returns default data related to the order such as the origin address,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/SLCreationEligibilityApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/SLCreationEligibilityApiResponse.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
+
+import com.google.gson.annotations.SerializedName
+
+data class SLCreationEligibilityApiResponse(
+    @SerializedName("is_eligible")
+    val isEligible: Boolean,
+    @SerializedName("reason")
+    val reason: String
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/SLCreationEligibilityApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/SLCreationEligibilityApiResponse.kt
@@ -6,5 +6,5 @@ data class SLCreationEligibilityApiResponse(
     @SerializedName("is_eligible")
     val isEligible: Boolean,
     @SerializedName("reason")
-    val reason: String
+    val reason: String?
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -114,6 +114,36 @@ constructor(
         }
     }
 
+    suspend fun checkShippingLabelCreationEligibility(
+        site: SiteModel,
+        orderId: Long,
+        canCreatePackage: Boolean,
+        canCreatePaymentMethod: Boolean,
+        canCreateCustomsForm: Boolean
+    ): WooPayload<SLCreationEligibilityApiResponse> {
+        val url = WOOCOMMERCE.connect.label.order(orderId).creation_eligibility.pathV1
+        val params = mapOf(
+                "can_create_package" to canCreatePackage.toString(),
+                "can_create_payment_method" to canCreatePaymentMethod.toString(),
+                "can_create_customs_form" to canCreateCustomsForm.toString()
+        )
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                params,
+                SLCreationEligibilityApiResponse::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> {
+                WooPayload(response.data)
+            }
+            is JetpackError -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
     suspend fun verifyAddress(
         site: SiteModel,
         address: ShippingLabelAddress,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
@@ -79,7 +79,7 @@ object WCShippingLabelSqlUtils {
                 .endWhere().execute()
     }
 
-    fun insertOrUpdateSLCreationEligibility(eligibility: WCShippingLabelCreationEligibility) : Int {
+    fun insertOrUpdateSLCreationEligibility(eligibility: WCShippingLabelCreationEligibility): Int {
         val result = WellSql.select(WCShippingLabelCreationEligibility::class.java)
                 .where().beginGroup()
                 .equals(WCShippingLabelCreationEligibilityTable.ID, eligibility.id)
@@ -106,7 +106,7 @@ object WCShippingLabelSqlUtils {
     fun getSLCreationEligibilityForOrder(
         localSiteId: Int,
         orderId: Long
-    ) : WCShippingLabelCreationEligibility? {
+    ): WCShippingLabelCreationEligibility? {
         return WellSql.select(WCShippingLabelCreationEligibility::class.java)
                 .where()
                 .equals(WCShippingLabelCreationEligibilityTable.LOCAL_SITE_ID, localSiteId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
@@ -82,7 +82,7 @@ object WCShippingLabelSqlUtils {
     fun insertOrUpdateSLCreationEligibility(eligibility: WCShippingLabelCreationEligibility) : Int {
         val result = WellSql.select(WCShippingLabelCreationEligibility::class.java)
                 .where().beginGroup()
-                .equals(WCShippingLabelModelTable.ID, eligibility.id)
+                .equals(WCShippingLabelCreationEligibilityTable.ID, eligibility.id)
                 .or()
                 .beginGroup()
                 .equals(WCShippingLabelCreationEligibilityTable.REMOTE_ORDER_ID, eligibility.remoteOrderId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
@@ -14,7 +14,7 @@ object WCShippingLabelSqlUtils {
         return WellSql.select(WCShippingLabelModel::class.java)
                 .where()
                 .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, localSiteId)
-                .equals(WCShippingLabelModelTable.LOCAL_ORDER_ID, orderId)
+                .equals(WCShippingLabelModelTable.REMOTE_ORDER_ID, orderId)
                 .endWhere()
                 .asModel
     }
@@ -27,7 +27,7 @@ object WCShippingLabelSqlUtils {
         return WellSql.select(WCShippingLabelModel::class.java)
                 .where()
                 .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, localSiteId)
-                .equals(WCShippingLabelModelTable.LOCAL_ORDER_ID, orderId)
+                .equals(WCShippingLabelModelTable.REMOTE_ORDER_ID, orderId)
                 .equals(WCShippingLabelModelTable.REMOTE_SHIPPING_LABEL_ID, remoteShippingLabelId)
                 .endWhere()
                 .asModel.firstOrNull()
@@ -46,7 +46,7 @@ object WCShippingLabelSqlUtils {
                 .or()
                 .beginGroup()
                 .equals(WCShippingLabelModelTable.REMOTE_SHIPPING_LABEL_ID, shippingLabel.remoteShippingLabelId)
-                .equals(WCShippingLabelModelTable.LOCAL_ORDER_ID, shippingLabel.localOrderId)
+                .equals(WCShippingLabelModelTable.REMOTE_ORDER_ID, shippingLabel.remoteOrderId)
                 .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, shippingLabel.localSiteId)
                 .endGroup()
                 .endGroup().endWhere()
@@ -67,7 +67,7 @@ object WCShippingLabelSqlUtils {
     fun deleteShippingLabelsForOrder(orderId: Long): Int =
             WellSql.delete(WCShippingLabelModel::class.java)
                     .where()
-                    .equals(WCShippingLabelModelTable.LOCAL_ORDER_ID, orderId)
+                    .equals(WCShippingLabelModelTable.REMOTE_ORDER_ID, orderId)
                     .endWhere().execute()
 
     fun deleteShippingLabelsForSite(localSiteId: Int): Int {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCShippingLabelSqlUtils.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.fluxc.persistence
 
+import com.wellsql.generated.WCShippingLabelCreationEligibilityTable
 import com.wellsql.generated.WCShippingLabelModelTable
 import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelCreationEligibility
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 
 object WCShippingLabelSqlUtils {
@@ -75,5 +77,42 @@ object WCShippingLabelSqlUtils {
                 .or()
                 .equals(WCShippingLabelModelTable.LOCAL_SITE_ID, 0) // Should never happen, but sanity cleanup
                 .endWhere().execute()
+    }
+
+    fun insertOrUpdateSLCreationEligibility(eligibility: WCShippingLabelCreationEligibility) : Int {
+        val result = WellSql.select(WCShippingLabelCreationEligibility::class.java)
+                .where().beginGroup()
+                .equals(WCShippingLabelModelTable.ID, eligibility.id)
+                .or()
+                .beginGroup()
+                .equals(WCShippingLabelCreationEligibilityTable.REMOTE_ORDER_ID, eligibility.remoteOrderId)
+                .equals(WCShippingLabelCreationEligibilityTable.LOCAL_SITE_ID, eligibility.localSiteId)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel
+
+        return if (result.isEmpty()) {
+            // Insert
+            WellSql.insert(eligibility).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            val oldId = result[0].id
+            WellSql.update(WCShippingLabelCreationEligibility::class.java).whereId(oldId)
+                    .put(eligibility, UpdateAllExceptId(WCShippingLabelCreationEligibility::class.java)).execute()
+        }
+    }
+
+    fun getSLCreationEligibilityForOrder(
+        localSiteId: Int,
+        orderId: Long
+    ) : WCShippingLabelCreationEligibility? {
+        return WellSql.select(WCShippingLabelCreationEligibility::class.java)
+                .where()
+                .equals(WCShippingLabelCreationEligibilityTable.LOCAL_SITE_ID, localSiteId)
+                .equals(WCShippingLabelCreationEligibilityTable.REMOTE_ORDER_ID, orderId)
+                .endWhere()
+                .asModel
+                .firstOrNull()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -123,6 +123,33 @@ class WCShippingLabelStore @Inject constructor(
         }
     }
 
+    suspend fun checkShippingLabelCreationEligibility(
+        site: SiteModel,
+        orderId: Long,
+        canCreatePackage: Boolean,
+        canCreatePaymentMethod: Boolean,
+        canCreateCustomsForm: Boolean
+    ): WooResult<Boolean> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "printShippingLabel") {
+            val response = restClient.checkShippingLabelCreationEligibility(
+                    site = site,
+                    orderId = orderId,
+                    canCreatePackage = canCreatePackage,
+                    canCreatePaymentMethod = canCreatePaymentMethod,
+                    canCreateCustomsForm = canCreateCustomsForm
+            )
+            return@withDefaultContext when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+                response.result != null -> {
+                    WooResult(response.result.isEligible)
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
     suspend fun verifyAddress(
         site: SiteModel,
         address: ShippingLabelAddress,


### PR DESCRIPTION
This PR integrates the shipping [label creation eligibility endpoint](https://github.com/Automattic/woocommerce-services/pull/2334), as discussed on Slack, I decided to cache the result, to follow the same flow as other order details, and to avoid abrupt UI changes when loading the order details.

The PR includes a second change fc14073, which does the following:
1. Renames `localOrderId` in the shipping label model to `remoteOrderId` as it's what it contains.
2. Removes the columns holding the account settings, as they are not used by the app, and they are not linked to a single shipping label, but to the account. The same settings are fetched using https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/a20c110c79a8918e49563ec28585b6d59e07f1fc/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt#L296
And if we need to cache them, we should do it in a separate table anyway.

This change can be in a separate PR, as it's unrelated, but I decided to combine both of them to handle all the DB changes in one single migration.

#### Testing
1. Open the example app.
2. Click on Woo, then "Shipping Labels"
3. Click on "Check Label Creation Eligibility"
4. Enter the order id, and the other parameters.
5. Confirm that the eligibility is printed in the logs.
6. Retry with the same parameters and confirm that the eligibility is fetched from the DB.
7. Retry with different parameters and confirm that it's fetched from the API.