### PR TITLE
Added endpoint to fetch user info for a store

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -96,7 +96,7 @@ class WooCommerceFragment : Fragment() {
                         prependToLog("${it.type}: ${it.message}")
                     }
                     result.model?.let {
-                        prependToLog("Current user is: ${it.value}")
+                        prependToLog("Current user is: ${it.joinToString(", ")}")
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -11,6 +11,7 @@ import kotlinx.android.synthetic.main.fragment_woocommerce.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -30,6 +31,7 @@ import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserStore
 import org.wordpress.android.fluxc.store.WCDataStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
@@ -44,6 +46,7 @@ class WooCommerceFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject lateinit var wooCommerceStore: WooCommerceStore
     @Inject lateinit var wooDataStore: WCDataStore
+    @Inject lateinit var wooUserStore: WCUserStore
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
@@ -81,6 +84,22 @@ class WooCommerceFragment : Fragment() {
             getFirstWCSite()?.let {
                 dispatcher.dispatch(WCCoreActionBuilder.newFetchProductSettingsAction(it))
             } ?: showNoWCSitesToast()
+        }
+
+        get_user_role.setOnClickListener {
+            getFirstWCSite()?.let { site ->
+                coroutineScope.launch {
+                    val result = withContext(Dispatchers.Default) {
+                        wooUserStore.fetchUserRole(site)
+                    }
+                    result.error?.let {
+                        prependToLog("${it.type}: ${it.message}")
+                    }
+                    result.model?.let {
+                        prependToLog("Current user is: ${it.value}")
+                    }
+                }
+            }
         }
 
         orders.setOnClickListener {

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -36,6 +36,12 @@
             android:layout_height="wrap_content"
             android:text="Fetch WC product settings" />
 
+        <Button
+            android:id="@+id/get_user_role"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Get user_role" />
+
         <View
             android:id="@+id/divider1"
             style="@style/Divider" />

--- a/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPAPIEndpointTest.java
@@ -26,6 +26,10 @@ public class WPAPIEndpointTest {
 
         // Settings
         assertEquals("/settings/", WPAPI.settings.getEndpoint());
+
+        // Users
+        assertEquals("/users/", WPAPI.users.getEndpoint());
+        assertEquals("/users/me/", WPAPI.users.me.getEndpoint());
     }
 
     @Test
@@ -34,6 +38,7 @@ public class WPAPIEndpointTest {
         assertEquals("wp/v2/pages/", WPAPI.pages.getUrlV2());
         assertEquals("wp/v2/media/", WPAPI.media.getUrlV2());
         assertEquals("wp/v2/comments/", WPAPI.comments.getUrlV2());
-        assertEquals("wp/v2/settings/", WPAPI.settings.getUrlV2());
+        assertEquals("wp/v2/users/", WPAPI.users.getUrlV2());
+        assertEquals("wp/v2/users/me/", WPAPI.users.me.getUrlV2());
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.UserRole
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRole
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserStore
@@ -72,7 +72,7 @@ class WCUserStoreTest {
         assertThat(invalidRequestResult.error).isEqualTo(error)
     }
 
-    private suspend fun fetchUserRole(): WooResult<UserRole> {
+    private suspend fun fetchUserRole(): WooResult<WCUserRole> {
         val fetchUserRolePayload = WooPayload(sampleUserApiResponse)
         whenever(restClient.fetchUserInfo(site)).thenReturn(fetchUserRolePayload)
         whenever(restClient.fetchUserInfo(errorSite)).thenReturn(WooPayload(error))

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -65,6 +65,7 @@ class WCUserStoreTest {
     fun `fetch user role`() = test {
         val result = fetchUserRole()
         val userRole = mapper.map(sampleUserApiResponse!!)
+        assertThat(result.model?.size).isEqualTo(userRole.size)
         assertThat(result.model).isEqualTo(userRole)
 
         val invalidRequestResult = store.fetchUserRole(errorSite)
@@ -72,7 +73,7 @@ class WCUserStoreTest {
         assertThat(invalidRequestResult.error).isEqualTo(error)
     }
 
-    private suspend fun fetchUserRole(): WooResult<WCUserRole> {
+    private suspend fun fetchUserRole(): WooResult<List<WCUserRole>> {
         val fetchUserRolePayload = WooPayload(sampleUserApiResponse)
         whenever(restClient.fetchUserInfo(site)).thenReturn(fetchUserRolePayload)
         whenever(restClient.fetchUserInfo(errorSite)).thenReturn(WooPayload(error))

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -1,0 +1,81 @@
+package org.wordpress.android.fluxc.wc.user
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.yarolegovich.wellsql.WellSql
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.UserRole
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserStore
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCUserStoreTest {
+    private val restClient = mock <WCUserRestClient>()
+    private val site = SiteModel().apply { id = 321 }
+    private val errorSite = SiteModel().apply { id = 123 }
+    private val mapper = WCUserMapper()
+    private lateinit var store: WCUserStore
+
+    private val sampleUserApiResponse = WCUserTestUtils.generateSampleUApiResponse()
+    private val error = WooError(INVALID_RESPONSE, NETWORK_ERROR, "Invalid site ID")
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(
+                        SiteModel::class.java
+                ),
+                WellSqlConfig.ADDON_WOOCOMMERCE
+        )
+        WellSql.init(config)
+        config.reset()
+
+        store = WCUserStore(
+                restClient,
+                initCoroutineEngine(),
+                mapper
+        )
+
+        // Insert the site into the db so it's available later when testing user role
+        SiteSqlUtils.insertOrUpdateSite(site)
+    }
+
+    @Test
+    fun `fetch user role`() = test {
+        val result = fetchUserRole()
+        val userRole = mapper.map(sampleUserApiResponse!!)
+        assertThat(result.model).isEqualTo(userRole)
+
+        val invalidRequestResult = store.fetchUserRole(errorSite)
+        assertThat(invalidRequestResult.model).isNull()
+        assertThat(invalidRequestResult.error).isEqualTo(error)
+    }
+
+    private suspend fun fetchUserRole(): WooResult<UserRole> {
+        val fetchUserRolePayload = WooPayload(sampleUserApiResponse)
+        whenever(restClient.fetchUserInfo(site)).thenReturn(fetchUserRolePayload)
+        whenever(restClient.fetchUserInfo(errorSite)).thenReturn(WooPayload(error))
+        return store.fetchUserRole(site)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -67,6 +67,7 @@ class WCUserStoreTest {
         val userRole = mapper.map(sampleUserApiResponse!!)
         assertThat(result.model?.size).isEqualTo(userRole.size)
         assertThat(result.model).isEqualTo(userRole)
+        assertThat(result.model?.get(0)?.isSupported() == true)
 
         val invalidRequestResult = store.fetchUserRole(errorSite)
         assertThat(invalidRequestResult.model).isNull()

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserTestUtils.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.wc.user
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import org.wordpress.android.fluxc.UnitTestUtils
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient.UserApiResponse
+
+object WCUserTestUtils {
+    fun generateSampleUApiResponse(): UserApiResponse? {
+        val json = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/store-user-role.json")
+        val responseType = object : TypeToken<UserApiResponse>() {}.type
+        return Gson().fromJson(json, responseType) as? UserApiResponse
+    }
+}

--- a/example/src/test/resources/wc/store-user-role.json
+++ b/example/src/test/resources/wc/store-user-role.json
@@ -1,0 +1,49 @@
+{
+  "id": 1,
+  "name": "awootestshop",
+  "first_name": "Anitaa",
+  "last_name": "Murthy",
+  "email": "murthyanitaa@gmail.com",
+  "url": "",
+  "description": "",
+  "link": "https:\/\/awootestshop.mystagingwebsite.com\/author\/awootestshop\/",
+  "slug": "awootestshop",
+  "roles": [
+    "administrator"
+  ],
+  "avatar_urls": {
+    "24": "https:\/\/secure.gravatar.com\/avatar\/42968b94e80755359fbfc5965bd2ea61?s=24&d=mm&r=g",
+    "48": "https:\/\/secure.gravatar.com\/avatar\/42968b94e80755359fbfc5965bd2ea61?s=48&d=mm&r=g",
+    "96": "https:\/\/secure.gravatar.com\/avatar\/42968b94e80755359fbfc5965bd2ea61?s=96&d=mm&r=g"
+  },
+  "meta": [],
+  "woocommerce_meta": {
+    "activity_panel_inbox_last_read": "",
+    "activity_panel_reviews_last_read": "",
+    "categories_report_columns": "",
+    "coupons_report_columns": "",
+    "customers_report_columns": "",
+    "orders_report_columns": "",
+    "products_report_columns": "",
+    "revenue_report_columns": "",
+    "taxes_report_columns": "",
+    "variations_report_columns": "",
+    "dashboard_sections": "",
+    "dashboard_chart_type": "",
+    "dashboard_chart_interval": "",
+    "dashboard_leaderboard_rows": "",
+    "homepage_layout": "",
+    "homepage_stats": "",
+    "task_list_tracked_started_tasks": "",
+    "help_panel_highlight_shown": "",
+    "android_app_banner_dismissed": ""
+  },
+  "_links": {
+    "self": [{
+      "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wp\/v2\/users\/1"
+    }],
+    "collection": [{
+      "href": "https:\/\/awootestshop.mystagingwebsite.com\/wp-json\/wp\/v2\/users"
+    }]
+  }
+}

--- a/fluxc-processor/src/main/resources/wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-api-endpoints.txt
@@ -11,3 +11,6 @@
 /comments/<id>/
 
 /settings/
+
+/users/
+/users/me/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/UserRole.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/UserRole.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
+
+enum class UserRole(val value: String = "") {
+    ADMINISTRATOR("administrator"),
+    EDITOR("editor"),
+    AUTHOR("author"),
+    CONTRIBUTOR("contributor"),
+    SUBSCRIBER("subscriber"),
+    OTHER;
+
+    companion object {
+        private val valueMap = values().associateBy(UserRole::value)
+
+        /**
+         * Convert the base value into the associated UserRole object
+         */
+        fun fromValue(value: String) = valueMap[value]
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/UserRole.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/UserRole.kt
@@ -12,8 +12,11 @@ enum class UserRole(val value: String = "") {
         private val valueMap = values().associateBy(UserRole::value)
 
         /**
-         * Convert the base value into the associated UserRole object
+         * Convert the base value into the associated UserRole object.
+         * There are plugins available that can add custom roles.
+         * So if we are unable to find a matching [UserRole] object, [OTHER] is returned.
+         * This is not currently supported by our app.
          */
-        fun fromValue(value: String) = valueMap[value]
+        fun fromValue(value: String) = valueMap[value] ?: OTHER
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserMapper.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient.UserApiResponse
+import javax.inject.Inject
+
+class WCUserMapper
+@Inject constructor() {
+    fun map(user: UserApiResponse): UserRole {
+        return UserRole.fromValue(user.roles[0]) ?: UserRole.OTHER
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserMapper.kt
@@ -5,7 +5,9 @@ import javax.inject.Inject
 
 class WCUserMapper
 @Inject constructor() {
-    fun map(user: UserApiResponse): UserRole {
-        return UserRole.fromValue(user.roles[0]) ?: UserRole.OTHER
+    fun map(user: UserApiResponse): List<UserRole> {
+        val userRoles = mutableListOf<UserRole>()
+        user.roles.map { userRoles.add(UserRole.fromValue(it)) }
+        return userRoles
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserMapper.kt
@@ -5,9 +5,9 @@ import javax.inject.Inject
 
 class WCUserMapper
 @Inject constructor() {
-    fun map(user: UserApiResponse): List<UserRole> {
-        val userRoles = mutableListOf<UserRole>()
-        user.roles.map { userRoles.add(UserRole.fromValue(it)) }
+    fun map(user: UserApiResponse): List<WCUserRole> {
+        val userRoles = mutableListOf<WCUserRole>()
+        user.roles.map { userRoles.add(WCUserRole.fromValue(it)) }
         return userRoles
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRestClient.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPAPI
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.handleResult
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class WCUserRestClient @Inject constructor(
+    dispatcher: Dispatcher,
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
+    appContext: Context?,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchUserInfo(
+        site: SiteModel
+    ): WooPayload<UserApiResponse> {
+        val url = WPAPI.users.me.urlV2
+        val params = mapOf(
+                "context" to "edit"
+        )
+
+        return jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                params,
+                UserApiResponse::class.java
+        ).handleResult()
+    }
+
+    data class UserApiResponse(
+        val id: Long,
+        val username: String?,
+        val name: String?,
+        @SerializedName("first_name") val firstName: String?,
+        @SerializedName("last_name") val lastName: String?,
+        val email: String?,
+        val roles: List<String>
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRole.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRole.kt
@@ -1,20 +1,21 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
 
-enum class UserRole(val value: String = "") {
+enum class WCUserRole(val value: String = "") {
     ADMINISTRATOR("administrator"),
     EDITOR("editor"),
     AUTHOR("author"),
-    CONTRIBUTOR("contributor"),
+    CUSTOMER("customer"),
     SUBSCRIBER("subscriber"),
+    SHOP_MANAGER("shop_manager"),
     OTHER;
 
     companion object {
-        private val valueMap = values().associateBy(UserRole::value)
+        private val valueMap = values().associateBy(WCUserRole::value)
 
         /**
          * Convert the base value into the associated UserRole object.
          * There are plugins available that can add custom roles.
-         * So if we are unable to find a matching [UserRole] object, [OTHER] is returned.
+         * So if we are unable to find a matching [WCUserRole] object, [OTHER] is returned.
          * This is not currently supported by our app.
          */
         fun fromValue(value: String) = valueMap[value] ?: OTHER

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRole.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRole.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
 
 enum class WCUserRole(val value: String = "") {
+    OWNER("owner"),
     ADMINISTRATOR("administrator"),
     EDITOR("editor"),
     AUTHOR("author"),
@@ -20,4 +21,6 @@ enum class WCUserRole(val value: String = "") {
          */
         fun fromValue(value: String) = valueMap[value] ?: OTHER
     }
+
+    fun isSupported() = this == ADMINISTRATOR
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserStore.kt
@@ -16,7 +16,7 @@ class WCUserStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine,
     private val mapper: WCUserMapper
 ) {
-    suspend fun fetchUserRole(site: SiteModel): WooResult<UserRole> {
+    suspend fun fetchUserRole(site: SiteModel): WooResult<List<UserRole>> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchUserInfo") {
             val response = restClient.fetchUserInfo(site)
             return@withDefaultContext when {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserStore.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WCUserStore @Inject constructor(
+    private val restClient: WCUserRestClient,
+    private val coroutineEngine: CoroutineEngine,
+    private val mapper: WCUserMapper
+) {
+    suspend fun fetchUserRole(site: SiteModel): WooResult<UserRole> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchUserInfo") {
+            val response = restClient.fetchUserInfo(site)
+            return@withDefaultContext when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> {
+                    WooResult(mapper.map(response.result))
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserStore.kt
@@ -16,7 +16,7 @@ class WCUserStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine,
     private val mapper: WCUserMapper
 ) {
-    suspend fun fetchUserRole(site: SiteModel): WooResult<List<UserRole>> {
+    suspend fun fetchUserRole(site: SiteModel): WooResult<List<WCUserRole>> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchUserInfo") {
             val response = restClient.fetchUserInfo(site)
             return@withDefaultContext when {


### PR DESCRIPTION
Fixes #1978 

This PR adds the relevant endpoint to fetch the current user's role for a store. The Woo API's don't support roles other than Admin or Store manager. So we use this API to get the current user's role and display an error message if their role does not have the relevant access.

### Changes
- Added a new endpoint `/wp/v2/users/me`.
- Added new store, rest client, mapper classes to fetch the role of the current user.
- Added unit tests for `WCUserStore`.
- Added new button to example app to test the new endpoint.

### Notes
- I added an enum class `WCUserRole` that holds the list of default roles currently supported in Woo. 
- Custom roles for aa store can be created using external plugins. We currently don't support any roles other than Admin and Shop manager so I added an `OTHER` as well to the `UserRole` enum.
- I also found that a single user can have more than 1 user role defined. So added support for that as well.

### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/116804541-17779600-ab3d-11eb-9505-5c26bf6225b1.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/116804544-18a8c300-ab3d-11eb-880e-a60381940a82.png" width="300"/>

### Testing
- Login to a test store as an admin, shop manager, customer, subscriber etc from the example app.
- Click on `Woo` -> `Get User Role` and verify that the current user role is displayed correctly.
- Install the [User Role Editor](https://user-images.githubusercontent.com/22608780/116804544-18a8c300-ab3d-11eb-880e-a60381940a82.png) plugin on your test site.
- Add multiple user roles for a single user. You can also add custom user roles.
- Open the app and follow Step 2 and verify that the current user roles are displayed correctly. If a user has a custom user role, notice that `OTHER` is displayed.