### PR TITLE
Fix a rare crash when fetching the system status endpoint

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -48,11 +48,11 @@ class WooSystemRestClient @Inject constructor(
     }
 
     data class ActivePluginsResponse(
-        @SerializedName("active_plugins") private val activePlugins: List<SystemPluginModel>,
-        @SerializedName("inactive_plugins") private val inactivePlugins: List<SystemPluginModel>
+        @SerializedName("active_plugins") private val activePlugins: List<SystemPluginModel>?,
+        @SerializedName("inactive_plugins") private val inactivePlugins: List<SystemPluginModel>?
     ) {
         val plugins: List<SystemPluginModel>
-            get() = activePlugins.map { it.copy(isActive = true) } + inactivePlugins
+            get() = activePlugins.orEmpty().map { it.copy(isActive = true) } + inactivePlugins.orEmpty()
 
         data class SystemPluginModel(
             val name: String,


### PR DESCRIPTION
This is needed to fix the issue https://github.com/woocommerce/woocommerce-android/issues/3925, in some stores, the `inactive_plugin` field is missing from the response, so I changed the response fields to be nullable all, to avoid any issues with them missing.

### Testing
1. Open the example app.
2. Click on Woo.
3. Click on Shipping Labels.
4. Click on Get shipping plugin info.
5. Confirm that the functionality is not impacted.