### PR TITLE
Fixing post `Plugin DSL` Jitpack build fail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id "org.jetbrains.kotlin.android.extensions" apply false
     id "org.jetbrains.kotlin.jvm" apply false
     id "org.jetbrains.kotlin.kapt" apply false
+    id "maven-publish"
 
 //    id "com.automattic.android.fetchstyle"
 //    id "com.automattic.android.configure"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
     id "org.jetbrains.kotlin.android.extensions" apply false
     id "org.jetbrains.kotlin.jvm" apply false
     id "org.jetbrains.kotlin.kapt" apply false
-    id "maven-publish"
 
 //    id "com.automattic.android.fetchstyle"
 //    id "com.automattic.android.configure"

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/TestUtils.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/TestUtils.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 public class TestUtils {
     public static final int DEFAULT_TIMEOUT_MS = 30000;
     public static final int MULTIPLE_UPLOADS_TIMEOUT_MS = 60000;
+    public static final int CACHE_TIMEOUT_MS = 500;
 
     private static final String SAMPLE_IMAGE = "pony.jpg";
     private static final String SAMPLE_VIDEO = "pony.mp4";

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -216,15 +216,27 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
 
     @Test
     public void testFetchBlockLayouts() throws InterruptedException {
-        testFetchBlockLayouts(false);
+        testFetchBlockLayouts(false, false);
+    }
+
+    @Test
+    public void testFetchBlockLayoutsFromCache() throws InterruptedException {
+        testFetchBlockLayouts(false, false);
+        testFetchBlockLayouts(false, true);
     }
 
     @Test
     public void testFetchBlockLayoutsBeta() throws InterruptedException {
-        testFetchBlockLayouts(true);
+        testFetchBlockLayouts(true, false);
     }
 
-    private void testFetchBlockLayouts(boolean isBeta) throws InterruptedException {
+    @Test
+    public void testFetchBlockLayoutsBetaFromCache() throws InterruptedException {
+        testFetchBlockLayouts(true, false);
+        testFetchBlockLayouts(true, true);
+    }
+
+    private void testFetchBlockLayouts(boolean isBeta, boolean preferCache) throws InterruptedException {
         authenticateAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_TEST1,
                 BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         SiteModel firstSite = mSiteStore.getSites().get(0);
@@ -239,9 +251,10 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         mNextEvent = TestEvents.BLOCK_LAYOUTS_FETCHED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchBlockLayoutsAction(
                 new SiteStore.FetchBlockLayoutsPayload(firstSite, supportedBlocks,
-                        320.0f, 480.0f, 1.0f, isBeta)));
+                        320.0f, 480.0f, 1.0f, isBeta, preferCache)));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch
+                .await(preferCache ? TestUtils.CACHE_TIMEOUT_MS : TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestXMLRPC.java
@@ -236,15 +236,27 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
 
     @Test
     public void testFetchBlockLayouts() throws InterruptedException {
-        testFetchBlockLayouts(false);
+        testFetchBlockLayouts(false, false);
+    }
+
+    @Test
+    public void testFetchBlockLayoutsFromCache() throws InterruptedException {
+        testFetchBlockLayouts(false, false);
+        testFetchBlockLayouts(false, true);
     }
 
     @Test
     public void testFetchBlockLayoutsBeta() throws InterruptedException {
-        testFetchBlockLayouts(true);
+        testFetchBlockLayouts(true, false);
     }
 
-    private void testFetchBlockLayouts(boolean isBeta) throws InterruptedException {
+    @Test
+    public void testFetchBlockLayoutsBetaFromCache() throws InterruptedException {
+        testFetchBlockLayouts(true, false);
+        testFetchBlockLayouts(true, true);
+    }
+
+    private void testFetchBlockLayouts(boolean isBeta, boolean preferCache) throws InterruptedException {
         fetchSites(BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE,
                 BuildConfig.TEST_WPORG_URL_SH_SIMPLE_ENDPOINT);
@@ -260,9 +272,10 @@ public class ReleaseStack_SiteTestXMLRPC extends ReleaseStack_Base {
         mNextEvent = TestEvents.BLOCK_LAYOUTS_FETCHED;
         mDispatcher.dispatch(SiteActionBuilder.newFetchBlockLayoutsAction(
                 new SiteStore.FetchBlockLayoutsPayload(firstSite, supportedBlocks,
-                        320.0f, 480.0f, 1.0f, isBeta)));
+                        320.0f, 480.0f, 1.0f, isBeta, preferCache)));
         mCountDownLatch = new CountDownLatch(1);
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(mCountDownLatch
+                .await(preferCache ? TestUtils.CACHE_TIMEOUT_MS : TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @SuppressWarnings("unused")

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "org.jetbrains.kotlin.android"
     id "org.jetbrains.kotlin.android.extensions"
     id "org.jetbrains.kotlin.kapt"
-    id "maven-publish"
+    id "maven"
 }
 
 android {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "org.jetbrains.kotlin.android"
     id "org.jetbrains.kotlin.android.extensions"
     id "org.jetbrains.kotlin.kapt"
-    id "com.github.dcendents.android-maven"
+    id "maven-publish"
 }
 
 android {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -1552,6 +1552,17 @@ public class SiteStore extends Store {
         return SiteSqlUtils.getBlockLayoutContent(site, slug);
     }
 
+    /**
+     * Gets the cached page layout
+     *
+     * @param site the current site
+     * @param slug the slug of the layout
+     * @return the layout or null if the layout is not cached
+     */
+    public @Nullable GutenbergLayout getBlockLayout(@NonNull SiteModel site, @NonNull String slug) {
+        return SiteSqlUtils.getBlockLayout(site, slug);
+    }
+
     public List<PostFormatModel> getPostFormats(SiteModel site) {
         return SiteSqlUtils.getPostFormats(site);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java
@@ -179,19 +179,22 @@ public class SiteStore extends Store {
         @Nullable public Float previewHeight;
         @Nullable public Float scale;
         @Nullable public Boolean isBeta;
+        @Nullable public Boolean preferCache;
 
         public FetchBlockLayoutsPayload(@NonNull SiteModel site,
                                         @Nullable List<String> supportedBlocks,
                                         @Nullable Float previewWidth,
                                         @Nullable Float previewHeight,
                                         @Nullable Float scale,
-                                        @Nullable Boolean isBeta) {
+                                        @Nullable Boolean isBeta,
+                                        @Nullable Boolean preferCache) {
             this.site = site;
             this.supportedBlocks = supportedBlocks;
             this.previewWidth = previewWidth;
             this.previewHeight = previewHeight;
             this.scale = scale;
             this.isBeta = isBeta;
+            this.preferCache = preferCache;
         }
     }
 
@@ -1966,6 +1969,7 @@ public class SiteStore extends Store {
     }
 
     private void fetchBlockLayouts(FetchBlockLayoutsPayload payload) {
+        if (payload.preferCache != null && payload.preferCache && cachedLayoutsRetrieved(payload.site)) return;
         if (payload.site.isUsingWpComRestApi()) {
             mSiteRestClient
                     .fetchWpComBlockLayouts(payload.site, payload.supportedBlocks,
@@ -2242,17 +2246,29 @@ public class SiteStore extends Store {
     private void handleFetchedBlockLayouts(FetchedBlockLayoutsResponsePayload payload) {
         if (payload.isError()) {
             // Return cached layouts on error
-            List<GutenbergLayout> layouts = SiteSqlUtils.getBlockLayouts(payload.site);
-            List<GutenbergLayoutCategory> categories = SiteSqlUtils.getBlockLayoutCategories(payload.site);
-            if (!layouts.isEmpty() && !categories.isEmpty()) {
-                emitChange(new OnBlockLayoutsFetched(layouts, categories, null));
-            } else {
+            if (!cachedLayoutsRetrieved(payload.site)) {
                 emitChange(new OnBlockLayoutsFetched(payload.layouts, payload.categories, payload.error));
             }
         } else {
             SiteSqlUtils.insertOrReplaceBlockLayouts(payload.site, payload.categories, payload.layouts);
             emitChange(new OnBlockLayoutsFetched(payload.layouts, payload.categories, payload.error));
         }
+    }
+
+    /**
+     * Emits a new [OnBlockLayoutsFetched] event with cached layouts for a given site
+     *
+     * @param site the site for which the cached layouts should be retrieved
+     * @return true if cached layouts were retrieved successfully
+     */
+    private boolean cachedLayoutsRetrieved(SiteModel site) {
+        List<GutenbergLayout> layouts = SiteSqlUtils.getBlockLayouts(site);
+        List<GutenbergLayoutCategory> categories = SiteSqlUtils.getBlockLayoutCategories(site);
+        if (!layouts.isEmpty() && !categories.isEmpty()) {
+            emitChange(new OnBlockLayoutsFetched(layouts, categories, null));
+            return true;
+        }
+        return false;
     }
 
     // Automated Transfers

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.android.library"
     id "org.jetbrains.kotlin.android"
     id "org.jetbrains.kotlin.kapt"
-    id "com.github.dcendents.android-maven"
+    id "maven-publish"
 }
 
 android {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.android.library"
     id "org.jetbrains.kotlin.android"
     id "org.jetbrains.kotlin.kapt"
-    id "maven-publish"
+    id "maven"
 }
 
 android {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,6 @@ pluginManagement {
     gradle.ext.kotlinVersion = '1.4.10'
 
     plugins {
-        id "com.github.dcendents.android-maven" version "2.0"
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
         id "org.jetbrains.kotlin.android.extensions" version gradle.ext.kotlinVersion
         id "org.jetbrains.kotlin.jvm" version gradle.ext.kotlinVersion


### PR DESCRIPTION
This PR is not meant to be merged. It's playground with description for working on the fix.

This PR is build on top of commits from `issue/14426-cachedLayouts` branch as this was a branch where @antonis reported the problem.

Here I'll present my experiments and outcomes for what I tried to do to fix the problem in timespan of 30 minutes (so it might be a little chaotic):

Root cause: please see description of #1998 . TLDR; Jitpack forcefully adds `buildscript { ... }` to `build.gradle` before `plugin { ... }` and it crashes the build.

### Try 1

Replace `com.github.dcendents.android-maven` with `maven-publish`

#### Why?

My first thought was to use the [suggested by Jitpack](https://jitpack.io/docs/ANDROID/#create-your-release) solution and use `maven-publish` plugin. This setup also works for [Automattic-Tracks-Android](https://github.com/Automattic/Automattic-Tracks-Android/blob/develop/AutomatticTracks/build.gradle#L4).

#### Outcome:

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/4dc456eda01e4ecaf6982605a35ab1d818e2992c

[Jitpack build.log](https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/fixing-post-plugin-dsl-jitpack-fail-1.17.0-beta-2-g4dc456e-27/build.log), it still reports

```
WARNING:
Gradle 'install' task not found. Please add the 'maven' or 'android-maven' plugin.
See the documentation and examples: https://jitpack.io/docs/

Adding android plugin
Adding maven plugin
```

### Try 2

Apply `maven-publish` to the root project.

#### Why?

At this point I've successfully executed `./gradlew install` locally and it appeared that everything works fine (I mean: that `install` task is present, so Jitpack reports a false positive with `Gradle 'install' task not found`).

I've decided to add `maven-publish` to the root project to test if Jitpack will allow build to just execute `install` task without check - I'm not sure how they exactly check for task availability (probably `grep` on `./gradlew tasks --all` result but I've wanted to check it).

#### Outcome:

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/8428a0d0ab2d08ba10b94001fe62efaa1f3cefdf

[Jitpack build.log](https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/8428a0d0ab/build.log), same as above.

### Try 3

Use `maven` instead of `maven-publish`

#### Why?

I've followed Jitpack suggestion from logs:

```
Gradle 'install' task not found. Please add the 'maven' or 'android-maven' plugin.
```

to see if it still reports a false positive with plugin/tasks availability.

#### Outcome:

https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/28abe8c4c362efe66d0d10028c69f8b7635b1d53

[Jitpack build.log](https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/28abe8c4c3/build.log), same as above.

### What's next

I've created a `diff` of result of `./gradlew tasks --all` with current `develop` vs. last commit from issue/1960-use-plugin-dsl branch. 

https://editor.mergely.com/mfunHlV4/

You can see that the only difference with what tasks are available is... lack of the warning at the very beginning 🙃. ~This made me believe more into blaiming some internals of Jitpack but maybe I'm missing something~

Update 👆 : this diff proves that Plugin DSL migration didn't change anything with presence of tasks - we've got exactly the same plugins applied and the same tasks available. Jitpack did and still for some reasons thinks that we don't have any `install` task in the project

Update 2 : ok, now I see it's kinda obvious but I haven't seen this. `./gradlew tasks --all` fails because we forgot to update Jitpack steps from since change regarding gradle properties in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1964/ . 

