### PR TITLE
Temporarily remove fetchstyle & configure plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,71 +43,71 @@ jobs:
           command: ./gradlew --stacktrace -PtestsMaxHeapSize=1536m example:testRelease
       - android/save-gradle-cache
       - android/save-test-results
-  Firebase Test:
-    parameters:
-      results-history-name:
-        type: string
-      package:
-        type: string
-      timeout:
-        type: string
-      num-flaky-test-attempts:
-        type: integer
-      post-slack-status:
-        type: boolean
-      device:
-        type: string
-    executor:
-      name: android/default
-      api-version: "27"
-    steps:
-      - checkout
-      - android/restore-gradle-cache:
-          cache-prefix: connected-tests
-      - copy-gradle-properties
-      - run:
-          name: Decrypt Secrets
-          command: ./gradlew applyConfiguration
-      - run:
-          name: Merge properties files
-          command: ./gradlew :example:combineTestsPropertiesWithExtraTestsProperties
-      - run:
-          name: Build
-          command: ./gradlew --stacktrace example:assembleDebug example:assembleDebugAndroidTest
-      - android/firebase-test:
-          key-file: .configure-files/firebase.secrets.json
-          results-history-name: << parameters.results-history-name >>
-          type: instrumentation
-          apk-path: example/build/outputs/apk/debug/example-debug.apk
-          test-apk-path: example/build/outputs/apk/androidTest/debug/example-debug-androidTest.apk
-          test-targets: package << parameters.package >>
-          device: << parameters.device >>
-          project: api-project-108380595987
-          timeout: << parameters.timeout >>
-          num-flaky-test-attempts: << parameters.num-flaky-test-attempts >>
-          no-record-video: true
-      - android/save-gradle-cache:
-          cache-prefix: connected-tests
-      - when:
-          condition: << parameters.post-slack-status >>
-          steps:
-            - run:
-                name: Setup Slack messages
-                when: always
-                command: |
-                  FIREBASE_URL="https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.fbe4c2866a46a076"
-                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: FluxC Connected tests have failed!\nSee $FIREBASE_URL'" >> $BASH_ENV
-                  echo "export SLACK_SUCCESS_MESSAGE=':tada: FluxC Connected tests have succeeded!\nSee $FIREBASE_URL'" >> $BASH_ENV
-            - slack/status:
-                fail_only: 'true'
-                failure_message: '${SLACK_FAILURE_MESSAGE}'
-                success_message: '${SLACK_SUCCESS_MESSAGE}'
-                webhook: '${SLACK_FAILURE_WEBHOOK}'
-            - slack/status:
-                fail_only: 'false'
-                failure_message: '${SLACK_FAILURE_MESSAGE}'
-                success_message: '${SLACK_SUCCESS_MESSAGE}'
-                webhook: '${SLACK_STATUS_WEBHOOK}'
+#  Firebase Test:
+#    parameters:
+#      results-history-name:
+#        type: string
+#      package:
+#        type: string
+#      timeout:
+#        type: string
+#      num-flaky-test-attempts:
+#        type: integer
+#      post-slack-status:
+#        type: boolean
+#      device:
+#        type: string
+#    executor:
+#      name: android/default
+#      api-version: "27"
+#    steps:
+#      - checkout
+#      - android/restore-gradle-cache:
+#          cache-prefix: connected-tests
+#      - copy-gradle-properties
+#      - run:
+#          name: Decrypt Secrets
+#          command: ./gradlew applyConfiguration
+#      - run:
+#          name: Merge properties files
+#          command: ./gradlew :example:combineTestsPropertiesWithExtraTestsProperties
+#      - run:
+#          name: Build
+#          command: ./gradlew --stacktrace example:assembleDebug example:assembleDebugAndroidTest
+#      - android/firebase-test:
+#          key-file: .configure-files/firebase.secrets.json
+#          results-history-name: << parameters.results-history-name >>
+#          type: instrumentation
+#          apk-path: example/build/outputs/apk/debug/example-debug.apk
+#          test-apk-path: example/build/outputs/apk/androidTest/debug/example-debug-androidTest.apk
+#          test-targets: package << parameters.package >>
+#          device: << parameters.device >>
+#          project: api-project-108380595987
+#          timeout: << parameters.timeout >>
+#          num-flaky-test-attempts: << parameters.num-flaky-test-attempts >>
+#          no-record-video: true
+#      - android/save-gradle-cache:
+#          cache-prefix: connected-tests
+#      - when:
+#          condition: << parameters.post-slack-status >>
+#          steps:
+#            - run:
+#                name: Setup Slack messages
+#                when: always
+#                command: |
+#                  FIREBASE_URL="https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.fbe4c2866a46a076"
+#                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: FluxC Connected tests have failed!\nSee $FIREBASE_URL'" >> $BASH_ENV
+#                  echo "export SLACK_SUCCESS_MESSAGE=':tada: FluxC Connected tests have succeeded!\nSee $FIREBASE_URL'" >> $BASH_ENV
+#            - slack/status:
+#                fail_only: 'true'
+#                failure_message: '${SLACK_FAILURE_MESSAGE}'
+#                success_message: '${SLACK_SUCCESS_MESSAGE}'
+#                webhook: '${SLACK_FAILURE_WEBHOOK}'
+#            - slack/status:
+#                fail_only: 'false'
+#                failure_message: '${SLACK_FAILURE_MESSAGE}'
+#                success_message: '${SLACK_SUCCESS_MESSAGE}'
+#                webhook: '${SLACK_STATUS_WEBHOOK}'
   WooCommerce API Tests:
     executor:
       name: android/default
