### PR TITLE
Fix/attribute list null value

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -102,7 +102,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var height = ""
 
     val attributeList: Array<ProductAttribute>
-        get() = Gson().fromJson(attributes, Array<ProductAttribute>::class.java)
+        get() = Gson().fromJson(attributes, Array<ProductAttribute>::class.java) ?: emptyArray()
 
     class ProductTriplet(val id: Long, val name: String, val slug: String) {
         fun toJson(): JsonObject {
@@ -227,7 +227,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             return false
         }
 
-        for (i in 0 until thisAttributes.size) {
+        for (i in thisAttributes.indices) {
             if (!thisAttributes[i].isSameAttribute(otherAttributes[i])) {
                 return false
             }


### PR DESCRIPTION
Summary
==========
This PR address a test bug happening at `ReleaseStack_WCProductTest#testUpdateDownloadableFiles`, the reason for the issue is that `attributeList` can return null from the JSON serialization when the `attributes` field is also null.

How to test
==========
Execute the Release stack tests and verify they are all green ✅ 