### PR TITLE
ExPlat: Add support to experiment_names parameter

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
@@ -60,8 +60,6 @@ class ExperimentsFragment : Fragment() {
                     "anonymousId=$anonymousId")
             GlobalScope.launch(Dispatchers.Default) {
                 val result = experimentStore.fetchAssignments(platform, experimentNames, anonymousId)
-                result.assignments.variations // Contained variations for experiments which were currently running
-                result.assignments.variations // Contains variations only for the requests experiments
                 withContext(Dispatchers.Main) {
                     onAssignmentsFetched(result)
                 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
@@ -54,10 +54,11 @@ class ExperimentsFragment : Fragment() {
         generate_anon_id_button.setOnClickListener { anon_id_edit_text.setText(UUID.randomUUID().toString()) }
         fetch_assignments.setOnClickListener {
             val platform = selectedPlatform ?: WORDPRESS_COM
+            val experimentNames = experiment_names_edit_text.text.split(',').map { it.trim() }
             val anonymousId = anon_id_edit_text.text.toString()
-            prependToLog("Fetching assignments with: platform=$platform, anonymousId=$anonymousId")
+            prependToLog("Fetching assignments with: platform=$platform, experimentNames=$experimentNames, anonymousId=$anonymousId")
             GlobalScope.launch(Dispatchers.Default) {
-                val result = experimentStore.fetchAssignments(platform, anonymousId)
+                val result = experimentStore.fetchAssignments(platform, experimentNames, anonymousId)
                 withContext(Dispatchers.Main) {
                     onAssignmentsFetched(result)
                 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExperimentsFragment.kt
@@ -56,9 +56,12 @@ class ExperimentsFragment : Fragment() {
             val platform = selectedPlatform ?: WORDPRESS_COM
             val experimentNames = experiment_names_edit_text.text.split(',').map { it.trim() }
             val anonymousId = anon_id_edit_text.text.toString()
-            prependToLog("Fetching assignments with: platform=$platform, experimentNames=$experimentNames, anonymousId=$anonymousId")
+            prependToLog("Fetching assignments with: platform=$platform, experimentNames=$experimentNames, " +
+                    "anonymousId=$anonymousId")
             GlobalScope.launch(Dispatchers.Default) {
                 val result = experimentStore.fetchAssignments(platform, experimentNames, anonymousId)
+                result.assignments.variations // Contained variations for experiments which were currently running
+                result.assignments.variations // Contains variations only for the requests experiments
                 withContext(Dispatchers.Main) {
                     onAssignmentsFetched(result)
                 }

--- a/example/src/main/res/layout/fragment_experiments.xml
+++ b/example/src/main/res/layout/fragment_experiments.xml
@@ -21,6 +21,20 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="Experiment names (separated by comma)"
+        tools:ignore="HardcodedText" />
+
+    <EditText
+        android:id="@+id/experiment_names_edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Experiment names"
+        android:inputType="text"
+        tools:ignore="HardcodedText" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="Anonymous ID for this participant"
         tools:ignore="HardcodedText" />
 

--- a/example/src/test/java/org/wordpress/android/fluxc/experiments/ExperimentStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/experiments/ExperimentStoreTest.kt
@@ -43,18 +43,18 @@ class ExperimentStoreTest {
 
     @Test
     fun `fetch assignments emits correct event when successful`() = test {
-        whenever(experimentRestClient.fetchAssignments(defaultPlatform)).thenReturn(successfulPayload)
+        whenever(experimentRestClient.fetchAssignments(defaultPlatform, emptyList())).thenReturn(successfulPayload)
 
-        val onAssignmentsFetched = experimentStore.fetchAssignments(defaultPlatform)
+        val onAssignmentsFetched = experimentStore.fetchAssignments(defaultPlatform, emptyList())
 
         assertThat(onAssignmentsFetched).isEqualTo(OnAssignmentsFetched(successfulAssignments))
     }
 
     @Test
     fun `fetch assignments stores result locally when successful`() = test {
-        whenever(experimentRestClient.fetchAssignments(defaultPlatform)).thenReturn(successfulPayload)
+        whenever(experimentRestClient.fetchAssignments(defaultPlatform, emptyList())).thenReturn(successfulPayload)
 
-        experimentStore.fetchAssignments(defaultPlatform)
+        experimentStore.fetchAssignments(defaultPlatform, emptyList())
 
         verify(sharedPreferences).edit()
         inOrder(sharedPreferencesEditor).apply {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClient.kt
@@ -28,11 +28,15 @@ class ExperimentRestClient(
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchAssignments(
         platform: Platform,
+        experimentNames: List<String>,
         anonymousId: String? = null,
         version: String = DEFAULT_VERSION
     ): FetchedAssignmentsPayload {
         val url = WPCOMV2.experiments.version(version).assignments.platform(platform.value).url
-        val params = mapOf("anon_id" to anonymousId.orEmpty())
+        val params = mapOf(
+                "experiment_names" to experimentNames.joinToString(),
+                "anon_id" to anonymousId.orEmpty()
+        )
         val response = wpComGsonRequestBuilder.syncGetRequest(
                 this,
                 url,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ExperimentStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ExperimentStore.kt
@@ -28,9 +28,10 @@ class ExperimentStore @Inject constructor(
 
     suspend fun fetchAssignments(
         platform: Platform,
+        experimentNames: List<String>,
         anonymousId: String? = null
     ) = coroutineEngine.withDefaultContext(API, this, "fetchAssignments") {
-        val fetchedPayload = experimentRestClient.fetchAssignments(platform, anonymousId)
+        val fetchedPayload = experimentRestClient.fetchAssignments(platform, experimentNames, anonymousId)
         if (!fetchedPayload.isError) {
             storeFetchedAssignments(fetchedPayload.assignments)
             OnAssignmentsFetched(assignments = Assignments.fromModel(fetchedPayload.assignments))


### PR DESCRIPTION
This PR updates the ExPlat implementation so it can support the new `experiment_names` parameter which was added to the "fetch assignments" endpoint, as defined in https://github.com/Automattic/experimentation-platform/issues/606.

This depends on #1969.

In practice, this mainly impacts the usage of `ExperimentStore::fetchAssignments`, which now requires a list of `String` with the experiment names as its second parameter:

```kotlin
val platform = Platform.WORDPRESS_ANDROID

// Before
val result = experimentStore.fetchAssignments(platform)
result.assignments.variations // Contained variations for all active experiments

// Now
val result = experimentStore.fetchAssignments(platform, listOf("experiment_one", "experiment_two"))
result.assignments.variations // Contains variations only for experiment_one and experiment_two (if they are active)
```

### To test

Make sure all unit tests pass and/or use the following steps on the example app:

1. On the initial screen, tap **Experiments**.
1. On the next screen, select a platform to query.
1. Under "Experiment names", add the name of all experiments which you want to request, separated by a comma (keep in mind only active experiments will be returned, so check Abacus if you want to see which ones to request).
1. Optionally, you can add or generate an Anonymous ID to be included in the request as well.
1. Tap **Fetch Assignments**.
1. Check the results printed by the in-app console and verify they match what was requested.

Repeat providing single/multiple experiment names and also no experiment name at all (which should return 0 assignments).