### PR TITLE
Recreate WCRefunds database to take into account changes in PR 1948.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1740,6 +1740,17 @@ open class WellSqlConfig : DefaultWellConfig {
                             "PREFERRED_BLOG_NAME TEXT,PREFERRED_BLOG_URL TEXT,PREFERRED_BLOG_BLAVATAR_URL TEXT," +
                             "DATE_LIKED TEXT,TIMESTAMP_FETCHED INTEGER)")
                 }
+                149 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCRefunds")
+                    db.execSQL(
+                            "CREATE TABLE WCRefunds (" +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "ORDER_ID INTEGER," +
+                                    "REFUND_ID INTEGER," +
+                                    "DATA TEXT NOT NULL)"
+                    )
+                }
             }
         }
         db.setTransactionSuccessful()


### PR DESCRIPTION
This is to fix [WooCommerce Android issue 3973](https://github.com/woocommerce/woocommerce-android/issues/3973).

## What this PR does:

In #1948, I introduced changes into the value stored in the `data` column of the `WCRefund` table. Specifically, I'm adding `shipping_lines` key-data pair from API responses into the table. The data then gets used by FluxC and Woo Android to display and process refunds properly.

**The problem**: If the app already has existing Refund data in `WCRefund` table prior to this change, then that data will not contain the `shipping_lines` key-data pair yet. This will then crash the app in Order Details view, because FluxC expects them to exist, yet they don't.

**The solution**: Here we're dropping the `WCRefund` table and recreating it. That way, when Order Details is opened, the app will fetch new Refund data thru API, and this new data will contain the `shipping_lines` key-data pair, thus avoiding the error.

## Testing instructions:

**To replicate the issue:**

1. This might be a bit tricky to get, but first you need a site with an Order with some already refunded item in it, and make sure this Order is already opened in the app at least once. 
2. Switch to `release/6.6` branch in WooCommerce Android and run the app. Open the same Order again, and check that now the app crashes. Log will say something like this:

```
NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter shippingLineItems
    at com.woocommerce.android.ui.orders.details.OrderDetailRepository.getOrderRefunds(OrderDetailRepository.kt:280)
    at com.woocommerce.android.ui.orders.details.OrderDetailViewModel.checkIfFetchNeeded(OrderDetailViewModel.kt:185)
    at com.woocommerce.android.ui.orders.details.OrderDetailViewModel.start(OrderDetailViewModel.kt:131)
    at com.woocommerce.android.ui.orders.details.OrderDetailViewModel.<init>(OrderDetailViewModel.kt:124)
    at com.woocommerce.android.ui.orders.details.OrderDetailViewModel_Factory.newInstance(OrderDetailViewModel_Factory.java:55)
...
```

For step 1, in case you have an Order with Refund but it doesn't cause a crash, it likely means that its data is already correct. To make it broken, you can use Flipper app to edit the data in WCRefund table. Specifically, edit the "Data" column value in `WCRefunds` table and delete ~`"line_items":[]`~ `shipping_lines:[]` in it. Then continue to step 2.


**To test the fix:**

1. Update your local WooCommerce Android branch's fluxC version to point to this PR's hash ( `e66a8210bd9a4913c56b3abe8189da4ab0e10f1b` )
2. Run app.
3. Open the same Order again (make sure internet is connected), check that now the Order Details is opening correctly without crash.