### PR TITLE
Take into account shipping lines in API responses related to refund.

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundFixtures.kt
@@ -8,5 +8,6 @@ val REFUND_RESPONSE = RefundResponse(
         "10.00",
         "No reason",
         false,
+        emptyList(),
         emptyList()
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
@@ -31,7 +31,8 @@ class RefundMapper
                             it.sku,
                             it.price?.toBigDecimalOrNull()
                     )
-                }
+                },
+                response.shippingLineItems
         )
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/WCRefundModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/WCRefundModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.model.refunds
 
+import com.google.gson.JsonArray
 import com.google.gson.annotations.SerializedName
 import java.math.BigDecimal
 import java.util.Date
@@ -10,7 +11,8 @@ data class WCRefundModel(
     val amount: BigDecimal,
     val reason: String?,
     val automaticGatewayRefund: Boolean,
-    val items: List<WCRefundItem>
+    val items: List<WCRefundItem>,
+    val shippingLineItems: List<WCRefundShippingLine>
 ) {
     data class WCRefundItem(
         val itemId: Long,
@@ -26,5 +28,18 @@ data class WCRefundModel(
         val total: BigDecimal? = null,
         val sku: String? = null,
         val price: BigDecimal? = null
+    )
+
+    data class WCRefundShippingLine(
+        val id: Long,
+        val total: BigDecimal,
+        @SerializedName("total_tax")
+        val totalTax: BigDecimal,
+        @SerializedName("method_id")
+        val methodId: String? = null,
+        @SerializedName("method_title")
+        val methodTitle: String? = null,
+        @SerializedName("meta_data")
+        val metaData: JsonArray? = null
     )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/WCRefundModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/WCRefundModel.kt
@@ -4,7 +4,15 @@ import com.google.gson.JsonArray
 import com.google.gson.annotations.SerializedName
 import java.math.BigDecimal
 import java.util.Date
-
+/**
+ * Note:
+ * For the purpose of creating a refund through API, only a list of `WCRefundItem` is accepted. To be able to refund
+ * shipping lines, they will need to be converted into a list of `WCRefundItem` before being sent to the API.
+ *
+ * On the other hand, for the purpose of fetching a refund through API and persisting the data, product items and
+ * shipping lines are listed separately in the API response. To mimic that, here we also add `shippingLineItems` as
+ * one of the class properties.
+ */
 data class WCRefundModel(
     val id: Long,
     val dateCreated: Date,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundShippingLine
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
@@ -143,6 +144,7 @@ constructor(
         @SerializedName("amount") val amount: String?,
         @SerializedName("reason") val reason: String?,
         @SerializedName("refunded_payment") val refundedPayment: Boolean?,
-        @SerializedName("line_items") val items: List<LineItem>
+        @SerializedName("line_items") val items: List<LineItem>,
+        @SerializedName("shipping_lines") val shippingLineItems: List<WCRefundShippingLine>
     )
 }


### PR DESCRIPTION
This PR is required to enable [Woo Mobile PR #3825](https://github.com/woocommerce/woocommerce-android/pull/3825).

Update: This PR is already approved, but let's postpone merging until the above PR is ready.

## What this PR does.

When a refund involves shipping lines, the API responses for both creating and fetching such refund treats the shipping lines separately from refunded products/items. 

An example response for fetching a single Refund where a shipping line is refunded looks like this:
```
{
  "data": [
  {
    "id": 181,
    "date_created": "2021-04-12T14:37:56",
    "date_created_gmt": "2021-04-12T07:37:56",
    "amount": "15.00",
    "reason": "",
    "refunded_by": 1032737,
    "meta_data": [],
    "line_items": [],
    "shipping_lines": [
      {
        "id": 87,
        "method_title": "Shipping",
        "method_id": "",
        "instance_id": "0",
        "total": "-1.00",
        "total_tax": "0.00",
        "taxes": [],
        "meta_data": [
          {
            "id": 651,
            "key": "_refunded_item_id",
            "value": "72",
            "display_key": "_refunded_item_id",
            "display_value": "72"
          }
        ]
      }
    ]
}
```

Note these two separate arrays within the main `data` object:
- "line_items": for refunded products, this one's empty because in the example we're not refunding a product
- "shipping_lines": for refunded shipping lines


With this PR, we're taking into account the values returned in `shipping_lines` by putting them the WCRefundModel. My use case right now is so that I can grab the refunded item id data from the app's DB, so I can:
- Display information about already refunded shipping lines
- Exclude already refunded shipping lines being refunded again.

