### PR TITLE
Improve Jetpack tunnel query parameters syntax

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -35,8 +35,9 @@ class JetpackTunnelGsonRequestTest {
         // Verify that the request was built and wrapped as expected
         assertEquals(WPCOMREST.jetpack_blogs.site(DUMMY_SITE_ID).rest_api.urlV1_1, UrlUtils.removeQuery(request?.url))
         val parsedUri = Uri.parse(request?.url)
-        assertEquals(2, parsedUri.queryParameterNames.size)
-        assertEquals("/&_method=get&context=view", parsedUri.getQueryParameter("path"))
+        assertEquals(3, parsedUri.queryParameterNames.size)
+        assertEquals("/&_method=get", parsedUri.getQueryParameter("path"))
+        assertEquals("{\"context\":\"view\"}", parsedUri.getQueryParameter("query"))
         assertEquals("true", parsedUri.getQueryParameter("json"))
 
         // The wrapped GET request should have no body
@@ -134,8 +135,9 @@ class JetpackTunnelGsonRequestTest {
         assertEquals(0, parsedUri.queryParameterNames.size)
         val body = String(request?.body!!)
         val generatedBody = gson.fromJson(body, HashMap<String, String>()::class.java)
-        assertEquals(2, generatedBody.size)
-        assertEquals("/wp/v2/posts/6&_method=delete&force=true", generatedBody["path"])
+        assertEquals(3, generatedBody.size)
+        assertEquals("{\"force\":\"true\"}", generatedBody["body"])
+        assertEquals("/wp/v2/posts/6&_method=delete", generatedBody["path"])
         assertEquals("true", generatedBody["json"])
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
 import java.lang.reflect.Type
-import java.net.URLEncoder
 
 /**
  * A request making a WP-API call to a Jetpack site via the WordPress.com /jetpack-blogs/$site/rest-api/ tunnel.
@@ -20,11 +19,12 @@ import java.net.URLEncoder
  *
  * Example request:
  * https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/$siteId/rest-api/
- * ?path=%2Fwp%2Fv2%2Fposts%2F%26_method%3Dget%26status%3Ddraft&json=true
+ * ?path=%2Fwp%2Fv2%2Fposts%2F%26json%3Dtrue%26_method%3Dget&query=%7B%22status%22%3A%22draft%22%7D
  *
  * Broken down, the GET parameters are:
- * path=/wp/v2/posts/&_method=get&status=draft
+ * path=/wp/v2/posts/&_method=get
  * json=true
+ * query={"status":"draft"}
  *
  * The path parameter is sent HTML-encoded so that it's discernible from the other arguments by WordPress.com.
  * In this example, this would become a GET request to {JSON endpoint root}/wp/v2/posts/?status=draft.
@@ -62,17 +62,18 @@ import java.net.URLEncoder
  *
  * ## DELETE
  *
- * DELETE requests are also made as POST requests to /jetpack-blogs/$siteId/rest-api/, but with no `body` parameter.
- * Instead, any arguments intended for the WP-API endpoint are added to the `path` parameter.
+ * DELETE requests are also made as POST requests to /jetpack-blogs/$siteId/rest-api/.
+ * Any arguments intended for the WP-API endpoint are added to the `body` parameter.
  *
  * Example request:
  * https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/$siteId/rest-api/
  *
  * Body (Form URL-Encoded):
- * path=%2Fwp%2Fv2%2Fposts%2F123456%2F%26_method%3Ddelete%26force%3Dtrue&json=true
+ * path=%2Fwp%2Fv2%2Fposts%2F123456%2F%26_method%3Ddelete%26&body=%7B%22force%22%3A%22true%22%7De&json=true
  *
  * Broken down, the POST parameters are:
- * path=/wp/v2/posts/123456&_method=delete&force=true
+ * path=/wp/v2/posts/123456&_method=delete
+ * body={"force":"true"}
  * json=true
  *
  * # Responses
@@ -216,7 +217,7 @@ object JetpackTunnelGsonRequest {
         listener: (T?) -> Unit,
         errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
-        val wrappedBody = createTunnelBody(method = "delete", params = params, path = wpApiEndpoint)
+        val wrappedBody = createTunnelBody(method = "delete", body = params, path = wpApiEndpoint)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
     }
 
@@ -240,8 +241,11 @@ object JetpackTunnelGsonRequest {
     private fun createTunnelParams(params: Map<String, String>, path: String): MutableMap<String, String> {
         val finalParams = mutableMapOf<String, String>()
         with(finalParams) {
-            put("path", buildRestApiPath(path, params, "get"))
+            put("path", "$path&_method=get")
             put("json", "true")
+            if (params.isNotEmpty()) {
+                put("query", gson.toJson(params))
+            }
         }
         return finalParams
     }
@@ -249,27 +253,16 @@ object JetpackTunnelGsonRequest {
     private fun createTunnelBody(
         method: String,
         body: Map<String, Any> = mapOf(),
-        params: Map<String, String> = mapOf(),
         path: String
     ): MutableMap<String, Any> {
         val finalBody = mutableMapOf<String, Any>()
         with(finalBody) {
-            put("path", buildRestApiPath(path, params, method))
+            put("path", "$path&_method=$method")
             put("json", "true")
             if (body.isNotEmpty()) {
                 put("body", gson.toJson(body))
             }
         }
         return finalBody
-    }
-
-    private fun buildRestApiPath(path: String, params: Map<String, String>, method: String): String {
-        var result = "$path&_method=$method"
-        if (params.isNotEmpty()) {
-            for (param in params) {
-                result += "&" + URLEncoder.encode(param.key, "UTF-8") + "=" + URLEncoder.encode(param.value, "UTF-8")
-            }
-        }
-        return result
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -202,7 +202,7 @@ object JetpackTunnelGsonRequest {
      *
      * @param wpApiEndpoint the WP-API request endpoint (e.g. /wp/v2/posts/)
      * @param siteId the WordPress.com site ID
-     * @param params the parameters to append to the request URL
+     * @param params the parameters of the request, those will be put in the tunnelled request body
      * @param type the Type defining the expected response
      * @param listener the success listener
      * @param errorListener the error listener


### PR DESCRIPTION
In order to implement https://github.com/woocommerce/woocommerce-android/issues/2069, to quote the original issue:

> Currently when requests are sent to the remote site, the URL parameters for the endpoint are encoded in the path parameter to the WordPress.com endpoint for the Jetpack proxy. There are also cases where the parameters for the remote site are set as actual parameters on the proxy endpoint. The proxy endpoint will pass these parameters along in most cases, but we've seen some strange behavior because of it.
> 
> Because of this, let's change how we send parameters to the remote site. Instead of appending them to the path property, bundle them all in a JSON object, URL-encode it, and use the query parameter on the rest-api endpoint. This works for POST requests as well as the body can contain JSON that isn't URL-encoded.

This PR makes this change, by passing path params in the `query` object.
And regarding the DELETE endpoint, its parameters are added to the `body` object, because the backend ignores the `query` parameter for endpoints other than GET (p1619607553382000-slack-CGPNUU63E), and to align with iOS's implementation.

### Testing
Open the example app, and try playing with different scenarios.