### PR TITLE
ExPlat: Add name property to all Variations and remove unnecessary payload

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
@@ -16,9 +16,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.experiments.Assignments
-import org.wordpress.android.fluxc.model.experiments.Variation
-import org.wordpress.android.fluxc.model.experiments.Variation.Control
-import org.wordpress.android.fluxc.model.experiments.Variation.Treatment
 import org.wordpress.android.fluxc.store.ExperimentStore
 import org.wordpress.android.fluxc.store.ExperimentStore.FetchAssignmentsPayload
 import org.wordpress.android.fluxc.store.ExperimentStore.OnAssignmentsFetched
@@ -52,6 +49,7 @@ class ExperimentsFragment : Fragment() {
             override fun onItemSelected(parent: AdapterView<*>, view: View?, pos: Int, id: Long) {
                 selectedPlatform = Platform.fromValue(parent.getItemAtPosition(pos) as String)
             }
+
             override fun onNothingSelected(parent: AdapterView<*>) {}
         }
         generate_anon_id_button.setOnClickListener { anon_id_edit_text.setText(UUID.randomUUID().toString()) }
@@ -94,13 +92,8 @@ class ExperimentsFragment : Fragment() {
 
     private fun handleAssignments(assignments: Assignments) {
         assignments.variations.forEach { entry ->
-            prependToLog("${entry.key}: ${getVariationString(entry.value)}")
+            prependToLog("${entry.key}: ${entry.value.name}")
         }
-    }
-
-    private fun getVariationString(variation: Variation) = when (variation) {
-        is Control -> "control"
-        is Treatment -> variation.name
     }
 
     private fun prependToLog(s: String) = (activity as MainExampleActivity).prependToLog(s)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.experiments.Assignments
 import org.wordpress.android.fluxc.store.ExperimentStore
-import org.wordpress.android.fluxc.store.ExperimentStore.FetchAssignmentsPayload
 import org.wordpress.android.fluxc.store.ExperimentStore.OnAssignmentsFetched
 import org.wordpress.android.fluxc.store.ExperimentStore.Platform
 import org.wordpress.android.fluxc.store.ExperimentStore.Platform.WORDPRESS_COM
@@ -56,10 +55,9 @@ class ExperimentsFragment : Fragment() {
         fetch_assignments.setOnClickListener {
             val platform = selectedPlatform ?: WORDPRESS_COM
             val anonymousId = anon_id_edit_text.text.toString()
-            val payload = FetchAssignmentsPayload(platform, anonymousId)
-            prependToLog("Fetching assignments with payload: $payload")
+            prependToLog("Fetching assignments with: platform=$platform, anonymousId=$anonymousId")
             GlobalScope.launch(Dispatchers.Default) {
-                val result = experimentStore.fetchAssignments(payload)
+                val result = experimentStore.fetchAssignments(platform, anonymousId)
                 withContext(Dispatchers.Main) {
                     onAssignmentsFetched(result)
                 }

--- a/example/src/test/java/org/wordpress/android/fluxc/experiments/ExperimentStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/experiments/ExperimentStoreTest.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.model.experiments.AssignmentsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.experiments.ExperimentRestClient
 import org.wordpress.android.fluxc.store.ExperimentStore
 import org.wordpress.android.fluxc.store.ExperimentStore.Companion.EXPERIMENT_ASSIGNMENTS_KEY
-import org.wordpress.android.fluxc.store.ExperimentStore.FetchAssignmentsPayload
 import org.wordpress.android.fluxc.store.ExperimentStore.FetchedAssignmentsPayload
 import org.wordpress.android.fluxc.store.ExperimentStore.OnAssignmentsFetched
 import org.wordpress.android.fluxc.store.ExperimentStore.Platform.CALYPSO
@@ -46,7 +45,7 @@ class ExperimentStoreTest {
     fun `fetch assignments emits correct event when successful`() = test {
         whenever(experimentRestClient.fetchAssignments(defaultPlatform)).thenReturn(successfulPayload)
 
-        val onAssignmentsFetched = experimentStore.fetchAssignments(FetchAssignmentsPayload(defaultPlatform))
+        val onAssignmentsFetched = experimentStore.fetchAssignments(defaultPlatform)
 
         assertThat(onAssignmentsFetched).isEqualTo(OnAssignmentsFetched(successfulAssignments))
     }
@@ -55,7 +54,7 @@ class ExperimentStoreTest {
     fun `fetch assignments stores result locally when successful`() = test {
         whenever(experimentRestClient.fetchAssignments(defaultPlatform)).thenReturn(successfulPayload)
 
-        experimentStore.fetchAssignments(FetchAssignmentsPayload(defaultPlatform))
+        experimentStore.fetchAssignments(defaultPlatform)
 
         verify(sharedPreferences).edit()
         inOrder(sharedPreferencesEditor).apply {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
@@ -30,13 +30,14 @@ data class Assignments(
     }
 }
 
-sealed class Variation {
-    object Control : Variation()
-    data class Treatment(val name: String) : Variation()
-
+sealed class Variation(open val name: String) {
+    object Control : Variation(CONTROL)
+    data class Treatment(override val name: String = TREATMENT) : Variation(name)
     companion object {
+        private const val CONTROL = "control"
+        private const val TREATMENT = "treatment"
         fun fromName(name: String?) = when (name) {
-            null -> Control
+            CONTROL, null -> Control
             else -> Treatment(name)
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/experiments/AssignmentsModel.kt
@@ -32,10 +32,9 @@ data class Assignments(
 
 sealed class Variation(open val name: String) {
     object Control : Variation(CONTROL)
-    data class Treatment(override val name: String = TREATMENT) : Variation(name)
+    data class Treatment(override val name: String) : Variation(name)
     companion object {
         private const val CONTROL = "control"
-        private const val TREATMENT = "treatment"
         fun fromName(name: String?) = when (name) {
             CONTROL, null -> Control
             else -> Treatment(name)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ExperimentStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ExperimentStore.kt
@@ -27,9 +27,10 @@ class ExperimentStore @Inject constructor(
     private val gson: Gson by lazy { GsonBuilder().serializeNulls().create() }
 
     suspend fun fetchAssignments(
-        fetchPayload: FetchAssignmentsPayload
+        platform: Platform,
+        anonymousId: String? = null
     ) = coroutineEngine.withDefaultContext(API, this, "fetchAssignments") {
-        val fetchedPayload = experimentRestClient.fetchAssignments(fetchPayload.platform, fetchPayload.anonId)
+        val fetchedPayload = experimentRestClient.fetchAssignments(platform, anonymousId)
         if (!fetchedPayload.isError) {
             storeFetchedAssignments(fetchedPayload.assignments)
             OnAssignmentsFetched(assignments = Assignments.fromModel(fetchedPayload.assignments))
@@ -52,11 +53,6 @@ class ExperimentStore @Inject constructor(
     fun clearCachedAssignments() {
         preferenceUtils.getFluxCPreferences().edit().remove(EXPERIMENT_ASSIGNMENTS_KEY).apply()
     }
-
-    data class FetchAssignmentsPayload(
-        val platform: Platform,
-        val anonId: String? = null
-    )
 
     data class FetchedAssignmentsPayload(
         val assignments: AssignmentsModel


### PR DESCRIPTION
This PR updates the ExPlat implementation with two general improvements:

1. 2db91c8 → Adds a `name` property to all `Variation`s, including `Control`, to make it easier to log its value (we can now just call `Variation.name` with no need to check its type first).
2. a9e9ec7 → Removes unnecessary `FetchAssignmentsPayload` so that less boilerplate is required when calling `ExperimentStore::fetchAssignments`.

### To test

I'd trust the existing unit tests with this one, so just make sure they all pass.