### PR TITLE
Woo: Adds option to fetch user name + role of the current user 

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -96,7 +96,7 @@ class WooCommerceFragment : Fragment() {
                         prependToLog("${it.type}: ${it.message}")
                     }
                     result.model?.let {
-                        prependToLog("Current user is: ${it.joinToString(", ")}")
+                        prependToLog("Current user is: ${it.roles}")
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -31,8 +31,8 @@ import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserStore
 import org.wordpress.android.fluxc.store.WCDataStore
+import org.wordpress.android.fluxc.store.WCUserStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnWCProductSettingsChanged

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserSqlUtilsTest.kt
@@ -1,0 +1,106 @@
+package org.wordpress.android.fluxc.wc.user
+
+import com.yarolegovich.wellsql.WellSql
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.user.WCUserModel
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.persistence.WCUserSqlUtils
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import kotlin.test.assertEquals
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WCUserSqlUtilsTest {
+    val site = SiteModel().apply {
+        email = "test@example.org"
+        name = "Test Site"
+        siteId = 24
+    }
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(
+                appContext,
+                listOf(SiteModel::class.java, WCUserModel::class.java),
+                WellSqlConfig.ADDON_WOOCOMMERCE)
+        WellSql.init(config)
+        config.reset()
+
+        // Insert the site into the db so it's available later
+        SiteSqlUtils.insertOrUpdateSite(site)
+    }
+
+    @Test
+    fun testInsertOrUpdateUserSite() {
+        val userApiResponse = WCUserTestUtils.generateSampleUApiResponse()
+        val user = WCUserTestUtils.getSampleUser(userApiResponse, site)
+
+        // Test inserting a user
+        var rowsAffected = WCUserSqlUtils.insertOrUpdateUser(user)
+        assertEquals(1, rowsAffected)
+
+        var savedUser = WCUserSqlUtils.getUserBySiteAndEmail(site.id, user.email)
+        assertEquals(savedUser?.localSiteId, user.localSiteId)
+        assertEquals(savedUser?.username, user.username)
+        assertEquals(savedUser?.email, user.email)
+        assertEquals(savedUser?.roles, user.roles)
+
+        // Test updating the same user
+        user.apply {
+            username = "testing"
+        }
+        rowsAffected = WCUserSqlUtils.insertOrUpdateUser(user)
+        assertEquals(1, rowsAffected)
+        savedUser = WCUserSqlUtils.getUserBySiteAndEmail(site.id, user.email)
+        assertEquals(savedUser?.localSiteId, user.localSiteId)
+        assertEquals(savedUser?.username, user.username)
+        assertEquals(savedUser?.email, user.email)
+        assertEquals(savedUser?.roles, user.roles)
+    }
+
+    @Test
+    fun testGetUsersForSite() {
+        val userApiResponse = WCUserTestUtils.generateSampleUApiResponse()
+        val user = WCUserTestUtils.getSampleUser(userApiResponse, site)
+
+        // Insert user
+        val rowsAffected = WCUserSqlUtils.insertOrUpdateUser(user)
+        assertEquals(1, rowsAffected)
+
+        // Get user for site and verify
+        val savedUsersExists = WCUserSqlUtils.getUsersBySite(site.id)
+        assertEquals(1, savedUsersExists.size)
+
+        // Get user for a site that does not exist
+        val nonExistingSite = SiteModel().apply { id = 400 }
+        val savedUsers = WCUserSqlUtils.getUsersBySite(nonExistingSite.id)
+        assertEquals(0, savedUsers.size)
+    }
+
+    @Test
+    fun testDeleteSiteDeletesUserList() {
+        val userApiResponse = WCUserTestUtils.generateSampleUApiResponse()
+        val user = WCUserTestUtils.getSampleUser(userApiResponse, site)
+
+        // Insert user
+        val rowsAffected = WCUserSqlUtils.insertOrUpdateUser(user)
+        assertEquals(1, rowsAffected)
+
+        // Get user for site and verify
+        var savedUsers = WCUserSqlUtils.getUsersBySite(site.id)
+        assertEquals(1, savedUsers.size)
+
+        // Delete site and verify users are deleted via foreign key constraint
+        SiteSqlUtils.deleteSite(site)
+        savedUsers = WCUserSqlUtils.getUsersBySite(site.id)
+        assertEquals(0, savedUsers.size)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserSqlUtilsTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.WCUserSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
@@ -64,6 +65,7 @@ class WCUserSqlUtilsTest {
         assertEquals(savedUser?.username, user.username)
         assertEquals(savedUser?.email, user.email)
         assertEquals(savedUser?.roles, user.roles)
+        assertTrue(savedUser?.isUserEligible() == true)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserSqlUtilsTest.kt
@@ -66,6 +66,25 @@ class WCUserSqlUtilsTest {
         assertEquals(savedUser?.email, user.email)
         assertEquals(savedUser?.roles, user.roles)
         assertTrue(savedUser?.isUserEligible() == true)
+
+        // Test updating user's role
+        user.apply { roles = "[\"author\",\"administrator\"]" }
+        rowsAffected = WCUserSqlUtils.insertOrUpdateUser(user)
+        assertEquals(1, rowsAffected)
+        savedUser = WCUserSqlUtils.getUserBySiteAndEmail(site.id, user.email)
+        assertTrue(savedUser?.isUserEligible() == true)
+
+        user.apply { roles = "[\"author\",\"customer\"]" }
+        rowsAffected = WCUserSqlUtils.insertOrUpdateUser(user)
+        assertEquals(1, rowsAffected)
+        savedUser = WCUserSqlUtils.getUserBySiteAndEmail(site.id, user.email)
+        assertTrue(savedUser?.isUserEligible() == false)
+
+        user.apply { roles = "[\"administrator\",\"shop_manager\"]" }
+        rowsAffected = WCUserSqlUtils.insertOrUpdateUser(user)
+        assertEquals(1, rowsAffected)
+        savedUser = WCUserSqlUtils.getUserBySiteAndEmail(site.id, user.email)
+        assertTrue(savedUser?.isUserEligible() == true)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -64,15 +64,15 @@ class WCUserStoreTest {
     @Test
     fun `fetch user role`() = test {
         val result = fetchUserRole()
-        val userRole = mapper.map(sampleUserApiResponse!!)
+        val userRole = mapper.map(sampleUserApiResponse!!, site)
         assertThat(result.model).isEqualTo(userRole)
         assertThat(result.model?.id).isEqualTo(userRole.id)
         assertThat(result.model?.username).isEqualTo(userRole.username)
         assertThat(result.model?.firstName).isEqualTo(userRole.firstName)
         assertThat(result.model?.lastName).isEqualTo(userRole.lastName)
         assertThat(result.model?.email).isEqualTo(userRole.email)
-        assertThat(result.model?.roles?.size).isEqualTo(userRole.roles.size)
-        assertThat(result.model?.roles?.get(0)?.isSupported() == true)
+        assertThat(result.model?.getUserRoles()?.size).isEqualTo(userRole.getUserRoles().size)
+        assertThat(result.model?.getUserRoles()?.get(0)?.isSupported() == true)
 
         val invalidRequestResult = store.fetchUserRole(errorSite)
         assertThat(invalidRequestResult.model).isNull()

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -13,7 +13,7 @@ import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.user.WCUserMapper
-import org.wordpress.android.fluxc.model.user.WCUserRole
+import org.wordpress.android.fluxc.model.user.WCUserModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
@@ -65,16 +65,21 @@ class WCUserStoreTest {
     fun `fetch user role`() = test {
         val result = fetchUserRole()
         val userRole = mapper.map(sampleUserApiResponse!!)
-        assertThat(result.model?.size).isEqualTo(userRole.size)
         assertThat(result.model).isEqualTo(userRole)
-        assertThat(result.model?.get(0)?.isSupported() == true)
+        assertThat(result.model?.id).isEqualTo(userRole.id)
+        assertThat(result.model?.username).isEqualTo(userRole.username)
+        assertThat(result.model?.firstName).isEqualTo(userRole.firstName)
+        assertThat(result.model?.lastName).isEqualTo(userRole.lastName)
+        assertThat(result.model?.email).isEqualTo(userRole.email)
+        assertThat(result.model?.roles?.size).isEqualTo(userRole.roles.size)
+        assertThat(result.model?.roles?.get(0)?.isSupported() == true)
 
         val invalidRequestResult = store.fetchUserRole(errorSite)
         assertThat(invalidRequestResult.model).isNull()
         assertThat(invalidRequestResult.error).isEqualTo(error)
     }
 
-    private suspend fun fetchUserRole(): WooResult<List<WCUserRole>> {
+    private suspend fun fetchUserRole(): WooResult<WCUserModel> {
         val fetchUserRolePayload = WooPayload(sampleUserApiResponse)
         whenever(restClient.fetchUserInfo(site)).thenReturn(fetchUserRolePayload)
         whenever(restClient.fetchUserInfo(errorSite)).thenReturn(WooPayload(error))

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -12,17 +12,17 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.user.WCUserMapper
+import org.wordpress.android.fluxc.model.user.WCUserRole
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRole
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserStore
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.store.WCUserStore
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
-import org.wordpress.android.fluxc.persistence.WCUserSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCUserStore
 import org.wordpress.android.fluxc.test
@@ -77,7 +76,17 @@ class WCUserStoreTest {
         assertThat(result.model?.getUserRoles()?.size).isEqualTo(userRole.getUserRoles().size)
         assertThat(result.model?.getUserRoles()?.get(0)?.isSupported() == true)
 
-        val savedUser = WCUserSqlUtils.getUserBySiteAndEmail(site.id, userRole.email)
+        val invalidRequestResult = store.fetchUserRole(errorSite)
+        assertThat(invalidRequestResult.model).isNull()
+        assertThat(invalidRequestResult.error).isEqualTo(error)
+    }
+
+    @Test
+    fun `get user role from db`() = test {
+        val result = fetchUserRole()
+        val userRole = mapper.map(sampleUserApiResponse!!, site)
+
+        val savedUser = store.getUserByEmail(site, userRole.email)
         assertNotNull(savedUser)
         assertThat(savedUser.remoteUserId).isEqualTo(userRole.remoteUserId)
         assertThat(savedUser.username).isEqualTo(userRole.username)
@@ -86,10 +95,6 @@ class WCUserStoreTest {
         assertThat(savedUser.email).isEqualTo(userRole.email)
         assertThat(savedUser.getUserRoles().size).isEqualTo(userRole.getUserRoles().size)
         assertTrue(savedUser.getUserRoles()[0].isSupported())
-
-        val invalidRequestResult = store.fetchUserRole(errorSite)
-        assertThat(invalidRequestResult.model).isNull()
-        assertThat(invalidRequestResult.error).isEqualTo(error)
     }
 
     private suspend fun fetchUserRole(): WooResult<WCUserModel> {

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserStoreTest.kt
@@ -94,7 +94,7 @@ class WCUserStoreTest {
         assertThat(savedUser.lastName).isEqualTo(userRole.lastName)
         assertThat(savedUser.email).isEqualTo(userRole.email)
         assertThat(savedUser.getUserRoles().size).isEqualTo(userRole.getUserRoles().size)
-        assertTrue(savedUser.getUserRoles()[0].isSupported())
+        assertTrue(savedUser.isUserEligible())
     }
 
     private suspend fun fetchUserRole(): WooResult<WCUserModel> {

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserTestUtils.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.fluxc.wc.user
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.UnitTestUtils
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.user.WCUserModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient.UserApiResponse
 
 object WCUserTestUtils {
@@ -10,5 +12,39 @@ object WCUserTestUtils {
         val json = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/store-user-role.json")
         val responseType = object : TypeToken<UserApiResponse>() {}.type
         return Gson().fromJson(json, responseType) as? UserApiResponse
+    }
+
+    fun getSampleUser(
+        userApiResponse: UserApiResponse?,
+        siteModel: SiteModel
+    ): WCUserModel {
+        return WCUserModel().apply {
+            remoteUserId = userApiResponse?.id ?: 0L
+            username = userApiResponse?.username ?: ""
+            firstName = userApiResponse?.firstName ?: ""
+            lastName = userApiResponse?.lastName ?: ""
+            email = userApiResponse?.email ?: ""
+            roles = userApiResponse?.roles.toString()
+
+            localSiteId = siteModel.id
+        }
+    }
+
+    private fun generateSampleUser(
+        firstName: String = "",
+        lastName: String = "",
+        username: String = "",
+        email: String = "",
+        roles: String = "",
+        siteId: Int = 6
+    ): WCUserModel {
+        return WCUserModel().apply {
+            localSiteId = siteId
+            this.firstName = firstName
+            this.lastName = lastName
+            this.username = username
+            this.email = email
+            this.roles = roles
+        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 149
+        return 151
     }
 
     override fun getDbName(): String {
@@ -1749,6 +1749,19 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "ORDER_ID INTEGER," +
                                     "REFUND_ID INTEGER," +
                                     "DATA TEXT NOT NULL)"
+                    )
+                }
+                150 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL(
+                            "CREATE TABLE WCUserModel (" +
+                                    "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                                    "LOCAL_SITE_ID INTEGER," +
+                                    "REMOTE_USER_ID INTEGER," +
+                                    "FIRST_NAME TEXT," +
+                                    "LAST_NAME TEXT," +
+                                    "USERNAME TEXT," +
+                                    "EMAIL TEXT," +
+                                    "ROLE TEXT)"
                     )
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1761,7 +1761,7 @@ open class WellSqlConfig : DefaultWellConfig {
                                     "LAST_NAME TEXT," +
                                     "USERNAME TEXT," +
                                     "EMAIL TEXT," +
-                                    "ROLE TEXT)"
+                                    "ROLES TEXT)"
                     )
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserMapper.kt
@@ -1,18 +1,21 @@
 package org.wordpress.android.fluxc.model.user
 
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient.UserApiResponse
 import javax.inject.Inject
 
 class WCUserMapper
 @Inject constructor() {
-    fun map(user: UserApiResponse): WCUserModel {
-        return WCUserModel(
-                id = user.id,
-                username = user.username ?: "",
-                firstName = user.firstName ?: "",
-                lastName = user.lastName ?: "",
-                email = user.email ?: "",
-                roles = user.roles.map { WCUserRole.fromValue(it) }
-        )
+    fun map(user: UserApiResponse, siteModel: SiteModel): WCUserModel {
+        return WCUserModel().apply {
+            remoteUserId = user.id
+            username = user.username ?: ""
+            firstName = user.firstName ?: ""
+            lastName = user.lastName ?: ""
+            email = user.email ?: ""
+            roles = user.roles.toString()
+
+            localSiteId = siteModel.id
+        }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserMapper.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
+package org.wordpress.android.fluxc.model.user
 
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient.UserApiResponse
 import javax.inject.Inject

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserMapper.kt
@@ -5,9 +5,14 @@ import javax.inject.Inject
 
 class WCUserMapper
 @Inject constructor() {
-    fun map(user: UserApiResponse): List<WCUserRole> {
-        val userRoles = mutableListOf<WCUserRole>()
-        user.roles.map { userRoles.add(WCUserRole.fromValue(it)) }
-        return userRoles
+    fun map(user: UserApiResponse): WCUserModel {
+        return WCUserModel(
+                id = user.id,
+                username = user.username ?: "",
+                firstName = user.firstName ?: "",
+                lastName = user.lastName ?: "",
+                email = user.email ?: "",
+                roles = user.roles.map { WCUserRole.fromValue(it) }
+        )
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
@@ -38,4 +38,6 @@ data class WCUserModel(@PrimaryKey @Column private var id: Int = 0) : Identifiab
         }
         return userRoles
     }
+
+    fun isUserEligible() = getUserRoles().none { !it.isSupported() }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.model.user
+
+data class WCUserModel(
+    val id: Long,
+    val firstName: String,
+    val lastName: String,
+    val username: String,
+    val email: String,
+    var roles: List<WCUserRole>
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
@@ -5,10 +5,15 @@ import com.google.gson.JsonElement
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+@RawConstraints(
+        "FOREIGN KEY(LOCAL_SITE_ID) REFERENCES SiteModel(_id) ON DELETE CASCADE",
+        "UNIQUE (EMAIL, LOCAL_SITE_ID) ON CONFLICT REPLACE"
+)
 data class WCUserModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     @Column var localSiteId = 0
     @Column var remoteUserId: Long = 0L

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
@@ -1,10 +1,36 @@
 package org.wordpress.android.fluxc.model.user
 
-data class WCUserModel(
-    val id: Long,
-    val firstName: String,
-    val lastName: String,
-    val username: String,
-    val email: String,
-    var roles: List<WCUserRole>
-)
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+
+@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
+data class WCUserModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var localSiteId = 0
+    @Column var remoteUserId: Long = 0L
+    @Column var firstName: String = ""
+    @Column var lastName: String = ""
+    @Column var username: String = ""
+    @Column var email: String = ""
+    @Column var roles: String = ""
+
+    override fun getId() = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    fun getUserRoles(): ArrayList<WCUserRole> {
+        val userRoles = ArrayList<WCUserRole>()
+        if (roles.isNotEmpty()) {
+            Gson().fromJson(roles, JsonElement::class.java).asJsonArray.forEach {
+                userRoles.add(WCUserRole.valueOf(it.asString))
+            }
+        }
+        return userRoles
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
@@ -39,5 +39,5 @@ data class WCUserModel(@PrimaryKey @Column private var id: Int = 0) : Identifiab
         return userRoles
     }
 
-    fun isUserEligible() = getUserRoles().none { !it.isSupported() }
+    fun isUserEligible() = getUserRoles().any { it.isSupported() }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserModel.kt
@@ -33,7 +33,7 @@ data class WCUserModel(@PrimaryKey @Column private var id: Int = 0) : Identifiab
         val userRoles = ArrayList<WCUserRole>()
         if (roles.isNotEmpty()) {
             Gson().fromJson(roles, JsonElement::class.java).asJsonArray.forEach {
-                userRoles.add(WCUserRole.valueOf(it.asString))
+                userRoles.add(WCUserRole.fromValue(it.asString))
             }
         }
         return userRoles

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserRole.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserRole.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
+package org.wordpress.android.fluxc.model.user
 
 enum class WCUserRole(val value: String = "") {
     OWNER("owner"),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserRole.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/user/WCUserRole.kt
@@ -22,5 +22,5 @@ enum class WCUserRole(val value: String = "") {
         fun fromValue(value: String) = valueMap[value] ?: OTHER
     }
 
-    fun isSupported() = this == ADMINISTRATOR
+    fun isSupported() = this == ADMINISTRATOR || this == SHOP_MANAGER
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
 
 import android.content.Context
 import com.android.volley.RequestQueue
+import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
@@ -49,6 +50,6 @@ class WCUserRestClient @Inject constructor(
         @SerializedName("first_name") val firstName: String?,
         @SerializedName("last_name") val lastName: String?,
         val email: String?,
-        val roles: List<String>
+        val roles: JsonElement
     )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCUserSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCUserSqlUtils.kt
@@ -1,0 +1,53 @@
+package org.wordpress.android.fluxc.persistence
+
+import com.wellsql.generated.WCUserModelTable
+import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.fluxc.model.user.WCUserModel
+
+object WCUserSqlUtils {
+    fun getUsersBySite(
+        localSiteId: Int
+    ): List<WCUserModel> {
+        return WellSql.select(WCUserModel::class.java)
+                .where()
+                .equals(WCUserModelTable.LOCAL_SITE_ID, localSiteId)
+                .endWhere()
+                .asModel
+    }
+
+    fun getUserBySiteAndEmail(
+        localSiteId: Int,
+        userEmail: String
+    ): WCUserModel? {
+        return WellSql.select(WCUserModel::class.java)
+                .where()
+                .equals(WCUserModelTable.LOCAL_SITE_ID, localSiteId)
+                .equals(WCUserModelTable.EMAIL, userEmail)
+                .endWhere()
+                .asModel.firstOrNull()
+    }
+
+    fun insertOrUpdateUser(user: WCUserModel): Int {
+        val result = WellSql.select(WCUserModel::class.java)
+                .where().beginGroup()
+                .equals(WCUserModelTable.ID, user.id)
+                .or()
+                .beginGroup()
+                .equals(WCUserModelTable.LOCAL_SITE_ID, user.localSiteId)
+                .equals(WCUserModelTable.EMAIL, user.email)
+                .endGroup()
+                .endGroup().endWhere()
+                .asModel.firstOrNull()
+
+        return if (result == null) {
+            // Insert
+            WellSql.insert(user).asSingleTransaction(true).execute()
+            1
+        } else {
+            // Update
+            val oldId = result.id
+            WellSql.update(WCUserModel::class.java).whereId(oldId)
+                    .put(user, UpdateAllExceptId(WCUserModel::class.java)).execute()
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.user.WCUserMapper
-import org.wordpress.android.fluxc.model.user.WCUserRole
+import org.wordpress.android.fluxc.model.user.WCUserModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -19,7 +19,7 @@ class WCUserStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine,
     private val mapper: WCUserMapper
 ) {
-    suspend fun fetchUserRole(site: SiteModel): WooResult<List<WCUserRole>> {
+    suspend fun fetchUserRole(site: SiteModel): WooResult<WCUserModel> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchUserInfo") {
             val response = restClient.fetchUserInfo(site)
             return@withDefaultContext when {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
@@ -34,4 +34,6 @@ class WCUserStore @Inject constructor(
             }
         }
     }
+
+    fun getUserByEmail(site: SiteModel, email: String) = WCUserSqlUtils.getUserBySiteAndEmail(site.id, email)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
@@ -1,10 +1,13 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
+package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.user.WCUserMapper
+import org.wordpress.android.fluxc.model.user.WCUserRole
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.user.WCUserRestClient
+import org.wordpress.android.fluxc.persistence.WCUserSqlUtils
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
@@ -25,7 +26,9 @@ class WCUserStore @Inject constructor(
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
-                    WooResult(mapper.map(response.result, site))
+                    val user = mapper.map(response.result, site)
+                    WCUserSqlUtils.insertOrUpdateUser(user)
+                    WooResult(user)
                 }
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCUserStore.kt
@@ -25,7 +25,7 @@ class WCUserStore @Inject constructor(
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
-                    WooResult(mapper.map(response.result))
+                    WooResult(mapper.map(response.result, site))
                 }
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }


### PR DESCRIPTION
Adds option to fetch user name + role of the current user after logging into the Woo app. 

### Background
The Woo app currently supports only administrator and shop manager role. This is part of the changes in woocommerce/woocommerce-android#3846. So once a user is logged in, we fetch the role of the current user and display an error message if the role does not match admin or shop manager. 

The latest design for that error screen, specifies that we display the user's first and last name along with their role.

### Changes
This PR adds a new model `WCUserModel` that is fetched by the client when calling the `/wp/v2/users/me` API endpoint. Previously, we used to return just the role of the user. This PR returns the `WCUserModel` instead since it includes the user name along with the list of roles.

## Update
- I updated this PR to add a new table to the local db. This just stores the `WCUserModel` as a table and caches the result. 

### Testing
- Run `WCUserStoreTest` and ensure that all tests pass.
- Login to a test store as an admin, shop manager, customer, subscriber etc from the example app.
  - Click on Woo -> Get User Role and verify that the current user role is displayed correctly.
  - Install the User Role Editor plugin on your test site.
  - Add multiple user roles for a single user. You can also add custom user roles.
  - Open the app and follow Step 2 and verify that the current user roles are displayed correctly. If a user has a custom user role, notice that OTHER is displayed.