### PR TITLE
Adds option to return cached page layouts when available

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/TestUtils.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/TestUtils.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 public class TestUtils {
     public static final int DEFAULT_TIMEOUT_MS = 30000;
     public static final int MULTIPLE_UPLOADS_TIMEOUT_MS = 60000;
+    public static final int CACHE_TIMEOUT_MS = 500;
 
     private static final String SAMPLE_IMAGE = "pony.jpg";
     private static final String SAMPLE_VIDEO = "pony.mp4";

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -216,15 +216,27 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @Test
     public void testFetchBlockLayouts() throws InterruptedException {
-        testFetchBlockLayouts(false);
+        testFetchBlockLayouts(false, false);
+    }
+
+    @Test
+    public void testFetchBlockLayoutsFromCache() throws InterruptedException {
+        testFetchBlockLayouts(false, false);
+        testFetchBlockLayouts(false, true);
     }
 
     @Test
     public void testFetchBlockLayoutsBeta() throws InterruptedException {
-        testFetchBlockLayouts(true);
+        testFetchBlockLayouts(true, false);
     }
 
-    private void testFetchBlockLayouts(boolean isBeta) throws InterruptedException {
+    @Test
+    public void testFetchBlockLayoutsBetaFromCache() throws InterruptedException {
+        testFetchBlockLayouts(true, false);
+        testFetchBlockLayouts(true, true);
+    }
+
+    private void testFetchBlockLayouts(boolean isBeta, boolean preferCache) throws InterruptedException {
         authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
                 BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         SiteModel firstSite = mSiteStore.getSites().get(0);
@@ -239,9 +251,10 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mNextEvent = TestEvents.BLOCK_LAYOUTS_FETCHED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchBlockLayoutsAction(
                 new SiteStore.FetchBlockLayoutsPayload(firstSite, supportedBlocks,
-                        320.0f, 480.0f, 1.0f, isBeta)));
+                        320.0f, 480.0f, 1.0f, isBeta, preferCache)));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch
+                .await(preferCache ? TestUtils.CACHE_TIMEOUT_MS : TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -236,15 +236,27 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
 
     @Test
     public void testFetchBlockLayouts() throws InterruptedException {
-        testFetchBlockLayouts(false);
+        testFetchBlockLayouts(false, false);
+    }
+
+    @Test
+    public void testFetchBlockLayoutsFromCache() throws InterruptedException {
+        testFetchBlockLayouts(false, false);
+        testFetchBlockLayouts(false, true);
     }
 
     @Test
     public void testFetchBlockLayoutsBeta() throws InterruptedException {
-        testFetchBlockLayouts(true);
+        testFetchBlockLayouts(true, false);
     }
 
-    private void testFetchBlockLayouts(boolean isBeta) throws InterruptedException {
+    @Test
+    public void testFetchBlockLayoutsBetaFromCache() throws InterruptedException {
+        testFetchBlockLayouts(true, false);
+        testFetchBlockLayouts(true, true);
+    }
+
+    private void testFetchBlockLayouts(boolean isBeta, boolean preferCache) throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
@@ -260,9 +272,10 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TestEvents.BLOCK_LAYOUTS_FETCHED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchBlockLayoutsAction(
                 new SiteStore.FetchBlockLayoutsPayload(firstSite, supportedBlocks,
-                        320.0f, 480.0f, 1.0f, isBeta)));
+                        320.0f, 480.0f, 1.0f, isBeta, preferCache)));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch
+                .await(preferCache ? TestUtils.CACHE_TIMEOUT_MS : TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1552,6 +1552,17 @@ public class SiteStore extends Store {
         return SiteSqlUtils.getBlockLayoutContent(site, slug);
     }
 
+    /**
+     * Gets the cached page layout
+     *
+     * @param site the current site
+     * @param slug the slug of the layout
+     * @return the layout or null if the layout is not cached
+     */
+    public @Nullable GutenbergLayout getBlockLayout(@NonNull SiteModel site, @NonNull String slug) {
+        return SiteSqlUtils.getBlockLayout(site, slug);
+    }
+
     public List<PostFormatModel> getPostFormats(SiteModel site) {
         return SiteSqlUtils.getPostFormats(site);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -179,19 +179,22 @@ public class SiteStore extends Store {
         @Nullable public Float previewHeight;
         @Nullable public Float scale;
         @Nullable public Boolean isBeta;
+        @Nullable public Boolean preferCache;
 
         public FetchBlockLayoutsPayload(@NonNull SiteModel site,
                                         @Nullable List<String> supportedBlocks,
                                         @Nullable Float previewWidth,
                                         @Nullable Float previewHeight,
                                         @Nullable Float scale,
-                                        @Nullable Boolean isBeta) {
+                                        @Nullable Boolean isBeta,
+                                        @Nullable Boolean preferCache) {
             this.site = site;
             this.supportedBlocks = supportedBlocks;
             this.previewWidth = previewWidth;
             this.previewHeight = previewHeight;
             this.scale = scale;
             this.isBeta = isBeta;
+            this.preferCache = preferCache;
         }
     }
 
@@ -1966,6 +1969,7 @@ public class SiteStore extends Store {
     }
 
     private void fetchBlockLayouts(FetchBlockLayoutsPayload payload) {
+        if (payload.preferCache != null && payload.preferCache && cachedLayoutsRetrieved(payload.site)) return;
         if (payload.site.isUsingWpComRestApi()) {
             mSiteRestClient
                     .fetchWpComBlockLayouts(payload.site, payload.supportedBlocks,
@@ -2242,17 +2246,29 @@ public class SiteStore extends Store {
     private void handleFetchedBlockLayouts(FetchedBlockLayoutsResponsePayload payload) {
         if (payload.isError()) {
             // Return cached layouts on error
-            List<GutenbergLayout> layouts = SiteSqlUtils.getBlockLayouts(payload.site);
-            List<GutenbergLayoutCategory> categories = SiteSqlUtils.getBlockLayoutCategories(payload.site);
-            if (!layouts.isEmpty() && !categories.isEmpty()) {
-                emitChange(new OnBlockLayoutsFetched(layouts, categories, null));
-            } else {
+            if (!cachedLayoutsRetrieved(payload.site)) {
                 emitChange(new OnBlockLayoutsFetched(payload.layouts, payload.categories, payload.error));
             }
         } else {
             SiteSqlUtils.insertOrReplaceBlockLayouts(payload.site, payload.categories, payload.layouts);
             emitChange(new OnBlockLayoutsFetched(payload.layouts, payload.categories, payload.error));
         }
+    }
+
+    /**
+     * Emits a new [OnBlockLayoutsFetched] event with cached layouts for a given site
+     *
+     * @param site the site for which the cached layouts should be retrieved
+     * @return true if cached layouts were retrieved successfully
+     */
+    private boolean cachedLayoutsRetrieved(SiteModel site) {
+        List<GutenbergLayout> layouts = SiteSqlUtils.getBlockLayouts(site);
+        List<GutenbergLayoutCategory> categories = SiteSqlUtils.getBlockLayoutCategories(site);
+        if (!layouts.isEmpty() && !categories.isEmpty()) {
+            emitChange(new OnBlockLayoutsFetched(layouts, categories, null));
+            return true;
+        }
+        return false;
     }
 
     // Automated Transfers


### PR DESCRIPTION
This PR adds an option to return cached page layouts when available.
Connected tests were also added verifying that previously cached layouts can be restored from cache. Note that there were already [tests in place](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/5f2fb2f652ec711d17c5b7392c54491b1259f370/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java#L743) for the caching mechanism.

⚠️ **Do not merge** without the [Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14606)