### PR TITLE
Generate Variations only with Valid Attributes

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -883,6 +883,7 @@ class WCProductStore @Inject constructor(
     ): WooResult<WCProductVariationModel> =
             coroutineEngine?.withDefaultContext(T.API, this, "generateEmptyVariation") {
                 product.attributeList
+                        .filter { it.variation }
                         .map { ProductVariantOption(it.id, it.name, "") }
                         .let { Gson().toJson(it) }
                         .let { wcProductRestClient.generateEmptyVariation(site, product.remoteProductId, it) }


### PR DESCRIPTION
Summary
==========
This PR address a small improvement needed by https://github.com/woocommerce/woocommerce-android/pull/3912 changes in order to avoid unnecessary data to be sent to the Store when updating a Product Variation.

How to Test
==========
1. Go to a Variable Product at `Update Product` section
2. Click at the `Generate Variation` button
3. Inspect the request and verify that only the Attributes enabled in the site as `use for variations` was sent inside JSON body