### PR TITLE
ExPlat: Fix request parameter separator to prevent adding spaces

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClientTest.kt
@@ -100,7 +100,7 @@ class ExperimentRestClientTest {
 
         val expectedUrl = "$EXPERIMENTS_ENDPOINT/$DEFAULT_VERSION/assignments/${defaultPlatform.value}/"
         val expectedParams = mapOf(
-                "experiment_names" to "experiment_one, experiment_two, experiment_three",
+                "experiment_names" to "experiment_one,experiment_two,experiment_three",
                 "anon_id" to ""
         )
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClient.kt
@@ -36,7 +36,7 @@ class ExperimentRestClient @Inject constructor(
     ): FetchedAssignmentsPayload {
         val url = WPCOMV2.experiments.version(version).assignments.platform(platform.value).url
         val params = mapOf(
-                "experiment_names" to experimentNames.joinToString(),
+                "experiment_names" to experimentNames.joinToString(","),
                 "anon_id" to anonymousId.orEmpty()
         )
         val response = wpComGsonRequestBuilder.syncGetRequest(


### PR DESCRIPTION
This PR fixes a bug that went undetected on #1970, where only the first experiment was being returned when the `experiment_names` parameter was separated with a comma + space, instead of just a comma.

The change is pretty straightforward as we just updated the separator parameter in the `joinToString` function.

### To test

Make sure all unit tests pass and/or use the following steps on the example app:

1. On the initial screen, tap **Experiments**.
1. On the next screen, select `wpandroid`.
1. Under "Experiment names", add the following experiment names, separated by a comma (you can add as many spaces as you like there):
    - `explat_test_android_mock_experiment_1`
    - `explat_test_android_mock_experiment_2`
1. Tap **Fetch Assignments**.
1. Check the results printed by the in-app console and verify they contain assignments for both experiments.