### PR TITLE
Add some delay between installing and configuring plugin

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -819,8 +819,8 @@ public class PluginStore extends Store {
         // Once the plugin is installed activate it and enable auto-updates
         if (!payload.isError() && payload.plugin != null) {
             try {
-                // Give half a second to the server as otherwise the following configure call may fail
-                Thread.sleep(500);
+                // Give a second to the server as otherwise the following configure call may fail
+                Thread.sleep(1000);
             } catch (InterruptedException e) {
                 // https://www.javaspecialists.eu/archive/Issue056-Shutting-down-Threads-Cleanly.html
                 Thread.currentThread().interrupt();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -816,9 +816,16 @@ public class PluginStore extends Store {
         }
         emitChange(event);
 
-        // Once the plugin is installed activate it and enable autoupdates
-        // This is only a temporary solution as we are trying to get this implemented on the server side
+        // Once the plugin is installed activate it and enable auto-updates
         if (!payload.isError() && payload.plugin != null) {
+            try {
+                // Give half a second to the server as otherwise the following configure call may fail
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                // https://www.javaspecialists.eu/archive/Issue056-Shutting-down-Threads-Cleanly.html
+                Thread.currentThread().interrupt();
+            }
+
             ConfigureSitePluginPayload configurePayload = new ConfigureSitePluginPayload(payload.site,
                     payload.plugin.getName(), payload.plugin.getSlug(), true, true);
             mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(configurePayload));


### PR DESCRIPTION
In a rare case, when we configure a plugin after installing it, the server will return `unknown_plugin` error. Adding half a second delay should help with this.

It looks like we no longer have to configure the plugin after it's installed, so I considered removing that implementation completely. However, if we do that, we'll have to re-fetch the plugins so the local DB will reflect that it's enabled on remote. I think it's better to do the configuration call because it's faster and it guarantees the behavior we want. So, I removed the comment stating that it's a temporary solution.

_P.S: I don't plan to open a WPAndroid PR to update the hash since it's such a minor improvement. These changes should make it to WPAndroid with another hash update or the release tag._

**To test:**
* Run `ReleaseStack_PluginTestJetpack.testInstallAndDeleteSitePlugin` a few times