### PR TITLE
Add configure plugin 0.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,71 +43,71 @@ jobs:
           command: ./gradlew --stacktrace -PtestsMaxHeapSize=1536m example:testRelease
       - android/save-gradle-cache
       - android/save-test-results
-#  Firebase Test:
-#    parameters:
-#      results-history-name:
-#        type: string
-#      package:
-#        type: string
-#      timeout:
-#        type: string
-#      num-flaky-test-attempts:
-#        type: integer
-#      post-slack-status:
-#        type: boolean
-#      device:
-#        type: string
-#    executor:
-#      name: android/default
-#      api-version: "27"
-#    steps:
-#      - checkout
-#      - android/restore-gradle-cache:
-#          cache-prefix: connected-tests
-#      - copy-gradle-properties
-#      - run:
-#          name: Decrypt Secrets
-#          command: ./gradlew applyConfiguration
-#      - run:
-#          name: Merge properties files
-#          command: ./gradlew :example:combineTestsPropertiesWithExtraTestsProperties
-#      - run:
-#          name: Build
-#          command: ./gradlew --stacktrace example:assembleDebug example:assembleDebugAndroidTest
-#      - android/firebase-test:
-#          key-file: .configure-files/firebase.secrets.json
-#          results-history-name: << parameters.results-history-name >>
-#          type: instrumentation
-#          apk-path: example/build/outputs/apk/debug/example-debug.apk
-#          test-apk-path: example/build/outputs/apk/androidTest/debug/example-debug-androidTest.apk
-#          test-targets: package << parameters.package >>
-#          device: << parameters.device >>
-#          project: api-project-108380595987
-#          timeout: << parameters.timeout >>
-#          num-flaky-test-attempts: << parameters.num-flaky-test-attempts >>
-#          no-record-video: true
-#      - android/save-gradle-cache:
-#          cache-prefix: connected-tests
-#      - when:
-#          condition: << parameters.post-slack-status >>
-#          steps:
-#            - run:
-#                name: Setup Slack messages
-#                when: always
-#                command: |
-#                  FIREBASE_URL="https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.fbe4c2866a46a076"
-#                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: FluxC Connected tests have failed!\nSee $FIREBASE_URL'" >> $BASH_ENV
-#                  echo "export SLACK_SUCCESS_MESSAGE=':tada: FluxC Connected tests have succeeded!\nSee $FIREBASE_URL'" >> $BASH_ENV
-#            - slack/status:
-#                fail_only: 'true'
-#                failure_message: '${SLACK_FAILURE_MESSAGE}'
-#                success_message: '${SLACK_SUCCESS_MESSAGE}'
-#                webhook: '${SLACK_FAILURE_WEBHOOK}'
-#            - slack/status:
-#                fail_only: 'false'
-#                failure_message: '${SLACK_FAILURE_MESSAGE}'
-#                success_message: '${SLACK_SUCCESS_MESSAGE}'
-#                webhook: '${SLACK_STATUS_WEBHOOK}'
+  Firebase Test:
+    parameters:
+      results-history-name:
+        type: string
+      package:
+        type: string
+      timeout:
+        type: string
+      num-flaky-test-attempts:
+        type: integer
+      post-slack-status:
+        type: boolean
+      device:
+        type: string
+    executor:
+      name: android/default
+      api-version: "27"
+    steps:
+      - checkout
+      - android/restore-gradle-cache:
+          cache-prefix: connected-tests
+      - copy-gradle-properties
+      - run:
+          name: Decrypt Secrets
+          command: ./gradlew applyConfiguration
+      - run:
+          name: Merge properties files
+          command: ./gradlew :example:combineTestsPropertiesWithExtraTestsProperties
+      - run:
+          name: Build
+          command: ./gradlew --stacktrace example:assembleDebug example:assembleDebugAndroidTest
+      - android/firebase-test:
+          key-file: .configure-files/firebase.secrets.json
+          results-history-name: << parameters.results-history-name >>
+          type: instrumentation
+          apk-path: example/build/outputs/apk/debug/example-debug.apk
+          test-apk-path: example/build/outputs/apk/androidTest/debug/example-debug-androidTest.apk
+          test-targets: package << parameters.package >>
+          device: << parameters.device >>
+          project: api-project-108380595987
+          timeout: << parameters.timeout >>
+          num-flaky-test-attempts: << parameters.num-flaky-test-attempts >>
+          no-record-video: true
+      - android/save-gradle-cache:
+          cache-prefix: connected-tests
+      - when:
+          condition: << parameters.post-slack-status >>
+          steps:
+            - run:
+                name: Setup Slack messages
+                when: always
+                command: |
+                  FIREBASE_URL="https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.fbe4c2866a46a076"
+                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: FluxC Connected tests have failed!\nSee $FIREBASE_URL'" >> $BASH_ENV
+                  echo "export SLACK_SUCCESS_MESSAGE=':tada: FluxC Connected tests have succeeded!\nSee $FIREBASE_URL'" >> $BASH_ENV
+            - slack/status:
+                fail_only: 'true'
+                failure_message: '${SLACK_FAILURE_MESSAGE}'
+                success_message: '${SLACK_SUCCESS_MESSAGE}'
+                webhook: '${SLACK_FAILURE_WEBHOOK}'
+            - slack/status:
+                fail_only: 'false'
+                failure_message: '${SLACK_FAILURE_MESSAGE}'
+                success_message: '${SLACK_SUCCESS_MESSAGE}'
+                webhook: '${SLACK_STATUS_WEBHOOK}'
   WooCommerce API Tests:
     executor:
       name: android/default
