### PR TITLE
Handle custom errors for capturePayment endpoint

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
@@ -5,8 +5,16 @@ import org.junit.Assert
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.CUSTOM_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError.CaptureFailed
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError.MissingOrder
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError.UncapturablePayment
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError.WCPayServerError
 import javax.inject.Inject
+
+private const val DUMMY_PAYMENT_ID = "dummy payment id"
 
 class MockedStack_WCPayTest : MockedStack_Base() {
     @Inject internal lateinit var payRestClient: PayRestClient
@@ -27,5 +35,51 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         Assert.assertTrue(result.result?.token?.isNotEmpty() == true)
         Assert.assertTrue(result.result?.isTestMode == true)
+    }
+
+    @Test
+    fun whenValidDataProvidedForCapturePaymentThenSuccessReturned() = runBlocking {
+        interceptor.respondWithError("wc-pay-capture-terminal-payment-response-success.json", 200)
+
+        val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+
+        Assert.assertFalse(result.isError)
+        Assert.assertTrue(result.result != null)
+    }
+
+    @Test
+    fun whenInvalidOrderIdProvidedForCapturePaymentThenInvalidIdIsReturned() = runBlocking {
+        interceptor.respondWithError("wc-pay-capture-terminal-payment-response-missing-order.json", 404)
+
+        val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+
+        Assert.assertTrue(result.error is MissingOrder)
+    }
+
+    @Test
+    fun whenPaymentAlreadyCapturedThenUncapturableErrorReturned() = runBlocking {
+        interceptor.respondWithError("wc-pay-capture-terminal-payment-response-uncapturable.json", 409)
+
+        val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+
+        Assert.assertTrue(result.error is UncapturablePayment)
+    }
+
+    @Test
+    fun whenPaymentCaptureFailsThenCaptureFailedErrorReturned() = runBlocking {
+        interceptor.respondWithError("wc-pay-capture-terminal-payment-response-capture-error.json", 502)
+
+        val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+
+        Assert.assertTrue(result.error is CaptureFailed)
+    }
+
+    @Test
+    fun whenUnexpectedErrorOccursDuringCaptureThenWCPayServerErrorReturned() = runBlocking {
+        interceptor.respondWithError("wc-pay-capture-terminal-payment-response-unexpected-error.json", 500)
+
+        val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+
+        Assert.assertTrue(result.error is WCPayServerError)
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
@@ -4,14 +4,12 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.pay.WCCapturePaymentErrorType.CAPTURE_ERROR
+import org.wordpress.android.fluxc.model.pay.WCCapturePaymentErrorType.MISSING_ORDER
+import org.wordpress.android.fluxc.model.pay.WCCapturePaymentErrorType.PAYMENT_ALREADY_CAPTURED
+import org.wordpress.android.fluxc.model.pay.WCCapturePaymentErrorType.SERVER_ERROR
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.CUSTOM_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError.CaptureFailed
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError.MissingOrder
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError.UncapturablePayment
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient.CaptureTerminalPaymentError.WCPayServerError
 import javax.inject.Inject
 
 private const val DUMMY_PAYMENT_ID = "dummy payment id"
@@ -44,7 +42,7 @@ class MockedStack_WCPayTest : MockedStack_Base() {
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
         Assert.assertFalse(result.isError)
-        Assert.assertTrue(result.result != null)
+        Assert.assertTrue(result.status != null)
     }
 
     @Test
@@ -53,7 +51,7 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
-        Assert.assertTrue(result.error is MissingOrder)
+        Assert.assertTrue(result.error.type == MISSING_ORDER)
     }
 
     @Test
@@ -62,7 +60,7 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
-        Assert.assertTrue(result.error is UncapturablePayment)
+        Assert.assertTrue(result.error.type == PAYMENT_ALREADY_CAPTURED)
     }
 
     @Test
@@ -71,7 +69,7 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
-        Assert.assertTrue(result.error is CaptureFailed)
+        Assert.assertTrue(result.error.type == CAPTURE_ERROR)
     }
 
     @Test
