### PR TITLE
Support `_fields` when fetching list of orders by ids

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -39,38 +39,31 @@ class OrderApiResponse : Response {
         val total: String? = null
     }
 
-    val id: Long? = null
-    val number: String? = null
-    val status: String? = null
+    val billing: Billing? = null
+    val coupon_lines: List<CouponLine>? = null
     val currency: String? = null
+    val customer_note: String? = null
     val date_created_gmt: String? = null
     val date_modified_gmt: String? = null
-    val total: String? = null
-    val total_tax: String? = null
-    val shipping_total: String? = null
-    val payment_method: String? = null
-    val payment_method_title: String? = null
     val date_paid_gmt: String? = null
-    val prices_include_tax: Boolean = false
-
-    val customer_note: String? = null
-
     val discount_total: String? = null
-    val coupon_lines: List<CouponLine>? = null
-
-    val billing: Billing? = null
-    val shipping: Shipping? = null
-
+    // Same as shipping_lines, it's a list of objects
+    val fee_lines: JsonElement? = null
+    val id: Long? = null
     // This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand.
     // See WCOrderModel.LineItem
     val line_items: JsonElement? = null
-
+    val number: String? = null
+    val payment_method: String? = null
+    val payment_method_title: String? = null
+    val prices_include_tax: Boolean = false
     val refunds: List<Refund>? = null
-
+    val shipping: Shipping? = null
     // This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand.
     // See WCOrderModel.ShippingLines
     val shipping_lines: JsonElement? = null
-
-    // Same as shipping_lines, it's a list of objects
-    val fee_lines: JsonElement? = null
+    val shipping_total: String? = null
+    val status: String? = null
+    val total: String? = null
+    val total_tax: String? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -60,11 +60,6 @@ class OrderRestClient @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    private val ORDER_FIELDS = "id,number,status,currency,date_created_gmt,total,total_tax,shipping_total," +
-            "payment_method,payment_method_title,prices_include_tax,customer_note,discount_total," +
-            "coupon_lines,refunds,billing,shipping,line_items,date_paid_gmt,shipping_lines,fee_lines"
-    private val TRACKING_FIELDS = "tracking_id,tracking_number,tracking_link,tracking_provider,date_shipped"
-
     /**
      * Makes a GET call to `/wc/v3/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * retrieving a list of orders for the given WooCommerce [SiteModel].
@@ -181,8 +176,8 @@ class OrderRestClient @Inject constructor(
         val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
         val params = mapOf(
                 "per_page" to remoteOrderIds.size.toString(),
-                "include" to remoteOrderIds.map { it.value }.joinToString()
-        )
+                "include" to remoteOrderIds.map { it.value }.joinToString(),
+                "_fields" to ORDER_FIELDS)
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderApiResponse>? ->
                     val orderModels = response?.map {
@@ -809,5 +804,40 @@ class OrderRestClient @Inject constructor(
                 }
 
         return providers
+    }
+
+    companion object {
+        private val ORDER_FIELDS = arrayOf(
+                "billing",
+                "coupon_lines",
+                "currency",
+                "customer_note",
+                "date_created_gmt",
+                "date_modified_gmt",
+                "date_paid_gmt",
+                "discount_total",
+                "fee_lines",
+                "id",
+                "line_items",
+                "number",
+                "payment_method",
+                "payment_method_title",
+                "prices_include_tax",
+                "refunds",
+                "shipping",
+                "shipping_lines",
+                "shipping_total",
+                "status",
+                "total",
+                "total_tax"
+        ).joinToString(separator = ",")
+
+        private val TRACKING_FIELDS = arrayOf(
+                "date_shipped",
+                "tracking_id",
+                "tracking_link",
+                "tracking_number",
+                "tracking_provider"
+        ).joinToString(separator = ",")
     }
 }


### PR DESCRIPTION
Closes #1354 

This PR is a complementary to #1157 

It adds `_fields` to the call that doesn't have it yet: `OrderRestClient#fetchOrdersByIds`.

I also added some improvements to readability of the fields we request and added one: `date_modified_gmt` which we were missing.

### Result

On below screens you can see 4 calls.
- 2 first requests "ids" of the orders. There are 2 calls as on test project I have 16 orders and we batch this request by 15 orders per request
- next 2 requests are requests that fetch "rich" `Orders`

You can see that after we reduced size of the requests roughly by half.

> Note: `Duration` is not a good measurement, if you take a look at first two calls, they weren't influence by changes in this PR but duration vary ~20%.

#### Before
<img width="1028" alt="before" src="https://user-images.githubusercontent.com/5845095/116994712-5b9f9d80-acd9-11eb-83d7-6df693cd87ce.png">

#### After
<img width="1031" alt="after" src="https://user-images.githubusercontent.com/5845095/116994724-60fce800-acd9-11eb-847a-c23057da40e7.png">

### How to test

There are basically two equivalent ways, please choose the one you find more effortless:

#### Using `Flipper`
1. Run the `WCAndroid` app (build from this PR), go to `Orders`. 
2. Open `Flipper` app, select `databases` plugin
3. Select `tracks.db` and run `DELETE FROM WCOrderModel` in `SQL` section
4. Refresh the orders
3. Smoke test orders list and details: make sure all expected fields are present

or

#### Reinstalling the app
1. Remove `WCAndroid` from Android device (or just remove app's data)
2. Install the app (build from this PR)
3. Log in, go to `orders`
3. Smoke test orders list and details: make sure all expected fields are present

You can use app build from this PR: https://github.com/woocommerce/woocommerce-android/pull/3962

