### PR TITLE
Revert "Use Plugin DSL"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,22 @@
+buildscript {
+    ext.kotlinVersion = '1.4.10'
+    ext.kotlinCoroutinesVersion = '1.3.9'
 
-plugins {
-    // Those declarations are just a workaround for a false-positive Kotlin Gradle Plugin warning
-    // https://youtrack.jetbrains.com/issue/KT-46200
-    id "com.android.application" apply false
-    id "org.jetbrains.kotlin.android" apply false
-    id "org.jetbrains.kotlin.android.extensions" apply false
-    id "org.jetbrains.kotlin.jvm" apply false
-    id "org.jetbrains.kotlin.kapt" apply false
+    repositories {
+        google()
+        jcenter()
+        //maven { url "https://dl.bintray.com/automattic/maven/" }
+    }
 
-//    id "com.automattic.android.fetchstyle"
-//    id "com.automattic.android.configure"
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.0.1'
+        //classpath 'com.automattic.android:fetchstyle:1.1'
+        //classpath 'com.automattic.android:configure:0.5.0'
+    }
 }
+
+//apply plugin: 'com.automattic.android.fetchstyle'
+//apply plugin: 'com.automattic.android.configure'
 
 allprojects {
     apply plugin: 'checkstyle'
@@ -34,6 +40,17 @@ allprojects {
 }
 
 subprojects {
+    configurations.all {
+        resolutionStrategy {
+            forcedModules = [
+                    // Needed for com.nhaarman:mockito-kotlin-kt1.1
+                    // Can possibly be dropped when v2 of mockito-kotlin is released
+                    "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+            ]
+        }
+    }
+
     configurations {
         ktlint
     }
@@ -65,5 +82,4 @@ ext {
     appcompat_version = '1.0.2'
     mockitoVersion = '3.3.3'
     assertJVersion = '3.19.0'
-    kotlinCoroutinesVersion = '1.3.9'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,9 +1,16 @@
-plugins {
-    id "com.android.application"
-    id "org.jetbrains.kotlin.android"
-    id "org.jetbrains.kotlin.android.extensions"
-    id "org.jetbrains.kotlin.kapt"
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
 }
+
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 28
@@ -86,6 +93,8 @@ dependencies {
     implementation project(':fluxc')
     implementation project(':plugins:woocommerce')
 
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
@@ -112,7 +121,7 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
     testImplementation 'junit:junit:4.13'
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$gradle.ext.kotlinVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -1,8 +1,19 @@
-plugins {
-    id "java"
-    id "maven"
-    id "org.jetbrains.kotlin.jvm"
-    id "org.jetbrains.kotlin.kapt"
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt'
+
+repositories {
+    jcenter()
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-    id "com.android.library"
-    id "org.jetbrains.kotlin.android"
-    id "org.jetbrains.kotlin.android.extensions"
-    id "org.jetbrains.kotlin.kapt"
-    id "com.github.dcendents.android-maven"
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
+apply plugin: 'com.github.dcendents.android-maven'
+
+repositories {
+    jcenter()
 }
 
 android {
@@ -51,13 +63,15 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
 
     implementation "androidx.exifinterface:exifinterface:1.0.0"
 
     // WordPress libs
-    implementation('org.wordpress:utils:1.30.3-beta.1') {
+    implementation ('org.wordpress:utils:1.30.3-beta.1') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -1,8 +1,19 @@
-plugins {
-    id "com.android.application"
-    id "org.jetbrains.kotlin.android"
-    id "org.jetbrains.kotlin.kapt"
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
 }
+
+repositories {
+    jcenter()
+}
+
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 29
@@ -45,6 +56,8 @@ android.buildTypes.all { buildType ->
 
 dependencies {
     implementation project(':fluxc');
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     // WordPress libs
     implementation('org.wordpress:utils:1.20.0') {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -1,8 +1,20 @@
-plugins {
-    id "com.android.library"
-    id "org.jetbrains.kotlin.android"
-    id "org.jetbrains.kotlin.kapt"
-    id "com.github.dcendents.android-maven"
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+apply plugin: 'com.github.dcendents.android-maven'
+
+repositories {
+    jcenter()
 }
 
 android {
@@ -29,6 +41,7 @@ android {
 dependencies {
     implementation project(':fluxc')
 
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     // WordPress libs

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,41 +1,4 @@
-pluginManagement {
-    gradle.ext.kotlinVersion = '1.4.10'
-
-    plugins {
-        id "com.github.dcendents.android-maven" version "2.0"
-        id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
-        id "org.jetbrains.kotlin.android.extensions" version gradle.ext.kotlinVersion
-        id "org.jetbrains.kotlin.jvm" version gradle.ext.kotlinVersion
-        id "org.jetbrains.kotlin.kapt" version gradle.ext.kotlinVersion
-    }
-    repositories {
-        gradlePluginPortal()
-        google()
-        jcenter()
-        maven { url "https://dl.bintray.com/automattic/maven/" }
-    }
-    resolutionStrategy {
-        eachPlugin {
-            // TODO: Remove this as soon as we update to AGP >= 4.2.0
-            if (requested.id.id.contains("com.android")) {
-                useModule("com.android.tools.build:gradle:4.0.2")
-            }
-            // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.fetchstyle") {
-                useModule("com.automattic.android:fetchstyle:1.1")
-            }
-            // TODO: Remove this as soon as configure starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.configure") {
-                useModule("com.automattic.android:configure:0.5.0")
-            }
-        }
-    }
-}
-
-include ':fluxc',
-        ':fluxc-processor',
-        ':fluxc-annotations',
-        ':plugins:woocommerce',
-        ':example',
-        ':instaflux',
-        ':tests:api'
+include ':fluxc', ':fluxc-processor', ':fluxc-annotations', ':plugins:woocommerce'
+include ':example'
+include ':instaflux'
+include ':tests:api'


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-FluxC-Android#1973

### Context

We're experiencing an issue with Jitpack builds. For some reason, Jitpack doesn't seem to find either `install` nor `publishToMavenLocal` tasks, even with `maven-publish`, `com.github.dcendents.android-maven`, or `maven` plugins (I've did some tests)

When Jitpack doesn't find those tasks, it forcefully adds plugins (see below). It worked like this before too:
<img width="694" alt="image" src="https://user-images.githubusercontent.com/5845095/117677073-6c0ab900-b1ae-11eb-9e43-f426fe397994.png"> 

[Look at build of 1.16.2 version](https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/1.16.2/build.log)

### Issue

The problem is that Jitpack adds those plugins using `buildscript { ... }` and this force addition breaks build when Plugin DSL is applied:

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/5845095/117677309-a1afa200-b1ae-11eb-8771-17c70a172668.png"> e.g. here: https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/8428a0d0ab/build.log

I'd like to revert this PR to unblock everyone working on FluxC.


