### PR TITLE
Parse preferred blog info and bio from like endpoints

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/LikeModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/LikeModel.kt
@@ -32,8 +32,17 @@ class LikeModel : Identifiable {
         get() = StringUtils.notNullStr(field)
     @Column var likerAvatarUrl: String? = null
         get() = StringUtils.notNullStr(field)
+    @Column var likerBio: String? = null
+        get() = StringUtils.notNullStr(field)
     @Column var likerSiteId: Long = 0
     @Column var likerSiteUrl: String? = null
+        get() = StringUtils.notNullStr(field)
+    @Column var preferredBlogId: Long = 0
+    @Column var preferredBlogName: String? = null
+        get() = StringUtils.notNullStr(field)
+    @Column var preferredBlogUrl: String? = null
+        get() = StringUtils.notNullStr(field)
+    @Column var preferredBlogBlavatarUrl: String? = null
         get() = StringUtils.notNullStr(field)
 
     override fun setId(id: Int) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/common/LikeWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/common/LikeWPComRestResponse.kt
@@ -5,10 +5,25 @@ class LikeWPComRestResponse {
         var likes: List<LikeWPComRestResponse>? = null
     }
 
+    inner class PreferredBlogResponse {
+        var id: Long = 0
+        var name: String? = null
+        var url: String? = null
+        var icon: PreferredBlogIcon? = null
+    }
+
+    inner class PreferredBlogIcon {
+        var ico: String? = null
+        var img: String? = null
+    }
+
     var ID: Long = 0
     var login: String? = null
     var name: String? = null
     var avatar_URL: String? = null
+    var bio: String? = null
     var site_ID: Long = 0
     var primary_blog: String? = null
+
+    var preferred_blog: PreferredBlogResponse? = null
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/common/LikesResponseUtilsProvider.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/common/LikesResponseUtilsProvider.kt
@@ -24,20 +24,25 @@ class LikesResponseUtilsProvider @Inject constructor() {
 
     private fun likeResponseToLike(
         response: LikeWPComRestResponse,
-        siteid: Long,
+        siteId: Long,
         commentId: Long,
         likeType: LikeType
     ): LikeModel {
         return LikeModel().apply {
-            remoteSiteId = siteid
+            remoteSiteId = siteId
             type = likeType.typeName
             remoteItemId = commentId
             remoteLikeId = response.ID
             likerLogin = response.login
             likerName = response.name
             likerAvatarUrl = response.avatar_URL
+            likerBio = response.bio
             likerSiteId = response.site_ID
             likerSiteUrl = response.primary_blog
+            preferredBlogId = response.preferred_blog?.id ?: 0
+            preferredBlogName = response.preferred_blog?.name
+            preferredBlogUrl = response.preferred_blog?.url
+            preferredBlogBlavatarUrl = response.preferred_blog?.icon?.img
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 143
+        return 144
     }
 
     override fun getDbName(): String {
@@ -1653,6 +1653,12 @@ open class WellSqlConfig : DefaultWellConfig {
                 142 -> migrate(version) {
                     db.execSQL("ALTER TABLE CommentModel ADD HAS_PARENT BOOLEAN")
                     db.execSQL("ALTER TABLE CommentModel ADD PARENT_ID INTEGER")
+                }
+                143 -> migrate(version) {
+                    db.execSQL("ALTER TABLE LikeModel ADD PREFERRED_BLOG_ID INTEGER")
+                    db.execSQL("ALTER TABLE LikeModel ADD PREFERRED_BLOG_NAME TEXT")
+                    db.execSQL("ALTER TABLE LikeModel ADD PREFERRED_BLOG_URL TEXT")
+                    db.execSQL("ALTER TABLE LikeModel ADD PREFERRED_BLOG_BLAVATAR_URL TEXT")
                 }
             }
         }


### PR DESCRIPTION
This PR adds the parsing of preferred blog info and bio from like endpoints. It is a companion PR to the WPAndroid PR [here](https://github.com/wordpress-mobile/WordPress-Android/pull/14437). You can use that PR and description to test this.

Requires D59220 endpoint changes to be shipped first (now deployed).