### PR TITLE
issue/1953-woo-update-product-attributes

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -201,9 +201,6 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * Returns true if this product has the same attributes as the passed product
      */
     fun hasSameAttributes(otherProduct: WCProductModel): Boolean {
-        AppLog.e(T.API, "this attributes = ${this.attributes}")
-        AppLog.e(T.API, "other attributes = ${otherProduct.attributes}")
-
         // do a quick string comparison first so we can avoid parsing the attributes when possible
         if (this.attributes == otherProduct.attributes) {
             return true

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -136,6 +136,14 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             return commaSeparatedOptions
         }
 
+        fun isSameAttribute(other: ProductAttribute): Boolean {
+            return id == other.id &&
+                    name == other.name &&
+                    variation == other.variation &&
+                    visible == other.visible &&
+                    options == other.options
+        }
+
         fun asGlobalAttribute(siteID: Int) =
                 WCGlobalAttributeSqlUtils.fetchSingleStoredAttribute(id.toInt(), siteID)
 
@@ -187,6 +195,22 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         getAttribute(updatedAttribute.id.toInt())
                 ?.let { removeAttribute(it.id.toInt()) }
         addAttribute(updatedAttribute)
+    }
+
+    fun hasSameAttributes(otherProduct: WCProductModel): Boolean {
+        val otherAttributes = otherProduct.attributeList
+        val thisAttributes = this.attributeList
+        if (thisAttributes.size != otherAttributes.size) {
+            return false
+        }
+
+        for (i in 0 until thisAttributes.size) {
+            if (!thisAttributes.get(i).isSameAttribute(otherAttributes.get(i))) {
+                return false
+            }
+        }
+
+        return true
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -155,6 +155,20 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
                             option = selectedOption
                     )
                 }
+
+        fun toJson(): JsonObject {
+            val jsonOptions = JsonArray().also {
+                for (option in options) {
+                    it.add(option)
+                }
+            }
+            return JsonObject().also { json ->
+                json.addProperty("id", id)
+                json.addProperty("name", name)
+                json.addProperty("visible", visible)
+                json.add("options", jsonOptions)
+            }
+        }
     }
 
     override fun getId() = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -205,7 +205,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         }
 
         for (i in 0 until thisAttributes.size) {
-            if (!thisAttributes.get(i).isSameAttribute(otherAttributes.get(i))) {
+            if (!thisAttributes[i].isSameAttribute(otherAttributes[i])) {
                 return false
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -197,7 +197,13 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         addAttribute(updatedAttribute)
     }
 
+    /**
+     * Returns true if this product has the same attributes as the passed product
+     */
     fun hasSameAttributes(otherProduct: WCProductModel): Boolean {
+        AppLog.e(T.API, "this attributes = $attributes")
+        AppLog.e(T.API, "other attributes = ${otherProduct.attributes}")
+
         val otherAttributes = otherProduct.attributeList
         val thisAttributes = this.attributeList
         if (thisAttributes.size != otherAttributes.size) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -198,8 +198,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     }
 
     fun hasSameAttributes(otherProduct: WCProductModel): Boolean {
-        val otherAttributes = otherProduct.attributeList
-        val thisAttributes = this.attributeList
+        val otherAttributes = otherProduct.getAttributeList()
+        val thisAttributes = this.getAttributeList()
         if (thisAttributes.size != otherAttributes.size) {
             return false
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -201,8 +201,13 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * Returns true if this product has the same attributes as the passed product
      */
     fun hasSameAttributes(otherProduct: WCProductModel): Boolean {
-        AppLog.e(T.API, "this attributes = $attributes")
+        AppLog.e(T.API, "this attributes = ${this.attributes}")
         AppLog.e(T.API, "other attributes = ${otherProduct.attributes}")
+
+        // do a quick string comparison first so we can avoid parsing the attributes when possible
+        if (this.attributes == otherProduct.attributes) {
+            return true
+        }
 
         val otherAttributes = otherProduct.attributeList
         val thisAttributes = this.attributeList

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -166,6 +166,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
                 json.addProperty("id", id)
                 json.addProperty("name", name)
                 json.addProperty("visible", visible)
+                json.addProperty("variation", variation)
                 json.add("options", jsonOptions)
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -204,21 +204,6 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             return false
         }
 
-        fun logAttributes(name: String, attributes: Array<ProductAttribute>) {
-            AppLog.e(T.API, name)
-            for (i in 0 until attributes.size) {
-                AppLog.e(T.API, "* ${attributes[i].name}")
-                AppLog.e(T.API,  " id = ${attributes[i].id}")
-                AppLog.e(T.API,  " variation = ${attributes[i].variation}")
-                AppLog.e(T.API,  " visible = ${attributes[i].visible}")
-                AppLog.e(T.API,  " options = ${attributes[i].options}")
-            }
-        }
-
-        // TODO: remove logging
-        logAttributes("*** otherAttributes", otherAttributes)
-        logAttributes("*** thisAttributes", thisAttributes)
-
         for (i in 0 until thisAttributes.size) {
             if (!thisAttributes[i].isSameAttribute(otherAttributes[i])) {
                 return false

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -198,11 +198,26 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     }
 
     fun hasSameAttributes(otherProduct: WCProductModel): Boolean {
-        val otherAttributes = otherProduct.getAttributeList()
-        val thisAttributes = this.getAttributeList()
+        val otherAttributes = otherProduct.attributeList
+        val thisAttributes = this.attributeList
         if (thisAttributes.size != otherAttributes.size) {
             return false
         }
+
+        fun logAttributes(name: String, attributes: Array<ProductAttribute>) {
+            AppLog.e(T.API, name)
+            for (i in 0 until attributes.size) {
+                AppLog.e(T.API, "* ${attributes[i].name}")
+                AppLog.e(T.API,  " id = ${attributes[i].id}")
+                AppLog.e(T.API,  " variation = ${attributes[i].variation}")
+                AppLog.e(T.API,  " visible = ${attributes[i].visible}")
+                AppLog.e(T.API,  " options = ${attributes[i].options}")
+            }
+        }
+
+        // TODO: remove logging
+        logAttributes("*** otherAttributes", otherAttributes)
+        logAttributes("*** thisAttributes", thisAttributes)
 
         for (i in 0 until thisAttributes.size) {
             if (!thisAttributes[i].isSameAttribute(otherAttributes[i])) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1284,7 +1284,7 @@ class ProductRestClient(
                 }
             }
         }
-        if (storedWCProductModel.attributes != updatedProductModel.attributes) {
+        if (!storedWCProductModel.hasSameAttributes(updatedProductModel)) {
             JsonParser().apply {
                 body["attributes"] = try {
                     parse(updatedProductModel.attributes).asJsonArray


### PR DESCRIPTION
Fixes #1953 - previously updating a product would always pass the list of attributes, even when they haven't changed. This was because we did a naive comparison of the attributes as a string, which would lead FluxC to think attributes had changed when only the order of elements had changed.

This PR addresses this by comparing the attributes as models rather than strings.

This also moves the `ProductAttribute.toJson()` function from WCAndroid, since it makes more sense to have that in FluxC. Last but not least, it corrects a bug in the WCAndroid version of that function that would output an attribute's options as a simple comma-separated string rather than a JSON array, resulting in a crash when an array was expected.

To test, use Flipper with [this draft WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/3840) and:

- Go to product detail
- Make a simple change
- Update the product
- Verify via Flipper that attributes aren't sent

Then:

- Make a change to an attribute
- Update the product
- Verify via Flipper that attributes _are_ sent

PS: This really should've been a single commit, but I had to add several commits in order to test the changes in WCAndroid.