### PR TITLE
Move lazysodium dependency to maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
+        mavenCentral()
     }
 
     task checkstyle(type: Checkstyle) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.example.di;
 import android.content.Context;
 import android.text.TextUtils;
 
-import com.goterl.lazycode.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.exceptions.SodiumException;
 
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLoggingKey;

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -104,8 +104,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
     // Encrypted Logging
-    api "com.goterl.lazycode:lazysodium-android:4.1.0@aar"
-    api "net.java.dev.jna:jna:4.5.1@aar"
+    api "com.goterl:lazysodium-android:5.0.2@aar"
+    api "net.java.dev.jna:jna:5.5.0@aar"
 }
 
 version = android.defaultConfig.versionName

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
-import com.goterl.lazycode.lazysodium.interfaces.Box
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream
-import com.goterl.lazycode.lazysodium.utils.KeyPair
+import com.goterl.lazysodium.interfaces.Box
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.KeyPair
 
 /**
  * A class representing an Encrypted Secret Stream Key.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptionUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptionUtils.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
-import com.goterl.lazycode.lazysodium.LazySodiumAndroid
-import com.goterl.lazycode.lazysodium.SodiumAndroid
+import com.goterl.lazysodium.LazySodiumAndroid
+import com.goterl.lazysodium.SodiumAndroid
 
 /**
  * Convenience helpers for Encrypted Logging

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt
@@ -1,9 +1,9 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
 import android.util.Base64
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream.State
-import com.goterl.lazycode.lazysodium.utils.Key
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.interfaces.SecretStream.State
+import com.goterl.lazysodium.utils.Key
 import dagger.Reusable
 import javax.inject.Inject
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/SecretStreamKey.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/SecretStreamKey.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.model.encryptedlogging
 
-import com.goterl.lazycode.lazysodium.interfaces.Box
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream
-import com.goterl.lazycode.lazysodium.utils.Key
+import com.goterl.lazysodium.interfaces.Box
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.Key
 
 /**
  * A class representing an unencrypted Secret Stream Key.

--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.instaflux;
 import android.content.Context;
 import android.text.TextUtils;
 
-import com.goterl.lazycode.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.exceptions.SodiumException;
 
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLoggingKey;
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptionUtils;


### PR DESCRIPTION
Updates lazysodium to the latest version which is hosted at `mavenCentral()`.

We'll need to test the encrypted logging feature in WPAndroid to verify these changes, but I think it's safe to merge it in before that and open a separate PR if there are any issues.