### PR TITLE
Shipping Labels: support customs form

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -440,7 +440,7 @@ class WooShippingLabelFragment : Fragment() {
                                     )
                                 }
 
-                        WCShippingPackageCustoms (
+                        WCShippingPackageCustoms(
                                 id = "default",
                                 contentsType = if (isInternational) WCContentType.Merchandise else null,
                                 restrictionType = if (isInternational) WCRestrictionType.None else null,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -409,16 +409,17 @@ class WooShippingLabelFragment : Fragment() {
                                         "Length: $length\n" +
                                         "Weight: $weight"
                         )
+                        return@launch
                     }
                     prependToLog("Retrieving rates")
 
                     val box = ShippingLabelPackage(
                             "default",
-                            boxId!!,
-                            height!!,
-                            length!!,
-                            width!!,
-                            weight!!
+                            boxId,
+                            height,
+                            length,
+                            width,
+                            weight
                     )
 
                     val isInternational = destination.country != origin.country
@@ -442,10 +443,8 @@ class WooShippingLabelFragment : Fragment() {
                         WCShippingPackageCustoms (
                                 id = "default",
                                 contentsType = if (isInternational) WCContentType.Merchandise else null,
-                                contentsExplanation = null,
                                 restrictionType = if (isInternational) WCRestrictionType.None else null,
-                                restrictionComments = null,
-                                itn = null,
+                                itn = "AES X20160406131357",
                                 nonDeliveryOption = if (isInternational) WCNonDeliveryOption.Return else null,
                                 customsItems = customsItems
                         )
@@ -475,7 +474,7 @@ class WooShippingLabelFragment : Fragment() {
                     val rate = ratesResult.model!!.packageRates.first().shippingOptions.first().rates.first()
                     val packageData = WCShippingLabelPackageData(
                             id = "default",
-                            boxId = "medium_flat_box_top",
+                            boxId = boxId,
                             length = length,
                             height = height,
                             width = width,
@@ -486,6 +485,7 @@ class WooShippingLabelFragment : Fragment() {
                             carrierId = rate.carrierId,
                             products = order.getLineItemList().map { it.productId!! }
                     )
+                    prependToLog("Purchasing label")
                     val result = wcShippingLabelStore.purchaseShippingLabels(
                             site,
                             order.remoteOrderId,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -482,6 +482,7 @@ class WooShippingLabelFragment : Fragment() {
                             shipmentId = rate.shipmentId,
                             rateId = rate.rateId,
                             serviceId = rate.serviceId,
+                            serviceName = rate.title,
                             carrierId = rate.carrierId,
                             products = order.getLineItemList().map { it.productId!! }
                     )

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -40,11 +40,16 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.model.shippinglabels.WCContentType
+import org.wordpress.android.fluxc.model.shippinglabels.WCCustomsItem
+import org.wordpress.android.fluxc.model.shippinglabels.WCNonDeliveryOption
+import org.wordpress.android.fluxc.model.shippinglabels.WCRestrictionType
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageData
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPaperSize
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingPackageCustoms
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
@@ -52,6 +57,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.math.BigDecimal
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -342,7 +348,8 @@ class WooShippingLabelFragment : Fragment() {
                                                         order.remoteOrderId,
                                                         origin,
                                                         destination,
-                                                        listOf(box)
+                                                        listOf(box),
+                                                        null
                                                 )
 
                                                 result.error?.let {
@@ -413,12 +420,44 @@ class WooShippingLabelFragment : Fragment() {
                             width!!,
                             weight!!
                     )
+
+                    val isInternational = destination.country != origin.country
+                    val customsData = if (isInternational) {
+                        val customsItems =
+                                order.getLineItemList().map {
+                                    val quantity = it.quantity ?: 0f
+                                    WCCustomsItem(
+                                            productId = it.productId!!,
+                                            description = it.name.orEmpty(),
+                                            value = (it.price?.toBigDecimal() ?: BigDecimal.ZERO).multiply(
+                                                    BigDecimal.valueOf(quantity.toDouble())
+                                            ),
+                                            quantity = quantity,
+                                            weight = 1f,
+                                            hsTariffNumber = null,
+                                            originCountry = "US"
+                                    )
+                                }
+
+                        WCShippingPackageCustoms (
+                                id = "default",
+                                contentsType = if (isInternational) WCContentType.Merchandise else null,
+                                contentsExplanation = null,
+                                restrictionType = if (isInternational) WCRestrictionType.None else null,
+                                restrictionComments = null,
+                                itn = null,
+                                nonDeliveryOption = if (isInternational) WCNonDeliveryOption.Return else null,
+                                customsItems = customsItems
+                        )
+                    } else null
+
                     val ratesResult = wcShippingLabelStore.getShippingRates(
                             site,
                             order.remoteOrderId,
-                            origin,
+                            if (isInternational) origin.copy(phone = "0000000000") else origin,
                             destination,
-                            listOf(box)
+                            listOf(box),
+                            customsData?.let { listOf(it) }
                     )
                     if (ratesResult.isError) {
                         prependToLog(
@@ -450,9 +489,10 @@ class WooShippingLabelFragment : Fragment() {
                     val result = wcShippingLabelStore.purchaseShippingLabels(
                             site,
                             order.remoteOrderId,
-                            origin,
+                            if (isInternational) origin.copy(phone = "0000000000") else origin,
                             destination,
-                            listOf(packageData)
+                            listOf(packageData),
+                            customsData?.let { listOf(it) }
                     )
 
                     result.error?.let {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPackageData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPackageData.kt
@@ -12,6 +12,7 @@ data class WCShippingLabelPackageData(
     @SerializedName("shipment_id") val shipmentId: String,
     @SerializedName("rate_id") val rateId: String,
     @SerializedName("service_id") val serviceId: String,
+    @SerializedName("service_name") val serviceName: String,
     @SerializedName("carrier_id") val carrierId: String,
     val products: List<Long>
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingPackageCustoms.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingPackageCustoms.kt
@@ -1,0 +1,66 @@
+package org.wordpress.android.fluxc.model.shippinglabels
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+import java.math.BigDecimal
+
+data class WCShippingPackageCustoms(
+    @Expose(serialize = false) val id: String,
+    @SerializedName("contents_type") val contentsType: WCContentType?,
+    @SerializedName("contents_explanation") val contentsExplanation: String?,
+    @SerializedName("restriction_type") val restrictionType: WCRestrictionType?,
+    @SerializedName("restriction_comments") val restrictionComments: String?,
+    @SerializedName("non_delivery_option") val nonDeliveryOption: WCNonDeliveryOption?,
+    @SerializedName("itn") val itn: String?,
+    @SerializedName("items") val customsItems: List<WCCustomsItem>?
+) {
+    init {
+        if (contentsType == WCContentType.Other && contentsExplanation.isNullOrEmpty()) {
+            throw IllegalArgumentException("you have to specify contentsExplanation when the contentsType is Other")
+        }
+        if (restrictionType == WCRestrictionType.Other && restrictionComments.isNullOrEmpty()) {
+            throw IllegalArgumentException("you have to specify restrictionComments when the restrictionType is Other")
+        }
+    }
+}
+
+data class WCCustomsItem(
+    @SerializedName("product_id") val productId: Long,
+    val description: String,
+    val quantity: Float,
+    val value: BigDecimal,
+    val weight: Float,
+    @SerializedName("hs_tariff_number") val hsTariffNumber: String?,
+    @SerializedName("origin_country") val originCountry: String
+)
+
+enum class WCContentType {
+    @SerializedName("merchandise")
+    Merchandise,
+    @SerializedName("documents")
+    Documents,
+    @SerializedName("gift")
+    Gift,
+    @SerializedName("sample")
+    Sample,
+    @SerializedName("other")
+    Other
+}
+
+enum class WCRestrictionType {
+    @SerializedName("none")
+    None,
+    @SerializedName("quarantine")
+    Quarantine,
+    @SerializedName("sanitary_phytosanitary_inspection")
+    SanitaryInspection,
+    @SerializedName("other")
+    Other
+}
+
+enum class WCNonDeliveryOption {
+    @SerializedName("abandon")
+    Abandon,
+    @SerializedName("return")
+    Return
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingPackageCustoms.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingPackageCustoms.kt
@@ -7,9 +7,9 @@ import java.math.BigDecimal
 data class WCShippingPackageCustoms(
     @Expose(serialize = false) val id: String,
     @SerializedName("contents_type") val contentsType: WCContentType?,
-    @SerializedName("contents_explanation") val contentsExplanation: String?,
+    @SerializedName("contents_explanation") val contentsExplanation: String? = null,
     @SerializedName("restriction_type") val restrictionType: WCRestrictionType?,
-    @SerializedName("restriction_comments") val restrictionComments: String?,
+    @SerializedName("restriction_comments") val restrictionComments: String? = null,
     @SerializedName("non_delivery_option") val nonDeliveryOption: WCNonDeliveryOption?,
     @SerializedName("itn") val itn: String?,
     @SerializedName("items") val customsItems: List<WCCustomsItem>?

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -253,7 +253,7 @@ class ShippingLabelRestClient @Inject constructor(
             "destination" to destination.toMap(),
             "packages" to packages.map { labelPackage ->
                 val customs = customsData?.first { it.id == labelPackage.id }
-                labelPackage.toMap() + customs.toMap()
+                labelPackage.toMap() + (customs?.toMap() ?: emptyMap())
             }
         )
 
@@ -290,7 +290,7 @@ class ShippingLabelRestClient @Inject constructor(
                 "destination" to destination,
                 "packages" to packagesData.map { labelPackage ->
                     val customs = customsData?.first { it.id == labelPackage.id }
-                    labelPackage.toMap() + customs.toMap()
+                    labelPackage.toMap() + (customs?.toMap() ?: emptyMap())
                 }
         )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -359,7 +359,7 @@ class ShippingLabelRestClient @Inject constructor(
         ) {
             data class Rate(
                 val title: String,
-                val insurance: BigDecimal,
+                val insurance: String,
                 val rate: BigDecimal,
                 @SerializedName("rate_id") val rateId: String,
                 @SerializedName("service_id") val serviceId: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageData
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingPackageCustoms
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
@@ -242,14 +243,18 @@ class ShippingLabelRestClient @Inject constructor(
         orderId: Long,
         origin: ShippingLabelAddress,
         destination: ShippingLabelAddress,
-        packages: List<ShippingLabelPackage>
+        packages: List<ShippingLabelPackage>,
+        customsData: List<WCShippingPackageCustoms>?
     ): WooPayload<ShippingRatesApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).rates.pathV1
 
         val params = mapOf(
             "origin" to origin.toMap(),
             "destination" to destination.toMap(),
-            "packages" to packages.map { it.toMap() }
+            "packages" to packages.map { labelPackage ->
+                val customs = customsData?.first { it.id == labelPackage.id }
+                labelPackage.toMap() + customs.toMap()
+            }
         )
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
@@ -274,15 +279,19 @@ class ShippingLabelRestClient @Inject constructor(
         orderId: Long,
         origin: ShippingLabelAddress,
         destination: ShippingLabelAddress,
-        packagesData: List<WCShippingLabelPackageData>
+        packagesData: List<WCShippingLabelPackageData>,
+        customsData: List<WCShippingPackageCustoms>?
     ): WooPayload<ShippingLabelStatusApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).pathV1
 
         val params = mapOf(
                 "async" to true,
-                "origin" to origin.toMap(),
-                "destination" to destination.toMap(),
-                "packages" to packagesData.map { it.toMap() }
+                "origin" to origin,
+                "destination" to destination,
+                "packages" to packagesData.map { labelPackage ->
+                    val customs = customsData?.first { it.id == labelPackage.id }
+                    labelPackage.toMap() + customs.toMap()
+                }
         )
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -359,7 +359,7 @@ class ShippingLabelRestClient @Inject constructor(
         ) {
             data class Rate(
                 val title: String,
-                val insurance: String,
+                val insurance: String?,
                 val rate: BigDecimal,
                 @SerializedName("rate_id") val rateId: String,
                 @SerializedName("service_id") val serviceId: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.Shi
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageData
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPaperSize
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingPackageCustoms
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult.ShippingOption
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingRatesResult.ShippingPackage
@@ -228,10 +229,11 @@ class WCShippingLabelStore @Inject constructor(
         orderId: Long,
         origin: ShippingLabelAddress,
         destination: ShippingLabelAddress,
-        packages: List<ShippingLabelPackage>
+        packages: List<ShippingLabelPackage>,
+        customsData: List<WCShippingPackageCustoms>?
     ): WooResult<WCShippingRatesResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "getShippingRates") {
-            val response = restClient.getShippingRates(site, orderId, origin, destination, packages)
+            val response = restClient.getShippingRates(site, orderId, origin, destination, packages, customsData)
             return@withDefaultContext when {
                 response.isError -> {
                     WooResult(response.error)
@@ -359,10 +361,18 @@ class WCShippingLabelStore @Inject constructor(
         orderId: Long,
         origin: ShippingLabelAddress,
         destination: ShippingLabelAddress,
-        packagesData: List<WCShippingLabelPackageData>
+        packagesData: List<WCShippingLabelPackageData>,
+        customsData: List<WCShippingPackageCustoms>?
     ): WooResult<List<WCShippingLabelModel>> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "purchaseShippingLabels") {
-            val response = restClient.purchaseShippingLabels(site, orderId, origin, destination, packagesData)
+            val response = restClient.purchaseShippingLabels(
+                    site,
+                    orderId,
+                    origin,
+                    destination,
+                    packagesData,
+                    customsData
+            )
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)
                 response.result?.labels != null -> {


### PR DESCRIPTION
Needed for https://github.com/woocommerce/woocommerce-android/issues/3526, this PR adds the ability to pass customs information along the requests to fetch rates and purchase shipping labels.

Please don't merge until https://github.com/woocommerce/woocommerce-android/pull/4060 is reviewed too to avoid breaking the app.

#### Testing
1. Make sure your store has been set up to purchase shipping labels (check p91TBi-3xD-p2 for steps) 
2. Create an order with an international shipping address. 
3. Open the example app, and click on Woo.
4. Click on Shipping Labels.
5. Click on Puchase shipping label, and enter the order id.
6. Enter the package details.
7. Confirm that the purchase is successful.

For choosing the right dimensions, please pick something that you know is a valid value in the web client.