### PR TITLE
Woo Shipping Labels: expose box_weight in the package data model

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -352,8 +352,8 @@ class WCShippingLabelStoreTest {
     fun `get packages`() = test {
         val expectedResult = WCPackagesResult(
                 listOf(
-                        CustomPackage("Krabica", false, "1 x 2 x 3"),
-                        CustomPackage("Obalka", true, "2 x 3 x 4")
+                        CustomPackage("Krabica", false, "1 x 2 x 3", 1f),
+                        CustomPackage("Obalka", true, "2 x 3 x 4", 5f)
                 ),
                 listOf(
                         PredefinedOption("USPS Priority Mail Flat Rate Boxes",
@@ -362,13 +362,15 @@ class WCShippingLabelStoreTest {
                                                 "small_flat_box",
                                                 "Small Flat Rate Box",
                                                 false,
-                                                "21.91 x 13.65 x 4.13"
+                                                "21.91 x 13.65 x 4.13",
+                                                0f
                                         ),
                                         PredefinedPackage(
                                                 "medium_flat_box_top",
                                                 "Medium Flat Rate Box 1, Top Loading",
                                                 false,
-                                                "28.57 x 22.22 x 15.24"
+                                                "28.57 x 22.22 x 15.24",
+                                                0f
                                         )
                                 )
                         ),
@@ -378,7 +380,8 @@ class WCShippingLabelStoreTest {
                                         "LargePaddedPouch",
                                         "Large Padded Pouch",
                                         true,
-                                        "30.22 x 35.56 x 2.54"
+                                        "30.22 x 35.56 x 2.54",
+                                        0f
                                 ))
                         )
                 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCPackagesResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCPackagesResult.kt
@@ -7,7 +7,8 @@ data class WCPackagesResult(
     data class CustomPackage(
         val title: String,
         val isLetter: Boolean,
-        val dimensions: String
+        val dimensions: String,
+        val boxWeight: Float
     )
 
     data class PredefinedOption(
@@ -18,7 +19,8 @@ data class WCPackagesResult(
             val id: String,
             val title: String,
             val isLetter: Boolean,
-            val dimensions: String
+            val dimensions: String,
+            val boxWeight: Float
         )
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -279,7 +279,8 @@ class WCShippingLabelStore @Inject constructor(
                                 id = definition.id,
                                 title = definition.name,
                                 isLetter = definition.isLetter,
-                                dimensions = definition.outerDimensions
+                                dimensions = definition.outerDimensions,
+                                boxWeight = definition.boxWeight ?: 0f
                         )
                 )
             }
@@ -289,7 +290,12 @@ class WCShippingLabelStore @Inject constructor(
 
     private fun getCustomPackages(result: GetPackageTypesResponse): List<CustomPackage> {
         return result.formData.customData.map {
-            CustomPackage(it.name, it.isLetter, it.outerDimensions ?: it.innerDimensions ?: "")
+            CustomPackage(
+                    title = it.name,
+                    isLetter = it.isLetter,
+                    dimensions = it.outerDimensions ?: it.innerDimensions ?: "",
+                    boxWeight = it.boxWeight ?: 0f
+            )
         }
     }
 


### PR DESCRIPTION
To implement https://github.com/woocommerce/woocommerce-android/issues/3829, we need to include the box_weight in the calculation, this PR exposes it.