### PR TITLE
Merge release/1.16.2 into develop

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1740,6 +1740,17 @@ open class WellSqlConfig : DefaultWellConfig {
                             "PREFERRED_BLOG_NAME TEXT,PREFERRED_BLOG_URL TEXT,PREFERRED_BLOG_BLAVATAR_URL TEXT," +
                             "DATE_LIKED TEXT,TIMESTAMP_FETCHED INTEGER)")
                 }
+                149 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCRefunds")
+                    db.execSQL(
+                            "CREATE TABLE WCRefunds (" +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "ORDER_ID INTEGER," +
+                                    "REFUND_ID INTEGER," +
+                                    "DATA TEXT NOT NULL)"
+                    )
+                }
             }
         }
         db.setTransactionSuccessful()


### PR DESCRIPTION
We just made a hotfix of FluxC 1.16.2, cut from 1.16.1 tag, in order to fix an issue in the beta of WC 6.6. So time to merge this back to `develop`.

This PR replaces https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1993 which was created the wrong way around (`develop` -> `release/1.16.2` instead of `release/1.16.2` -> `develop`. \cc @hafizrahman 