### PR TITLE
Jetpack App (Basics): Add jetpack scheme

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -101,7 +101,8 @@ public class AccountStore extends Store {
 
     public enum AuthEmailPayloadScheme {
         WORDPRESS("wordpress"),
-        WOOCOMMERCE("woocommerce");
+        WOOCOMMERCE("woocommerce"),
+        JETPACK("jetpack");
 
         private final String mString;
 


### PR DESCRIPTION
### Description

This PR adds "jetpack" scheme in the `AuthEmailPayloadScheme` for the Jetpack app.

### How to test

WordPress-Android PR: wordpress-mobile/WordPress-Android#14644