### PR TITLE
Use `Plugin DSL` but with working Jitpack build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,16 @@
-buildscript {
-    ext.kotlinVersion = '1.4.10'
-    ext.kotlinCoroutinesVersion = '1.3.9'
 
-    repositories {
-        google()
-        jcenter()
-        //maven { url "https://dl.bintray.com/automattic/maven/" }
-    }
+plugins {
+    // Those declarations are just a workaround for a false-positive Kotlin Gradle Plugin warning
+    // https://youtrack.jetbrains.com/issue/KT-46200
+    id "com.android.application" apply false
+    id "org.jetbrains.kotlin.android" apply false
+    id "org.jetbrains.kotlin.android.extensions" apply false
+    id "org.jetbrains.kotlin.jvm" apply false
+    id "org.jetbrains.kotlin.kapt" apply false
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
-        //classpath 'com.automattic.android:fetchstyle:1.1'
-        //classpath 'com.automattic.android:configure:0.5.0'
-    }
+//    id "com.automattic.android.fetchstyle"
+//    id "com.automattic.android.configure"
 }
-
-//apply plugin: 'com.automattic.android.fetchstyle'
-//apply plugin: 'com.automattic.android.configure'
 
 allprojects {
     apply plugin: 'checkstyle'
@@ -40,17 +34,6 @@ allprojects {
 }
 
 subprojects {
-    configurations.all {
-        resolutionStrategy {
-            forcedModules = [
-                    // Needed for com.nhaarman:mockito-kotlin-kt1.1
-                    // Can possibly be dropped when v2 of mockito-kotlin is released
-                    "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
-                    "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-            ]
-        }
-    }
-
     configurations {
         ktlint
     }
@@ -82,4 +65,5 @@ ext {
     appcompat_version = '1.0.2'
     mockitoVersion = '3.3.3'
     assertJVersion = '3.19.0'
+    kotlinCoroutinesVersion = '1.3.9'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,16 +1,9 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-    }
+plugins {
+    id "com.android.application"
+    id "org.jetbrains.kotlin.android"
+    id "org.jetbrains.kotlin.android.extensions"
+    id "org.jetbrains.kotlin.kapt"
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 28
@@ -93,8 +86,6 @@ dependencies {
     implementation project(':fluxc')
     implementation project(':plugins:woocommerce')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
@@ -121,7 +112,7 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
     testImplementation 'junit:junit:4.13'
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$gradle.ext.kotlinVersion"
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -1,19 +1,8 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-    }
-}
-
-apply plugin: 'java'
-apply plugin: 'maven'
-apply plugin: 'kotlin'
-apply plugin: 'kotlin-kapt'
-
-repositories {
-    jcenter()
+plugins {
+    id "java"
+    id "maven"
+    id "org.jetbrains.kotlin.jvm"
+    id "org.jetbrains.kotlin.kapt"
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'com.github.dcendents.android-maven'
-
-repositories {
-    jcenter()
+plugins {
+    id "com.android.library"
+    id "org.jetbrains.kotlin.android"
+    id "org.jetbrains.kotlin.android.extensions"
+    id "org.jetbrains.kotlin.kapt"
+    id "com.github.dcendents.android-maven"
 }
 
 android {
@@ -63,15 +51,13 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
 
     implementation "androidx.exifinterface:exifinterface:1.0.0"
 
     // WordPress libs
-    implementation ('org.wordpress:utils:1.30.3-beta.1') {
+    implementation('org.wordpress:utils:1.30.3-beta.1') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -1,19 +1,8 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-    }
+plugins {
+    id "com.android.application"
+    id "org.jetbrains.kotlin.android"
+    id "org.jetbrains.kotlin.kapt"
 }
-
-repositories {
-    jcenter()
-}
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 29
@@ -56,8 +45,6 @@ android.buildTypes.all { buildType ->
 
 dependencies {
     implementation project(':fluxc');
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     // WordPress libs
     implementation('org.wordpress:utils:1.20.0') {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 before_install:
-  - cp gradle.properties-example gradle.properties
+  - cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -1,20 +1,8 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'com.github.dcendents.android-maven'
-
-repositories {
-    jcenter()
+plugins {
+    id "com.android.library"
+    id "org.jetbrains.kotlin.android"
+    id "org.jetbrains.kotlin.kapt"
+    id "com.github.dcendents.android-maven"
 }
 
 android {
@@ -41,7 +29,6 @@ android {
 dependencies {
     implementation project(':fluxc')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     // WordPress libs

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,41 @@
-include ':fluxc', ':fluxc-processor', ':fluxc-annotations', ':plugins:woocommerce'
-include ':example'
-include ':instaflux'
-include ':tests:api'
+pluginManagement {
+    gradle.ext.kotlinVersion = '1.4.10'
+
+    plugins {
+        id "com.github.dcendents.android-maven" version "2.0"
+        id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
+        id "org.jetbrains.kotlin.android.extensions" version gradle.ext.kotlinVersion
+        id "org.jetbrains.kotlin.jvm" version gradle.ext.kotlinVersion
+        id "org.jetbrains.kotlin.kapt" version gradle.ext.kotlinVersion
+    }
+    repositories {
+        gradlePluginPortal()
+        google()
+        jcenter()
+        maven { url "https://dl.bintray.com/automattic/maven/" }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            // TODO: Remove this as soon as we update to AGP >= 4.2.0
+            if (requested.id.id.contains("com.android")) {
+                useModule("com.android.tools.build:gradle:4.0.2")
+            }
+            // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
+            if (requested.id.id == "com.automattic.android.fetchstyle") {
+                useModule("com.automattic.android:fetchstyle:1.1")
+            }
+            // TODO: Remove this as soon as configure starts supporting Plugin Marker Artifacts
+            if (requested.id.id == "com.automattic.android.configure") {
+                useModule("com.automattic.android:configure:0.5.0")
+            }
+        }
+    }
+}
+
+include ':fluxc',
+        ':fluxc-processor',
+        ':fluxc-annotations',
+        ':plugins:woocommerce',
+        ':example',
+        ':instaflux',
+        ':tests:api'


### PR DESCRIPTION
This PR is a continuation of #1973 with only one change regarding Jitpack build. See https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/662e7067fe94007ffe5d9b01ea76420f4c4092d9

### Context

When we changed how we handle gradle properties in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1964/, we didn't update `jitpack.yml` to prepare `example/properties` directory. This was resulting with failed `./gradlew tasks --all` task so Jitpack couldn't find `install` task. When it can't find the task, `Jitpack` will use a safety mechanism which will try to add a plugin to the project (just amend root `build.gradle`) and rerun task. 

It didn't work for us with `Plugin DSL` as this safety mechanism uses `buildscript { ... }`

### Why it was working before
We've been using this safety mechanism since https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1964/ but it did work for us previously as we used `buildscript { ... }`.

In #1999 I've described progress on the fix. You can also find links to logs of failed builds.

### Fix

I've updated `jitpack.yml` in https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/662e7067fe94007ffe5d9b01ea76420f4c4092d9 with exactly the same command as we use to set up CircleCI build. https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/.circleci/config.yml#L13

Proof of the fix: https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/662e7067fe/build.log

Closes: #1960 