### PR TITLE
Added method to fetch the currency symbol for a store + unit test

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -225,6 +225,29 @@ open class WooCommerceStore @Inject constructor(
         }
     }
 
+    /**
+     * Fetches the currency symbol for display based on the site's settings and the device locale.
+     *
+     * If there is no [WCSettingsModel] associated with the given [site], the [currencyCode] will be returned if
+     * available, otherwise an empty string is returned.
+     *
+     * @param site the associated [SiteModel] - this will be used to resolve the corresponding [WCSettingsModel]
+     * @param currencyCode an optional, ISO 4217 currency code to use. If not supplied, the site's currency code
+     * will be used (obtained from the [WCSettingsModel] corresponding to the given [site]
+     */
+    fun getSiteCurrency(
+        site: SiteModel,
+        currencyCode: String? = null
+    ): String {
+        val siteSettings = getSiteSettings(site)
+
+        // Resolve the currency code to a localized symbol
+        val resolvedCurrencyCode = currencyCode?.takeIf { it.isNotEmpty() } ?: siteSettings?.currencyCode
+        return resolvedCurrencyCode?.let {
+            WCCurrencyUtils.getLocalizedCurrencySymbolForCode(it, LanguageUtils.getCurrentDeviceLanguage(appContext))
+        } ?: ""
+    }
+
     fun formatCurrencyForDisplay(
         amount: Double,
         site: SiteModel,


### PR DESCRIPTION
This tiny PR just adds a separate method to `WooCommerceStore` to fetch the currency symbol, without the currency value, for a given store. This is needed for fixing woocommerce/woocommerce-android#3651.

### To test
- Run `MockedStack_WCBaseStoreTest.kt`.