### PR TITLE
Add capture payment endpoint

### DIFF
--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -43,6 +43,7 @@
 /payment_gateways/<gateway_id>#String
 
 /payments/connection_tokens
+/payments/orders/<id>/capture_terminal_payment
 
 /taxes
 /taxes/classes/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/CapturePaymentApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/CapturePaymentApiResponse.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.pay
+
+import com.google.gson.annotations.SerializedName
+
+data class CapturePaymentApiResponse(
+    @SerializedName("status") val status: String,
+    @SerializedName("id") val paymentId: String
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -49,6 +49,7 @@ class PayRestClient @Inject constructor(
     }
 
     suspend fun capturePayment(site: SiteModel, paymentId: String, orderId: Long): WooPayload<CapturePaymentApiResponse> {
+        // TODO cardreader add error handling + introduce tests for both happy and error paths
         val url = WOOCOMMERCE.payments.orders.id(orderId).capture_terminal_payment.pathV3
         val params = mapOf(
                 "payment_intent_id" to paymentId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -5,7 +5,6 @@ import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
@@ -14,7 +13,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
-import org.wordpress.android.fluxc.network.utils.toMap
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -48,11 +46,15 @@ class PayRestClient @Inject constructor(
         }
     }
 
-    suspend fun capturePayment(site: SiteModel, paymentId: String, orderId: Long): WooPayload<CapturePaymentApiResponse> {
+    suspend fun capturePayment(
+        site: SiteModel,
+        paymentId: String,
+        orderId: Long
+    ): WooPayload<CapturePaymentApiResponse> {
         // TODO cardreader add error handling + introduce tests for both happy and error paths
         val url = WOOCOMMERCE.payments.orders.id(orderId).capture_terminal_payment.pathV3
         val params = mapOf(
-                "payment_intent_id" to paymentId,
+                "payment_intent_id" to paymentId
         )
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
@@ -31,4 +31,15 @@ class WCPayStore @Inject constructor(
             }
         }
     }
+
+    suspend fun capturePayment(site: SiteModel, paymentId: String, orderId: Long): WooResult<Unit> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "capturePayment") {
+            val response = restClient.capturePayment(site, paymentId, orderId)
+            return@withDefaultContext when {
+                response.isError -> WooResult(response.error)
+                else -> WooResult(Unit)
+            }
+
+        }
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
@@ -39,7 +39,6 @@ class WCPayStore @Inject constructor(
                 response.isError -> WooResult(response.error)
                 else -> WooResult(Unit)
             }
-
         }
     }
 }


### PR DESCRIPTION
This PR adds support  for `/payments/orders/<id>/capture_terminal_payment` endpoint which will be used to capture card-present payments. The development of this endpoint is not finished even on the server-side so this PR doesn't contain tests and error paths (except of generic "WooError"). I've added `TODO cardreader` - I plan to "fix or turn into tickets" all these todos before the code goes into production.

To test:
Test this in WCAndroid - https://github.com/woocommerce/woocommerce-android/pull/3943