@@ -80,6 +78,6 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
-        Assert.assertTrue(result.error is WCPayServerError)
+        Assert.assertTrue(result.error.type == SERVER_ERROR)
     }
 }

--- a/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-capture-error.json
+++ b/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-capture-error.json
@@ -1,0 +1,7 @@
+{
+  "code": "wcpay_capture_error",
+  "message": "Payment capture failed to complete with the following message: <ERROR_MESSAGE>",
+  "data": {
+    "status": 502
+  }
+}

--- a/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-missing-order.json
+++ b/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-missing-order.json
@@ -1,0 +1,7 @@
+{
+  "code": "wcpay_missing_order",
+  "message": "Order not found",
+  "data": {
+    "status": 404
+  }
+}

--- a/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-success.json
+++ b/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-success.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "status": "succeeded",
+    "id": "dummy_payment_id"
+  }
+}

--- a/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-uncapturable.json
+++ b/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-uncapturable.json
@@ -1,0 +1,7 @@
+{
+  "code": "wcpay_payment_uncapturable",
+  "message": "The payment cannot be captured",
+  "data": {
+    "status": 409
+  }
+}

--- a/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-unexpected-error.json
+++ b/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-unexpected-error.json
@@ -1,0 +1,7 @@
+{
+  "code": "wcpay_server_error",
+  "message": "Unexpected server error",
+  "data": {
+    "status": 500
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCCapturePaymentResponsePayload.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCCapturePaymentResponsePayload.kt
@@ -9,7 +9,7 @@ class WCCapturePaymentResponsePayload(
     val paymentId: String,
     val orderId: Long,
     val status: String?
-) : Payload<WCCapturePaymentError>() {
+) : Payload<WCCapturePaymentError?>() {
     public constructor(
         error: WCCapturePaymentError,
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCCapturePaymentResponsePayload.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCCapturePaymentResponsePayload.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.fluxc.model.pay
+
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.Store.OnChangedError
+
+class WCCapturePaymentResponsePayload(
+    val site: SiteModel,
+    val paymentId: String,
+    val orderId: Long,
+    val status: String?
+) : Payload<WCCapturePaymentError>() {
+    public constructor(
+        error: WCCapturePaymentError,
+        site: SiteModel,
+        paymentId: String,
+        orderId: Long
+    ) : this(site, paymentId, orderId, null) {
+        this.error = error
+    }
+}
+
+class WCCapturePaymentError(
+    val type: WCCapturePaymentErrorType = WCCapturePaymentErrorType.GENERIC_ERROR,
+    val message: String = ""
+) : OnChangedError
+
+enum class WCCapturePaymentErrorType {
+    GENERIC_ERROR,
+    PAYMENT_ALREADY_CAPTURED,
+    MISSING_ORDER,
+    CAPTURE_ERROR,
+    SERVER_ERROR,
+    NETWORK_ERROR
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.pay.WCCapturePaymentResponsePayload
 import org.wordpress.android.fluxc.model.pay.WCConnectionTokenResult
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -32,13 +33,9 @@ class WCPayStore @Inject constructor(
         }
     }
 
-    suspend fun capturePayment(site: SiteModel, paymentId: String, orderId: Long): WooResult<Unit> {
+    suspend fun capturePayment(site: SiteModel, paymentId: String, orderId: Long): WCCapturePaymentResponsePayload {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "capturePayment") {
-            val response = restClient.capturePayment(site, paymentId, orderId)
-            return@withDefaultContext when {
-                response.isError -> WooResult(response.error)
-                else -> WooResult(Unit)
-            }
+            return@withDefaultContext restClient.capturePayment(site, paymentId, orderId)
         }
     }
 }


### PR DESCRIPTION
This PR adds support for transforming [errors specific to capturePayment endpoint](https://github.com/Automattic/woocommerce-payments/pull/1689#discussion_r623880571) and returning them back to the client. Unfortunately, `WooResult` and `WooError` do not support custom errors so I decided to fallback to the default FluxC `Payload`. I've tried to extend `WooResult` in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1983 but decided to close the PR since the introduced complexity wasn't imo worth it.

The client apps don't need to be updated, so feel free to merge this PR.