### PR TITLE
Adds method to get cached page layout content

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -326,7 +326,6 @@ public class SiteSqlUtils {
     }
 
     public static @Nullable String getBlockLayoutContent(@NonNull SiteModel site, @NonNull String slug) {
-        ArrayList<GutenbergLayout> blockLayouts = new ArrayList<>();
         List<GutenbergLayoutModel> layouts =
                 WellSql.select(GutenbergLayoutModel.class)
                        .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.database.sqlite.SQLiteConstraintException;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.wellsql.generated.AccountModelTable;
 import com.wellsql.generated.GutenbergLayoutCategoriesModelTable;
@@ -322,6 +323,20 @@ public class SiteSqlUtils {
             blockLayouts.add(GutenbergLayoutModelKt.transform(layout, categories));
         }
         return blockLayouts;
+    }
+
+    public static @Nullable String getBlockLayoutContent(@NonNull SiteModel site, @NonNull String slug) {
+        ArrayList<GutenbergLayout> blockLayouts = new ArrayList<>();
+        List<GutenbergLayoutModel> layouts =
+                WellSql.select(GutenbergLayoutModel.class)
+                       .where()
+                       .equals(GutenbergLayoutModelTable.SITE_ID, site.getId())
+                       .equals(GutenbergLayoutModelTable.SLUG, slug)
+                       .endWhere().getAsModel();
+        if (layouts.size() == 1) {
+            return layouts.get(0).getContent();
+        }
+        return null;
     }
 
     public static void insertOrReplaceBlockLayouts(@NonNull SiteModel site,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1492,6 +1492,17 @@ public class SiteStore extends Store {
         }
     }
 
+    /**
+     * Gets the cached content of a page layout
+     *
+     * @param site the current site
+     * @param slug the slug of the layout
+     * @return the content or null if the content is not cached
+     */
+    public @Nullable String getBlockLayoutContent(@NonNull SiteModel site, @NonNull String slug) {
+        return SiteSqlUtils.getBlockLayoutContent(site, slug);
+    }
+
     public List<PostFormatModel> getPostFormats(SiteModel site) {
         return SiteSqlUtils.getPostFormats(site);
     }


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/WordPress-Android/issues/14421

`WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/14422

Note: This PR is targeting `1.14.0` (`WordPress-Android`: 17.1)

## Description
Adds method to get cached page layout content

## To test: 
Check [Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14422).