### PR TITLE
Updates configure plugin to 0.6.1

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ pluginManagement {
             }
             // TODO: Remove this as soon as configure starts supporting Plugin Marker Artifacts
             if (requested.id.id == "com.automattic.android.configure") {
-                useModule("com.automattic.android:configure:0.6.0")
+                useModule("com.automattic.android:configure:0.6.1")
             }
         }
     }


### PR DESCRIPTION
This PR fixes a build failure in Jitpack for configure plugin 0.6.0. The new version seems to fix the issue as [the build for this PR was successful](https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/update-configure-plugin-to-0.6.1-1.17.0-beta-3-g591b0f5-52/build.log).