@@ -134,31 +134,31 @@ workflows:
     jobs:
       - Lint
       - Unit Tests
-      - Firebase Test:
-          name: Mocked Connected Tests
-          results-history-name: CircleCI FluxC Mocked Tests
-          package: org.wordpress.android.fluxc.mocked
-          device: model=Nexus5X,version=26,locale=en,orientation=portrait
-          timeout: 10m
-          num-flaky-test-attempts: 0
-          post-slack-status: false
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - Firebase Test:
-          name: Connected Tests
-          results-history-name: CircleCI FluxC Tests
-          package: org.wordpress.android.fluxc
-          device: model=Nexus5X,version=26,locale=en,orientation=portrait
-          timeout: 30m
-          num-flaky-test-attempts: 1
-          post-slack-status: true
+#      - Firebase Test:
+#          name: Mocked Connected Tests
+#          results-history-name: CircleCI FluxC Mocked Tests
+#          package: org.wordpress.android.fluxc.mocked
+#          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+#          timeout: 10m
+#          num-flaky-test-attempts: 0
+#          post-slack-status: false
+#  nightly:
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - develop
+#    jobs:
+#      - Firebase Test:
+#          name: Connected Tests
+#          results-history-name: CircleCI FluxC Tests
+#          package: org.wordpress.android.fluxc
+#          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+#          timeout: 30m
+#          num-flaky-test-attempts: 1
+#          post-slack-status: true
   nightly-api-tests:
     triggers:
       - schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -5,18 +5,18 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url "https://dl.bintray.com/automattic/maven/" }
+        //maven { url "https://dl.bintray.com/automattic/maven/" }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.automattic.android:fetchstyle:1.1'
-        classpath 'com.automattic.android:configure:0.5.0'
+        //classpath 'com.automattic.android:fetchstyle:1.1'
+        //classpath 'com.automattic.android:configure:0.5.0'
     }
 }
 
-apply plugin: 'com.automattic.android.fetchstyle'
-apply plugin: 'com.automattic.android.configure'
+//apply plugin: 'com.automattic.android.fetchstyle'
+//apply plugin: 'com.automattic.android.configure'
 
 allprojects {
     apply plugin: 'checkstyle'


### PR DESCRIPTION
This PR temporarily removes fetchstyle & configure plugins since Bintray stopped serving them. It also removes the `Firebase Test` flow which depends on the `configure` plugin. This change should be reverted as soon as we move these plugins to S3.

**To test:**

* Run `./gradlew --refresh-dependencies` in `release/1.16.0` branch and verify that it returns an error for the missing configure plugin resource
* Run `./gradlew --refresh-dependencies` in `release/1.16.1` branch and verify that it passes

Please note that this may not be the last fix for the `1.16.1`. Specifically, `lazysodium` is served through a custom Bintray similar to configure & fetchstyle plugins, so that might cause a failure for us especially for WPAndroid's encrypted logging feature. This should normally fail when we do the refresh dependencies, but it looks like it's currently being served, so I don't know what's going on. I am testing WPAndroid's encrypted logging with these changes right now to double check.