@@ -134,31 +134,31 @@ workflows:
     jobs:
       - Lint
       - Unit Tests
-#      - Firebase Test:
-#          name: Mocked Connected Tests
-#          results-history-name: CircleCI FluxC Mocked Tests
-#          package: org.wordpress.android.fluxc.mocked
-#          device: model=Nexus5X,version=26,locale=en,orientation=portrait
-#          timeout: 10m
-#          num-flaky-test-attempts: 0
-#          post-slack-status: false
-#  nightly:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - develop
-#    jobs:
-#      - Firebase Test:
-#          name: Connected Tests
-#          results-history-name: CircleCI FluxC Tests
-#          package: org.wordpress.android.fluxc
-#          device: model=Nexus5X,version=26,locale=en,orientation=portrait
-#          timeout: 30m
-#          num-flaky-test-attempts: 1
-#          post-slack-status: true
+      - Firebase Test:
+          name: Mocked Connected Tests
+          results-history-name: CircleCI FluxC Mocked Tests
+          package: org.wordpress.android.fluxc.mocked
+          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+          timeout: 10m
+          num-flaky-test-attempts: 0
+          post-slack-status: false
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - Firebase Test:
+          name: Connected Tests
+          results-history-name: CircleCI FluxC Tests
+          package: org.wordpress.android.fluxc
+          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+          timeout: 30m
+          num-flaky-test-attempts: 1
+          post-slack-status: true
   nightly-api-tests:
     triggers:
       - schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id "org.jetbrains.kotlin.kapt" apply false
 
 //    id "com.automattic.android.fetchstyle"
-//    id "com.automattic.android.configure"
+    id "com.automattic.android.configure"
 }
 
 allprojects {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -130,6 +130,9 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestUtil 'androidx.test:orchestrator:1.2.0'
 
+    androidTestImplementation "com.goterl:lazysodium-android:5.0.2@aar"
+    androidTestImplementation "net.java.dev.jna:jna:5.5.0@aar"
+
     // Debug dependencies
     debugImplementation 'com.facebook.flipper:flipper:0.51.0'
     debugImplementation 'com.facebook.soloader:soloader:0.9.0'

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/LogEncrypterTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/LogEncrypterTest.kt
@@ -2,8 +2,8 @@ package org.wordpress.android.fluxc
 
 import android.util.Base64
 import android.util.Base64.DEFAULT
-import com.goterl.lazycode.lazysodium.interfaces.SecretStream
-import com.goterl.lazycode.lazysodium.utils.KeyPair
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.KeyPair
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
@@ -51,7 +51,7 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
-        Assert.assertTrue(result.error.type == MISSING_ORDER)
+        Assert.assertTrue(result.error?.type == MISSING_ORDER)
     }
 
     @Test
@@ -60,7 +60,7 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
-        Assert.assertTrue(result.error.type == PAYMENT_ALREADY_CAPTURED)
+        Assert.assertTrue(result.error?.type == PAYMENT_ALREADY_CAPTURED)
     }
 
     @Test
@@ -69,7 +69,7 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
-        Assert.assertTrue(result.error.type == CAPTURE_ERROR)
+        Assert.assertTrue(result.error?.type == CAPTURE_ERROR)
     }
 
     @Test
@@ -78,6 +78,6 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         val result = payRestClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
 
-        Assert.assertTrue(result.error.type == SERVER_ERROR)
+        Assert.assertTrue(result.error?.type == SERVER_ERROR)
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ pluginManagement {
         gradlePluginPortal()
         google()
         jcenter()
+        maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
         maven { url "https://dl.bintray.com/automattic/maven/" }
     }
     resolutionStrategy {
@@ -26,7 +27,7 @@ pluginManagement {
             }
             // TODO: Remove this as soon as configure starts supporting Plugin Marker Artifacts
             if (requested.id.id == "com.automattic.android.configure") {
-                useModule("com.automattic.android:configure:0.5.0")
+                useModule("com.automattic.android:configure:0.6.0")
             }
         }
     }


### PR DESCRIPTION
This PR partially reverts https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1986/ by upgrading configure plugin to `0.6.0` which is hosted at S3. Fetchstyle plugin is still commented out as it's not yet published.

* ba1a5559214a3c4482eca94808f3b9ce30c18c3a re-enables configure plugin and updates it to `0.6.0`
* 76456e9f2132167fa92538e182d5586b55e647dc removes the comments from firebase tests (no other change)
* 547573b2e196a91a5fc4e2c90683d8e25efc396d adds lazy sodium as an `androidTest` dependency to example project so `LogEncrypterTest` can use it
* 81a3db4cd71ffb3be1af4cd388dc2f4c0dbefac6 fixes a nullable access in mocked `WCPayTest` - this would have been caught if we were running these tests in CI, but since we temporarily disabled it, I had to fix it as part of this PR.
