### PR TITLE
Scan State: Get credentials availability

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
@@ -102,6 +102,7 @@ class ScanRestClientTest {
             requireNotNull(scanStateModel).apply {
                 assertEquals(state, State.fromValue(requireNotNull(scanResponse.state)))
                 assertEquals(hasCloud, requireNotNull(scanResponse.hasCloud))
+                assertEquals(hasValidCredentials, scanResponse.credentials?.firstOrNull()?.stillValid)
                 assertNull(reason)
                 assertNotNull(credentials)
                 assertNotNull(threats)

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/ScanStateSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/ScanStateSqlUtilsTest.kt
@@ -1,12 +1,13 @@
 package org.wordpress.android.fluxc.persistence
 
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
 import com.yarolegovich.wellsql.WellSql
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
@@ -21,7 +22,7 @@ class ScanStateSqlUtilsTest {
 
     @Before
     fun setUp() {
-        val appContext = RuntimeEnvironment.application.applicationContext
+        val appContext = ApplicationProvider.getApplicationContext<Application>()
 
         val config = WellSqlConfig(appContext)
         WellSql.init(config)

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/ScanStateSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/ScanStateSqlUtilsTest.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.ScanProgressStatus
+import java.util.Date
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class ScanStateSqlUtilsTest {
+    private val scanSqlUtils = ScanSqlUtils()
+    private lateinit var site: SiteModel
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+
+        val config = WellSqlConfig(appContext)
+        WellSql.init(config)
+        config.reset()
+
+        site = SiteModel().apply { id = 100 }
+    }
+
+    @Test
+    fun `given idle state scan state model, when model is saved, then save succeeds`() {
+        val scanStateModel = getScanStateModel(ScanStateModel.State.IDLE)
+
+        scanSqlUtils.replaceScanState(site, scanStateModel)
+        val scanStateFromDb = scanSqlUtils.getScanStateForSite(site)
+
+        assertEquals(scanStateModel, scanStateFromDb)
+    }
+
+    @Test
+    fun `given scanning state scan state model, when model is saved, then save succeeds`() {
+        val scanStateModel = getScanStateModel(ScanStateModel.State.SCANNING)
+
+        scanSqlUtils.replaceScanState(site, scanStateModel)
+        val scanStateFromDb = scanSqlUtils.getScanStateForSite(site)
+
+        assertEquals(scanStateModel, scanStateFromDb)
+    }
+
+    @Test
+    fun `given provisioning state scan state model, when model is saved, then save succeeds`() {
+        val scanStateModel = getScanStateModel(ScanStateModel.State.PROVISIONING)
+
+        scanSqlUtils.replaceScanState(site, scanStateModel)
+        val scanStateFromDb = scanSqlUtils.getScanStateForSite(site)
+
+        assertEquals(scanStateModel, scanStateFromDb)
+    }
+
+    private fun getScanStateModel(state: ScanStateModel.State): ScanStateModel {
+        var scanStateModel = ScanStateModel(
+                state = state,
+                reason = "reason",
+                hasCloud = true,
+                hasValidCredentials = true
+        )
+
+        if (state == ScanStateModel.State.IDLE) {
+            val mostRecentStatus = ScanProgressStatus(
+                    startDate = Date(),
+                    duration = 40,
+                    progress = 30,
+                    error = false,
+                    isInitial = true
+            )
+            scanStateModel = scanStateModel.copy(mostRecentStatus = mostRecentStatus)
+        } else if (state == ScanStateModel.State.SCANNING) {
+            val currentStatus = ScanProgressStatus(
+                    startDate = Date(),
+                    progress = 30,
+                    isInitial = true
+            )
+            scanStateModel = scanStateModel.copy(currentStatus = currentStatus)
+        }
+
+        return scanStateModel
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
@@ -171,6 +171,16 @@ class ScanStoreTest {
     }
 
     @Test
+    fun `get valid credentials status returns corresponding status from the db`() = test {
+        val scanStateModel = ScanStateModel(State.IDLE, hasValidCredentials = true)
+        whenever(scanSqlUtils.getScanStateForSite(siteModel)).thenReturn(scanStateModel)
+
+        val hasValidCredentials = scanStore.hasValidCredentials(siteModel)
+
+        Assert.assertEquals(true, hasValidCredentials)
+    }
+
+    @Test
     fun `success on start scan returns the success`() = test {
         val payload = ScanStartPayload(siteModel)
         whenever(scanRestClient.startScan(siteModel)).thenReturn(ScanStartResultPayload(siteModel))

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
@@ -52,6 +52,7 @@ import org.wordpress.android.fluxc.store.ScanStore.ScanStateErrorType
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.utils.BuildConfigWrapper
+import kotlin.test.assertEquals
 
 @RunWith(MockitoJUnitRunner::class)
 class ScanStoreTest {
@@ -172,12 +173,13 @@ class ScanStoreTest {
 
     @Test
     fun `get valid credentials status returns corresponding status from the db`() = test {
-        val scanStateModel = ScanStateModel(State.IDLE, hasValidCredentials = true)
+        val expectedHasValidCredentials = true
+        val scanStateModel = ScanStateModel(State.IDLE, hasValidCredentials = expectedHasValidCredentials)
         whenever(scanSqlUtils.getScanStateForSite(siteModel)).thenReturn(scanStateModel)
 
         val hasValidCredentials = scanStore.hasValidCredentials(siteModel)
 
-        Assert.assertEquals(true, hasValidCredentials)
+        assertEquals(expectedHasValidCredentials, hasValidCredentials)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
@@ -7,7 +7,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,7 +52,6 @@ import org.wordpress.android.fluxc.store.ScanStore.ScanStateErrorType
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.utils.BuildConfigWrapper
-import kotlin.test.assertEquals
 
 @RunWith(MockitoJUnitRunner::class)
 class ScanStoreTest {
@@ -168,7 +167,7 @@ class ScanStoreTest {
 
         verify(scanSqlUtils).getScanStateForSite(siteModel)
         verify(threatSqlUtils).getThreats(siteModel, listOf(CURRENT))
-        Assert.assertEquals(scanStateModel, scanStateFromDb)
+        assertEquals(scanStateModel, scanStateFromDb)
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/ScanStateModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/ScanStateModel.kt
@@ -10,7 +10,8 @@ data class ScanStateModel(
     val credentials: List<Credentials>? = null,
     val hasCloud: Boolean = false,
     val mostRecentStatus: ScanProgressStatus? = null,
-    val currentStatus: ScanProgressStatus? = null
+    val currentStatus: ScanProgressStatus? = null,
+    val hasValidCredentials: Boolean = false
 ) {
     enum class State(val value: String) {
         IDLE("idle"),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -230,7 +230,8 @@ class ScanRestClient(
                     progress = it.progress ?: 0,
                     isInitial = it.isInitial ?: false
                 )
-            }
+            },
+            hasValidCredentials = response.credentials?.firstOrNull()?.stillValid == true
         )
         return FetchedScanStatePayload(scanStateModel, site)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
@@ -74,7 +74,8 @@ class ScanSqlUtils @Inject constructor() {
             reason = reason,
             error = mostRecentStatus?.error ?: false,
             initial = isInitial,
-            hasCloud = hasCloud
+            hasCloud = hasCloud,
+            hasValidCredentials = hasValidCredentials
         )
     }
 
@@ -91,9 +92,10 @@ class ScanSqlUtils @Inject constructor() {
         @Column var reason: String? = null,
         @Column var error: Boolean = false,
         @Column var initial: Boolean = false,
-        @Column var hasCloud: Boolean = false
+        @Column var hasCloud: Boolean = false,
+        @Column var hasValidCredentials: Boolean = false
     ) : Identifiable {
-        constructor() : this(-1, 0, 0, "", 0, 0, 0, "", false, false, false)
+        constructor() : this(-1, 0, 0, "")
 
         override fun setId(id: Int) {
             this.id = id
@@ -133,7 +135,8 @@ class ScanSqlUtils @Inject constructor() {
                 hasCloud = hasCloud,
                 mostRecentStatus = mostRecentStatus,
                 currentStatus = currentStatus,
-                reason = reason
+                reason = reason,
+                hasValidCredentials = hasValidCredentials
             )
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 143
+        return 144
     }
 
     override fun getDbName(): String {
@@ -1653,6 +1653,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 142 -> migrate(version) {
                     db.execSQL("ALTER TABLE CommentModel ADD HAS_PARENT BOOLEAN")
                     db.execSQL("ALTER TABLE CommentModel ADD PARENT_ID INTEGER")
+                }
+                143 -> migrate(version) {
+                    db.execSQL("ALTER TABLE ScanState ADD HAS_VALID_CREDENTIALS BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
@@ -99,6 +99,12 @@ class ScanStore @Inject constructor(
             threatSqlUtils.getThreatByThreatId(threatId)
         }
 
+    suspend fun hasValidCredentials(site: SiteModel) =
+        coroutineEngine.withDefaultContext(AppLog.T.JETPACK_SCAN, this, "hasValidCredentials") {
+            val scanStateModel = scanSqlUtils.getScanStateForSite(site)
+            scanStateModel?.hasValidCredentials ?: false
+        }
+
     suspend fun addOrUpdateScanStateModelForSite(action: ScanAction, site: SiteModel, scanStateModel: ScanStateModel) {
         coroutineEngine.withDefaultContext(AppLog.T.JETPACK_SCAN, this, "addOrUpdateScanStateModelForSite") {
             scanSqlUtils.replaceScanState(site, scanStateModel)


### PR DESCRIPTION
### Description

This PR 
 - Adds new field `HAS_VALID_CREDENTIALS` in the `ScanState` table.
 - Sets this field to `true` if the scan state model has valid credentials (`still_valid = true`).
 - Exposes above value using `ScanStore.hasValidCredentials` method. 

### How to test
- WordPress-Android PR:  https://github.com/wordpress-mobile/WordPress-Android/pull/14447